### PR TITLE
Implement GitHub sweep issue deduplication and split admin endpoints

### DIFF
--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/GraphAdminController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/GraphAdminController.java
@@ -1,0 +1,20 @@
+package com.keplerops.groundcontrol.api.admin;
+
+import com.keplerops.groundcontrol.domain.requirements.service.GraphClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GraphAdminController {
+
+    private final GraphClient graphClient;
+
+    public GraphAdminController(GraphClient graphClient) {
+        this.graphClient = graphClient;
+    }
+
+    @PostMapping("/api/v1/admin/graph/materialize")
+    public void materializeGraph() {
+        graphClient.materializeGraph();
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/GraphController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/GraphController.java
@@ -6,11 +6,9 @@ import com.keplerops.groundcontrol.domain.requirements.service.GraphClient;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-// TODO: split admin/read endpoints into separate controllers
 @RestController
 public class GraphController {
 
@@ -22,11 +20,6 @@ public class GraphController {
         this.graphClient = graphClient;
         this.analysisService = analysisService;
         this.projectService = projectService;
-    }
-
-    @PostMapping("/api/v1/admin/graph/materialize")
-    public void materializeGraph() {
-        graphClient.materializeGraph();
     }
 
     @GetMapping("/api/v1/graph/ancestors/{uid}")

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/sweep/GitHubIssueSweepNotifier.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/sweep/GitHubIssueSweepNotifier.java
@@ -26,6 +26,7 @@ public class GitHubIssueSweepNotifier implements SweepNotifier {
     private static final Logger log = LoggerFactory.getLogger(GitHubIssueSweepNotifier.class);
     private static final DateTimeFormatter TIMESTAMP_FMT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC);
+    private static final String SWEEP_TITLE_PREFIX = "[Sweep]";
 
     private final GitHubClient gitHubClient;
     private final SweepProperties properties;
@@ -45,16 +46,42 @@ public class GitHubIssueSweepNotifier implements SweepNotifier {
 
     @Override
     public void notify(SweepReport report) {
-        // Each sweep creates a new issue; deduplication is not yet implemented.
-        // TODO: search for open sweep issues before creating a new one to avoid duplicates.
-        var title =
-                String.format("[Sweep] %d problems detected in %s", report.totalProblems(), report.projectIdentifier());
-        var body = formatBody(report);
         var repo = properties.github().repo();
         var labels = properties.github().labels();
 
+        if (hasOpenSweepIssue(repo, report.projectIdentifier())) {
+            log.info(
+                    "sweep_github_issue_skipped: open sweep issue already exists for project={}",
+                    report.projectIdentifier());
+            return;
+        }
+
+        var title =
+                String.format("[Sweep] %d problems detected in %s", report.totalProblems(), report.projectIdentifier());
+        var body = formatBody(report);
+
         var issue = gitHubClient.createIssue(repo, title, body, labels);
         log.info("sweep_github_issue_created: project={} issue={}", report.projectIdentifier(), issue.number());
+    }
+
+    private boolean hasOpenSweepIssue(String repo, String projectIdentifier) {
+        String[] parts = repo.split("/", 2);
+        if (parts.length != 2) {
+            log.warn("sweep_dedup_skipped: cannot parse owner/repo from '{}'", repo);
+            return false;
+        }
+        String owner = parts[0];
+        String repoName = parts[1];
+
+        try {
+            return gitHubClient.fetchAllIssues(owner, repoName).stream()
+                    .anyMatch(issue -> "OPEN".equalsIgnoreCase(issue.state())
+                            && issue.title().startsWith(SWEEP_TITLE_PREFIX)
+                            && issue.title().contains(projectIdentifier));
+        } catch (Exception e) {
+            log.warn("sweep_dedup_check_failed: falling back to creating new issue. error={}", e.getMessage());
+            return false;
+        }
     }
 
     static String formatBody(SweepReport report) {

--- a/backend/src/test/java/com/keplerops/groundcontrol/infrastructure/sweep/GitHubIssueSweepNotifierTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/infrastructure/sweep/GitHubIssueSweepNotifierTest.java
@@ -1,18 +1,104 @@
 package com.keplerops.groundcontrol.infrastructure.sweep;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.keplerops.groundcontrol.domain.requirements.service.CompletenessResult;
 import com.keplerops.groundcontrol.domain.requirements.service.CycleEdge;
 import com.keplerops.groundcontrol.domain.requirements.service.CycleResult;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubClient;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
 import com.keplerops.groundcontrol.domain.requirements.service.SweepReport;
 import com.keplerops.groundcontrol.domain.requirements.state.RelationType;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class GitHubIssueSweepNotifierTest {
+
+    @Nested
+    class Notify {
+
+        private GitHubClient gitHubClient;
+        private GitHubIssueSweepNotifier notifier;
+        private SweepReport report;
+
+        @BeforeEach
+        void setUp() {
+            gitHubClient = mock(GitHubClient.class);
+            var props = new SweepProperties(
+                    true,
+                    "0 * * * *",
+                    new SweepProperties.GitHubNotification(true, "owner/repo", List.of("sweep")),
+                    new SweepProperties.WebhookNotification(false, null));
+            notifier = new GitHubIssueSweepNotifier(gitHubClient, props);
+            report = new SweepReport(
+                    "my-project",
+                    Instant.now(),
+                    List.of(),
+                    List.of(new SweepReport.RequirementSummary("GC-001", "Orphan")),
+                    Map.of(),
+                    List.of(),
+                    List.of(),
+                    new CompletenessResult(1, Map.of("DRAFT", 1), List.of()));
+        }
+
+        @Test
+        void createsIssueWhenNoOpenSweepIssueExists() {
+            when(gitHubClient.fetchAllIssues("owner", "repo")).thenReturn(List.of());
+            when(gitHubClient.createIssue(anyString(), anyString(), anyString(), anyList()))
+                    .thenReturn(new GitHubIssueData(42, "title", "OPEN", "url", "body", List.of()));
+
+            notifier.notify(report);
+
+            verify(gitHubClient).createIssue(anyString(), anyString(), anyString(), anyList());
+        }
+
+        @Test
+        void skipsCreationWhenOpenSweepIssueAlreadyExists() {
+            var existingIssue = new GitHubIssueData(
+                    10, "[Sweep] 1 problems detected in my-project", "OPEN", "url", "body", List.of());
+            when(gitHubClient.fetchAllIssues("owner", "repo")).thenReturn(List.of(existingIssue));
+
+            notifier.notify(report);
+
+            verify(gitHubClient, never()).createIssue(any(), any(), any(), any());
+        }
+
+        @Test
+        void createsIssueWhenExistingSweepIssueIsClosed() {
+            var closedIssue = new GitHubIssueData(
+                    10, "[Sweep] 1 problems detected in my-project", "CLOSED", "url", "body", List.of());
+            when(gitHubClient.fetchAllIssues("owner", "repo")).thenReturn(List.of(closedIssue));
+            when(gitHubClient.createIssue(anyString(), anyString(), anyString(), anyList()))
+                    .thenReturn(new GitHubIssueData(11, "title", "OPEN", "url", "body", List.of()));
+
+            notifier.notify(report);
+
+            verify(gitHubClient).createIssue(anyString(), anyString(), anyString(), anyList());
+        }
+
+        @Test
+        void createsIssueWhenFetchThrowsException() {
+            when(gitHubClient.fetchAllIssues("owner", "repo"))
+                    .thenThrow(new RuntimeException("network error"));
+            when(gitHubClient.createIssue(anyString(), anyString(), anyString(), anyList()))
+                    .thenReturn(new GitHubIssueData(42, "title", "OPEN", "url", "body", List.of()));
+
+            notifier.notify(report);
+
+            verify(gitHubClient).createIssue(anyString(), anyString(), anyString(), anyList());
+        }
+    }
 
     @Test
     void formatsBodyWithAllSections() {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GraphAdminControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GraphAdminControllerTest.java
@@ -1,0 +1,35 @@
+package com.keplerops.groundcontrol.unit.api;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keplerops.groundcontrol.api.admin.GraphAdminController;
+import com.keplerops.groundcontrol.domain.requirements.service.GraphClient;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GraphAdminController.class)
+class GraphAdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GraphClient graphClient;
+
+    @Nested
+    class Materialize {
+
+        @Test
+        void returns200() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/graph/materialize")).andExpect(status().isOk());
+
+            verify(graphClient).materializeGraph();
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GraphControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GraphControllerTest.java
@@ -5,10 +5,8 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,17 +45,6 @@ class GraphControllerTest {
     @SuppressWarnings("UnusedVariable") // Required by Spring context
     @MockitoBean
     private ProjectService projectService;
-
-    @Nested
-    class Materialize {
-
-        @Test
-        void returns200() throws Exception {
-            mockMvc.perform(post("/api/v1/admin/graph/materialize")).andExpect(status().isOk());
-
-            verify(graphClient).materializeGraph();
-        }
-    }
 
     @Nested
     class Ancestors {


### PR DESCRIPTION
## Summary

This PR implements deduplication logic for GitHub sweep issues to prevent creating duplicate issues for the same project, and refactors the admin controller to separate concerns by moving the materialize endpoint to a dedicated `GraphAdminController`.

## Changes

- **GitHub Sweep Issue Deduplication**: Modified `GitHubIssueSweepNotifier` to check for existing open sweep issues before creating new ones. If an open issue already exists for the project, the notifier skips creation. If the check fails (e.g., network error), it gracefully falls back to creating a new issue with a warning log.
  
- **Controller Refactoring**: Extracted the `materializeGraph()` endpoint from `GraphController` into a new `GraphAdminController` to better separate admin operations from read-only graph operations.

- **Test Coverage**: Added comprehensive unit tests for the deduplication logic covering:
  - Creating an issue when no open sweep issue exists
  - Skipping creation when an open sweep issue already exists
  - Creating a new issue when an existing sweep issue is closed
  - Creating an issue when the fetch operation throws an exception
  
  Also added unit tests for the new `GraphAdminController`.

## Test Plan

- Unit tests added for `GitHubIssueSweepNotifier.notify()` deduplication logic
- Unit tests added for `GraphAdminController.materializeGraph()`
- Existing tests in `GraphControllerTest` updated to remove the materialize endpoint test

## Checklist

- [x] Code follows project coding standards
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Unit tests added for new functionality

https://claude.ai/code/session_012NyCBvJWpYXXZwBs3EZfJj