### PR TITLE
Fix SonarCloud reliability bug in SpaController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of returning empty lists
 - Added `buildProjectionForProject(UUID)` to GraphProjectionRegistryService
   for project-scoped JPA-based graph building
+- SonarCloud bug: bind SpaController path template variables to a
+  @PathVariable parameter to satisfy rule java:S6856
+- Set SonarCloud new code period to `previous_version` on main branch
+  so quality gate conditions can be evaluated
 
 ## [0.102.1] - 2026-04-05
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/web/SpaController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/web/SpaController.java
@@ -1,7 +1,9 @@
 package com.keplerops.groundcontrol.infrastructure.web;
 
+import java.util.Map;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 /**
  * Forwards non-API, non-static routes to {@code index.html} so that React Router can handle
@@ -26,7 +28,7 @@ public class SpaController {
     private static final String S6 = S5 + "/{f:" + NO_DOT + "}";
 
     @GetMapping({S1, S2, S3, S4, S5, S6})
-    public String forward() {
+    public String forward(@PathVariable Map<String, String> segments) {
         return "forward:/index.html";
     }
 }


### PR DESCRIPTION
## Summary
- Bind SPA path template variables to `@PathVariable Map<String, String>` parameter to fix SonarCloud rule java:S6856 (reliability rating = C -> A)
- This was the last failing quality gate condition on main

## Test plan
- [x] All tests pass locally
- [x] `make check` passes
- [ ] CI pipeline passes with sonar green