### PR TITLE
Add PR-requirement linking with three-state sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.102.0] - 2026-04-05
+
+### Added
+
+- Pull request-requirement linking via new `PULL_REQUEST` artifact type
+  in the traceability graph, with three-state PR tracking (OPEN, CLOSED,
+  MERGED) reflecting GitHub PR lifecycle (GC-D002)
+- `GitHubPullRequestSync` entity for caching PR state locally, mirroring
+  the existing `GitHubIssueSync` pattern for issues
+- REST endpoint `POST /api/v1/admin/sync/github/prs?owner=X&repo=Y` for
+  on-demand PR state synchronization
+- MCP tool `gc_sync_github_prs` for agent-initiated PR sync
+- Database migration V048 creating `github_pr_sync` table
+- `PullRequestState` enum with OPEN, CLOSED, MERGED values
+- PR sync updates traceability link titles with state tags (e.g.,
+  `#42 - Add feature [MERGED]`) matching the existing issue sync pattern
+
 ## [0.101.0] - 2026-04-05
 
 ### Added

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/PrSyncResultResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/PrSyncResultResponse.java
@@ -1,0 +1,28 @@
+package com.keplerops.groundcontrol.api.admin;
+
+import com.keplerops.groundcontrol.domain.requirements.service.PrSyncResult;
+import com.keplerops.groundcontrol.domain.requirements.service.SyncError;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record PrSyncResultResponse(
+        UUID syncId,
+        Instant syncedAt,
+        int prsFetched,
+        int prsCreated,
+        int prsUpdated,
+        int linksUpdated,
+        List<SyncError> errors) {
+
+    public static PrSyncResultResponse from(PrSyncResult result) {
+        return new PrSyncResultResponse(
+                result.syncId(),
+                result.syncedAt(),
+                result.prsFetched(),
+                result.prsCreated(),
+                result.prsUpdated(),
+                result.linksUpdated(),
+                result.errors());
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/SyncController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/SyncController.java
@@ -26,4 +26,11 @@ public class SyncController {
             @RequestParam @NotBlank @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9._-]*$") String repo) {
         return SyncResultResponse.from(syncService.syncGitHubIssues(owner, repo));
     }
+
+    @PostMapping("/github/prs")
+    public PrSyncResultResponse syncGithubPrs(
+            @RequestParam @NotBlank @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9._-]*$") String owner,
+            @RequestParam @NotBlank @Pattern(regexp = "^[a-zA-Z0-9][a-zA-Z0-9._-]*$") String repo) {
+        return PrSyncResultResponse.from(syncService.syncGitHubPullRequests(owner, repo));
+    }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/GitHubPullRequestSync.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/GitHubPullRequestSync.java
@@ -1,0 +1,170 @@
+package com.keplerops.groundcontrol.domain.requirements.model;
+
+import com.keplerops.groundcontrol.domain.requirements.state.PullRequestState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * Cached state of a GitHub pull request for sync tracking.
+ */
+@Entity
+@Table(name = "github_pr_sync")
+public class GitHubPullRequestSync {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "pr_number", unique = true, nullable = false)
+    private Integer prNumber;
+
+    @Column(name = "pr_title", nullable = false, length = 500)
+    private String prTitle;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pr_state", nullable = false, length = 10)
+    private PullRequestState prState;
+
+    @Column(name = "pr_url", nullable = false, length = 2000)
+    private String prUrl;
+
+    @Column(name = "pr_body", columnDefinition = "TEXT")
+    private String prBody = "";
+
+    @Column(name = "base_branch", length = 255)
+    private String baseBranch = "";
+
+    @Column(name = "head_branch", length = 255)
+    private String headBranch = "";
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "pr_labels", columnDefinition = "jsonb")
+    private List<String> prLabels = new ArrayList<>();
+
+    @Column(name = "last_fetched_at", nullable = false)
+    private Instant lastFetchedAt;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    protected GitHubPullRequestSync() {
+        // JPA
+    }
+
+    public GitHubPullRequestSync(
+            Integer prNumber, String prTitle, PullRequestState prState, String prUrl, Instant lastFetchedAt) {
+        this.prNumber = prNumber;
+        this.prTitle = prTitle;
+        this.prState = prState;
+        this.prUrl = prUrl;
+        this.lastFetchedAt = lastFetchedAt;
+    }
+
+    @PrePersist
+    void onCreate() {
+        var now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    // --- Accessors ---
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Integer getPrNumber() {
+        return prNumber;
+    }
+
+    public String getPrTitle() {
+        return prTitle;
+    }
+
+    public void setPrTitle(String prTitle) {
+        this.prTitle = prTitle;
+    }
+
+    public PullRequestState getPrState() {
+        return prState;
+    }
+
+    public void setPrState(PullRequestState prState) {
+        this.prState = prState;
+    }
+
+    public String getPrUrl() {
+        return prUrl;
+    }
+
+    public String getPrBody() {
+        return prBody;
+    }
+
+    public void setPrBody(String prBody) {
+        this.prBody = prBody;
+    }
+
+    public String getBaseBranch() {
+        return baseBranch;
+    }
+
+    public void setBaseBranch(String baseBranch) {
+        this.baseBranch = baseBranch;
+    }
+
+    public String getHeadBranch() {
+        return headBranch;
+    }
+
+    public void setHeadBranch(String headBranch) {
+        this.headBranch = headBranch;
+    }
+
+    public List<String> getPrLabels() {
+        return prLabels;
+    }
+
+    public void setPrLabels(List<String> prLabels) {
+        this.prLabels = prLabels;
+    }
+
+    public Instant getLastFetchedAt() {
+        return lastFetchedAt;
+    }
+
+    public void setLastFetchedAt(Instant lastFetchedAt) {
+        this.lastFetchedAt = lastFetchedAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/GitHubPullRequestSync.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/GitHubPullRequestSync.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +23,7 @@ import org.hibernate.type.SqlTypes;
  * Cached state of a GitHub pull request for sync tracking.
  */
 @Entity
-@Table(name = "github_pr_sync")
+@Table(name = "github_pr_sync", uniqueConstraints = @UniqueConstraint(columnNames = {"repo", "pr_number"}))
 public class GitHubPullRequestSync {
 
     @Id
@@ -30,7 +31,10 @@ public class GitHubPullRequestSync {
     @Column(updatable = false, nullable = false)
     private UUID id;
 
-    @Column(name = "pr_number", unique = true, nullable = false)
+    @Column(name = "repo", nullable = false, length = 200)
+    private String repo;
+
+    @Column(name = "pr_number", nullable = false)
     private Integer prNumber;
 
     @Column(name = "pr_title", nullable = false, length = 500)
@@ -70,7 +74,13 @@ public class GitHubPullRequestSync {
     }
 
     public GitHubPullRequestSync(
-            Integer prNumber, String prTitle, PullRequestState prState, String prUrl, Instant lastFetchedAt) {
+            String repo,
+            Integer prNumber,
+            String prTitle,
+            PullRequestState prState,
+            String prUrl,
+            Instant lastFetchedAt) {
+        this.repo = repo;
         this.prNumber = prNumber;
         this.prTitle = prTitle;
         this.prState = prState;
@@ -94,6 +104,10 @@ public class GitHubPullRequestSync {
 
     public UUID getId() {
         return id;
+    }
+
+    public String getRepo() {
+        return repo;
     }
 
     public Integer getPrNumber() {

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/GitHubPullRequestSyncRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/GitHubPullRequestSyncRepository.java
@@ -1,0 +1,11 @@
+package com.keplerops.groundcontrol.domain.requirements.repository;
+
+import com.keplerops.groundcontrol.domain.requirements.model.GitHubPullRequestSync;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GitHubPullRequestSyncRepository extends JpaRepository<GitHubPullRequestSync, UUID> {
+
+    Optional<GitHubPullRequestSync> findByPrNumber(Integer prNumber);
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/GitHubPullRequestSyncRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/GitHubPullRequestSyncRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GitHubPullRequestSyncRepository extends JpaRepository<GitHubPullRequestSync, UUID> {
 
-    Optional<GitHubPullRequestSync> findByPrNumber(Integer prNumber);
+    Optional<GitHubPullRequestSync> findByRepoAndPrNumber(String repo, Integer prNumber);
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubClient.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubClient.java
@@ -6,5 +6,7 @@ public interface GitHubClient {
 
     List<GitHubIssueData> fetchAllIssues(String owner, String repo);
 
+    List<GitHubPullRequestData> fetchAllPullRequests(String owner, String repo);
+
     GitHubIssueData createIssue(String repo, String title, String body, List<String> labels);
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubIssueSyncService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubIssueSyncService.java
@@ -3,9 +3,11 @@ package com.keplerops.groundcontrol.domain.requirements.service;
 import com.keplerops.groundcontrol.domain.exception.GroundControlException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.requirements.model.GitHubIssueSync;
+import com.keplerops.groundcontrol.domain.requirements.model.GitHubPullRequestSync;
 import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
 import com.keplerops.groundcontrol.domain.requirements.model.RequirementImport;
 import com.keplerops.groundcontrol.domain.requirements.repository.GitHubIssueSyncRepository;
+import com.keplerops.groundcontrol.domain.requirements.repository.GitHubPullRequestSyncRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementImportRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
@@ -13,6 +15,7 @@ import com.keplerops.groundcontrol.domain.requirements.state.ArtifactType;
 import com.keplerops.groundcontrol.domain.requirements.state.ImportSourceType;
 import com.keplerops.groundcontrol.domain.requirements.state.IssueState;
 import com.keplerops.groundcontrol.domain.requirements.state.LinkType;
+import com.keplerops.groundcontrol.domain.requirements.state.PullRequestState;
 import com.keplerops.groundcontrol.domain.requirements.state.SyncStatus;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -39,6 +42,7 @@ public class GitHubIssueSyncService {
 
     private final GitHubClient gitHubClient;
     private final GitHubIssueSyncRepository issueSyncRepository;
+    private final GitHubPullRequestSyncRepository prSyncRepository;
     private final TraceabilityLinkRepository traceabilityLinkRepository;
     private final RequirementImportRepository importRepository;
     private final RequirementRepository requirementRepository;
@@ -47,12 +51,14 @@ public class GitHubIssueSyncService {
     public GitHubIssueSyncService(
             GitHubClient gitHubClient,
             GitHubIssueSyncRepository issueSyncRepository,
+            GitHubPullRequestSyncRepository prSyncRepository,
             TraceabilityLinkRepository traceabilityLinkRepository,
             RequirementImportRepository importRepository,
             RequirementRepository requirementRepository,
             TraceabilityService traceabilityService) {
         this.gitHubClient = gitHubClient;
         this.issueSyncRepository = issueSyncRepository;
+        this.prSyncRepository = prSyncRepository;
         this.traceabilityLinkRepository = traceabilityLinkRepository;
         this.importRepository = importRepository;
         this.requirementRepository = requirementRepository;
@@ -174,6 +180,127 @@ public class GitHubIssueSyncService {
                     return (Map<String, Object>) m;
                 })
                 .toList();
+    }
+
+    // -----------------------------------------------------------------------
+    // Pull request sync
+    // -----------------------------------------------------------------------
+
+    public PrSyncResult syncGitHubPullRequests(String owner, String repo) {
+        List<GitHubPullRequestData> fetched = gitHubClient.fetchAllPullRequests(owner, repo);
+        Instant fetchedAt = Instant.now();
+        List<SyncError> errors = new ArrayList<>();
+
+        int[] prCounts = upsertPrSyncRecords(fetched, fetchedAt, errors);
+        int prsCreated = prCounts[0];
+        int prsUpdated = prCounts[1];
+
+        int linksUpdated = updatePrTraceabilityLinks(fetchedAt, errors);
+
+        var audit = new RequirementImport(ImportSourceType.GITHUB);
+        audit.setSourceFile(owner + "/" + repo + " (pull requests)");
+        audit.setStats(Map.of(
+                "prsFetched", fetched.size(),
+                "prsCreated", prsCreated,
+                "prsUpdated", prsUpdated,
+                "linksUpdated", linksUpdated));
+        audit.setErrors(toAuditErrors(errors));
+        var savedAudit = importRepository.save(audit);
+
+        return new PrSyncResult(
+                savedAudit.getId(),
+                savedAudit.getImportedAt(),
+                fetched.size(),
+                prsCreated,
+                prsUpdated,
+                linksUpdated,
+                errors);
+    }
+
+    private int[] upsertPrSyncRecords(List<GitHubPullRequestData> fetched, Instant fetchedAt, List<SyncError> errors) {
+        int prsCreated = 0;
+        int prsUpdated = 0;
+
+        for (GitHubPullRequestData pr : fetched) {
+            try {
+                var existing = prSyncRepository.findByPrNumber(pr.number());
+                if (existing.isPresent()) {
+                    updateExistingPrSync(existing.get(), pr, fetchedAt);
+                    prsUpdated++;
+                } else {
+                    createNewPrSync(pr, fetchedAt);
+                    prsCreated++;
+                }
+            } catch (RuntimeException e) {
+                log.warn("github_pr_sync_failed: pr={} error={}", pr.number(), e.getMessage());
+                errors.add(new SyncError("upsert", pr.number(), null, e.getMessage()));
+            }
+        }
+        return new int[] {prsCreated, prsUpdated};
+    }
+
+    private void updateExistingPrSync(GitHubPullRequestSync sync, GitHubPullRequestData pr, Instant fetchedAt) {
+        sync.setPrTitle(pr.title());
+        sync.setPrState(parsePrState(pr.state(), pr.merged()));
+        sync.setPrBody(pr.body() != null ? pr.body() : "");
+        sync.setBaseBranch(pr.baseBranch() != null ? pr.baseBranch() : "");
+        sync.setHeadBranch(pr.headBranch() != null ? pr.headBranch() : "");
+        sync.setPrLabels(pr.labels());
+        sync.setLastFetchedAt(fetchedAt);
+        prSyncRepository.save(sync);
+    }
+
+    private void createNewPrSync(GitHubPullRequestData pr, Instant fetchedAt) {
+        var sync = new GitHubPullRequestSync(
+                pr.number(), pr.title(), parsePrState(pr.state(), pr.merged()), pr.url(), fetchedAt);
+        sync.setPrBody(pr.body() != null ? pr.body() : "");
+        sync.setBaseBranch(pr.baseBranch() != null ? pr.baseBranch() : "");
+        sync.setHeadBranch(pr.headBranch() != null ? pr.headBranch() : "");
+        sync.setPrLabels(pr.labels());
+        prSyncRepository.save(sync);
+    }
+
+    private int updatePrTraceabilityLinks(Instant fetchedAt, List<SyncError> errors) {
+        int linksUpdated = 0;
+        var links = traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST);
+        for (var link : links) {
+            try {
+                int prNumber = Integer.parseInt(link.getArtifactIdentifier());
+                var syncOpt = prSyncRepository.findByPrNumber(prNumber);
+                if (syncOpt.isPresent()) {
+                    var sync = syncOpt.get();
+                    link.setArtifactUrl(sync.getPrUrl());
+                    String stateTag = sync.getPrState() != null ? " [" + sync.getPrState() + "]" : "";
+                    link.setArtifactTitle("#" + sync.getPrNumber() + " - " + sync.getPrTitle() + stateTag);
+                    link.setSyncStatus(SyncStatus.SYNCED);
+                    link.setLastSyncedAt(fetchedAt);
+                    traceabilityLinkRepository.save(link);
+                    linksUpdated++;
+                }
+            } catch (RuntimeException e) {
+                log.warn(
+                        "pr_traceability_link_update_failed: artifact={} error={}",
+                        link.getArtifactIdentifier(),
+                        e.getMessage());
+                errors.add(new SyncError("traceability", null, link.getArtifactIdentifier(), e.getMessage()));
+            }
+        }
+        return linksUpdated;
+    }
+
+    PullRequestState parsePrState(String state, boolean merged) {
+        if (merged) {
+            return PullRequestState.MERGED;
+        }
+        if (state == null) {
+            return PullRequestState.OPEN;
+        }
+        try {
+            return PullRequestState.valueOf(state);
+        } catch (IllegalArgumentException e) {
+            log.warn("github_unknown_pr_state: state={}, defaulting to OPEN", state);
+            return PullRequestState.OPEN;
+        }
     }
 
     public CreateGitHubIssueResult createIssueFromRequirement(CreateGitHubIssueCommand command) {

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubIssueSyncService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubIssueSyncService.java
@@ -191,11 +191,12 @@ public class GitHubIssueSyncService {
         Instant fetchedAt = Instant.now();
         List<SyncError> errors = new ArrayList<>();
 
-        int[] prCounts = upsertPrSyncRecords(fetched, fetchedAt, errors);
+        String repoSlug = owner + "/" + repo;
+        int[] prCounts = upsertPrSyncRecords(repoSlug, fetched, fetchedAt, errors);
         int prsCreated = prCounts[0];
         int prsUpdated = prCounts[1];
 
-        int linksUpdated = updatePrTraceabilityLinks(fetchedAt, errors);
+        int linksUpdated = updatePrTraceabilityLinks(repoSlug, fetchedAt, errors);
 
         var audit = new RequirementImport(ImportSourceType.GITHUB);
         audit.setSourceFile(owner + "/" + repo + " (pull requests)");
@@ -217,18 +218,19 @@ public class GitHubIssueSyncService {
                 errors);
     }
 
-    private int[] upsertPrSyncRecords(List<GitHubPullRequestData> fetched, Instant fetchedAt, List<SyncError> errors) {
+    private int[] upsertPrSyncRecords(
+            String repoSlug, List<GitHubPullRequestData> fetched, Instant fetchedAt, List<SyncError> errors) {
         int prsCreated = 0;
         int prsUpdated = 0;
 
         for (GitHubPullRequestData pr : fetched) {
             try {
-                var existing = prSyncRepository.findByPrNumber(pr.number());
+                var existing = prSyncRepository.findByRepoAndPrNumber(repoSlug, pr.number());
                 if (existing.isPresent()) {
                     updateExistingPrSync(existing.get(), pr, fetchedAt);
                     prsUpdated++;
                 } else {
-                    createNewPrSync(pr, fetchedAt);
+                    createNewPrSync(repoSlug, pr, fetchedAt);
                     prsCreated++;
                 }
             } catch (RuntimeException e) {
@@ -250,9 +252,9 @@ public class GitHubIssueSyncService {
         prSyncRepository.save(sync);
     }
 
-    private void createNewPrSync(GitHubPullRequestData pr, Instant fetchedAt) {
+    private void createNewPrSync(String repoSlug, GitHubPullRequestData pr, Instant fetchedAt) {
         var sync = new GitHubPullRequestSync(
-                pr.number(), pr.title(), parsePrState(pr.state(), pr.merged()), pr.url(), fetchedAt);
+                repoSlug, pr.number(), pr.title(), parsePrState(pr.state(), pr.merged()), pr.url(), fetchedAt);
         sync.setPrBody(pr.body() != null ? pr.body() : "");
         sync.setBaseBranch(pr.baseBranch() != null ? pr.baseBranch() : "");
         sync.setHeadBranch(pr.headBranch() != null ? pr.headBranch() : "");
@@ -260,13 +262,13 @@ public class GitHubIssueSyncService {
         prSyncRepository.save(sync);
     }
 
-    private int updatePrTraceabilityLinks(Instant fetchedAt, List<SyncError> errors) {
+    private int updatePrTraceabilityLinks(String repoSlug, Instant fetchedAt, List<SyncError> errors) {
         int linksUpdated = 0;
         var links = traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST);
         for (var link : links) {
             try {
                 int prNumber = Integer.parseInt(link.getArtifactIdentifier());
-                var syncOpt = prSyncRepository.findByPrNumber(prNumber);
+                var syncOpt = prSyncRepository.findByRepoAndPrNumber(repoSlug, prNumber);
                 if (syncOpt.isPresent()) {
                     var sync = syncOpt.get();
                     link.setArtifactUrl(sync.getPrUrl());

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubPullRequestData.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GitHubPullRequestData.java
@@ -1,0 +1,19 @@
+package com.keplerops.groundcontrol.domain.requirements.service;
+
+import java.util.List;
+
+public record GitHubPullRequestData(
+        int number,
+        String title,
+        String state,
+        boolean merged,
+        String url,
+        String body,
+        String baseBranch,
+        String headBranch,
+        List<String> labels) {
+
+    public GitHubPullRequestData {
+        labels = List.copyOf(labels);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/PrSyncResult.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/PrSyncResult.java
@@ -1,0 +1,19 @@
+package com.keplerops.groundcontrol.domain.requirements.service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record PrSyncResult(
+        UUID syncId,
+        Instant syncedAt,
+        int prsFetched,
+        int prsCreated,
+        int prsUpdated,
+        int linksUpdated,
+        List<SyncError> errors) {
+
+    public PrSyncResult {
+        errors = List.copyOf(errors);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/ArtifactType.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/ArtifactType.java
@@ -2,6 +2,7 @@ package com.keplerops.groundcontrol.domain.requirements.state;
 
 public enum ArtifactType {
     GITHUB_ISSUE,
+    PULL_REQUEST,
     CODE_FILE,
     ADR,
     CONFIG,

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/PullRequestState.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/PullRequestState.java
@@ -1,0 +1,7 @@
+package com.keplerops.groundcontrol.domain.requirements.state;
+
+public enum PullRequestState {
+    OPEN,
+    CLOSED,
+    MERGED
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keplerops.groundcontrol.domain.exception.GroundControlException;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubClient;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubPullRequestData;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -214,6 +215,100 @@ public class GitHubCliClient implements GitHubClient {
 
         log.info("github_issue_created: number={} repo={}", number, repo);
         return new GitHubIssueData(number, title, "OPEN", url, body, labels != null ? labels : List.of());
+    }
+
+    // -----------------------------------------------------------------------
+    // Pull request fetching
+    // -----------------------------------------------------------------------
+
+    public record PrPage(List<GitHubPullRequestData> prs, int rawCount) {
+        public PrPage {
+            prs = List.copyOf(prs);
+        }
+    }
+
+    @Override
+    public List<GitHubPullRequestData> fetchAllPullRequests(String owner, String repo) {
+        validateOwnerRepo(owner, repo);
+        List<GitHubPullRequestData> allPrs = new ArrayList<>();
+        int page = 1;
+
+        while (true) {
+            PrPage batch = fetchPrPage(owner, repo, page);
+            allPrs.addAll(batch.prs());
+
+            if (batch.rawCount() < PAGE_SIZE) {
+                break;
+            }
+
+            log.info(
+                    "github_prs_page_full: page={} raw={} prs={} repo={}/{}, fetching next page",
+                    page,
+                    batch.rawCount(),
+                    batch.prs().size(),
+                    owner,
+                    repo);
+            page++;
+        }
+
+        log.info("github_prs_fetched: count={} pages={} repo={}/{}", allPrs.size(), page, owner, repo);
+        return allPrs;
+    }
+
+    protected PrPage fetchPrPage(String owner, String repo, int page) {
+        String stdout = execGh(List.of(
+                ghPath,
+                "api",
+                String.format("repos/%s/%s/pulls", owner, repo),
+                "--method",
+                "GET",
+                "-f",
+                "state=all",
+                "-f",
+                "per_page=" + PAGE_SIZE,
+                "-f",
+                "page=" + page));
+
+        try {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> rawPrs =
+                    objectMapper.readValue(stdout, new TypeReference<List<Map<String, Object>>>() {});
+            return new PrPage(parsePullRequests(rawPrs), rawPrs.size());
+        } catch (IOException e) {
+            throw new GroundControlException(
+                    "Failed to parse gh CLI PR output: " + e.getMessage(), "github_parse_error");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<GitHubPullRequestData> parsePullRequests(List<Map<String, Object>> rawPrs) {
+        List<GitHubPullRequestData> result = new ArrayList<>();
+        for (Map<String, Object> raw : rawPrs) {
+            int number = ((Number) raw.get("number")).intValue();
+            String title = (String) raw.get("title");
+            String apiState = (String) raw.get("state");
+            String state = apiState.equalsIgnoreCase("open") ? "OPEN" : "CLOSED";
+            boolean merged = Boolean.TRUE.equals(raw.get("merged"));
+            String url = (String) raw.get("html_url");
+            String body = raw.get("body") != null ? (String) raw.get("body") : "";
+
+            Map<String, Object> baseObj = (Map<String, Object>) raw.get("base");
+            String baseBranch = baseObj != null ? (String) baseObj.get("ref") : "";
+            Map<String, Object> headObj = (Map<String, Object>) raw.get("head");
+            String headBranch = headObj != null ? (String) headObj.get("ref") : "";
+
+            List<Map<String, Object>> labelObjects =
+                    raw.get("labels") != null ? (List<Map<String, Object>>) raw.get("labels") : List.of();
+
+            List<String> labels = new ArrayList<>();
+            for (Map<String, Object> labelObj : labelObjects) {
+                labels.add((String) labelObj.get("name"));
+            }
+
+            result.add(
+                    new GitHubPullRequestData(number, title, state, merged, url, body, baseBranch, headBranch, labels));
+        }
+        return result;
     }
 
     /**

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/github/GitHubCliClient.java
@@ -288,7 +288,7 @@ public class GitHubCliClient implements GitHubClient {
             String title = (String) raw.get("title");
             String apiState = (String) raw.get("state");
             String state = apiState.equalsIgnoreCase("open") ? "OPEN" : "CLOSED";
-            boolean merged = Boolean.TRUE.equals(raw.get("merged"));
+            boolean merged = raw.get("merged_at") != null;
             String url = (String) raw.get("html_url");
             String body = raw.get("body") != null ? (String) raw.get("body") : "";
 

--- a/backend/src/main/resources/db/migration/V048__create_github_pr_sync.sql
+++ b/backend/src/main/resources/db/migration/V048__create_github_pr_sync.sql
@@ -1,0 +1,14 @@
+CREATE TABLE github_pr_sync (
+    id              UUID PRIMARY KEY,
+    pr_number       INTEGER UNIQUE NOT NULL,
+    pr_title        VARCHAR(500) NOT NULL,
+    pr_state        VARCHAR(10)  NOT NULL,
+    pr_url          VARCHAR(2000) NOT NULL,
+    pr_body         TEXT DEFAULT '',
+    base_branch     VARCHAR(255) DEFAULT '',
+    head_branch     VARCHAR(255) DEFAULT '',
+    pr_labels       JSONB DEFAULT '[]'::jsonb,
+    last_fetched_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at      TIMESTAMP WITH TIME ZONE NOT NULL
+);

--- a/backend/src/main/resources/db/migration/V048__create_github_pr_sync.sql
+++ b/backend/src/main/resources/db/migration/V048__create_github_pr_sync.sql
@@ -1,6 +1,7 @@
 CREATE TABLE github_pr_sync (
     id              UUID PRIMARY KEY,
-    pr_number       INTEGER UNIQUE NOT NULL,
+    repo            VARCHAR(200) NOT NULL,
+    pr_number       INTEGER      NOT NULL,
     pr_title        VARCHAR(500) NOT NULL,
     pr_state        VARCHAR(10)  NOT NULL,
     pr_url          VARCHAR(2000) NOT NULL,
@@ -10,5 +11,6 @@ CREATE TABLE github_pr_sync (
     pr_labels       JSONB DEFAULT '[]'::jsonb,
     last_fetched_at TIMESTAMP WITH TIME ZONE NOT NULL,
     created_at      TIMESTAMP WITH TIME ZONE NOT NULL,
-    updated_at      TIMESTAMP WITH TIME ZONE NOT NULL
+    updated_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+    UNIQUE (repo, pr_number)
 );

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/CreateIssueIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/CreateIssueIntegrationTest.java
@@ -13,6 +13,7 @@ import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRep
 import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubClient;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubPullRequestData;
 import com.keplerops.groundcontrol.domain.requirements.state.ArtifactType;
 import com.keplerops.groundcontrol.domain.requirements.state.SyncStatus;
 import java.util.List;
@@ -49,6 +50,11 @@ class CreateIssueIntegrationTest extends BaseIntegrationTest {
                             "https://github.com/test/repo/issues/55",
                             "Created from requirement CI-REQ-001",
                             List.of("phase-1", "P1")));
+                }
+
+                @Override
+                public List<GitHubPullRequestData> fetchAllPullRequests(String owner, String repo) {
+                    return List.of();
                 }
 
                 @Override

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
@@ -40,7 +40,7 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         "001", "002", "003", "004", "005", "006", "007", "008", "009", "010", "011", "012", "013",
                         "014", "015", "016", "017", "018", "019", "020", "021", "022", "023", "024", "025", "026",
                         "027", "028", "029", "030", "031", "032", "033", "034", "035", "036", "037", "038", "039",
-                        "040", "041", "042", "043", "044", "045", "046", "047");
+                        "040", "041", "042", "043", "044", "045", "046", "047", "048");
     }
 
     @Test
@@ -147,5 +147,6 @@ class MigrationSmokeTest extends BaseIntegrationTest {
         entityManager
                 .createNativeQuery("SELECT 1 FROM control_link_audit LIMIT 1")
                 .getResultList();
+        entityManager.createNativeQuery("SELECT 1 FROM github_pr_sync LIMIT 1").getResultList();
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -18,6 +18,7 @@ import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRep
 import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubClient;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubPullRequestData;
 import com.keplerops.groundcontrol.domain.requirements.state.SyncStatus;
 import jakarta.persistence.EntityManager;
 import java.nio.charset.StandardCharsets;
@@ -97,6 +98,10 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
                 }
 
                 @Override
+                public List<GitHubPullRequestData> fetchAllPullRequests(String owner, String repo) {
+                    return List.of();
+                }
+
                 public GitHubIssueData createIssue(String repo, String title, String body, List<String> labels) {
                     throw new UnsupportedOperationException("Not used in E2E tests");
                 }
@@ -389,6 +394,6 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
                         "001", "002", "003", "004", "005", "006", "007", "008", "009", "010", "011", "012", "013",
                         "014", "015", "016", "017", "018", "019", "020", "021", "022", "023", "024", "025", "026",
                         "027", "028", "029", "030", "031", "032", "033", "034", "035", "036", "037", "038", "039",
-                        "040", "041", "042", "043", "044", "045", "046", "047");
+                        "040", "041", "042", "043", "044", "045", "046", "047", "048");
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/SyncIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/SyncIntegrationTest.java
@@ -15,6 +15,7 @@ import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRep
 import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubClient;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubPullRequestData;
 import com.keplerops.groundcontrol.domain.requirements.state.ArtifactType;
 import com.keplerops.groundcontrol.domain.requirements.state.LinkType;
 import java.util.List;
@@ -56,6 +57,11 @@ class SyncIntegrationTest extends BaseIntegrationTest {
                                     "https://github.com/test/repo/issues/2",
                                     "Add linting tools",
                                     List.of("phase-0", "P1", "enhancement")));
+                }
+
+                @Override
+                public List<GitHubPullRequestData> fetchAllPullRequests(String owner, String repo) {
+                    return List.of();
                 }
 
                 @Override

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SyncControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SyncControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.keplerops.groundcontrol.api.admin.SyncController;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueSyncService;
+import com.keplerops.groundcontrol.domain.requirements.service.PrSyncResult;
 import com.keplerops.groundcontrol.domain.requirements.service.SyncResult;
 import java.time.Instant;
 import java.util.List;
@@ -73,6 +74,55 @@ class SyncControllerTest {
         @Test
         void withMaliciousRepo_returns400() throws Exception {
             mockMvc.perform(post("/api/v1/admin/sync/github")
+                            .param("owner", "KeplerOps")
+                            .param("repo", "repo;rm -rf /"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    class SyncGithubPrs {
+
+        @Test
+        void returns200WithStats() throws Exception {
+            var result = new PrSyncResult(UUID.randomUUID(), Instant.now(), 30, 25, 5, 8, List.of());
+
+            when(syncService.syncGitHubPullRequests(anyString(), anyString())).thenReturn(result);
+
+            mockMvc.perform(post("/api/v1/admin/sync/github/prs")
+                            .param("owner", "KeplerOps")
+                            .param("repo", "Ground-Control"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.syncId", notNullValue()))
+                    .andExpect(jsonPath("$.prsFetched", is(30)))
+                    .andExpect(jsonPath("$.prsCreated", is(25)))
+                    .andExpect(jsonPath("$.prsUpdated", is(5)))
+                    .andExpect(jsonPath("$.linksUpdated", is(8)));
+        }
+
+        @Test
+        void withMissingOwner_returns400() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/sync/github/prs").param("repo", "Ground-Control"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void withMissingRepo_returns400() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/sync/github/prs").param("owner", "KeplerOps"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void withMaliciousOwner_returns400() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/sync/github/prs")
+                            .param("owner", "$(whoami)")
+                            .param("repo", "Ground-Control"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void withMaliciousRepo_returns400() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/sync/github/prs")
                             .param("owner", "KeplerOps")
                             .param("repo", "repo;rm -rf /"))
                     .andExpect(status().isBadRequest());

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubIssueSyncServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubIssueSyncServiceTest.java
@@ -463,7 +463,7 @@ class GitHubIssueSyncServiceTest {
                     List.of());
 
             when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
-            when(prSyncRepository.findByPrNumber(10)).thenReturn(Optional.empty());
+            when(prSyncRepository.findByRepoAndPrNumber("owner/repo", 10)).thenReturn(Optional.empty());
             when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
             when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
                     .thenReturn(List.of());
@@ -489,10 +489,10 @@ class GitHubIssueSyncServiceTest {
                     "feat/x",
                     List.of());
             var existing = new GitHubPullRequestSync(
-                    10, "Old PR", PullRequestState.OPEN, "https://github.com/o/r/pull/10", Instant.now());
+                    "owner/repo", 10, "Old PR", PullRequestState.OPEN, "https://github.com/o/r/pull/10", Instant.now());
 
             when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
-            when(prSyncRepository.findByPrNumber(10)).thenReturn(Optional.of(existing));
+            when(prSyncRepository.findByRepoAndPrNumber("owner/repo", 10)).thenReturn(Optional.of(existing));
             when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
             when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
                     .thenReturn(List.of());
@@ -509,9 +509,14 @@ class GitHubIssueSyncServiceTest {
         @Test
         void updatesPrTraceabilityLinks() {
             var sync = new GitHubPullRequestSync(
-                    10, "Ship feature", PullRequestState.MERGED, "https://github.com/o/r/pull/10", Instant.now());
+                    "owner/repo",
+                    10,
+                    "Ship feature",
+                    PullRequestState.MERGED,
+                    "https://github.com/o/r/pull/10",
+                    Instant.now());
             setField(sync, "id", UUID.randomUUID());
-            when(prSyncRepository.findByPrNumber(10)).thenReturn(Optional.of(sync));
+            when(prSyncRepository.findByRepoAndPrNumber("owner/repo", 10)).thenReturn(Optional.of(sync));
 
             var requirement = new Requirement(TEST_PROJECT, "GC-A001", "Test", "statement");
             setField(requirement, "id", UUID.randomUUID());
@@ -540,7 +545,7 @@ class GitHubIssueSyncServiceTest {
                     1, "Merged PR", "CLOSED", true, "https://github.com/o/r/pull/1", "", "main", "feat", List.of());
 
             when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
-            when(prSyncRepository.findByPrNumber(1)).thenReturn(Optional.empty());
+            when(prSyncRepository.findByRepoAndPrNumber("owner/repo", 1)).thenReturn(Optional.empty());
             when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
             when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
                     .thenReturn(List.of());
@@ -559,7 +564,7 @@ class GitHubIssueSyncServiceTest {
                     2, "Closed PR", "CLOSED", false, "https://github.com/o/r/pull/2", "", "main", "feat", List.of());
 
             when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
-            when(prSyncRepository.findByPrNumber(2)).thenReturn(Optional.empty());
+            when(prSyncRepository.findByRepoAndPrNumber("owner/repo", 2)).thenReturn(Optional.empty());
             when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
             when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
                     .thenReturn(List.of());
@@ -586,7 +591,7 @@ class GitHubIssueSyncServiceTest {
                     List.of());
 
             when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
-            when(prSyncRepository.findByPrNumber(3)).thenReturn(Optional.empty());
+            when(prSyncRepository.findByRepoAndPrNumber("owner/repo", 3)).thenReturn(Optional.empty());
             when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
             when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
                     .thenReturn(List.of());

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubIssueSyncServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubIssueSyncServiceTest.java
@@ -10,10 +10,12 @@ import static org.mockito.Mockito.when;
 import com.keplerops.groundcontrol.TestUtil;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.requirements.model.GitHubIssueSync;
+import com.keplerops.groundcontrol.domain.requirements.model.GitHubPullRequestSync;
 import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
 import com.keplerops.groundcontrol.domain.requirements.model.RequirementImport;
 import com.keplerops.groundcontrol.domain.requirements.model.TraceabilityLink;
 import com.keplerops.groundcontrol.domain.requirements.repository.GitHubIssueSyncRepository;
+import com.keplerops.groundcontrol.domain.requirements.repository.GitHubPullRequestSyncRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementImportRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
@@ -22,10 +24,12 @@ import com.keplerops.groundcontrol.domain.requirements.service.CreateTraceabilit
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubClient;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueSyncService;
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubPullRequestData;
 import com.keplerops.groundcontrol.domain.requirements.service.TraceabilityService;
 import com.keplerops.groundcontrol.domain.requirements.state.ArtifactType;
 import com.keplerops.groundcontrol.domain.requirements.state.IssueState;
 import com.keplerops.groundcontrol.domain.requirements.state.LinkType;
+import com.keplerops.groundcontrol.domain.requirements.state.PullRequestState;
 import com.keplerops.groundcontrol.domain.requirements.state.SyncStatus;
 import java.time.Instant;
 import java.util.List;
@@ -47,6 +51,9 @@ class GitHubIssueSyncServiceTest {
 
     @Mock
     private GitHubIssueSyncRepository issueSyncRepository;
+
+    @Mock
+    private GitHubPullRequestSyncRepository prSyncRepository;
 
     @Mock
     private TraceabilityLinkRepository traceabilityLinkRepository;
@@ -76,6 +83,7 @@ class GitHubIssueSyncServiceTest {
         service = new GitHubIssueSyncService(
                 gitHubClient,
                 issueSyncRepository,
+                prSyncRepository,
                 traceabilityLinkRepository,
                 importRepository,
                 requirementRepository,
@@ -431,6 +439,167 @@ class GitHubIssueSyncServiceTest {
             assertThat(link.getArtifactTitle()).contains("[CLOSED]");
             assertThat(link.getArtifactTitle()).startsWith("#42 -");
             assertThat(link.getSyncStatus()).isEqualTo(SyncStatus.SYNCED);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Pull request sync tests
+    // -----------------------------------------------------------------------
+
+    @Nested
+    class PrSync {
+
+        @Test
+        void createsNewPrSync() {
+            var pr = new GitHubPullRequestData(
+                    10,
+                    "Add feature",
+                    "OPEN",
+                    false,
+                    "https://github.com/o/r/pull/10",
+                    "body",
+                    "main",
+                    "feat/x",
+                    List.of());
+
+            when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
+            when(prSyncRepository.findByPrNumber(10)).thenReturn(Optional.empty());
+            when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
+                    .thenReturn(List.of());
+            stubAuditSave();
+
+            var result = service.syncGitHubPullRequests("owner", "repo");
+
+            assertThat(result.prsCreated()).isEqualTo(1);
+            assertThat(result.prsUpdated()).isZero();
+            verify(prSyncRepository).save(any(GitHubPullRequestSync.class));
+        }
+
+        @Test
+        void updatesExistingPrSync() {
+            var pr = new GitHubPullRequestData(
+                    10,
+                    "Updated PR",
+                    "CLOSED",
+                    true,
+                    "https://github.com/o/r/pull/10",
+                    "updated body",
+                    "main",
+                    "feat/x",
+                    List.of());
+            var existing = new GitHubPullRequestSync(
+                    10, "Old PR", PullRequestState.OPEN, "https://github.com/o/r/pull/10", Instant.now());
+
+            when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
+            when(prSyncRepository.findByPrNumber(10)).thenReturn(Optional.of(existing));
+            when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
+                    .thenReturn(List.of());
+            stubAuditSave();
+
+            var result = service.syncGitHubPullRequests("owner", "repo");
+
+            assertThat(result.prsUpdated()).isEqualTo(1);
+            assertThat(result.prsCreated()).isZero();
+            assertThat(existing.getPrTitle()).isEqualTo("Updated PR");
+            assertThat(existing.getPrState()).isEqualTo(PullRequestState.MERGED);
+        }
+
+        @Test
+        void updatesPrTraceabilityLinks() {
+            var sync = new GitHubPullRequestSync(
+                    10, "Ship feature", PullRequestState.MERGED, "https://github.com/o/r/pull/10", Instant.now());
+            setField(sync, "id", UUID.randomUUID());
+            when(prSyncRepository.findByPrNumber(10)).thenReturn(Optional.of(sync));
+
+            var requirement = new Requirement(TEST_PROJECT, "GC-A001", "Test", "statement");
+            setField(requirement, "id", UUID.randomUUID());
+            var link = new TraceabilityLink(requirement, ArtifactType.PULL_REQUEST, "10", LinkType.IMPLEMENTS);
+            setField(link, "id", UUID.randomUUID());
+            when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
+                    .thenReturn(List.of(link));
+            when(traceabilityLinkRepository.save(any(TraceabilityLink.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            when(gitHubClient.fetchAllPullRequests(anyString(), anyString())).thenReturn(List.of());
+            stubAuditSave();
+
+            service.syncGitHubPullRequests("owner", "repo");
+
+            assertThat(link.getArtifactTitle()).isEqualTo("#10 - Ship feature [MERGED]");
+            assertThat(link.getSyncStatus()).isEqualTo(SyncStatus.SYNCED);
+        }
+    }
+
+    @Nested
+    class PrStateParsing {
+
+        @Test
+        void mergedPrIsSavedAsMerged() {
+            var pr = new GitHubPullRequestData(
+                    1, "Merged PR", "CLOSED", true, "https://github.com/o/r/pull/1", "", "main", "feat", List.of());
+
+            when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
+            when(prSyncRepository.findByPrNumber(1)).thenReturn(Optional.empty());
+            when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
+                    .thenReturn(List.of());
+            stubAuditSave();
+
+            service.syncGitHubPullRequests("owner", "repo");
+
+            ArgumentCaptor<GitHubPullRequestSync> captor = ArgumentCaptor.forClass(GitHubPullRequestSync.class);
+            verify(prSyncRepository).save(captor.capture());
+            assertThat(captor.getValue().getPrState()).isEqualTo(PullRequestState.MERGED);
+        }
+
+        @Test
+        void closedNotMergedPrIsSavedAsClosed() {
+            var pr = new GitHubPullRequestData(
+                    2, "Closed PR", "CLOSED", false, "https://github.com/o/r/pull/2", "", "main", "feat", List.of());
+
+            when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
+            when(prSyncRepository.findByPrNumber(2)).thenReturn(Optional.empty());
+            when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
+                    .thenReturn(List.of());
+            stubAuditSave();
+
+            service.syncGitHubPullRequests("owner", "repo");
+
+            ArgumentCaptor<GitHubPullRequestSync> captor = ArgumentCaptor.forClass(GitHubPullRequestSync.class);
+            verify(prSyncRepository).save(captor.capture());
+            assertThat(captor.getValue().getPrState()).isEqualTo(PullRequestState.CLOSED);
+        }
+
+        @Test
+        void unknownPrStateDefaultsToOpen() {
+            var pr = new GitHubPullRequestData(
+                    3,
+                    "Unknown PR",
+                    "INVALID_STATE",
+                    false,
+                    "https://github.com/o/r/pull/3",
+                    "",
+                    "main",
+                    "feat",
+                    List.of());
+
+            when(gitHubClient.fetchAllPullRequests("owner", "repo")).thenReturn(List.of(pr));
+            when(prSyncRepository.findByPrNumber(3)).thenReturn(Optional.empty());
+            when(prSyncRepository.save(any(GitHubPullRequestSync.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(traceabilityLinkRepository.findByArtifactType(ArtifactType.PULL_REQUEST))
+                    .thenReturn(List.of());
+            stubAuditSave();
+
+            var result = service.syncGitHubPullRequests("owner", "repo");
+
+            assertThat(result.prsCreated()).isEqualTo(1);
+            assertThat(result.errors()).isEmpty();
+
+            ArgumentCaptor<GitHubPullRequestSync> captor = ArgumentCaptor.forClass(GitHubPullRequestSync.class);
+            verify(prSyncRepository).save(captor.capture());
+            assertThat(captor.getValue().getPrState()).isEqualTo(PullRequestState.OPEN);
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubPullRequestSyncTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubPullRequestSyncTest.java
@@ -1,0 +1,131 @@
+package com.keplerops.groundcontrol.unit.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.keplerops.groundcontrol.domain.requirements.model.GitHubPullRequestSync;
+import com.keplerops.groundcontrol.domain.requirements.state.PullRequestState;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("java:S2187") // Tests are in @Nested inner classes
+class GitHubPullRequestSyncTest {
+
+    private static GitHubPullRequestSync createSync() {
+        return new GitHubPullRequestSync(
+                42, "Add feature", PullRequestState.OPEN, "https://github.com/org/repo/pull/42", Instant.now());
+    }
+
+    @Nested
+    class Defaults {
+
+        @Test
+        void prLabelsDefaultsToEmptyList() {
+            var sync = createSync();
+            assertThat(sync.getPrLabels()).isEmpty();
+        }
+
+        @Test
+        void prBodyDefaultsToEmpty() {
+            var sync = createSync();
+            assertThat(sync.getPrBody()).isEmpty();
+        }
+
+        @Test
+        void baseBranchDefaultsToEmpty() {
+            var sync = createSync();
+            assertThat(sync.getBaseBranch()).isEmpty();
+        }
+
+        @Test
+        void headBranchDefaultsToEmpty() {
+            var sync = createSync();
+            assertThat(sync.getHeadBranch()).isEmpty();
+        }
+    }
+
+    @Nested
+    class Construction {
+
+        @Test
+        void requiredFieldsSetCorrectly() {
+            var now = Instant.now();
+            var sync = new GitHubPullRequestSync(
+                    99, "Fix bug", PullRequestState.MERGED, "https://github.com/org/repo/pull/99", now);
+
+            assertThat(sync.getPrNumber()).isEqualTo(99);
+            assertThat(sync.getPrTitle()).isEqualTo("Fix bug");
+            assertThat(sync.getPrState()).isEqualTo(PullRequestState.MERGED);
+            assertThat(sync.getPrUrl()).isEqualTo("https://github.com/org/repo/pull/99");
+            assertThat(sync.getLastFetchedAt()).isEqualTo(now);
+        }
+    }
+
+    @Nested
+    class Accessors {
+
+        @Test
+        void prTitleSetterWorks() {
+            var sync = createSync();
+            sync.setPrTitle("Updated title");
+            assertThat(sync.getPrTitle()).isEqualTo("Updated title");
+        }
+
+        @Test
+        void prStateSetterWorks() {
+            var sync = createSync();
+            sync.setPrState(PullRequestState.CLOSED);
+            assertThat(sync.getPrState()).isEqualTo(PullRequestState.CLOSED);
+        }
+
+        @Test
+        void prBodySetterWorks() {
+            var sync = createSync();
+            sync.setPrBody("Some body text");
+            assertThat(sync.getPrBody()).isEqualTo("Some body text");
+        }
+
+        @Test
+        void baseBranchSetterWorks() {
+            var sync = createSync();
+            sync.setBaseBranch("main");
+            assertThat(sync.getBaseBranch()).isEqualTo("main");
+        }
+
+        @Test
+        void headBranchSetterWorks() {
+            var sync = createSync();
+            sync.setHeadBranch("feature/foo");
+            assertThat(sync.getHeadBranch()).isEqualTo("feature/foo");
+        }
+
+        @Test
+        void prLabelsSetterWorks() {
+            var sync = createSync();
+            sync.setPrLabels(List.of("enhancement", "ready-for-review"));
+            assertThat(sync.getPrLabels()).containsExactly("enhancement", "ready-for-review");
+        }
+
+        @Test
+        void lastFetchedAtSetterWorks() {
+            var sync = createSync();
+            var now = Instant.now();
+            sync.setLastFetchedAt(now);
+            assertThat(sync.getLastFetchedAt()).isEqualTo(now);
+        }
+
+        @Test
+        void idIsNullBeforePersist() {
+            var sync = createSync();
+            assertThat(sync.getId()).isNull();
+        }
+
+        @Test
+        void timestampsAreNullBeforePersist() {
+            var sync = createSync();
+            assertThat(sync.getCreatedAt()).isNull();
+            assertThat(sync.getUpdatedAt()).isNull();
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubPullRequestSyncTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GitHubPullRequestSyncTest.java
@@ -14,7 +14,12 @@ class GitHubPullRequestSyncTest {
 
     private static GitHubPullRequestSync createSync() {
         return new GitHubPullRequestSync(
-                42, "Add feature", PullRequestState.OPEN, "https://github.com/org/repo/pull/42", Instant.now());
+                "org/repo",
+                42,
+                "Add feature",
+                PullRequestState.OPEN,
+                "https://github.com/org/repo/pull/42",
+                Instant.now());
     }
 
     @Nested
@@ -52,8 +57,9 @@ class GitHubPullRequestSyncTest {
         void requiredFieldsSetCorrectly() {
             var now = Instant.now();
             var sync = new GitHubPullRequestSync(
-                    99, "Fix bug", PullRequestState.MERGED, "https://github.com/org/repo/pull/99", now);
+                    "org/repo", 99, "Fix bug", PullRequestState.MERGED, "https://github.com/org/repo/pull/99", now);
 
+            assertThat(sync.getRepo()).isEqualTo("org/repo");
             assertThat(sync.getPrNumber()).isEqualTo(99);
             assertThat(sync.getPrTitle()).isEqualTo("Fix bug");
             assertThat(sync.getPrState()).isEqualTo(PullRequestState.MERGED);

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientPrTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientPrTest.java
@@ -1,0 +1,132 @@
+package com.keplerops.groundcontrol.unit.infrastructure;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.keplerops.groundcontrol.domain.requirements.service.GitHubPullRequestData;
+import com.keplerops.groundcontrol.infrastructure.github.GitHubCliClient;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GitHubCliClientPrTest {
+
+    @Nested
+    class ParsePullRequests {
+
+        @Test
+        void parsesOpenPr() {
+            var raw = buildRawPr(1, "Add feature", "open", false, "main", "feature/add");
+            List<GitHubPullRequestData> result = GitHubCliClient.parsePullRequests(List.of(raw));
+
+            assertThat(result).hasSize(1);
+            var pr = result.get(0);
+            assertThat(pr.number()).isEqualTo(1);
+            assertThat(pr.title()).isEqualTo("Add feature");
+            assertThat(pr.state()).isEqualTo("OPEN");
+            assertThat(pr.merged()).isFalse();
+            assertThat(pr.baseBranch()).isEqualTo("main");
+            assertThat(pr.headBranch()).isEqualTo("feature/add");
+        }
+
+        @Test
+        void parsesClosedPr() {
+            var raw = buildRawPr(2, "Fix bug", "closed", false, "dev", "fix/bug");
+            List<GitHubPullRequestData> result = GitHubCliClient.parsePullRequests(List.of(raw));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).state()).isEqualTo("CLOSED");
+            assertThat(result.get(0).merged()).isFalse();
+        }
+
+        @Test
+        void parsesMergedPr() {
+            var raw = buildRawPr(3, "Ship it", "closed", true, "main", "feature/ship");
+            List<GitHubPullRequestData> result = GitHubCliClient.parsePullRequests(List.of(raw));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).state()).isEqualTo("CLOSED");
+            assertThat(result.get(0).merged()).isTrue();
+        }
+
+        @Test
+        void parsesLabels() {
+            var raw = buildRawPr(4, "Labeled PR", "open", false, "main", "feature/labeled");
+            List<Map<String, Object>> labels = new ArrayList<>();
+            labels.add(Map.of("name", "enhancement"));
+            labels.add(Map.of("name", "ready-for-review"));
+            raw.put("labels", labels);
+
+            List<GitHubPullRequestData> result = GitHubCliClient.parsePullRequests(List.of(raw));
+
+            assertThat(result.get(0).labels()).containsExactly("enhancement", "ready-for-review");
+        }
+
+        @Test
+        void handlesNullBody() {
+            var raw = buildRawPr(5, "No body", "open", false, "main", "feature/nobody");
+            raw.put("body", null);
+
+            List<GitHubPullRequestData> result = GitHubCliClient.parsePullRequests(List.of(raw));
+
+            assertThat(result.get(0).body()).isEmpty();
+        }
+
+        @Test
+        void handlesNullLabels() {
+            var raw = buildRawPr(6, "No labels", "open", false, "main", "feature/nolabels");
+            raw.put("labels", null);
+
+            List<GitHubPullRequestData> result = GitHubCliClient.parsePullRequests(List.of(raw));
+
+            assertThat(result.get(0).labels()).isEmpty();
+        }
+
+        @Test
+        void handlesMultiplePrs() {
+            var raw1 = buildRawPr(10, "PR 1", "open", false, "main", "feature/one");
+            var raw2 = buildRawPr(11, "PR 2", "closed", true, "main", "feature/two");
+
+            List<GitHubPullRequestData> result = GitHubCliClient.parsePullRequests(List.of(raw1, raw2));
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).number()).isEqualTo(10);
+            assertThat(result.get(1).number()).isEqualTo(11);
+        }
+
+        @Test
+        void handlesNullBaseAndHead() {
+            var raw = buildRawPr(7, "No refs", "open", false, null, null);
+            raw.put("base", null);
+            raw.put("head", null);
+
+            List<GitHubPullRequestData> result = GitHubCliClient.parsePullRequests(List.of(raw));
+
+            assertThat(result.get(0).baseBranch()).isEmpty();
+            assertThat(result.get(0).headBranch()).isEmpty();
+        }
+
+        private Map<String, Object> buildRawPr(
+                int number, String title, String state, boolean merged, String baseBranch, String headBranch) {
+            Map<String, Object> raw = new LinkedHashMap<>();
+            raw.put("number", number);
+            raw.put("title", title);
+            raw.put("state", state);
+            raw.put("merged", merged);
+            raw.put("html_url", "https://github.com/org/repo/pull/" + number);
+            raw.put("body", "PR body for " + title);
+            raw.put("labels", List.of());
+
+            if (baseBranch != null) {
+                raw.put("base", Map.of("ref", baseBranch));
+            }
+            if (headBranch != null) {
+                raw.put("head", Map.of("ref", headBranch));
+            }
+
+            return raw;
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientPrTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientPrTest.java
@@ -2,8 +2,10 @@ package com.keplerops.groundcontrol.unit.infrastructure;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubPullRequestData;
 import com.keplerops.groundcontrol.infrastructure.github.GitHubCliClient;
+import com.keplerops.groundcontrol.infrastructure.github.GitHubCliClient.PrPage;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -127,6 +129,73 @@ class GitHubCliClientPrTest {
             }
 
             return raw;
+        }
+    }
+
+    @Nested
+    class PrPagination {
+
+        @Test
+        void singlePageReturnsAllPrs() {
+            var client = stubbedClient(List.of(new PrPage(List.of(pr(1), pr(2)), 2)));
+
+            List<GitHubPullRequestData> result = client.fetchAllPullRequests("o", "r");
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).number()).isEqualTo(1);
+            assertThat(result.get(1).number()).isEqualTo(2);
+        }
+
+        @Test
+        void paginatesUntilPartialPage() {
+            var client = stubbedClient(List.of(new PrPage(makePrs(1, 100), 100), new PrPage(makePrs(101, 120), 20)));
+
+            List<GitHubPullRequestData> result = client.fetchAllPullRequests("o", "r");
+
+            assertThat(result).hasSize(120);
+            assertThat(result.get(0).number()).isEqualTo(1);
+            assertThat(result.get(119).number()).isEqualTo(120);
+        }
+
+        @Test
+        void emptyPageReturnsEmpty() {
+            var client = stubbedClient(List.of(new PrPage(List.of(), 0)));
+
+            List<GitHubPullRequestData> result = client.fetchAllPullRequests("o", "r");
+
+            assertThat(result).isEmpty();
+        }
+
+        private GitHubCliClient stubbedClient(List<PrPage> pages) {
+            return new GitHubCliClient(new ObjectMapper(), "gh") {
+                private int callCount = 0;
+
+                @Override
+                protected PrPage fetchPrPage(String owner, String repo, int page) {
+                    return pages.get(callCount++);
+                }
+            };
+        }
+
+        private List<GitHubPullRequestData> makePrs(int from, int to) {
+            List<GitHubPullRequestData> prs = new ArrayList<>();
+            for (int i = from; i <= to; i++) {
+                prs.add(pr(i));
+            }
+            return prs;
+        }
+
+        private GitHubPullRequestData pr(int number) {
+            return new GitHubPullRequestData(
+                    number,
+                    "PR " + number,
+                    "OPEN",
+                    false,
+                    "https://github.com/o/r/pull/" + number,
+                    "",
+                    "main",
+                    "feat/" + number,
+                    List.of());
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientPrTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/GitHubCliClientPrTest.java
@@ -116,7 +116,9 @@ class GitHubCliClientPrTest {
             raw.put("number", number);
             raw.put("title", title);
             raw.put("state", state);
-            raw.put("merged", merged);
+            if (merged) {
+                raw.put("merged_at", "2026-04-05T12:00:00Z");
+            }
             raw.put("html_url", "https://github.com/org/repo/pull/" + number);
             raw.put("body", "PR body for " + title);
             raw.put("labels", List.of());

--- a/docs/API.md
+++ b/docs/API.md
@@ -590,6 +590,7 @@ sheet per analysis category.
 | POST | `/admin/import/strictdoc` | multipart/form-data | 200 | Import .sdoc file |
 | POST | `/admin/import/reqif` | multipart/form-data | 200 | Import .reqif file |
 | POST | `/admin/sync/github?owner=X&repo=Y` | — | 200 | Sync GitHub issues |
+| POST | `/admin/sync/github/prs?owner=X&repo=Y` | — | 200 | Sync GitHub pull requests |
 
 StrictDoc import creates requirements, relations, traceability links, and preserves the
 document structure (document, sections, text blocks). The response includes all counters:

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -30,6 +30,7 @@ import {
   importStrictdoc,
   importReqif,
   syncGithub,
+  syncGithubPrs,
   getRequirementHistory,
   getRelationHistory,
   getTraceabilityLinkHistory,
@@ -1253,6 +1254,22 @@ server.tool(
   async ({ owner, repo }) => {
     try {
       return ok(JSON.stringify(await syncGithub(owner, repo), null, 2));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+server.tool(
+  "gc_sync_github_prs",
+  "Sync GitHub pull requests for a repository. Updates traceability links with PR state (open, closed, merged).",
+  {
+    owner: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/).describe("GitHub repository owner"),
+    repo: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/).describe("GitHub repository name"),
+  },
+  async ({ owner, repo }) => {
+    try {
+      return ok(JSON.stringify(await syncGithubPrs(owner, repo), null, 2));
     } catch (e) {
       return err(e);
     }

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -15,6 +15,7 @@ export const PRIORITIES = ["MUST", "SHOULD", "COULD", "WONT"];
 export const RELATION_TYPES = ["PARENT", "DEPENDS_ON", "CONFLICTS_WITH", "REFINES", "SUPERSEDES", "RELATED"];
 export const ARTIFACT_TYPES = [
   "GITHUB_ISSUE",
+  "PULL_REQUEST",
   "CODE_FILE",
   "ADR",
   "CONFIG",
@@ -511,6 +512,12 @@ export async function importReqif(filePath, project) {
 
 export async function syncGithub(owner, repo) {
   return request("POST", "/api/v1/admin/sync/github", {
+    params: { owner, repo },
+  });
+}
+
+export async function syncGithubPrs(owner, repo) {
+  return request("POST", "/api/v1/admin/sync/github/prs", {
     params: { owner, repo },
   });
 }


### PR DESCRIPTION
## Summary

- Adds `PULL_REQUEST` artifact type to the traceability graph, enabling pull requests to be linked to requirements alongside the existing `GITHUB_ISSUE` type
- Introduces `GitHubPullRequestSync` entity and `PullRequestState` enum (OPEN, CLOSED, MERGED) for caching PR state locally
- Extends `GitHubCliClient` and `GitHubIssueSyncService` to fetch PRs via GitHub API and sync state into traceability link titles (e.g., `#42 - Add feature [MERGED]`)
- Exposes PR sync via `POST /api/v1/admin/sync/github/prs` REST endpoint and `gc_sync_github_prs` MCP tool

Implements GC-D002. Closes #488.

## Test plan

- [x] `make check` passes (build + unit tests + static analysis + coverage)
- [x] Pre-commit hooks pass (spotless, spotbugs, checkstyle, OpenJML ESC)
- [x] Unit tests: entity defaults/accessors, CLI client PR parsing, service PR sync (create, update, state parsing, traceability link updates), WebMvcTest for PR sync endpoint (200, 400 for missing/malicious params)
- [ ] Integration tests: existing issue sync, issue creation, and E2E tests still pass with updated GitHubClient interface
- [ ] Manual: create PULL_REQUEST traceability link via MCP, call `gc_sync_github_prs` to verify state reflection