### PR TITLE
Implement GitHub issue deduplication for sweep notifications

### DIFF
--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/AdminGraphController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/AdminGraphController.java
@@ -1,0 +1,20 @@
+package com.keplerops.groundcontrol.api.admin;
+
+import com.keplerops.groundcontrol.domain.requirements.service.GraphClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AdminGraphController {
+
+    private final GraphClient graphClient;
+
+    public AdminGraphController(GraphClient graphClient) {
+        this.graphClient = graphClient;
+    }
+
+    @PostMapping("/api/v1/admin/graph/materialize")
+    public void materializeGraph() {
+        graphClient.materializeGraph();
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/GraphController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/GraphController.java
@@ -6,11 +6,9 @@ import com.keplerops.groundcontrol.domain.requirements.service.GraphClient;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-// TODO: split admin/read endpoints into separate controllers
 @RestController
 public class GraphController {
 
@@ -22,11 +20,6 @@ public class GraphController {
         this.graphClient = graphClient;
         this.analysisService = analysisService;
         this.projectService = projectService;
-    }
-
-    @PostMapping("/api/v1/admin/graph/materialize")
-    public void materializeGraph() {
-        graphClient.materializeGraph();
     }
 
     @GetMapping("/api/v1/graph/ancestors/{uid}")

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/sweep/GitHubIssueSweepNotifier.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/sweep/GitHubIssueSweepNotifier.java
@@ -2,6 +2,7 @@ package com.keplerops.groundcontrol.infrastructure.sweep;
 
 import com.keplerops.groundcontrol.domain.requirements.service.CycleResult;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubClient;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
 import com.keplerops.groundcontrol.domain.requirements.service.SweepNotifier;
 import com.keplerops.groundcontrol.domain.requirements.service.SweepReport;
 import com.keplerops.groundcontrol.domain.requirements.service.SweepReport.ConsistencyViolationSummary;
@@ -26,6 +27,7 @@ public class GitHubIssueSweepNotifier implements SweepNotifier {
     private static final Logger log = LoggerFactory.getLogger(GitHubIssueSweepNotifier.class);
     private static final DateTimeFormatter TIMESTAMP_FMT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC);
+    private static final String SWEEP_TITLE_PREFIX = "[Sweep]";
 
     private final GitHubClient gitHubClient;
     private final SweepProperties properties;
@@ -45,16 +47,39 @@ public class GitHubIssueSweepNotifier implements SweepNotifier {
 
     @Override
     public void notify(SweepReport report) {
-        // Each sweep creates a new issue; deduplication is not yet implemented.
-        // TODO: search for open sweep issues before creating a new one to avoid duplicates.
-        var title =
-                String.format("[Sweep] %d problems detected in %s", report.totalProblems(), report.projectIdentifier());
-        var body = formatBody(report);
         var repo = properties.github().repo();
+        var projectIdentifier = report.projectIdentifier();
+
+        if (hasOpenSweepIssue(repo, projectIdentifier)) {
+            log.info(
+                    "sweep_github_issue_skipped: project={} open sweep issue already exists",
+                    projectIdentifier);
+            return;
+        }
+
+        var title = String.format(
+                "%s %d problems detected in %s", SWEEP_TITLE_PREFIX, report.totalProblems(), projectIdentifier);
+        var body = formatBody(report);
         var labels = properties.github().labels();
 
         var issue = gitHubClient.createIssue(repo, title, body, labels);
-        log.info("sweep_github_issue_created: project={} issue={}", report.projectIdentifier(), issue.number());
+        log.info("sweep_github_issue_created: project={} issue={}", projectIdentifier, issue.number());
+    }
+
+    private boolean hasOpenSweepIssue(String repo, String projectIdentifier) {
+        String[] parts = repo.split("/", 2);
+        if (parts.length != 2) {
+            log.warn("sweep_github_dedup_skipped: cannot parse owner/repo from '{}'", repo);
+            return false;
+        }
+        String owner = parts[0];
+        String repoName = parts[1];
+
+        List<GitHubIssueData> issues = gitHubClient.fetchAllIssues(owner, repoName);
+        return issues.stream()
+                .filter(i -> "OPEN".equalsIgnoreCase(i.state()))
+                .anyMatch(i -> i.title().startsWith(SWEEP_TITLE_PREFIX)
+                        && i.title().contains(projectIdentifier));
     }
 
     static String formatBody(SweepReport report) {

--- a/backend/src/test/java/com/keplerops/groundcontrol/infrastructure/sweep/GitHubIssueSweepNotifierTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/infrastructure/sweep/GitHubIssueSweepNotifierTest.java
@@ -1,15 +1,23 @@
 package com.keplerops.groundcontrol.infrastructure.sweep;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.keplerops.groundcontrol.domain.requirements.service.CompletenessResult;
 import com.keplerops.groundcontrol.domain.requirements.service.CycleEdge;
 import com.keplerops.groundcontrol.domain.requirements.service.CycleResult;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubClient;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
 import com.keplerops.groundcontrol.domain.requirements.service.SweepReport;
 import com.keplerops.groundcontrol.domain.requirements.state.RelationType;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class GitHubIssueSweepNotifierTest {
@@ -65,5 +73,80 @@ class GitHubIssueSweepNotifierTest {
         assertThat(body).doesNotContain("### Coverage Gaps");
         assertThat(body).doesNotContain("### Cross-Wave Violations");
         assertThat(body).doesNotContain("### Consistency Violations");
+    }
+
+    @Nested
+    class Deduplication {
+
+        private final GitHubClient gitHubClient = mock(GitHubClient.class);
+        private final SweepProperties properties = new SweepProperties(
+                true,
+                "0 0 * * * *",
+                new SweepProperties.GitHubNotification(true, "owner/repo", List.of("sweep")),
+                null);
+        private final GitHubIssueSweepNotifier notifier = new GitHubIssueSweepNotifier(gitHubClient, properties);
+
+        private SweepReport minimalReport(String project) {
+            return new SweepReport(
+                    project,
+                    Instant.parse("2026-03-20T06:00:00Z"),
+                    List.of(),
+                    List.of(new SweepReport.RequirementSummary("GC-1", "Req")),
+                    Map.of(),
+                    List.of(),
+                    List.of(),
+                    new CompletenessResult(1, Map.of("DRAFT", 1), List.of()));
+        }
+
+        @Test
+        void createsIssueWhenNoOpenSweepIssueExists() {
+            when(gitHubClient.fetchAllIssues("owner", "repo")).thenReturn(List.of());
+            when(gitHubClient.createIssue(any(), any(), any(), any()))
+                    .thenReturn(new GitHubIssueData(42, "[Sweep] 1 problems detected in my-project", "OPEN", "url",
+                            "body", List.of("sweep")));
+
+            notifier.notify(minimalReport("my-project"));
+
+            verify(gitHubClient).createIssue(any(), any(), any(), any());
+        }
+
+        @Test
+        void skipsCreatingIssueWhenOpenSweepIssueAlreadyExists() {
+            var existing = new GitHubIssueData(
+                    10, "[Sweep] 3 problems detected in my-project", "OPEN", "url", "body", List.of("sweep"));
+            when(gitHubClient.fetchAllIssues("owner", "repo")).thenReturn(List.of(existing));
+
+            notifier.notify(minimalReport("my-project"));
+
+            verify(gitHubClient, never()).createIssue(any(), any(), any(), any());
+        }
+
+        @Test
+        void createsIssueWhenExistingSweepIssueIsClosed() {
+            var closed = new GitHubIssueData(
+                    10, "[Sweep] 3 problems detected in my-project", "CLOSED", "url", "body", List.of("sweep"));
+            when(gitHubClient.fetchAllIssues("owner", "repo")).thenReturn(List.of(closed));
+            when(gitHubClient.createIssue(any(), any(), any(), any()))
+                    .thenReturn(new GitHubIssueData(11, "[Sweep] 1 problems detected in my-project", "OPEN", "url",
+                            "body", List.of("sweep")));
+
+            notifier.notify(minimalReport("my-project"));
+
+            verify(gitHubClient).createIssue(any(), any(), any(), any());
+        }
+
+        @Test
+        void doesNotSuppressIssuesForDifferentProject() {
+            var otherProject = new GitHubIssueData(
+                    10, "[Sweep] 3 problems detected in other-project", "OPEN", "url", "body", List.of("sweep"));
+            when(gitHubClient.fetchAllIssues("owner", "repo")).thenReturn(List.of(otherProject));
+            when(gitHubClient.createIssue(any(), any(), any(), any()))
+                    .thenReturn(new GitHubIssueData(11, "[Sweep] 1 problems detected in my-project", "OPEN", "url",
+                            "body", List.of("sweep")));
+
+            notifier.notify(minimalReport("my-project"));
+
+            verify(gitHubClient).createIssue(any(), any(), any(), any());
+        }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AdminGraphControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AdminGraphControllerTest.java
@@ -1,0 +1,35 @@
+package com.keplerops.groundcontrol.unit.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keplerops.groundcontrol.api.admin.AdminGraphController;
+import com.keplerops.groundcontrol.domain.requirements.service.GraphClient;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminGraphController.class)
+class AdminGraphControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GraphClient graphClient;
+
+    @Nested
+    class Materialize {
+
+        @Test
+        void returns200() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/graph/materialize")).andExpect(status().isOk());
+
+            Mockito.verify(graphClient).materializeGraph();
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GraphControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GraphControllerTest.java
@@ -5,10 +5,8 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,17 +45,6 @@ class GraphControllerTest {
     @SuppressWarnings("UnusedVariable") // Required by Spring context
     @MockitoBean
     private ProjectService projectService;
-
-    @Nested
-    class Materialize {
-
-        @Test
-        void returns200() throws Exception {
-            mockMvc.perform(post("/api/v1/admin/graph/materialize")).andExpect(status().isOk());
-
-            verify(graphClient).materializeGraph();
-        }
-    }
 
     @Nested
     class Ancestors {


### PR DESCRIPTION
## Summary

Implements deduplication logic for GitHub sweep issue notifications to prevent creating duplicate issues when a sweep report is processed multiple times. Also refactors the admin graph materialization endpoint into a separate controller for better separation of concerns.

## Related Issues

Closes the TODO comment about implementing deduplication in `GitHubIssueSweepNotifier`.

## Changes

- **GitHubIssueSweepNotifier**: Added `hasOpenSweepIssue()` method that checks for existing open sweep issues before creating a new one. Issues are matched by project identifier in the title, and only OPEN issues are considered (closed issues allow new ones to be created).
- **GitHubIssueSweepNotifier**: Extracted sweep title prefix to a constant `SWEEP_TITLE_PREFIX` for consistency.
- **AdminGraphController**: Created new dedicated controller for admin graph operations, moving the `materializeGraph()` endpoint from `GraphController`.
- **GraphController**: Removed the `materializeGraph()` POST endpoint and the TODO comment about splitting admin/read endpoints.
- **GitHubIssueSweepNotifierTest**: Added comprehensive nested test class `Deduplication` with four test cases covering:
  - Creating an issue when no open sweep issue exists
  - Skipping creation when an open sweep issue already exists for the same project
  - Creating a new issue when an existing sweep issue is closed
  - Creating an issue for a project even when an open sweep issue exists for a different project
- **AdminGraphControllerTest**: Added new test class with unit tests for the materialization endpoint.
- **GraphControllerTest**: Removed the `Materialize` nested test class (moved to `AdminGraphControllerTest`).

## Test Plan

- [x] Unit tests added for deduplication logic and new admin controller
- [x] Existing tests pass with refactored endpoint location
- [x] No coverage regression (new tests cover the added functionality)

## Checklist

- [x] Code follows project coding standards
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Better separation of concerns with dedicated admin controller

https://claude.ai/code/session_01VBdV19WueiGD3wApNchDnJ