### PR TITLE
Batch Cypher queries for graph materialization

### DIFF
--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,1 +1,8 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "ground-control"

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
@@ -8,6 +8,8 @@ import com.keplerops.groundcontrol.domain.requirements.service.GraphClient;
 import com.keplerops.groundcontrol.domain.requirements.service.PathResult;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -49,31 +51,57 @@ public class AgeGraphService implements GraphClient {
         jdbcTemplate.execute(
                 "SELECT * FROM ag_catalog.cypher('" + graph + "', $$ MATCH (n) DETACH DELETE n $$) AS (v agtype)");
 
-        // Create nodes for all requirements
+        // Batch-create nodes for all requirements in a single Cypher statement
         List<Requirement> requirements = requirementRepository.findAll();
-        for (Requirement req : requirements) {
-            String cypher = String.format(
-                    "SELECT * FROM ag_catalog.cypher('%s', $$ CREATE (:Requirement {uid: '%s', title: '%s', status: '%s', wave: %s, requirement_type: '%s', priority: '%s'}) $$) AS (v agtype)",
-                    graph,
-                    escapeCypher(req.getUid()),
-                    escapeCypher(req.getTitle()),
-                    req.getStatus().name(),
-                    req.getWave() != null ? req.getWave().toString() : "null",
-                    req.getRequirementType().name(),
-                    req.getPriority().name());
-            jdbcTemplate.execute(cypher);
+        if (!requirements.isEmpty()) {
+            StringBuilder nodesCypher = new StringBuilder("SELECT * FROM ag_catalog.cypher('")
+                    .append(graph)
+                    .append("', $$ CREATE ");
+            for (int i = 0; i < requirements.size(); i++) {
+                if (i > 0) nodesCypher.append(", ");
+                Requirement req = requirements.get(i);
+                nodesCypher
+                        .append("(:Requirement {uid: '")
+                        .append(escapeCypher(req.getUid()))
+                        .append("', title: '")
+                        .append(escapeCypher(req.getTitle()))
+                        .append("', status: '")
+                        .append(req.getStatus().name())
+                        .append("', wave: ")
+                        .append(req.getWave() != null ? req.getWave().toString() : "null")
+                        .append(", requirement_type: '")
+                        .append(req.getRequirementType().name())
+                        .append("', priority: '")
+                        .append(req.getPriority().name())
+                        .append("'})");
+            }
+            nodesCypher.append(" $$) AS (v agtype)");
+            jdbcTemplate.execute(nodesCypher.toString());
         }
 
-        // Create edges for all relations
+        // Batch-create edges grouped by relation type: one UNWIND query per type
         List<RequirementRelation> relations = relationRepository.findAllWithSourceAndTarget();
-        for (RequirementRelation rel : relations) {
-            String cypher = String.format(
-                    "SELECT * FROM ag_catalog.cypher('%s', $$ MATCH (s:Requirement {uid: '%s'}), (t:Requirement {uid: '%s'}) CREATE (s)-[:%s]->(t) $$) AS (v agtype)",
-                    graph,
-                    escapeCypher(rel.getSource().getUid()),
-                    escapeCypher(rel.getTarget().getUid()),
-                    rel.getRelationType().name());
-            jdbcTemplate.execute(cypher);
+        Map<String, List<RequirementRelation>> byType = relations.stream()
+                .collect(Collectors.groupingBy(r -> r.getRelationType().name()));
+        for (Map.Entry<String, List<RequirementRelation>> entry : byType.entrySet()) {
+            String relType = entry.getKey();
+            StringBuilder pairList = new StringBuilder("[");
+            List<RequirementRelation> relList = entry.getValue();
+            for (int i = 0; i < relList.size(); i++) {
+                if (i > 0) pairList.append(", ");
+                RequirementRelation rel = relList.get(i);
+                pairList
+                        .append("['")
+                        .append(escapeCypher(rel.getSource().getUid()))
+                        .append("', '")
+                        .append(escapeCypher(rel.getTarget().getUid()))
+                        .append("']");
+            }
+            pairList.append("]");
+            String edgeCypher = String.format(
+                    "SELECT * FROM ag_catalog.cypher('%s', $$ UNWIND %s AS pair MATCH (s:Requirement {uid: pair[0]}), (t:Requirement {uid: pair[1]}) CREATE (s)-[:%s]->(t) $$) AS (v agtype)",
+                    graph, pairList, relType);
+            jdbcTemplate.execute(edgeCypher);
         }
 
         log.info("graph_materialized: nodes={} edges={} graph={}", requirements.size(), relations.size(), graph);

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -12,8 +13,10 @@ import static org.mockito.Mockito.when;
 
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
+import com.keplerops.groundcontrol.domain.requirements.model.RequirementRelation;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRelationRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
+import com.keplerops.groundcontrol.domain.requirements.state.RelationType;
 import com.keplerops.groundcontrol.infrastructure.age.AgeGraphService;
 import com.keplerops.groundcontrol.infrastructure.age.AgeProperties;
 import java.util.List;
@@ -129,8 +132,52 @@ class AgeGraphServiceTest {
 
             enabledService.materializeGraph();
 
-            // LOAD, SET, DETACH DELETE, and one CREATE for the requirement
+            // LOAD, SET, DETACH DELETE, and one bulk CREATE for the requirement
             verify(jdbcTemplate, atLeast(4)).execute(anyString());
+        }
+
+        @Test
+        void materializeGraph_batchesAllNodesIntoOneCypherStatement() {
+            var req1 = new Requirement(TEST_PROJECT, "GC-A001", "Req One", "Statement");
+            var req2 = new Requirement(TEST_PROJECT, "GC-A002", "Req Two", "Statement");
+            var req3 = new Requirement(TEST_PROJECT, "GC-A003", "Req Three", "Statement");
+            when(requirementRepository.findAll()).thenReturn(List.of(req1, req2, req3));
+            when(relationRepository.findAllWithSourceAndTarget()).thenReturn(List.of());
+
+            enabledService.materializeGraph();
+
+            // Exactly one CREATE statement regardless of node count (LOAD + SET + DETACH DELETE + 1 bulk CREATE = 4)
+            verify(jdbcTemplate, times(4)).execute(anyString());
+            verify(jdbcTemplate).execute(contains("GC-A001"));
+        }
+
+        @Test
+        void materializeGraph_batchesEdgesByRelationType() {
+            var req1 = new Requirement(TEST_PROJECT, "GC-A001", "Req One", "Statement");
+            var req2 = new Requirement(TEST_PROJECT, "GC-A002", "Req Two", "Statement");
+            var req3 = new Requirement(TEST_PROJECT, "GC-A003", "Req Three", "Statement");
+            var rel1 = new RequirementRelation(req1, req2, RelationType.PARENT);
+            var rel2 = new RequirementRelation(req2, req3, RelationType.PARENT);
+            var rel3 = new RequirementRelation(req1, req3, RelationType.DEPENDS_ON);
+            when(requirementRepository.findAll()).thenReturn(List.of(req1, req2, req3));
+            when(relationRepository.findAllWithSourceAndTarget()).thenReturn(List.of(rel1, rel2, rel3));
+
+            enabledService.materializeGraph();
+
+            // LOAD + SET + DETACH DELETE + 1 node CREATE + 2 edge UNWIND (one per relation type) = 6
+            verify(jdbcTemplate, times(6)).execute(anyString());
+        }
+
+        @Test
+        void materializeGraph_skipsNodeCreateWhenNoRequirements() {
+            when(requirementRepository.findAll()).thenReturn(List.of());
+            when(relationRepository.findAllWithSourceAndTarget()).thenReturn(List.of());
+
+            enabledService.materializeGraph();
+
+            // Only LOAD + SET + DETACH DELETE, no CREATE
+            verify(jdbcTemplate, times(3)).execute(anyString());
+            verify(jdbcTemplate, never()).execute(contains("CREATE"));
         }
 
         @Test


### PR DESCRIPTION
## Summary

Optimize `AgeGraphService.materializeGraph()` to batch create nodes and edges using single Cypher statements instead of executing one query per node/edge. This reduces database round-trips and improves performance when materializing graphs with many requirements and relations.

## Related Issues

<!-- Link to GitHub issues if applicable -->

## Changes

- **Node creation**: Combine all requirement nodes into a single `CREATE` statement instead of executing one per requirement
- **Edge creation**: Group relations by type and use `UNWIND` to batch-create edges per relation type, reducing queries from N to the number of distinct relation types
- **Empty collection handling**: Skip node creation entirely when no requirements exist
- **Build configuration**: Add `pluginManagement` block to `settings.gradle.kts` for explicit repository configuration

## Test Plan

- [x] Added unit tests for batch node creation (`materializeGraph_batchesAllNodesIntoOneCypherStatement`)
- [x] Added unit tests for batched edge creation by type (`materializeGraph_batchesEdgesByRelationType`)
- [x] Added unit tests for empty collection handling (`materializeGraph_skipsNodeCreateWhenNoRequirements`)
- [x] Existing tests pass with new batching logic

## Checklist

- [x] Code follows project coding standards
- [x] No business logic changes, infrastructure optimization only
- [x] Domain layer unaffected
- [ ] CHANGELOG.md updated (if required by project)

https://claude.ai/code/session_01DCwvyRptxnsE5ddcvWVzsg