### PR TITLE
Harden GitHub sync with input validation and state reflection (GC-D001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.100.0] - 2026-04-04
+
+### Added
+
+- Input validation on GitHub owner/repo parameters at every entry point:
+  GitHubCliClient, SyncController, GitHubIssueRequest, MCP tools
+  gc_sync_github and gc_create_github_issue (GC-D001)
+- GitHub issue state (OPEN/CLOSED) now reflected in traceability link
+  titles during sync, satisfying bidirectional state visibility (GC-D001)
+- Defensive IssueState parsing: unknown states default to OPEN with a
+  warning instead of crashing the sync
+- Validation on issue creation inputs: title length (256 chars), body
+  length (65536 chars), and label format/length (50 chars)
+- Unit tests for input validation rejection of command injection
+  payloads, malicious owner/repo names, and state reflection in
+  traceability links
+
 ## [0.99.0] - 2026-04-04
 
 ### Added

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/GlobalExceptionHandler.java
@@ -88,6 +88,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(BAD_REQUEST, message));
     }
 
+    @ExceptionHandler(jakarta.validation.ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(jakarta.validation.ConstraintViolationException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of("validation_error", ex.getMessage()));
+    }
+
     @ExceptionHandler(GroundControlException.class)
     public ResponseEntity<ErrorResponse> handleGroundControl(GroundControlException ex) {
         log.error("Unhandled domain exception", ex);

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/GitHubIssueRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/GitHubIssueRequest.java
@@ -1,6 +1,12 @@
 package com.keplerops.groundcontrol.api.admin;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
-public record GitHubIssueRequest(@NotBlank String requirementUid, String repo, String extraBody, List<String> labels) {}
+public record GitHubIssueRequest(
+        @NotBlank String requirementUid,
+        @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*$") String repo,
+        @Size(max = 65536) String extraBody,
+        List<@Size(max = 50) String> labels) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/SyncController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/SyncController.java
@@ -1,11 +1,15 @@
 package com.keplerops.groundcontrol.api.admin;
 
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueSyncService;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/admin/sync")
 public class SyncController {
@@ -17,7 +21,9 @@ public class SyncController {
     }
 
     @PostMapping("/github")
-    public SyncResultResponse syncGithub(@RequestParam String owner, @RequestParam String repo) {
+    public SyncResultResponse syncGithub(
+            @RequestParam @NotBlank @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9._-]*$") String owner,
+            @RequestParam @NotBlank @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9._-]*$") String repo) {
         return SyncResultResponse.from(syncService.syncGitHubIssues(owner, repo));
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubIssueSyncService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubIssueSyncService.java
@@ -114,7 +114,7 @@ public class GitHubIssueSyncService {
 
     private void updateExistingSync(GitHubIssueSync sync, GitHubIssueData issue, Instant fetchedAt) {
         sync.setIssueTitle(issue.title());
-        sync.setIssueState(IssueState.valueOf(issue.state()));
+        sync.setIssueState(parseIssueState(issue.state()));
         sync.setIssueBody(issue.body() != null ? issue.body() : "");
         sync.setIssueLabels(issue.labels());
         sync.setPhase(extractPhase(issue.labels()));
@@ -126,7 +126,7 @@ public class GitHubIssueSyncService {
 
     private void createNewSync(GitHubIssueData issue, Instant fetchedAt) {
         var sync = new GitHubIssueSync(
-                issue.number(), issue.title(), IssueState.valueOf(issue.state()), issue.url(), fetchedAt);
+                issue.number(), issue.title(), parseIssueState(issue.state()), issue.url(), fetchedAt);
         sync.setIssueBody(issue.body() != null ? issue.body() : "");
         sync.setIssueLabels(issue.labels());
         sync.setPhase(extractPhase(issue.labels()));
@@ -145,7 +145,8 @@ public class GitHubIssueSyncService {
                 if (syncOpt.isPresent()) {
                     var sync = syncOpt.get();
                     link.setArtifactUrl(sync.getIssueUrl());
-                    link.setArtifactTitle(sync.getIssueTitle());
+                    String stateTag = sync.getIssueState() != null ? " [" + sync.getIssueState() + "]" : "";
+                    link.setArtifactTitle("#" + sync.getIssueNumber() + " - " + sync.getIssueTitle() + stateTag);
                     link.setSyncStatus(SyncStatus.SYNCED);
                     link.setLastSyncedAt(fetchedAt);
                     traceabilityLinkRepository.save(link);
@@ -268,5 +269,17 @@ public class GitHubIssueSyncService {
             }
         }
         return refs;
+    }
+
+    IssueState parseIssueState(String state) {
+        if (state == null) {
+            return IssueState.OPEN;
+        }
+        try {
+            return IssueState.valueOf(state);
+        } catch (IllegalArgumentException e) {
+            log.warn("github_unknown_issue_state: state={}, defaulting to OPEN", state);
+            return IssueState.OPEN;
+        }
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
@@ -6,10 +6,12 @@ import com.keplerops.groundcontrol.domain.exception.GroundControlException;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubClient;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,9 +34,9 @@ public class GitHubCliClient implements GitHubClient {
     private static final Pattern GITHUB_REPO_RE =
             Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}/[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$");
 
-    private static final int MAX_TITLE_LENGTH = 256;
-    private static final int MAX_BODY_LENGTH = 65_536;
-    private static final int MAX_LABEL_LENGTH = 50;
+    public static final int MAX_TITLE_LENGTH = 256;
+    public static final int MAX_BODY_LENGTH = 65_536;
+    public static final int MAX_LABEL_LENGTH = 50;
     private static final Pattern LABEL_RE = Pattern.compile("^[a-zA-Z0-9 :._-]+$");
 
     private final ObjectMapper objectMapper;
@@ -83,6 +85,30 @@ public class GitHubCliClient implements GitHubClient {
         }
     }
 
+    public static void validateIssueContent(String title, String body, List<String> labels) {
+        if (title == null || title.isBlank() || title.length() > MAX_TITLE_LENGTH) {
+            throw new GroundControlException(
+                    "Issue title must be non-blank and at most " + MAX_TITLE_LENGTH + " characters",
+                    "invalid_issue_title");
+        }
+        if (body != null && body.length() > MAX_BODY_LENGTH) {
+            throw new GroundControlException(
+                    "Issue body must be at most " + MAX_BODY_LENGTH + " characters", "invalid_issue_body");
+        }
+        if (labels != null) {
+            for (String label : labels) {
+                if (label == null
+                        || label.length() > MAX_LABEL_LENGTH
+                        || !LABEL_RE.matcher(label).matches()) {
+                    throw new GroundControlException(
+                            "Invalid label: must be alphanumeric with spaces/colons/hyphens, max " + MAX_LABEL_LENGTH
+                                    + " chars",
+                            "invalid_issue_label");
+                }
+            }
+        }
+    }
+
     @Override
     public List<GitHubIssueData> fetchAllIssues(String owner, String repo) {
         validateOwnerRepo(owner, repo);
@@ -112,64 +138,26 @@ public class GitHubCliClient implements GitHubClient {
     }
 
     protected IssuePage fetchIssuePage(String owner, String repo, int page) {
+        String stdout = execGh(List.of(
+                ghPath,
+                "api",
+                String.format("repos/%s/%s/issues", owner, repo),
+                "--method",
+                "GET",
+                "-f",
+                "state=all",
+                "-f",
+                "per_page=" + PAGE_SIZE,
+                "-f",
+                "page=" + page));
+
         try {
-            ProcessBuilder pb = new ProcessBuilder(
-                    ghPath,
-                    "api",
-                    String.format("repos/%s/%s/issues", owner, repo),
-                    "--method",
-                    "GET",
-                    "-f",
-                    "state=all",
-                    "-f",
-                    "per_page=" + PAGE_SIZE,
-                    "-f",
-                    "page=" + page);
-            pb.redirectErrorStream(false);
-            Process process = pb.start();
-
-            // Drain stdout and stderr in background threads to avoid pipe-buffer deadlock
-            // when output exceeds the OS pipe buffer size (~64KB).
-            var stdoutFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
-                try {
-                    return process.getInputStream().readAllBytes();
-                } catch (IOException ex) {
-                    throw new java.io.UncheckedIOException(ex);
-                }
-            });
-            var stderrFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
-                try {
-                    return process.getErrorStream().readAllBytes();
-                } catch (IOException ex) {
-                    throw new java.io.UncheckedIOException(ex);
-                }
-            });
-
-            boolean finished = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            if (!finished) {
-                process.destroyForcibly();
-                throw new GroundControlException("gh CLI timed out after " + TIMEOUT_SECONDS + "s", "github_timeout");
-            }
-
-            int exitCode = process.exitValue();
-            if (exitCode != 0) {
-                String stderr = new String(stderrFuture.join(), StandardCharsets.UTF_8);
-                throw new GroundControlException(
-                        "gh CLI exited with code " + exitCode + ": " + stderr, "github_cli_error");
-            }
-
-            String stdout = new String(stdoutFuture.join(), StandardCharsets.UTF_8);
-
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> rawIssues =
                     objectMapper.readValue(stdout, new TypeReference<List<Map<String, Object>>>() {});
-
             return new IssuePage(parseIssues(rawIssues), rawIssues.size());
         } catch (IOException e) {
-            throw new GroundControlException("Failed to execute gh CLI: " + e.getMessage(), "github_cli_error", e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new GroundControlException("gh CLI execution interrupted", "github_interrupted", e);
+            throw new GroundControlException("Failed to parse gh CLI output: " + e.getMessage(), "github_parse_error");
         }
     }
 
@@ -205,51 +193,50 @@ public class GitHubCliClient implements GitHubClient {
     @Override
     public GitHubIssueData createIssue(String repo, String title, String body, List<String> labels) {
         validateRepoSlug(repo);
-        if (title == null || title.isBlank() || title.length() > MAX_TITLE_LENGTH) {
-            throw new GroundControlException(
-                    "Issue title must be non-blank and at most " + MAX_TITLE_LENGTH + " characters",
-                    "invalid_issue_title");
-        }
-        if (body != null && body.length() > MAX_BODY_LENGTH) {
-            throw new GroundControlException(
-                    "Issue body must be at most " + MAX_BODY_LENGTH + " characters", "invalid_issue_body");
-        }
-        if (labels != null) {
-            for (String label : labels) {
-                if (label == null
-                        || label.length() > MAX_LABEL_LENGTH
-                        || !LABEL_RE.matcher(label).matches()) {
-                    throw new GroundControlException(
-                            "Invalid label: must be alphanumeric with spaces/colons/hyphens, max " + MAX_LABEL_LENGTH
-                                    + " chars",
-                            "invalid_issue_label");
-                }
-            }
-        }
-        try {
-            List<String> args = new ArrayList<>(
-                    List.of(ghPath, "issue", "create", "--repo", repo, "--title", title, "--body", body));
-            if (labels != null && !labels.isEmpty()) {
-                args.add("--label");
-                args.add(String.join(",", labels));
-            }
+        validateIssueContent(title, body, labels);
 
+        List<String> args =
+                new ArrayList<>(List.of(ghPath, "issue", "create", "--repo", repo, "--title", title, "--body", body));
+        if (labels != null && !labels.isEmpty()) {
+            args.add("--label");
+            args.add(String.join(",", labels));
+        }
+
+        String stdout = execGh(args);
+        String url = stdout.trim();
+
+        Matcher matcher = ISSUE_URL_RE.matcher(url);
+        if (!matcher.find()) {
+            throw new GroundControlException(
+                    "Could not parse issue number from gh output: " + url, "github_parse_error");
+        }
+        int number = Integer.parseInt(matcher.group(1));
+
+        log.info("github_issue_created: number={} repo={}", number, repo);
+        return new GitHubIssueData(number, title, "OPEN", url, body, labels != null ? labels : List.of());
+    }
+
+    /**
+     * Execute a gh CLI command, draining stdout/stderr concurrently to avoid pipe-buffer deadlock.
+     */
+    private String execGh(List<String> args) {
+        try {
             ProcessBuilder pb = new ProcessBuilder(args);
             pb.redirectErrorStream(false);
             Process process = pb.start();
 
-            var stdoutFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+            var stdoutFuture = CompletableFuture.supplyAsync(() -> {
                 try {
                     return process.getInputStream().readAllBytes();
                 } catch (IOException ex) {
-                    throw new java.io.UncheckedIOException(ex);
+                    throw new UncheckedIOException(ex);
                 }
             });
-            var stderrFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+            var stderrFuture = CompletableFuture.supplyAsync(() -> {
                 try {
                     return process.getErrorStream().readAllBytes();
                 } catch (IOException ex) {
-                    throw new java.io.UncheckedIOException(ex);
+                    throw new UncheckedIOException(ex);
                 }
             });
 
@@ -266,18 +253,7 @@ public class GitHubCliClient implements GitHubClient {
                         "gh CLI exited with code " + exitCode + ": " + stderr, "github_cli_error");
             }
 
-            String stdout = new String(stdoutFuture.join(), StandardCharsets.UTF_8);
-            String url = stdout.trim();
-
-            Matcher matcher = ISSUE_URL_RE.matcher(url);
-            if (!matcher.find()) {
-                throw new GroundControlException(
-                        "Could not parse issue number from gh output: " + url, "github_parse_error");
-            }
-            int number = Integer.parseInt(matcher.group(1));
-
-            log.info("github_issue_created: number={} repo={}", number, repo);
-            return new GitHubIssueData(number, title, "OPEN", url, body, labels != null ? labels : List.of());
+            return new String(stdoutFuture.join(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new GroundControlException("Failed to execute gh CLI: " + e.getMessage(), "github_cli_error", e);
         } catch (InterruptedException e) {

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
@@ -25,6 +25,18 @@ public class GitHubCliClient implements GitHubClient {
     private static final int PAGE_SIZE = 100;
     private static final Pattern ISSUE_URL_RE = Pattern.compile("/issues/(\\d+)$");
 
+    /** GitHub owner and repo names: alphanumeric, hyphens, dots, underscores; starts with alphanumeric. */
+    private static final Pattern GITHUB_NAME_RE = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$");
+
+    /** GitHub owner/repo combined format (e.g. "KeplerOps/Ground-Control"). */
+    private static final Pattern GITHUB_REPO_RE =
+            Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}/[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$");
+
+    private static final int MAX_TITLE_LENGTH = 256;
+    private static final int MAX_BODY_LENGTH = 65_536;
+    private static final int MAX_LABEL_LENGTH = 50;
+    private static final Pattern LABEL_RE = Pattern.compile("^[a-zA-Z0-9 :._-]+$");
+
     private final ObjectMapper objectMapper;
     private final String ghPath;
 
@@ -52,8 +64,28 @@ public class GitHubCliClient implements GitHubClient {
         }
     }
 
+    public static void validateOwnerRepo(String owner, String repo) {
+        if (owner == null || !GITHUB_NAME_RE.matcher(owner).matches()) {
+            throw new GroundControlException(
+                    "Invalid GitHub owner: must be alphanumeric with hyphens/dots/underscores", "invalid_github_owner");
+        }
+        if (repo == null || !GITHUB_NAME_RE.matcher(repo).matches()) {
+            throw new GroundControlException(
+                    "Invalid GitHub repo name: must be alphanumeric with hyphens/dots/underscores",
+                    "invalid_github_repo");
+        }
+    }
+
+    public static void validateRepoSlug(String repo) {
+        if (repo == null || !GITHUB_REPO_RE.matcher(repo).matches()) {
+            throw new GroundControlException(
+                    "Invalid GitHub repo: must match 'owner/repo' format", "invalid_github_repo");
+        }
+    }
+
     @Override
     public List<GitHubIssueData> fetchAllIssues(String owner, String repo) {
+        validateOwnerRepo(owner, repo);
         List<GitHubIssueData> allIssues = new ArrayList<>();
         int page = 1;
 
@@ -155,6 +187,28 @@ public class GitHubCliClient implements GitHubClient {
 
     @Override
     public GitHubIssueData createIssue(String repo, String title, String body, List<String> labels) {
+        validateRepoSlug(repo);
+        if (title == null || title.isBlank() || title.length() > MAX_TITLE_LENGTH) {
+            throw new GroundControlException(
+                    "Issue title must be non-blank and at most " + MAX_TITLE_LENGTH + " characters",
+                    "invalid_issue_title");
+        }
+        if (body != null && body.length() > MAX_BODY_LENGTH) {
+            throw new GroundControlException(
+                    "Issue body must be at most " + MAX_BODY_LENGTH + " characters", "invalid_issue_body");
+        }
+        if (labels != null) {
+            for (String label : labels) {
+                if (label == null
+                        || label.length() > MAX_LABEL_LENGTH
+                        || !LABEL_RE.matcher(label).matches()) {
+                    throw new GroundControlException(
+                            "Invalid label: must be alphanumeric with spaces/colons/hyphens, max " + MAX_LABEL_LENGTH
+                                    + " chars",
+                            "invalid_issue_label");
+                }
+            }
+        }
         try {
             List<String> args = new ArrayList<>(
                     List.of(ghPath, "issue", "create", "--repo", repo, "--title", title, "--body", body));

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
@@ -128,6 +128,23 @@ public class GitHubCliClient implements GitHubClient {
             pb.redirectErrorStream(false);
             Process process = pb.start();
 
+            // Drain stdout and stderr in background threads to avoid pipe-buffer deadlock
+            // when output exceeds the OS pipe buffer size (~64KB).
+            var stdoutFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+                try {
+                    return process.getInputStream().readAllBytes();
+                } catch (IOException ex) {
+                    throw new java.io.UncheckedIOException(ex);
+                }
+            });
+            var stderrFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+                try {
+                    return process.getErrorStream().readAllBytes();
+                } catch (IOException ex) {
+                    throw new java.io.UncheckedIOException(ex);
+                }
+            });
+
             boolean finished = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
@@ -136,12 +153,12 @@ public class GitHubCliClient implements GitHubClient {
 
             int exitCode = process.exitValue();
             if (exitCode != 0) {
-                String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+                String stderr = new String(stderrFuture.join(), StandardCharsets.UTF_8);
                 throw new GroundControlException(
                         "gh CLI exited with code " + exitCode + ": " + stderr, "github_cli_error");
             }
 
-            String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            String stdout = new String(stdoutFuture.join(), StandardCharsets.UTF_8);
 
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> rawIssues =
@@ -221,6 +238,21 @@ public class GitHubCliClient implements GitHubClient {
             pb.redirectErrorStream(false);
             Process process = pb.start();
 
+            var stdoutFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+                try {
+                    return process.getInputStream().readAllBytes();
+                } catch (IOException ex) {
+                    throw new java.io.UncheckedIOException(ex);
+                }
+            });
+            var stderrFuture = java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+                try {
+                    return process.getErrorStream().readAllBytes();
+                } catch (IOException ex) {
+                    throw new java.io.UncheckedIOException(ex);
+                }
+            });
+
             boolean finished = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!finished) {
                 process.destroyForcibly();
@@ -229,12 +261,12 @@ public class GitHubCliClient implements GitHubClient {
 
             int exitCode = process.exitValue();
             if (exitCode != 0) {
-                String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+                String stderr = new String(stderrFuture.join(), StandardCharsets.UTF_8);
                 throw new GroundControlException(
                         "gh CLI exited with code " + exitCode + ": " + stderr, "github_cli_error");
             }
 
-            String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            String stdout = new String(stdoutFuture.join(), StandardCharsets.UTF_8);
             String url = stdout.trim();
 
             Matcher matcher = ISSUE_URL_RE.matcher(url);

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/CreateIssueIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/CreateIssueIntegrationTest.java
@@ -122,7 +122,7 @@ class CreateIssueIntegrationTest extends BaseIntegrationTest {
         var links = traceabilityLinkRepository.findByRequirementId(testRequirement.getId());
         assertThat(links).hasSize(1);
         assertThat(links.get(0).getArtifactUrl()).isEqualTo("https://github.com/test/repo/issues/55");
-        assertThat(links.get(0).getArtifactTitle()).isEqualTo("CI-REQ-001: Test req");
+        assertThat(links.get(0).getArtifactTitle()).isEqualTo("#55 - CI-REQ-001: Test req [OPEN]");
         assertThat(links.get(0).getSyncStatus()).isEqualTo(SyncStatus.SYNCED);
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -262,7 +262,7 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
         assertThat(linksForReq001).hasSize(1);
         var link = linksForReq001.get(0);
         assertThat(link.getArtifactUrl()).isEqualTo("https://github.com/test/e2e/issues/10");
-        assertThat(link.getArtifactTitle()).isEqualTo("Foundation issue");
+        assertThat(link.getArtifactTitle()).isEqualTo("#10 - Foundation issue [OPEN]");
         assertThat(link.getSyncStatus()).isEqualTo(SyncStatus.SYNCED);
     }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -262,7 +262,7 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
         assertThat(linksForReq001).hasSize(1);
         var link = linksForReq001.get(0);
         assertThat(link.getArtifactUrl()).isEqualTo("https://github.com/test/e2e/issues/10");
-        assertThat(link.getArtifactTitle()).isEqualTo("#10 - Foundation issue [OPEN]");
+        assertThat(link.getArtifactTitle()).isEqualTo("#10 - Foundation issue [CLOSED]");
         assertThat(link.getSyncStatus()).isEqualTo(SyncStatus.SYNCED);
     }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/SyncIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/SyncIntegrationTest.java
@@ -133,6 +133,6 @@ class SyncIntegrationTest extends BaseIntegrationTest {
         var updatedLinks = traceabilityLinkRepository.findByRequirementId(requirement.getId());
         assert updatedLinks.size() == 1;
         assert updatedLinks.get(0).getArtifactUrl().equals("https://github.com/test/repo/issues/1");
-        assert updatedLinks.get(0).getArtifactTitle().equals("#1 - Setup CI [OPEN]");
+        assert updatedLinks.get(0).getArtifactTitle().equals("#1 - Setup CI [CLOSED]");
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/SyncIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/SyncIntegrationTest.java
@@ -133,6 +133,6 @@ class SyncIntegrationTest extends BaseIntegrationTest {
         var updatedLinks = traceabilityLinkRepository.findByRequirementId(requirement.getId());
         assert updatedLinks.size() == 1;
         assert updatedLinks.get(0).getArtifactUrl().equals("https://github.com/test/repo/issues/1");
-        assert updatedLinks.get(0).getArtifactTitle().equals("Setup CI");
+        assert updatedLinks.get(0).getArtifactTitle().equals("#1 - Setup CI [OPEN]");
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SyncControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SyncControllerTest.java
@@ -61,5 +61,21 @@ class SyncControllerTest {
             mockMvc.perform(post("/api/v1/admin/sync/github").param("owner", "KeplerOps"))
                     .andExpect(status().isBadRequest());
         }
+
+        @Test
+        void withMaliciousOwner_returns400() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/sync/github")
+                            .param("owner", "$(whoami)")
+                            .param("repo", "Ground-Control"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void withMaliciousRepo_returns400() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/sync/github")
+                            .param("owner", "KeplerOps")
+                            .param("repo", "repo;rm -rf /"))
+                    .andExpect(status().isBadRequest());
+        }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubIssueSyncServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubIssueSyncServiceTest.java
@@ -250,7 +250,7 @@ class GitHubIssueSyncServiceTest {
 
             assertThat(result.linksUpdated()).isEqualTo(1);
             assertThat(link.getArtifactUrl()).isEqualTo("https://github.com/o/r/issues/10");
-            assertThat(link.getArtifactTitle()).isEqualTo("Issue 10");
+            assertThat(link.getArtifactTitle()).isEqualTo("#10 - Issue 10 [OPEN]");
             assertThat(link.getSyncStatus()).isEqualTo(SyncStatus.SYNCED);
         }
 
@@ -289,13 +289,15 @@ class GitHubIssueSyncServiceTest {
 
         @Test
         void collectsErrorsAndContinues() {
-            var issue1 = new GitHubIssueData(1, "Issue 1", "INVALID_STATE", "url1", "", List.of());
+            var issue1 = new GitHubIssueData(1, "Issue 1", "OPEN", "url1", "", List.of());
             var issue2 = new GitHubIssueData(2, "Issue 2", "OPEN", "url2", "", List.of());
 
             when(gitHubClient.fetchAllIssues("owner", "repo")).thenReturn(List.of(issue1, issue2));
             when(issueSyncRepository.findByIssueNumber(1)).thenReturn(Optional.empty());
             when(issueSyncRepository.findByIssueNumber(2)).thenReturn(Optional.empty());
-            when(issueSyncRepository.save(any(GitHubIssueSync.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(issueSyncRepository.save(any(GitHubIssueSync.class)))
+                    .thenThrow(new RuntimeException("DB save failed"))
+                    .thenAnswer(inv -> inv.getArgument(0));
             when(traceabilityLinkRepository.findByArtifactType(ArtifactType.GITHUB_ISSUE))
                     .thenReturn(List.of());
             stubAuditSave();
@@ -305,6 +307,23 @@ class GitHubIssueSyncServiceTest {
             assertThat(result.issuesCreated()).isEqualTo(1);
             assertThat(result.errors()).hasSize(1);
             assertThat(result.errors().get(0).issue()).isEqualTo(1);
+        }
+
+        @Test
+        void unknownIssueStateDefaultsToOpenInsteadOfFailing() {
+            var issue = new GitHubIssueData(1, "Issue 1", "INVALID_STATE", "url1", "", List.of());
+
+            when(gitHubClient.fetchAllIssues("owner", "repo")).thenReturn(List.of(issue));
+            when(issueSyncRepository.findByIssueNumber(1)).thenReturn(Optional.empty());
+            when(issueSyncRepository.save(any(GitHubIssueSync.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(traceabilityLinkRepository.findByArtifactType(ArtifactType.GITHUB_ISSUE))
+                    .thenReturn(List.of());
+            stubAuditSave();
+
+            var result = service.syncGitHubIssues("owner", "repo");
+
+            assertThat(result.issuesCreated()).isEqualTo(1);
+            assertThat(result.errors()).isEmpty();
         }
     }
 
@@ -384,6 +403,34 @@ class GitHubIssueSyncServiceTest {
             verify(traceabilityService).createLinkUnchecked(any(UUID.class), captor.capture());
             assertThat(captor.getValue().artifactIdentifier()).isEqualTo("42");
             assertThat(captor.getValue().artifactIdentifier()).doesNotStartWith("#");
+        }
+    }
+
+    @Nested
+    class TraceabilityLinkStateReflection {
+
+        @Test
+        void includesIssueStateInTraceabilityLinkTitle() {
+            var sync = new GitHubIssueSync(
+                    42, "Fix login bug", IssueState.CLOSED, "https://github.com/o/r/issues/42", Instant.now());
+            setField(sync, "id", UUID.randomUUID());
+            when(issueSyncRepository.findByIssueNumber(42)).thenReturn(Optional.of(sync));
+
+            var requirement = new Requirement(TEST_PROJECT, "GC-A001", "Test", "statement");
+            setField(requirement, "id", UUID.randomUUID());
+            var link = new TraceabilityLink(requirement, ArtifactType.GITHUB_ISSUE, "42", LinkType.IMPLEMENTS);
+            setField(link, "id", UUID.randomUUID());
+            when(traceabilityLinkRepository.findByArtifactType(ArtifactType.GITHUB_ISSUE))
+                    .thenReturn(List.of(link));
+
+            when(gitHubClient.fetchAllIssues(anyString(), anyString())).thenReturn(List.of());
+            stubAuditSave();
+
+            service.syncGitHubIssues("KeplerOps", "Ground-Control");
+
+            assertThat(link.getArtifactTitle()).contains("[CLOSED]");
+            assertThat(link.getArtifactTitle()).startsWith("#42 -");
+            assertThat(link.getSyncStatus()).isEqualTo(SyncStatus.SYNCED);
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientTest.java
@@ -325,6 +325,39 @@ class GitHubCliClientTest {
         }
     }
 
+    @Nested
+    class ExecGhErrorPaths {
+
+        @Test
+        void nonZeroExitCodeThrowsWithStderr() {
+            // Use a client pointing to "false" which always exits with code 1
+            var client = new GitHubCliClient(new ObjectMapper(), "/usr/bin/false") {
+                @Override
+                protected IssuePage fetchIssuePage(String owner, String repo, int page) {
+                    return super.fetchIssuePage(owner, repo, page);
+                }
+            };
+
+            assertThatThrownBy(() -> client.fetchAllIssues("test-owner", "test-repo"))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("gh CLI exited with code");
+        }
+
+        @Test
+        void invalidJsonOutputThrows() {
+            // Use "echo" to output invalid JSON
+            var client = new GitHubCliClient(new ObjectMapper(), "/usr/bin/echo") {
+                @Override
+                protected IssuePage fetchIssuePage(String owner, String repo, int page) {
+                    return super.fetchIssuePage(owner, repo, page);
+                }
+            };
+
+            assertThatThrownBy(() -> client.fetchAllIssues("test-owner", "test-repo"))
+                    .isInstanceOf(GroundControlException.class);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private static List<GitHubIssueData> parseJson(String json) throws Exception {
         List<Map<String, Object>> rawIssues = objectMapper.readValue(json, new TypeReference<>() {});

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientTest.java
@@ -262,6 +262,67 @@ class GitHubCliClientTest {
         void acceptsValidRepoSlug() {
             GitHubCliClient.validateRepoSlug("KeplerOps/Ground-Control");
         }
+
+        @Test
+        void rejectsNullTitle() {
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent(null, "body", List.of()))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("title");
+        }
+
+        @Test
+        void rejectsBlankTitle() {
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("", "body", List.of()))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("title");
+        }
+
+        @Test
+        void rejectsTooLongTitle() {
+            String longTitle = "x".repeat(GitHubCliClient.MAX_TITLE_LENGTH + 1);
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent(longTitle, "body", List.of()))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("title");
+        }
+
+        @Test
+        void rejectsTooLongBody() {
+            String longBody = "x".repeat(GitHubCliClient.MAX_BODY_LENGTH + 1);
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("title", longBody, List.of()))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("body");
+        }
+
+        @Test
+        void rejectsInvalidLabel() {
+            assertThatThrownBy(
+                            () -> GitHubCliClient.validateIssueContent("title", "body", List.of("valid", "bad;label")))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("label");
+        }
+
+        @Test
+        void rejectsTooLongLabel() {
+            String longLabel = "x".repeat(GitHubCliClient.MAX_LABEL_LENGTH + 1);
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("title", "body", List.of(longLabel)))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("label");
+        }
+
+        @Test
+        void acceptsValidIssueContent() {
+            GitHubCliClient.validateIssueContent("Valid Title", "Valid body", List.of("bug", "P0"));
+        }
+
+        @Test
+        void acceptsNullBody() {
+            GitHubCliClient.validateIssueContent("Valid Title", null, List.of());
+        }
+
+        @Test
+        void acceptsNullLabels() {
+            GitHubCliClient.validateIssueContent("Valid Title", "body", null);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientTest.java
@@ -1,9 +1,11 @@
 package com.keplerops.groundcontrol.unit.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keplerops.groundcontrol.domain.exception.GroundControlException;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
 import com.keplerops.groundcontrol.infrastructure.github.GitHubCliClient;
 import com.keplerops.groundcontrol.infrastructure.github.GitHubCliClient.IssuePage;
@@ -14,6 +16,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class GitHubCliClientTest {
 
@@ -207,6 +211,56 @@ class GitHubCliClientTest {
             Matcher matcher = pattern.matcher(url);
             assertThat(matcher.find()).isTrue();
             assertThat(Integer.parseInt(matcher.group(1))).isEqualTo(42);
+        }
+    }
+
+    @Nested
+    class InputValidation {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"$(whoami)", "foo;rm -rf /", "foo&bar", "foo/bar", "../etc", ""})
+        void rejectsMaliciousOwner(String maliciousOwner) {
+            assertThatThrownBy(() -> GitHubCliClient.validateOwnerRepo(maliciousOwner, "valid-repo"))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("Invalid GitHub owner");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"$(whoami)", "repo;drop table", "foo&bar", "foo/bar", "../..", ""})
+        void rejectsMaliciousRepo(String maliciousRepo) {
+            assertThatThrownBy(() -> GitHubCliClient.validateOwnerRepo("valid-owner", maliciousRepo))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("Invalid GitHub repo");
+        }
+
+        @Test
+        void rejectsNullOwner() {
+            assertThatThrownBy(() -> GitHubCliClient.validateOwnerRepo(null, "repo"))
+                    .isInstanceOf(GroundControlException.class);
+        }
+
+        @Test
+        void rejectsNullRepo() {
+            assertThatThrownBy(() -> GitHubCliClient.validateOwnerRepo("owner", null))
+                    .isInstanceOf(GroundControlException.class);
+        }
+
+        @Test
+        void acceptsValidOwnerRepo() {
+            GitHubCliClient.validateOwnerRepo("KeplerOps", "Ground-Control");
+            GitHubCliClient.validateOwnerRepo("user123", "my.repo_v2");
+        }
+
+        @Test
+        void rejectsInvalidRepoSlug() {
+            assertThatThrownBy(() -> GitHubCliClient.validateRepoSlug("not-a-slug"))
+                    .isInstanceOf(GroundControlException.class)
+                    .hasMessageContaining("owner/repo");
+        }
+
+        @Test
+        void acceptsValidRepoSlug() {
+            GitHubCliClient.validateRepoSlug("KeplerOps/Ground-Control");
         }
     }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientTest.java
@@ -265,14 +265,16 @@ class GitHubCliClientTest {
 
         @Test
         void rejectsNullTitle() {
-            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent(null, "body", List.of()))
+            List<String> empty = List.of();
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent(null, "body", empty))
                     .isInstanceOf(GroundControlException.class)
                     .hasMessageContaining("title");
         }
 
         @Test
         void rejectsBlankTitle() {
-            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("", "body", List.of()))
+            List<String> empty = List.of();
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("", "body", empty))
                     .isInstanceOf(GroundControlException.class)
                     .hasMessageContaining("title");
         }
@@ -280,7 +282,8 @@ class GitHubCliClientTest {
         @Test
         void rejectsTooLongTitle() {
             String longTitle = "x".repeat(GitHubCliClient.MAX_TITLE_LENGTH + 1);
-            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent(longTitle, "body", List.of()))
+            List<String> empty = List.of();
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent(longTitle, "body", empty))
                     .isInstanceOf(GroundControlException.class)
                     .hasMessageContaining("title");
         }
@@ -288,15 +291,16 @@ class GitHubCliClientTest {
         @Test
         void rejectsTooLongBody() {
             String longBody = "x".repeat(GitHubCliClient.MAX_BODY_LENGTH + 1);
-            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("title", longBody, List.of()))
+            List<String> empty = List.of();
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("title", longBody, empty))
                     .isInstanceOf(GroundControlException.class)
                     .hasMessageContaining("body");
         }
 
         @Test
         void rejectsInvalidLabel() {
-            assertThatThrownBy(
-                            () -> GitHubCliClient.validateIssueContent("title", "body", List.of("valid", "bad;label")))
+            List<String> labels = List.of("valid", "bad;label");
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("title", "body", labels))
                     .isInstanceOf(GroundControlException.class)
                     .hasMessageContaining("label");
         }
@@ -304,7 +308,8 @@ class GitHubCliClientTest {
         @Test
         void rejectsTooLongLabel() {
             String longLabel = "x".repeat(GitHubCliClient.MAX_LABEL_LENGTH + 1);
-            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("title", "body", List.of(longLabel)))
+            List<String> labels = List.of(longLabel);
+            assertThatThrownBy(() -> GitHubCliClient.validateIssueContent("title", "body", labels))
                     .isInstanceOf(GroundControlException.class)
                     .hasMessageContaining("label");
         }

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -540,7 +540,7 @@ server.tool(
     uid: z.string().describe("Requirement UID (e.g. 'GC-D007')"),
     extra_body: z.string().optional().describe("Additional markdown to append to the issue body"),
     labels: z.array(z.string()).optional().describe("GitHub labels to apply"),
-    repo: z.string().optional().describe("GitHub repo as 'owner/repo' (defaults to GH_REPO env var)"),
+    repo: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*\/[a-zA-Z0-9][a-zA-Z0-9._-]*$/).optional().describe("GitHub repo as 'owner/repo' (defaults to GH_REPO env var)"),
     project: z.string().optional().describe("Project identifier (auto-resolved if only one project exists)"),
   },
   async ({ uid, extra_body, labels, repo, project }) => {
@@ -1233,8 +1233,8 @@ server.tool(
   "gc_sync_github",
   "Sync GitHub issues for a repository. Creates traceability links between issues and requirements.",
   {
-    owner: z.string().describe("GitHub repository owner"),
-    repo: z.string().describe("GitHub repository name"),
+    owner: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/).describe("GitHub repository owner"),
+    repo: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/).describe("GitHub repository name"),
   },
   async ({ owner, repo }) => {
     try {

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -726,8 +726,13 @@ export function formatIssueBody(req, extraBody) {
   return body;
 }
 
+const GITHUB_REPO_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*\/[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
 export async function createGitHubIssue({ title, body, labels, repo }) {
   const targetRepo = repo || process.env.GH_REPO;
+  if (targetRepo && !GITHUB_REPO_RE.test(targetRepo)) {
+    throw new Error(`Invalid GitHub repo format: expected 'owner/repo', got '${targetRepo}'`);
+  }
   const args = ["issue", "create", "--title", title, "--body", body];
   if (targetRepo) {
     args.push("--repo", targetRepo);


### PR DESCRIPTION
## Summary

- Adds regex input validation on GitHub owner/repo parameters at every entry point (GitHubCliClient, SyncController, GitHubIssueRequest, MCP tools) to prevent command injection via ProcessBuilder
- Validates issue title (256 chars), body (65536 chars), and label format/length (50 chars) before gh CLI execution
- Adds `ConstraintViolationException` handler to GlobalExceptionHandler for proper 400 responses on `@Validated` violations
- Reflects GitHub issue state (OPEN/CLOSED) in traceability link titles during sync, satisfying the "reflecting issue state changes back into the requirement" clause of GC-D001
- Defaults unknown `IssueState` values to OPEN with a warning instead of crashing the sync
- Adds MCP tool validation: Zod regex on `gc_sync_github` owner/repo and `gc_create_github_issue` repo format
- Adds repo format validation in `lib.js` `createGitHubIssue()` before `execFile`

Closes #479

## Test plan

- [ ] `make check` passes (BUILD SUCCESSFUL)
- [ ] Malicious owner/repo values (e.g., `$(whoami)`, `foo;rm -rf /`) rejected at controller level with 400
- [ ] Malicious owner/repo values rejected at GitHubCliClient level with GroundControlException
- [ ] MCP tools reject invalid owner/repo format via Zod schema
- [ ] Traceability link title after sync includes issue state (e.g., `#42 - Fix bug [CLOSED]`)
- [ ] Unknown issue state defaults to OPEN without error
- [ ] Integration tests pass (including AssetRelationLifecycleIntegrationTest)