### PR TITLE
Fix graph visualization and SonarCloud quality gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.102.2] - 2026-04-06
+
+### Fixed
+
+- Graph visualization returns empty data when Apache AGE is disabled
+  (the default). The MixedGraphClient now falls back to building the
+  graph projection from JPA entities via GraphProjectionContributors
+  instead of returning empty lists
+- Added `buildProjectionForProject(UUID)` to GraphProjectionRegistryService
+  for project-scoped JPA-based graph building
+
 ## [0.102.1] - 2026-04-05
 
 ### Fixed

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphProjectionRegistryService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphProjectionRegistryService.java
@@ -29,4 +29,14 @@ public class GraphProjectionRegistryService {
         }
         return new GraphProjection(nodes, edges);
     }
+
+    public GraphProjection buildProjectionForProject(java.util.UUID projectId) {
+        var nodes = new ArrayList<com.keplerops.groundcontrol.domain.graph.model.GraphNode>();
+        var edges = new ArrayList<com.keplerops.groundcontrol.domain.graph.model.GraphEdge>();
+        for (var contributor : contributors) {
+            nodes.addAll(contributor.contributeNodes(projectId));
+            edges.addAll(contributor.contributeEdges(projectId));
+        }
+        return new GraphProjection(nodes, edges);
+    }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
@@ -140,7 +140,7 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
     @Override
     public GraphProjection getVisualization(UUID projectId) {
         if (!ageProperties.enabled()) {
-            return new GraphProjection(List.of(), List.of());
+            return graphProjectionRegistryService.buildProjectionForProject(projectId);
         }
         String graph = validateGraphName(ageProperties.graphName());
         String projectIdentifier = getProjectIdentifier(projectId);


### PR DESCRIPTION
## Summary
- Fix graph visualization returning empty when Apache AGE is disabled (the default) — now falls back to JPA-based graph projection
- Fix frontend TypeScript errors in graph.tsx (missing/unused imports) that broke Docker build
- Add 129 unit tests to raise SonarCloud coverage from 74.7% to 86.5%
- Review 3 SQL-injection security hotspots as SAFE (Apache AGE Cypher-in-SQL pattern)

## Test plan
- [x] All 129 new tests pass locally
- [x] `make check` passes (build + tests + static analysis)
- [x] Graph visualization endpoint returns JPA-based data when AGE is disabled
- [x] Frontend builds cleanly with TypeScript strict mode
- [ ] CI pipeline passes (build, test, sonar, docker, smoke)
- [ ] Deployed graph page loads with data