### PR TITLE
Add asset-centric traceability target types and fix CONTROL graph projection (GC-M017)

### DIFF
--- a/.claude/plans/snug-pondering-robin-agent-ad8def0992bed0ff6.md
+++ b/.claude/plans/snug-pondering-robin-agent-ad8def0992bed0ff6.md
@@ -1,0 +1,577 @@
+# GC-F001: Verification Result Storage -- Implementation Plan
+
+## Requirement Summary
+
+**UID:** GC-F001
+**Title:** Verification Result Storage
+**Statement:** Store verification results from any prover or verifier in a common schema, capturing: the requirement verified, the verifier used, the result (pass/fail/error/inconclusive), evidence artifacts, and timestamp.
+**Source:** ADR-014 (Pluggable Verification Architecture)
+**Status:** DRAFT, Wave 3, Priority MUST
+
+## Scope Boundaries
+
+**In scope:**
+1. Domain model (entity, enums, repository, service)
+2. REST API (CRUD endpoints)
+3. MCP tools (matching REST API)
+4. Database migrations (V049, V050)
+5. Tests (controller unit, service unit, migration smoke)
+
+**Out of scope:**
+- Infrastructure verifier adapters (OpenJmlAdapter, TlcAdapter, OpaAdapter, etc.)
+- Graph materialization for VerificationResult (separate feature)
+- Automated re-verification triggers based on expiresAt
+
+---
+
+## Phase 1: Domain Layer
+
+### Step 1.1: Create enum VerificationStatus
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/state/VerificationStatus.java`
+
+Simple enum with no state machine (verification results do not transition through states):
+
+```java
+public enum VerificationStatus {
+    PROVEN,
+    REFUTED,
+    TIMEOUT,
+    UNKNOWN,
+    ERROR
+}
+```
+
+No `canTransitionTo()` method needed -- this is a terminal classification, not a lifecycle state.
+
+### Step 1.2: Create enum AssuranceLevel
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/state/AssuranceLevel.java`
+
+```java
+public enum AssuranceLevel {
+    L0,
+    L1,
+    L2,
+    L3
+}
+```
+
+### Step 1.3: Create entity VerificationResult
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/model/VerificationResult.java`
+
+Follow the Control.java pattern exactly:
+- Extends `BaseEntity` (UUID id, Instant createdAt, updatedAt)
+- `@Entity @Audited`
+- `@NotAudited` on `@ManyToOne` to `Project` (matches Control pattern -- Project is not audited)
+- `@ManyToOne(fetch = FetchType.LAZY)` for `target` (TraceabilityLink) -- nullable
+- `@ManyToOne(fetch = FetchType.LAZY)` for `requirement` (Requirement) -- nullable
+- `@Enumerated(EnumType.STRING)` for `result` and `assuranceLevel`
+- `@Convert(converter = JacksonTextCollectionConverters.StringObjectMapConverter.class)` for `evidence` field (Map<String, Object>, stored as TEXT, matching the Control.java pattern for methodology_factors/effectiveness)
+- Constructor: `VerificationResult(Project project, String prover, VerificationStatus result, Instant verifiedAt)`
+
+Fields (mapped to ADR-014 schema):
+
+| Java field | Column | Type | Nullable | Notes |
+|-----------|--------|------|----------|-------|
+| project | project_id | FK -> project | NOT NULL | @NotAudited, FetchType.EAGER (matches Control) |
+| target | target_id | FK -> traceability_link | nullable | @NotAudited, FetchType.LAZY |
+| requirement | requirement_id | FK -> requirement | nullable | @NotAudited, FetchType.LAZY |
+| prover | prover | VARCHAR(50) | NOT NULL | Tool identifier string |
+| property | property | TEXT | nullable | Formal property checked |
+| result | result | VARCHAR(20) | NOT NULL | Enum: PROVEN, REFUTED, TIMEOUT, UNKNOWN, ERROR |
+| assuranceLevel | assurance_level | VARCHAR(5) | nullable | Enum: L0, L1, L2, L3 |
+| evidence | evidence | TEXT | nullable | JSON via StringObjectMapConverter |
+| verifiedAt | verified_at | TIMESTAMPTZ | NOT NULL | When verification ran |
+| expiresAt | expires_at | TIMESTAMPTZ | nullable | Re-verification trigger |
+
+Design decisions:
+- No `@UniqueConstraint` -- the same target can be verified multiple times by the same prover (each run is a distinct result).
+- `target` is nullable -- manual review results or design-level verifications may not have a TraceabilityLink yet.
+- `requirement` is nullable -- some verification results may be target-driven without a specific requirement linkage.
+- `project` uses EAGER fetch (matches Control pattern) since all list/get queries are project-scoped.
+- `target` and `requirement` use LAZY fetch to avoid N+1 on list queries.
+- Both `target` and `requirement` get `@NotAudited` since TraceabilityLink and Requirement are audited independently.
+
+### Step 1.4: Create repository VerificationResultRepository
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/repository/VerificationResultRepository.java`
+
+```java
+public interface VerificationResultRepository extends JpaRepository<VerificationResult, UUID> {
+    Optional<VerificationResult> findByIdAndProjectId(UUID id, UUID projectId);
+    List<VerificationResult> findByProjectIdOrderByVerifiedAtDesc(UUID projectId);
+    List<VerificationResult> findByProjectIdAndRequirementIdOrderByVerifiedAtDesc(UUID projectId, UUID requirementId);
+    List<VerificationResult> findByProjectIdAndTargetIdOrderByVerifiedAtDesc(UUID projectId, UUID targetId);
+    boolean existsByIdAndProjectId(UUID id, UUID projectId);
+}
+```
+
+Notable: ordering by `verifiedAt DESC` (not `createdAt DESC`) because verification results should be ordered by when the verification ran, not when the record was created in the database.
+
+### Step 1.5: Create command records
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/CreateVerificationResultCommand.java`
+
+```java
+public record CreateVerificationResultCommand(
+    UUID projectId,
+    UUID targetId,           // nullable
+    UUID requirementId,      // nullable
+    String prover,
+    String property,         // nullable
+    VerificationStatus result,
+    AssuranceLevel assuranceLevel,  // nullable
+    Map<String, Object> evidence,   // nullable
+    Instant verifiedAt,
+    Instant expiresAt        // nullable
+) {}
+```
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/UpdateVerificationResultCommand.java`
+
+```java
+public record UpdateVerificationResultCommand(
+    String prover,               // nullable (null = don't update)
+    String property,             // nullable
+    VerificationStatus result,   // nullable
+    AssuranceLevel assuranceLevel, // nullable
+    Map<String, Object> evidence,  // nullable
+    Instant verifiedAt,          // nullable
+    Instant expiresAt            // nullable
+) {}
+```
+
+### Step 1.6: Create service VerificationResultService
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/VerificationResultService.java`
+
+Follow the ControlService.java pattern:
+- `@Service @Transactional`
+- Constructor injection of `VerificationResultRepository`, `ProjectService`, `RequirementRepository` (for validating requirementId), `TraceabilityLinkRepository` (for validating targetId)
+- Methods:
+  - `create(CreateVerificationResultCommand)` -- validates project, optionally resolves target/requirement FKs, saves, logs
+  - `update(UUID projectId, UUID id, UpdateVerificationResultCommand)` -- find-or-throw, apply non-null fields, save, log
+  - `getById(UUID projectId, UUID id)` -- read-only, find-or-throw
+  - `listByProject(UUID projectId)` -- read-only, returns list ordered by verifiedAt DESC
+  - `listByRequirement(UUID projectId, UUID requirementId)` -- read-only, filter by requirement
+  - `listByTarget(UUID projectId, UUID targetId)` -- read-only, filter by target
+  - `delete(UUID projectId, UUID id)` -- find-or-throw, delete, log
+
+Logging pattern (matching Control):
+```
+log.info("verification_result_created: id={} prover={} project={}", ...)
+log.info("verification_result_updated: id={}", ...)
+log.info("verification_result_deleted: id={}", ...)
+```
+
+FK validation on create:
+- If `targetId` is provided, look up `TraceabilityLink` by ID and confirm it belongs to the same project (via its requirement's project). Throw NotFoundException if not found.
+- If `requirementId` is provided, look up `Requirement` by ID and confirm it belongs to the same project. Throw NotFoundException if not found.
+
+---
+
+## Phase 2: REST API Layer
+
+### Step 2.1: Create request DTO
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/api/verification/VerificationResultRequest.java`
+
+```java
+public record VerificationResultRequest(
+    UUID targetId,
+    UUID requirementId,
+    @NotBlank @Size(max = 50) String prover,
+    String property,
+    @NotNull VerificationStatus result,
+    AssuranceLevel assuranceLevel,
+    Map<String, Object> evidence,
+    @NotNull Instant verifiedAt,
+    Instant expiresAt
+) {}
+```
+
+### Step 2.2: Create update request DTO
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/api/verification/UpdateVerificationResultRequest.java`
+
+```java
+public record UpdateVerificationResultRequest(
+    @Size(max = 50) String prover,
+    String property,
+    VerificationStatus result,
+    AssuranceLevel assuranceLevel,
+    Map<String, Object> evidence,
+    Instant verifiedAt,
+    Instant expiresAt
+) {}
+```
+
+### Step 2.3: Create response DTO
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/api/verification/VerificationResultResponse.java`
+
+```java
+public record VerificationResultResponse(
+    UUID id,
+    String graphNodeId,
+    String projectIdentifier,
+    UUID targetId,
+    UUID requirementId,
+    String prover,
+    String property,
+    VerificationStatus result,
+    AssuranceLevel assuranceLevel,
+    Map<String, Object> evidence,
+    Instant verifiedAt,
+    Instant expiresAt,
+    Instant createdAt,
+    Instant updatedAt
+) {
+    public static VerificationResultResponse from(VerificationResult vr) {
+        return new VerificationResultResponse(
+            vr.getId(),
+            GraphIds.nodeId(GraphEntityType.VERIFICATION_RESULT, vr.getId()),
+            vr.getProject().getIdentifier(),
+            vr.getTarget() != null ? vr.getTarget().getId() : null,
+            vr.getRequirement() != null ? vr.getRequirement().getId() : null,
+            vr.getProver(),
+            vr.getProperty(),
+            vr.getResult(),
+            vr.getAssuranceLevel(),
+            vr.getEvidence(),
+            vr.getVerifiedAt(),
+            vr.getExpiresAt(),
+            vr.getCreatedAt(),
+            vr.getUpdatedAt()
+        );
+    }
+}
+```
+
+**Note:** This requires adding `VERIFICATION_RESULT` to the `GraphEntityType` enum.
+
+### Step 2.4: Create controller
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/api/verification/VerificationResultController.java`
+
+```
+@RestController
+@RequestMapping("/api/v1/verification-results")
+```
+
+Endpoints (following ControlController pattern):
+- `POST /` -- create, returns 201
+- `GET /` -- list by project, optional `requirementId` and `targetId` query params for filtering
+- `GET /{id}` -- get by ID
+- `PUT /{id}` -- update
+- `DELETE /{id}` -- delete, returns 204
+
+All endpoints accept `@RequestParam(required = false) String project`.
+
+The list endpoint supports optional filtering:
+- `GET /api/v1/verification-results?project=foo` -- all results for project
+- `GET /api/v1/verification-results?project=foo&requirementId=UUID` -- filter by requirement
+- `GET /api/v1/verification-results?project=foo&targetId=UUID` -- filter by target
+
+---
+
+## Phase 3: Database Migrations
+
+### Step 3.1: Main table migration
+
+**File:** `backend/src/main/resources/db/migration/V049__create_verification_result.sql`
+
+```sql
+CREATE TABLE verification_result (
+    id                UUID PRIMARY KEY,
+    project_id        UUID         NOT NULL REFERENCES project(id),
+    target_id         UUID         REFERENCES traceability_link(id),
+    requirement_id    UUID         REFERENCES requirement(id),
+    prover            VARCHAR(50)  NOT NULL,
+    property          TEXT,
+    result            VARCHAR(20)  NOT NULL,
+    assurance_level   VARCHAR(5),
+    evidence          TEXT,
+    verified_at       TIMESTAMPTZ  NOT NULL,
+    expires_at        TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ  NOT NULL,
+    updated_at        TIMESTAMPTZ  NOT NULL
+);
+
+CREATE INDEX idx_verification_result_project ON verification_result (project_id);
+CREATE INDEX idx_verification_result_target ON verification_result (target_id);
+CREATE INDEX idx_verification_result_requirement ON verification_result (requirement_id);
+CREATE INDEX idx_verification_result_result ON verification_result (result);
+CREATE INDEX idx_verification_result_prover ON verification_result (project_id, prover);
+CREATE INDEX idx_verification_result_verified_at ON verification_result (project_id, verified_at);
+```
+
+Design notes on indexes:
+- `idx_verification_result_project` -- required for all project-scoped queries
+- `idx_verification_result_target` / `idx_verification_result_requirement` -- for FK-based filtering
+- `idx_verification_result_result` -- for queries like "show all REFUTED results"
+- `idx_verification_result_prover` -- for queries like "show all openjml-esc results in this project"
+- `idx_verification_result_verified_at` -- for time-range queries and ordering
+
+### Step 3.2: Audit table migration
+
+**File:** `backend/src/main/resources/db/migration/V050__create_verification_result_audit.sql`
+
+```sql
+CREATE TABLE verification_result_audit (
+    id                UUID         NOT NULL,
+    rev               INTEGER      NOT NULL REFERENCES revinfo(rev),
+    revtype           SMALLINT     NOT NULL,
+    prover            VARCHAR(50),
+    property          TEXT,
+    result            VARCHAR(20),
+    assurance_level   VARCHAR(5),
+    evidence          TEXT,
+    verified_at       TIMESTAMPTZ,
+    expires_at        TIMESTAMPTZ,
+    PRIMARY KEY (id, rev)
+);
+```
+
+Note: The audit table omits `project_id`, `target_id`, and `requirement_id` because those ManyToOne relationships are `@NotAudited` (following the Control.java pattern where project_id is excluded from the audit table).
+
+---
+
+## Phase 4: Update Existing Files
+
+### Step 4.1: Add VERIFICATION_RESULT to GraphEntityType
+
+**File:** `backend/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphEntityType.java`
+
+Add `VERIFICATION_RESULT` to the enum. Current last entry is `CONTROL_LINK`.
+
+### Step 4.2: Update MigrationSmokeTest
+
+**File:** `backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java`
+
+1. Add `"049", "050"` to the `containsExactly()` assertion in `allFlywayMigrationsRan()`
+2. Add table existence checks in `auditTablesExist()`:
+   ```java
+   entityManager.createNativeQuery("SELECT 1 FROM verification_result LIMIT 1").getResultList();
+   entityManager.createNativeQuery("SELECT 1 FROM verification_result_audit LIMIT 1").getResultList();
+   ```
+
+---
+
+## Phase 5: Tests
+
+### Step 5.1: Service unit test
+
+**File:** `backend/src/test/java/com/keplerops/groundcontrol/unit/domain/VerificationResultServiceTest.java`
+
+Follow `ControlServiceTest.java` pattern exactly:
+- `@ExtendWith(MockitoExtension.class)`
+- `@Mock` VerificationResultRepository, ProjectService, RequirementRepository, TraceabilityLinkRepository
+- `@InjectMocks` VerificationResultService
+- `@Nested` classes: Create, Update, GetById, ListByProject, ListByRequirement, Delete
+
+Test cases:
+- **Create**: creates result with required fields, logs, returns entity
+- **Create with targetId**: validates target exists, sets relationship
+- **Create with requirementId**: validates requirement exists, sets relationship
+- **Create with invalid targetId**: throws NotFoundException
+- **Create with invalid requirementId**: throws NotFoundException
+- **Update**: applies non-null fields, preserves others
+- **GetById**: returns result
+- **GetById not found**: throws NotFoundException
+- **ListByProject**: returns list
+- **ListByRequirement**: filters by requirement
+- **ListByTarget**: filters by target
+- **Delete**: deletes and logs
+
+### Step 5.2: Controller unit test
+
+**File:** `backend/src/test/java/com/keplerops/groundcontrol/unit/api/VerificationResultControllerTest.java`
+
+Follow `ControlControllerTest.java` pattern exactly:
+- `@WebMvcTest(VerificationResultController.class)`
+- `@MockitoBean` VerificationResultService, ProjectService
+- Helper `makeVerificationResult()` that creates a VerificationResult with `TestUtil.setField()` for id/createdAt/updatedAt
+
+Test cases:
+- **createReturns201**: POST with valid JSON, assert 201 and response fields
+- **listReturnsResults**: GET list, assert array response
+- **getByIdReturnsResult**: GET by ID, assert fields
+- **updateReturnsUpdatedResult**: PUT with partial fields, assert update
+- **deleteReturns204**: DELETE, verify service called
+- **listFiltersByRequirement**: GET with requirementId param, verify service called with correct args
+- **listFiltersByTarget**: GET with targetId param, verify service called with correct args
+
+---
+
+## Phase 6: MCP Layer
+
+### Step 6.1: Add constants and API functions to lib.js
+
+**File:** `mcp/ground-control/lib.js`
+
+Add after the Control section (after line ~1687, before the Methodology Profile section):
+
+Constants:
+```javascript
+export const VERIFICATION_STATUSES = ["PROVEN", "REFUTED", "TIMEOUT", "UNKNOWN", "ERROR"];
+export const ASSURANCE_LEVELS = ["L0", "L1", "L2", "L3"];
+```
+
+API functions (5 functions):
+```javascript
+export async function createVerificationResult(data, project) {
+  return request("POST", "/api/v1/verification-results", { body: data, params: { project } });
+}
+
+export async function listVerificationResults({ requirementId, targetId, project } = {}) {
+  return request("GET", "/api/v1/verification-results", {
+    params: { requirementId, targetId, project },
+  });
+}
+
+export async function getVerificationResult(id, project) {
+  return request("GET", `/api/v1/verification-results/${encodeURIComponent(id)}`, {
+    params: { project },
+  });
+}
+
+export async function updateVerificationResult(id, data, project) {
+  return request("PUT", `/api/v1/verification-results/${encodeURIComponent(id)}`, {
+    body: data,
+    params: { project },
+  });
+}
+
+export async function deleteVerificationResult(id, project) {
+  await request("DELETE", `/api/v1/verification-results/${encodeURIComponent(id)}`, {
+    params: { project },
+  });
+}
+```
+
+### Step 6.2: Add tool definitions to index.js
+
+**File:** `mcp/ground-control/index.js`
+
+Add imports at the top (in the import block from `./lib.js`):
+```javascript
+createVerificationResult,
+listVerificationResults,
+getVerificationResult,
+updateVerificationResult,
+deleteVerificationResult,
+VERIFICATION_STATUSES,
+ASSURANCE_LEVELS,
+```
+
+Add 5 tool definitions before the `// Start` section (before line ~3670):
+
+**gc_create_verification_result** -- Create a verification result from any prover/verifier.
+- Schema: `target_id` (uuid, optional), `requirement_id` (uuid, optional), `prover` (string, required, max 50), `property` (string, optional), `result` (enum VERIFICATION_STATUSES, required), `assurance_level` (enum ASSURANCE_LEVELS, optional), `evidence` (record, optional), `verified_at` (string/ISO instant, required), `expires_at` (string/ISO instant, optional), `project` (string, optional)
+
+**gc_list_verification_results** -- List verification results, optionally filtered by requirement or target.
+- Schema: `requirement_id` (uuid, optional), `target_id` (uuid, optional), `project` (string, optional)
+
+**gc_get_verification_result** -- Get a verification result by UUID.
+- Schema: `id` (uuid, required), `project` (string, optional)
+
+**gc_update_verification_result** -- Update a verification result.
+- Schema: `id` (uuid, required), `prover` (string, optional), `property` (string, optional), `result` (enum, optional), `assurance_level` (enum, optional), `evidence` (record, optional), `verified_at` (string, optional), `expires_at` (string, optional), `project` (string, optional)
+
+**gc_delete_verification_result** -- Delete a verification result.
+- Schema: `id` (uuid, required), `project` (string, optional)
+
+---
+
+## File Creation/Modification Summary
+
+### New files to create (15 files):
+
+| # | File | Description |
+|---|------|-------------|
+| 1 | `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/state/VerificationStatus.java` | Result enum |
+| 2 | `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/state/AssuranceLevel.java` | Assurance level enum |
+| 3 | `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/model/VerificationResult.java` | JPA entity |
+| 4 | `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/repository/VerificationResultRepository.java` | Spring Data repository |
+| 5 | `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/CreateVerificationResultCommand.java` | Create command record |
+| 6 | `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/UpdateVerificationResultCommand.java` | Update command record |
+| 7 | `backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/VerificationResultService.java` | Domain service |
+| 8 | `backend/src/main/java/com/keplerops/groundcontrol/api/verification/VerificationResultRequest.java` | Create request DTO |
+| 9 | `backend/src/main/java/com/keplerops/groundcontrol/api/verification/UpdateVerificationResultRequest.java` | Update request DTO |
+| 10 | `backend/src/main/java/com/keplerops/groundcontrol/api/verification/VerificationResultResponse.java` | Response DTO |
+| 11 | `backend/src/main/java/com/keplerops/groundcontrol/api/verification/VerificationResultController.java` | REST controller |
+| 12 | `backend/src/main/resources/db/migration/V049__create_verification_result.sql` | Main table migration |
+| 13 | `backend/src/main/resources/db/migration/V050__create_verification_result_audit.sql` | Audit table migration |
+| 14 | `backend/src/test/java/com/keplerops/groundcontrol/unit/domain/VerificationResultServiceTest.java` | Service unit test |
+| 15 | `backend/src/test/java/com/keplerops/groundcontrol/unit/api/VerificationResultControllerTest.java` | Controller unit test |
+
+### Existing files to modify (4 files):
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `backend/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphEntityType.java` | Add `VERIFICATION_RESULT` enum value |
+| 2 | `backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java` | Add V049, V050 to version list; add table existence checks |
+| 3 | `mcp/ground-control/lib.js` | Add 2 constants + 5 API functions (~30 lines) |
+| 4 | `mcp/ground-control/index.js` | Add 7 imports + 5 tool definitions (~120 lines) |
+
+---
+
+## Implementation Order
+
+Execute in this exact sequence to maintain compilability at each step:
+
+1. **Enums first** (Steps 1.1, 1.2) -- no dependencies
+2. **GraphEntityType update** (Step 4.1) -- no dependencies, needed by Response DTO
+3. **Entity** (Step 1.3) -- depends on enums, BaseEntity, Project, Requirement, TraceabilityLink
+4. **Repository** (Step 1.4) -- depends on entity
+5. **Command records** (Step 1.5) -- depends on enums
+6. **Service** (Step 1.6) -- depends on repository, commands, ProjectService
+7. **DTOs** (Steps 2.1, 2.2, 2.3) -- depends on entity, enums, GraphEntityType, GraphIds
+8. **Controller** (Step 2.4) -- depends on service, DTOs, ProjectService
+9. **Migrations** (Steps 3.1, 3.2) -- independent of Java code, but must be present for integration tests
+10. **MigrationSmokeTest update** (Step 4.2) -- depends on migrations
+11. **Service test** (Step 5.1) -- depends on service, commands, entity
+12. **Controller test** (Step 5.2) -- depends on controller, DTOs, service
+13. **MCP lib.js** (Step 6.1) -- independent of backend
+14. **MCP index.js** (Step 6.2) -- depends on lib.js additions
+
+---
+
+## Dependency Considerations
+
+### Repository imports needed in VerificationResultService
+
+The service needs to resolve FK references. Preferred approach: inject `TraceabilityLinkRepository` and `RequirementRepository` directly. The service calls `findById()` on them to resolve the FK entities, then passes them to the entity setters. This matches how ControlService injects ProjectService to resolve project references.
+
+Both repositories exist at:
+- `backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/TraceabilityLinkRepository.java`
+- `backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/RequirementRepository.java`
+
+Both have `findById()` from JpaRepository. We validate project ownership:
+- For Requirement: `requirement.getProject().getId().equals(projectId)`
+- For TraceabilityLink: `traceabilityLink.getRequirement().getProject().getId().equals(projectId)`
+
+### No circular dependency risk
+
+The verification domain depends on:
+- `domain/projects/` (ProjectService for project resolution)
+- `domain/requirements/` (RequirementRepository, TraceabilityLinkRepository for FK resolution)
+
+Neither of those will depend on the verification domain.
+
+---
+
+## Potential Challenges
+
+1. **TraceabilityLink project validation**: TraceabilityLink does not have a direct `project_id` column. It belongs to a Requirement which belongs to a Project. The service must traverse `traceabilityLink.getRequirement().getProject()` to validate project ownership. Since TraceabilityLink has `@ManyToOne(fetch = FetchType.LAZY)` for `requirement`, this will trigger a lazy load -- acceptable for create operations.
+
+2. **evidence field serialization**: The `StringObjectMapConverter` stores as TEXT, not native JSONB. This matches the existing pattern (Control.methodology_factors, Control.effectiveness). The migration column type must be `TEXT` (not `JSONB`), consistent with existing migrations.
+
+3. **verifiedAt vs createdAt ordering**: The list endpoint orders by `verifiedAt DESC`, not `createdAt DESC`. A verification result might be created in the database after the actual verification ran (batch import scenario). The `verifiedAt` field captures the actual verification timestamp.
+
+4. **MCP snake_case conversion**: The `request()` function in lib.js auto-converts between snake_case (MCP) and camelCase (Java REST API). Fields like `target_id` in MCP become `targetId` in the JSON body sent to the backend. No special handling needed.
+
+5. **Controller list endpoint branching**: The list endpoint has three paths (all results, filter by requirement, filter by target). The controller should check which optional params are provided and call the appropriate service method. This is straightforward conditional logic in the controller.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.105.0] - 2026-04-06
+
+### Added
+
+- Asset-centric traceability target types: ISSUE, CODE, CONFIGURATION added
+  to AssetLinkTargetType for first-class traceability from assets to issues,
+  code files, and configuration artifacts (GC-M017)
+- ControlGraphProjectionContributor: projects Control entities as graph nodes
+  and ControlLink edges into the mixed-entity graph
+
+### Fixed
+
+- CONTROL asset links now produce graph edges in AssetGraphProjectionContributor
+  (previously silently dropped)
+- CONTROL risk-scenario links now produce graph edges in
+  RiskGraphProjectionContributor (same fix)
+- Stale JPA @Column(length=20) annotations on AssetLink.targetType and
+  RiskScenarioLink.targetType corrected to length=40 (matching V043 migration)
+
 ## [0.104.0] - 2026-04-06
 
 ### Added

--- a/architecture/adrs/012-formal-methods-process.md
+++ b/architecture/adrs/012-formal-methods-process.md
@@ -111,7 +111,7 @@ When in doubt, use L0 during pre-alpha. The bar rises at beta.
 - Version: OpenJML 21-0.21 (JDK 21 series)
 - Gradle tasks: `./gradlew downloadOpenJml` (fetches binary), `./gradlew openjmlEsc` (runs Z3 prover)
 - Defined in: `backend/gradle/openjml.gradle.kts`, applied from `build.gradle.kts`
-- Scope: `domain/requirements/state/` only (pure enums with no framework annotations)
+- Scope: `domain/requirements/state/` and `domain/verification/state/` only (pure enums with no framework annotations). Other `state/` packages (`assets`, `controls`, `riskscenarios`) contain L0 value enums not covered by ESC.
 - Gradle up-to-date checking: skips when source files haven't changed (~1s no-op)
 - **Known limitations**: OpenJML's bundled `CharSequence.jml` spec has invariant bugs that cause false positives on classes with `String` constructor parameters. JPA entities fail due to Hibernate's no-arg constructor leaving fields `null`. These classes remain at L1 (contract + test pairs). See `docs/CODING_STANDARDS.md` "OpenJML ESC Scoping" for design guidelines.
 

--- a/backend/.serena/.gitignore
+++ b/backend/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/backend/.serena/memories/GC-Traceability-Exploration-Report.md
+++ b/backend/.serena/memories/GC-Traceability-Exploration-Report.md
@@ -1,0 +1,688 @@
+# Ground Control Traceability Model - Comprehensive Exploration Report
+
+## Overview
+Ground Control implements a sophisticated traceability system connecting requirements, assets, and other entities through multiple types of relationships and links. The model supports bidirectional impact analysis across both the requirement dependency graph and asset topology.
+
+---
+
+## 1. TRACEABILITY LINK ENTITY (Requirement-to-Artifact Links)
+
+### TraceabilityLink Model
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/TraceabilityLink.java` (Lines 18-143)
+
+**Purpose:** Links a requirement to an external artifact for traceability
+
+**Key Fields:**
+- `requirement` (Requirement): The source requirement (ManyToOne, FetchType.LAZY, required)
+- `artifactType` (ArtifactType enum): Type of the artifact
+- `artifactIdentifier` (String): Unique identifier in external system (max 500 chars)
+- `linkType` (LinkType enum): Nature of the relationship
+- `syncStatus` (SyncStatus enum): Sync state with external source (default: SYNCED)
+- `artifactUrl` (String): URL to the artifact (max 2000 chars, default: "")
+- `artifactTitle` (String): Display name for the artifact (max 255 chars, default: "")
+- `lastSyncedAt` (Instant): Last synchronization timestamp
+
+**Uniqueness Constraint:**
+- Composite unique constraint on: requirement_id, artifact_type, artifact_identifier, link_type
+
+**JPA Annotations:**
+- @Audited (Hibernate Envers for audit trail)
+- @Entity, @Table, @SuppressWarnings for JML contract annotations
+
+---
+
+### ArtifactType Enum
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/ArtifactType.java`
+
+```
+GITHUB_ISSUE
+PULL_REQUEST
+CODE_FILE
+ADR (Architecture Decision Record)
+CONFIG
+POLICY
+TEST
+SPEC
+PROOF
+DOCUMENTATION
+RISK_SCENARIO
+CONTROL
+```
+
+---
+
+### LinkType Enum
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/LinkType.java`
+
+```
+IMPLEMENTS - artifact implements the requirement
+TESTS     - artifact tests/validates the requirement
+DOCUMENTS - artifact documents the requirement
+CONSTRAINS - artifact constrains the requirement
+VERIFIES  - artifact verifies the requirement
+```
+
+---
+
+### SyncStatus Enum
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/SyncStatus.java`
+
+```
+SYNCED  - artifact is in sync with Ground Control
+STALE   - artifact is out of sync
+BROKEN  - link to artifact is broken/invalid
+```
+
+---
+
+## 2. TRACEABILITY LINK REPOSITORY
+
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/TraceabilityLinkRepository.java`
+
+**Key Query Methods:**
+- `findByRequirementId(UUID)` → List<TraceabilityLink>
+- `findByRequirementIdIn(Collection<UUID>)` → List<TraceabilityLink> (bulk fetch)
+- `findByArtifactType(ArtifactType)` → List<TraceabilityLink>
+- `existsByRequirementIdAndArtifactTypeAndArtifactIdentifierAndLinkType(...)` → boolean (uniqueness check)
+- `existsByRequirementId(UUID)` → boolean
+- `existsByRequirementIdAndLinkType(UUID, LinkType)` → boolean (coverage check)
+- `findRequirementIdsWithLinkType(Collection<UUID> requirementIds, LinkType linkType)` → Set<UUID> (custom query for bulk coverage analysis)
+- `findByArtifactTypeAndArtifactIdentifierWithRequirement(...)` → List<TraceabilityLink> (JOIN FETCH requirement)
+
+---
+
+## 3. TRACEABILITY SERVICE
+
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityService.java` (Lines 15-90)
+
+**Purpose:** Service for managing traceability link lifecycle
+
+**Key Methods:**
+1. `createLink(UUID requirementId, CreateTraceabilityLinkCommand cmd)` → TraceabilityLink
+   - Validates requirement exists
+   - Prevents duplicate links
+   - Handles artifact type and link type validation
+
+2. `createLinkUnchecked(Requirement req, ArtifactType type, String identifier, LinkType linkType)` → TraceabilityLink
+   - Creates link without existence checks
+
+3. `createLink(Requirement req, ArtifactType type, String identifier, LinkType linkType)` → TraceabilityLink (Overloaded)
+   - Full implementation with validation
+   - Persists link to database
+   - Validates artifact identifier is non-empty
+
+4. `getLinksForRequirement(UUID requirementId)` → List<TraceabilityLink>
+   - Retrieves all links for a requirement
+
+5. `deleteLink(UUID linkId)` → void
+   - Deletes traceability link by ID
+
+**Fields:**
+- `requirementRepository` (RequirementRepository)
+- `traceabilityLinkRepository` (TraceabilityLinkRepository)
+
+---
+
+## 4. ASSET-CENTRIC TRACEABILITY (Asset Links)
+
+### AssetLink Model
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/model/AssetLink.java`
+
+**Purpose:** Links an operational asset to requirements, controls, risk scenarios, findings, or external artifacts
+
+**Key Fields:**
+- `asset` (OperationalAsset): Source asset (ManyToOne, required)
+- `targetType` (AssetLinkTargetType enum): Type of target entity
+- `targetEntityId` (UUID): ID of target in Ground Control (for internal targets)
+- `targetIdentifier` (String): External identifier (max 500 chars)
+- `linkType` (AssetLinkType enum): Relationship type
+- `targetUrl` (String): URL to target (max 2000 chars)
+- `targetTitle` (String): Display name (max 255 chars)
+
+**Uniqueness Constraints:**
+- Composite on: asset_id, target_type, target_identifier, link_type
+- Composite on: asset_id, target_type, target_entity_id, link_type
+
+---
+
+### AssetLinkType Enum
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetLinkType.java`
+
+```
+IMPLEMENTS    - asset implements the target
+MITIGATES     - asset mitigates the target risk
+SUBJECT_OF    - asset is subject of the target
+EVIDENCED_BY  - asset evidenced by the target
+GOVERNED_BY   - asset governed by the target
+DEPENDS_ON    - asset depends on the target
+ASSOCIATED    - asset associated with the target
+```
+
+---
+
+### AssetLinkTargetType Enum
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetLinkTargetType.java`
+
+```
+REQUIREMENT
+CONTROL
+RISK_SCENARIO
+RISK_REGISTER_RECORD
+RISK_ASSESSMENT_RESULT
+TREATMENT_PLAN
+METHODOLOGY_PROFILE
+THREAT_MODEL_ENTRY
+FINDING
+EVIDENCE
+AUDIT
+EXTERNAL
+```
+
+---
+
+## 5. ASSET RELATIONS (Asset-to-Asset Topology)
+
+### AssetRelation Model
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/model/AssetRelation.java`
+
+**Purpose:** Represents directed, typed relationships between operational assets (for topology/dependency modeling)
+
+**Key Fields:**
+- `source` (OperationalAsset): Source asset (ManyToOne, required)
+- `target` (OperationalAsset): Target asset (ManyToOne, required)
+- `relationType` (AssetRelationType enum): Type of relationship
+- `description` (String): Optional description (TEXT column)
+- `sourceSystem` (String): External source system (max 100 chars)
+- `externalSourceId` (String): External identifier for the relation (max 500 chars)
+- `collectedAt` (Instant): When the relation was collected
+- `confidence` (String): Confidence/quality metadata (max 50 chars)
+
+**Uniqueness Constraint:**
+- Composite on: source_id, target_id, relation_type
+
+**Self-Relation Validation:**
+- Constructor throws DomainValidationException if source equals target
+
+---
+
+### AssetRelationType Enum
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetRelationType.java`
+
+```
+CONTAINS          - source contains target
+DEPENDS_ON        - source depends on target
+COMMUNICATES_WITH - source communicates with target
+TRUST_BOUNDARY    - source is trust boundary to target
+SUPPORTS          - source supports target
+ACCESSES          - source accesses target
+DATA_FLOW         - data flows from source to target
+```
+
+---
+
+## 6. REQUIREMENT RELATIONS (Requirement Dependency Graph)
+
+### RequirementRelation Model
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/RequirementRelation.java`
+
+**Purpose:** Represents directed dependencies/relationships between requirements
+
+**Key Fields:**
+- `source` (Requirement): Source requirement (ManyToOne, required)
+- `target` (Requirement): Target requirement (ManyToOne, required)
+- `relationType` (RelationType enum): Type of relationship
+- `description` (String): Optional description (TEXT column)
+- `createdAt` (Instant): Creation timestamp
+
+**Uniqueness Constraint:**
+- Composite on: source_id, target_id, relation_type
+
+---
+
+### RelationType Enum
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/RelationType.java`
+
+```
+PARENT        - source is parent of target (hierarchy)
+DEPENDS_ON    - source depends on target
+CONFLICTS_WITH - source conflicts with target
+REFINES       - source refines target (decomposition)
+SUPERSEDES    - source supersedes target
+RELATED       - source related to target
+```
+
+**DAG Types (used for impact analysis):**
+- RelationType.PARENT
+- RelationType.DEPENDS_ON
+- RelationType.REFINES
+
+---
+
+## 7. IMPACT ANALYSIS FUNCTIONALITY
+
+### AnalysisService - Requirement Impact Analysis
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/AnalysisService.java` (Lines 31-518)
+
+**Key Method: `impactAnalysis(UUID requirementId)` (Lines 103-132)**
+
+```java
+public Set<Requirement> impactAnalysis(UUID requirementId) {
+    // 1. Find requirement and verify it exists
+    Requirement seed = requirementRepository.findById(requirementId)
+        .orElseThrow(() -> new NotFoundException(...));
+
+    // 2. Get all DAG-type relations for the project
+    UUID projectId = seed.getProject().getId();
+    List<RequirementRelation> relations = relationRepository
+        .findActiveByProjectAndRelationTypeIn(projectId, DAG_TYPES);
+
+    // 3. Build reverse adjacency list (downstream = those that depend on target)
+    // target -> list of sources (who depends on this target)
+    Map<UUID, List<UUID>> reverseAdj = new HashMap<>();
+    for (RequirementRelation rel : relations) {
+        UUID sourceId = rel.getSource().getId();
+        UUID targetId = rel.getTarget().getId();
+        reverseAdj.computeIfAbsent(targetId, k -> new ArrayList<>()).add(sourceId);
+    }
+
+    // 4. Find all reachable nodes from seed using BFS
+    Set<UUID> reachableIds = GraphAlgorithms.findReachable(requirementId, reverseAdj);
+
+    // 5. Fetch and return all impacted requirements
+    List<Requirement> fetched = requirementRepository.findAllById(reachableIds);
+    return new HashSet<>(fetched);
+}
+```
+
+**How It Works:**
+1. Builds reverse dependency graph (reverse edges of PARENT, DEPENDS_ON, REFINES relations)
+2. Uses BFS to find all nodes reachable from the seed requirement
+3. "Reachable" = all requirements that depend (directly or transitively) on the seed
+4. Returns set of all impacted requirements
+
+**DAG_TYPES Constant (Line 35-36):**
+```java
+private static final List<RelationType> DAG_TYPES =
+    List.of(RelationType.PARENT, RelationType.DEPENDS_ON, RelationType.REFINES);
+```
+
+---
+
+### AssetTopologyService - Asset Impact Analysis
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetTopologyService.java` (Lines 19-129)
+
+**Key Method: `computeImpactAnalysis(UUID projectId, UUID assetId)` (Lines 85-98)**
+
+```java
+private Set<OperationalAsset> computeImpactAnalysis(UUID projectId, UUID assetId) {
+    // 1. Get all active relations for project
+    List<AssetRelation> relations = relationRepository.findActiveByProjectId(projectId);
+
+    // 2. Build reverse adjacency map (target -> sources that depend on it)
+    Map<UUID, List<UUID>> reverseAdj = new HashMap<>();
+    for (AssetRelation rel : relations) {
+        UUID sourceId = rel.getSource().getId();
+        UUID targetId = rel.getTarget().getId();
+        reverseAdj.computeIfAbsent(targetId, k -> new ArrayList<>()).add(sourceId);
+    }
+
+    // 3. Find all reachable assets from seed
+    Set<UUID> reachableIds = GraphAlgorithms.findReachable(assetId, reverseAdj);
+
+    // 4. Fetch and return assets
+    return assetRepository.findAllById(reachableIds).stream().collect(Collectors.toSet());
+}
+```
+
+**Public Methods:**
+- `impactAnalysis(UUID projectId, UUID assetId)` - project-scoped analysis
+- `impactAnalysis(UUID assetId)` - DEPRECATED fallback to compute from asset's project
+
+**Related Methods:**
+- `detectCycles(UUID projectId)` - detects cycles in asset topology
+- `extractSubgraph(UUID projectId, List<String> rootUids)` - bidirectional subgraph extraction
+
+---
+
+### GraphAlgorithms Utility Class
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GraphAlgorithms.java`
+
+**Purpose:** Pure graph algorithms (no Spring dependencies) with JML contracts
+
+**Key Static Methods:**
+
+1. **`findCycles(Map<UUID, List<UUID>> adjacencyList)` → List<List<UUID>>`**
+   - Uses DFS with three-color marking (WHITE=unvisited, GRAY=visiting, BLACK=done)
+   - Reconstructs cycles by backtracking when back edge found
+   - Returns list of cycles, each as ordered list of UUIDs
+
+2. **`findReachable(UUID start, Map<UUID, List<UUID>> adjacencyList)` → Set<UUID>`**
+   - BFS from start node
+   - Returns all reachable nodes including start itself
+   - **Used by impact analysis**
+
+3. **`findReachableFromMultiple(Set<UUID> roots, Map<UUID, List<UUID>> adjacencyList)` → Set<UUID>`**
+   - BFS from multiple starting points
+   - Returns all reachable nodes from any root
+
+4. **`topologicalSort(Map<UUID, List<UUID>> dependsOn, Comparator<UUID> tieBreaker)` → List<UUID>`**
+   - Kahn's algorithm with tie-breaking
+   - Computes in-degree dynamically
+   - Omits nodes involved in cycles
+   - **Used by work order generation**
+
+---
+
+## 8. MIXED GRAPH SERVICE (Cross-Entity Path Finding)
+
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/MixedGraphService.java` (Lines 22-179)
+
+**Purpose:** Provides graph traversal and path finding across mixed entity types (requirements, assets, risks, controls, etc.)
+
+**Key Methods:**
+
+1. **`findPaths(UUID projectId, String sourceNodeId, String targetNodeId, int maxDepth, List<String> entityTypeNames)` → List<GraphPathResult>` (Lines 46-88)**
+   - BFS to find path from source to target node
+   - Filters projection by entity types if provided
+   - Returns single path if found (or empty list)
+   - Each path includes edge type information
+
+2. **`neighborhoodProjection(UUID projectId, List<String> rootNodeIds, int depth)` → GraphProjection`** (Lines 90-128)
+   - BFS traversal from root nodes up to max depth
+   - Returns subgraph containing all reachable nodes and edges
+
+3. **`traverse(UUID projectId, List<String> roots, int maxDepth, List<String> entityTypeNames)` → GraphProjection`**
+   - Wrapper for neighborhood projection with filtering
+
+4. **`extractSubgraph(UUID projectId, List<String> roots)` → GraphProjection`**
+   - Delegates to MixedGraphClient
+
+5. **`getVisualization(UUID projectId)` → GraphProjection`**
+   - Delegates to MixedGraphClient (gets full graph)
+
+**Helper Methods:**
+- `buildAdjacency(List<GraphEdge> edges)` → Map<String, Set<String>>
+  - Creates adjacency map from edge list
+
+- `buildEdgeLookup(List<GraphEdge> edges)` → Map<String, GraphEdge>
+  - Creates bidirectional edge lookup for quick access
+
+- `undirectedKey(String id1, String id2)` → String
+  - Creates sorted pair key for bidirectional edge lookup
+
+---
+
+## 9. GRAPH MODELS
+
+### GraphNode Record
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphNode.java`
+
+```java
+public record GraphNode(
+    String id,                          // Graph node ID
+    String domainId,                    // UUID as string
+    GraphEntityType entityType,         // Entity type in graph
+    String projectIdentifier,           // Project ID as string
+    String uid,                         // Human-readable UID (e.g., "REQ-001")
+    String label,                       // Display label
+    Map<String, Object> properties      // Flexible metadata
+)
+```
+
+---
+
+### GraphEdge Record
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphEdge.java`
+
+```java
+public record GraphEdge(
+    String id,                          // Edge ID
+    String edgeType,                    // Relation/link type (e.g., "DEPENDS_ON")
+    String sourceId,                    // Source node ID
+    String targetId,                    // Target node ID
+    GraphEntityType sourceEntityType,   // Source entity type
+    GraphEntityType targetEntityType,   // Target entity type
+    Map<String, Object> properties      // Flexible metadata
+)
+```
+
+---
+
+### GraphEntityType Enum
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphEntityType.java`
+
+```
+REQUIREMENT
+OPERATIONAL_ASSET
+OBSERVATION
+RISK_SCENARIO
+RISK_REGISTER_RECORD
+RISK_ASSESSMENT_RESULT
+TREATMENT_PLAN
+METHODOLOGY_PROFILE
+CONTROL
+CONTROL_LINK
+VERIFICATION_RESULT
+```
+
+---
+
+### GraphProjection Record
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphProjection.java`
+
+```java
+public record GraphProjection(
+    List<GraphNode> nodes,
+    List<GraphEdge> edges
+)
+```
+
+Represents a subgraph/projection of the full mixed graph
+
+---
+
+## 10. REST CONTROLLERS
+
+### AnalysisController
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/api/admin/AnalysisController.java`
+
+**Endpoints:**
+- `GET /api/v1/analysis/cycles` - Detect cycles in requirement DAG
+- `GET /api/v1/analysis/orphans` - Find requirements with no relations
+- `GET /api/v1/analysis/coverage-gaps?linkType=...` - Find requirements missing specific link types
+- `GET /api/v1/analysis/impact/{id}` - **IMPACT ANALYSIS** - get all impacted requirements
+- `GET /api/v1/analysis/consistency-violations` - Detect CONFLICTS_WITH/SUPERSEDES violations
+- `GET /api/v1/analysis/completeness` - Analyze requirement field completeness
+- `GET /api/v1/analysis/cross-wave` - Validate cross-wave dependencies
+- `GET /api/v1/analysis/work-order` - Get topologically sorted work order
+- `GET /api/v1/analysis/dashboard-stats` - Get requirement statistics
+- `GET /api/v1/analysis/semantic-similarity` - Find semantically similar requirements
+
+---
+
+### AssetController
+**File:** `/home/atomik/src/Ground-Control/backend/src/main/java/com/keplerops/groundcontrol/api/assets/AssetController.java`
+
+**Key Impact Analysis Endpoints:**
+- `POST /api/v1/assets/links` - Create asset link
+- `GET /api/v1/assets/{id}/links` - Get links from asset
+- `GET /api/v1/assets/links/target` - Get links by target
+- `POST /api/v1/assets/cycles` - **CYCLE DETECTION** - detect cycles in asset topology
+- `GET /api/v1/assets/impact-analysis/{id}` - **IMPACT ANALYSIS** - get impacted assets
+- `GET /api/v1/assets/subgraph` - Extract asset subgraph
+
+---
+
+## 11. KEY RELATIONSHIPS AND FLOWS
+
+### Traceability Link Flow
+```
+Requirement ←→ TraceabilityLink ←→ External Artifact
+    (via requirement_id)              (via artifactType + artifactIdentifier)
+
+Traceability Coverage Analysis:
+- Find requirements with TESTS link type → coverage of TESTS
+- Find requirements missing specific link types → coverage gaps
+```
+
+### Requirement Impact Analysis Flow
+```
+1. User queries impact of Requirement A
+2. Service finds all RequirementRelations with A as target
+   (where relationType in [PARENT, DEPENDS_ON, REFINES])
+3. Reverses edges: creates target→sources map
+4. BFS from A through reverse edges → finds all downstream dependents
+5. Returns all requirements that depend (directly/transitively) on A
+```
+
+### Asset Impact Analysis Flow
+```
+1. User queries impact of Asset X
+2. Service finds all AssetRelations with X as target
+3. Reverses edges: creates target→sources map
+4. BFS from X through reverse edges → finds all downstream dependents
+5. Returns all assets that depend (directly/transitively) on X
+```
+
+### Cross-Entity Traceability
+```
+Asset ←→ AssetLink ←→ Requirement (via targetEntityId)
+Asset ←→ AssetLink ←→ Control
+Asset ←→ AssetLink ←→ RiskScenario
+...
+
+Supports linking operational assets to any modeled entity type
+```
+
+---
+
+## 12. KEY REPOSITORIES
+
+**Requirement-side:**
+- RequirementRepository - fetch requirements by ID, project, status, etc.
+- RequirementRelationRepository - manage requirement dependency relations
+- TraceabilityLinkRepository - manage requirement-to-artifact links
+
+**Asset-side:**
+- OperationalAssetRepository - manage assets
+- AssetRelationRepository - manage asset-to-asset topology
+- AssetLinkRepository - manage asset-to-entity links
+- AssetExternalIdRepository - manage external IDs for assets
+
+---
+
+## 13. IMPACT ANALYSIS ALGORITHM SUMMARY
+
+### Common Pattern (Both Requirement and Asset)
+
+**Input:** ID of entity (Requirement or Asset)
+
+**Algorithm:**
+```
+1. Fetch entity, verify exists, get project ID
+2. Fetch all active relations for project
+3. Build reverse adjacency map:
+   - For each relation (source → target):
+     - Add source to reverseAdj[target]
+4. BFS from input entity through reverse edges:
+   - visited = {}
+   - queue = [input]
+   - while queue not empty:
+     - current = queue.pop()
+     - for each upstream in reverseAdj[current]:
+       - if upstream not visited:
+         - mark visited
+         - queue.push(upstream)
+5. Return all visited entities
+
+**Time Complexity:** O(V + E) where V = entities, E = relations
+**Space Complexity:** O(V) for visited set and queue
+```
+
+**Why Reverse Edges?**
+- Forward edges show what depends on what
+- To find "impact of X" = find all that depend on X
+- Must traverse reverse edges (upstream → downstream)
+
+---
+
+## 14. GRAPH TRAVERSAL & PATH FINDING
+
+**Mixed Graph Service** provides uniform interface for:
+- **Path Finding:** BFS between any two graph nodes
+- **Neighborhood Extraction:** BFS up to depth N from root nodes
+- **Entity Type Filtering:** Include/exclude entity types in results
+- **Bidirectional Lookup:** Fast edge type resolution
+
+**Supported Entity Types in Graph:**
+- REQUIREMENT
+- OPERATIONAL_ASSET
+- OBSERVATION
+- RISK_SCENARIO
+- RISK_REGISTER_RECORD
+- RISK_ASSESSMENT_RESULT
+- TREATMENT_PLAN
+- METHODOLOGY_PROFILE
+- CONTROL
+- CONTROL_LINK
+- VERIFICATION_RESULT
+
+---
+
+## 15. ANALYSIS SERVICE CAPABILITIES
+
+Beyond impact analysis, AnalysisService provides:
+
+1. **Cycle Detection** - DFS-based cycle finding
+2. **Orphan Detection** - requirements with no relations
+3. **Coverage Gaps** - requirements missing specific link types
+4. **Consistency Violations** - CONFLICTS_WITH on ACTIVE items, etc.
+5. **Completeness Analysis** - missing required fields
+6. **Cross-Wave Validation** - dependency ordering issues
+7. **Work Order Generation** - topologically sorted by dependencies and priority
+8. **Dashboard Statistics** - counts by status, wave, coverage metrics
+9. **Subgraph Extraction** - connected component extraction
+10. **Graph Visualization** - convert to GraphProjection for UI
+
+---
+
+## 16. KEY FILE LOCATIONS SUMMARY
+
+**Core Models:**
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/TraceabilityLink.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/RequirementRelation.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/Requirement.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/model/OperationalAsset.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/model/AssetLink.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/model/AssetRelation.java`
+
+**State Enums:**
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/ArtifactType.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/LinkType.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/SyncStatus.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/RelationType.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetLinkType.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetLinkTargetType.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetRelationType.java`
+
+**Services:**
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityService.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/AnalysisService.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GraphAlgorithms.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetTopologyService.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/MixedGraphService.java`
+
+**Controllers:**
+- `/src/main/java/com/keplerops/groundcontrol/api/admin/AnalysisController.java`
+- `/src/main/java/com/keplerops/groundcontrol/api/assets/AssetController.java`
+- `/src/main/java/com/keplerops/groundcontrol/api/requirements/RequirementGraphController.java`
+
+**Repositories:**
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/TraceabilityLinkRepository.java`
+
+**Graph Models:**
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphNode.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphEdge.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphEntityType.java`
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphProjection.java`

--- a/backend/.serena/memories/GC-Traceability-File-Structure.md
+++ b/backend/.serena/memories/GC-Traceability-File-Structure.md
@@ -1,0 +1,368 @@
+# Ground Control Traceability - Complete File Structure
+
+## REQUIREMENT-SIDE TRACEABILITY
+
+### Models (Domain)
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/TraceabilityLink.java` (Lines 18-143)
+  - Entities: TraceabilityLink class
+  - Key fields: requirement, artifactType, artifactIdentifier, linkType, syncStatus, artifactUrl, artifactTitle, lastSyncedAt
+  - Constructors: 2 (no-arg, full)
+  - Methods: getters/setters for all fields
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/RequirementRelation.java`
+  - Entities: RequirementRelation class
+  - Key fields: id (UUID), source (Requirement), target (Requirement), relationType, description, createdAt
+  - Validation: Self-relation check in constructor
+  - Methods: getters, setDescription
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/model/Requirement.java`
+  - Core requirement entity (referenced by TraceabilityLink)
+
+### Enums (State)
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/ArtifactType.java`
+  - Values: GITHUB_ISSUE, PULL_REQUEST, CODE_FILE, ADR, CONFIG, POLICY, TEST, SPEC, PROOF, DOCUMENTATION, RISK_SCENARIO, CONTROL (12 total)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/LinkType.java`
+  - Values: IMPLEMENTS, TESTS, DOCUMENTS, CONSTRAINS, VERIFIES (5 total)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/SyncStatus.java`
+  - Values: SYNCED, STALE, BROKEN (3 total)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/state/RelationType.java`
+  - Values: PARENT, DEPENDS_ON, CONFLICTS_WITH, REFINES, SUPERSEDES, RELATED (6 total)
+  - DAG Types used in impact analysis: PARENT, DEPENDS_ON, REFINES
+
+### Repositories (Data Access)
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/TraceabilityLinkRepository.java`
+  - Extends: JpaRepository<TraceabilityLink, UUID>
+  - Key methods:
+    * findByRequirementId(UUID) → List
+    * findByRequirementIdIn(Collection) → List (bulk)
+    * findByArtifactType(ArtifactType) → List
+    * existsByRequirementIdAndArtifactTypeAndArtifactIdentifierAndLinkType(...) → boolean
+    * existsByRequirementId(UUID) → boolean
+    * existsByRequirementIdAndLinkType(UUID, LinkType) → boolean
+    * findRequirementIdsWithLinkType(Collection, LinkType) → Set (custom query)
+    * findByArtifactTypeAndArtifactIdentifierWithRequirement(...) → List (JOIN FETCH)
+
+- RequirementRelationRepository
+  - Not fully explored but used by AnalysisService
+  - Key method: findActiveByProjectAndRelationTypeIn(UUID, List<RelationType>) → List<RequirementRelation>
+
+- RequirementRepository
+  - Not fully explored but core for accessing requirements
+
+### Services (Business Logic)
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityService.java` (Lines 15-90)
+  - Responsibilities: Lifecycle management of traceability links
+  - Key methods:
+    * createLink(UUID requirementId, CreateTraceabilityLinkCommand) → TraceabilityLink
+    * createLinkUnchecked(Requirement, ArtifactType, String, LinkType) → TraceabilityLink
+    * createLink(Requirement, ArtifactType, String, LinkType) → TraceabilityLink [overload]
+    * getLinksForRequirement(UUID) → List<TraceabilityLink>
+    * deleteLink(UUID) → void
+  - Fields: requirementRepository, traceabilityLinkRepository
+  - Constructor: 2 params (requirementRepository, traceabilityLinkRepository)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/AnalysisService.java` (Lines 31-518)
+  - Responsibilities: Comprehensive requirement analysis (impact, cycles, orphans, etc.)
+  - Key methods:
+    * impactAnalysis(UUID requirementId) → Set<Requirement> [Lines 103-132]
+    * detectCycles(UUID projectId) → List<Cycle>
+    * findOrphans(UUID projectId) → List<Requirement>
+    * findCoverageGaps(UUID projectId, LinkType) → List<Requirement>
+    * detectConsistencyViolations(UUID projectId) → List<ConsistencyViolation>
+    * analyzeCompleteness(UUID projectId) → CompletenessResult
+    * crossWaveValidation(UUID projectId) → List<RelationValidation>
+    * getWorkOrder(UUID projectId) → WorkOrderResult
+    * getDashboardStats(UUID projectId) → DashboardStats
+    * extractSubgraph(UUID projectId, List<String> rootUids) → Subgraph
+    * getGraphVisualization(UUID projectId) → GraphProjection
+  - Constants:
+    * DAG_TYPES = [PARENT, DEPENDS_ON, REFINES] [Lines 35-36]
+    * SATISFIED_STATUSES = [ACTIVE, DEPRECATED, ARCHIVED] [Line 38]
+    * PRIORITY_ORDER = [MUST→0, SHOULD→1, COULD→2, WONT→3] [Lines 40-41]
+  - Fields: requirementRepository, relationRepository, traceabilityLinkRepository, auditService
+  - Helper methods:
+    * indexRequirementsById() [Lines 204-210]
+    * buildDependencyMap() [Lines 212-223]
+    * computeBlockingStatuses() [Lines 225-243]
+    * findBlockers() [Lines 245-254]
+    * groupByWave() [Lines 256-262]
+    * buildWorkOrderResult() [Lines 264-292]
+    * topoSortWave() [Lines 294-332]
+    * buildWaveItems() [Lines 334-367]
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/GraphAlgorithms.java`
+  - Purpose: Pure graph algorithms (no Spring dependencies)
+  - Key static methods:
+    * findCycles(Map<UUID, List<UUID>>) → List<List<UUID>> [DFS with 3-color marking]
+    * findReachable(UUID, Map<UUID, List<UUID>>) → Set<UUID> [BFS from single node]
+    * findReachableFromMultiple(Set<UUID>, Map<UUID, List<UUID>>) → Set<UUID> [BFS from multiple roots]
+    * topologicalSort(Map<UUID, List<UUID>>, Comparator<UUID>) → List<UUID> [Kahn's algorithm]
+  - Helper methods:
+    * dfs() [private, recursive DFS]
+    * reconstructCycle() [private, cycle reconstruction]
+  - Constants: WHITE=0, GRAY=1, BLACK=2 [3-color marking for DFS]
+
+### Commands/DTOs
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/CreateTraceabilityLinkCommand.java`
+  - Used by TraceabilityService.createLink()
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityLinkChange.java`
+  - Audit trail for link changes
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityLinkRevision.java`
+  - Revision tracking for links
+
+### Controllers (REST API)
+- `/src/main/java/com/keplerops/groundcontrol/api/admin/AnalysisController.java` (Lines 15-109)
+  - Base path: /api/v1/analysis
+  - Endpoints:
+    * GET /cycles → List<CycleResponse>
+    * GET /orphans → List<RequirementSummaryResponse>
+    * GET /coverage-gaps?linkType=... → List<RequirementSummaryResponse>
+    * GET /impact/{id} → List<RequirementSummaryResponse> [IMPACT ANALYSIS]
+    * GET /consistency-violations → List<ConsistencyViolationResponse>
+    * GET /completeness → CompletenessResponse
+    * GET /cross-wave → List<RelationValidationResponse>
+    * GET /work-order → WorkOrderResponse
+    * GET /dashboard-stats → DashboardStatsResponse
+    * GET /semantic-similarity → SimilarityResultResponse
+  - Fields: analysisService, similarityService, projectService, defaultSimilarityThreshold
+  - Query param: project (optional, uses projectService.resolveProjectId)
+
+- `/src/main/java/com/keplerops/groundcontrol/api/requirements/RequirementGraphController.java`
+  - Not fully explored but handles requirement graph endpoints
+
+### Response DTOs
+- `/src/main/java/com/keplerops/groundcontrol/api/requirements/TraceabilityLinkResponse.java`
+- `/src/main/java/com/keplerops/groundcontrol/api/requirements/TraceabilityLinkHistoryResponse.java`
+- `/src/main/java/com/keplerops/groundcontrol/api/requirements/TraceabilityLinkRequest.java`
+
+---
+
+## ASSET-SIDE TRACEABILITY
+
+### Models (Domain)
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/model/OperationalAsset.java`
+  - Core asset entity (referenced by AssetLink and AssetRelation)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/model/AssetLink.java`
+  - Purpose: Links asset to requirement/control/risk/etc
+  - Key fields: asset (OperationalAsset), targetType (AssetLinkTargetType), targetEntityId (UUID), targetIdentifier (String), linkType (AssetLinkType), targetUrl, targetTitle
+  - Uniqueness constraints (2):
+    * (asset_id, target_type, target_identifier, link_type)
+    * (asset_id, target_type, target_entity_id, link_type)
+  - Methods: getters/setters for all fields
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/model/AssetRelation.java`
+  - Purpose: Asset-to-asset topology
+  - Key fields: source (OperationalAsset), target (OperationalAsset), relationType (AssetRelationType), description, sourceSystem, externalSourceId, collectedAt, confidence
+  - Uniqueness constraint: (source_id, target_id, relation_type)
+  - Validation: Self-relation check in constructor
+  - Methods: getters/setters
+
+### Enums (State)
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetLinkType.java`
+  - Values: IMPLEMENTS, MITIGATES, SUBJECT_OF, EVIDENCED_BY, GOVERNED_BY, DEPENDS_ON, ASSOCIATED (7 total)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetLinkTargetType.java`
+  - Values: REQUIREMENT, CONTROL, RISK_SCENARIO, RISK_REGISTER_RECORD, RISK_ASSESSMENT_RESULT, TREATMENT_PLAN, METHODOLOGY_PROFILE, THREAT_MODEL_ENTRY, FINDING, EVIDENCE, AUDIT, EXTERNAL (12 total)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetRelationType.java`
+  - Values: CONTAINS, DEPENDS_ON, COMMUNICATES_WITH, TRUST_BOUNDARY, SUPPORTS, ACCESSES, DATA_FLOW (7 total)
+
+### Repositories (Data Access)
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/repository/AssetLinkRepository.java`
+  - Extends: JpaRepository<AssetLink, UUID>
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/repository/AssetRelationRepository.java`
+  - Key method: findActiveByProjectId(UUID projectId) → List<AssetRelation>
+
+- OperationalAssetRepository
+  - Key methods:
+    * findByIdAndProjectId(UUID, UUID) → Optional<OperationalAsset>
+    * findByProjectIdAndUidIgnoreCase(UUID, String) → Optional<OperationalAsset>
+    * findAllById(Collection<UUID>) → List<OperationalAsset>
+
+- AssetExternalIdRepository
+  - Manages external IDs for assets
+
+### Services (Business Logic)
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java`
+  - Responsibilities: Asset lifecycle and cross-entity linking
+  - Fields: assetRepository, relationRepository, linkRepository, externalIdRepository, projectRepository, graphTargetResolverService
+  - Methods: (not fully explored)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetTopologyService.java` (Lines 19-129)
+  - Responsibilities: Asset topology analysis (impact, cycles, subgraph)
+  - Key methods:
+    * detectCycles(UUID projectId) → List<AssetCycleResult> [Lines 32-68]
+    * impactAnalysis(UUID projectId, UUID assetId) → Set<OperationalAsset> [Lines 70-75]
+    * impactAnalysis(UUID assetId) → Set<OperationalAsset> [Lines 77-83] [DEPRECATED]
+    * computeImpactAnalysis(UUID projectId, UUID assetId) → Set<OperationalAsset> [Lines 85-98]
+    * extractSubgraph(UUID projectId, List<String> rootUids) → AssetSubgraphResult [Lines 100-128]
+  - Impact Analysis Algorithm (same as requirement-side):
+    1. Get all active relations
+    2. Build reverse adjacency map (target → sources)
+    3. BFS from input asset through reverse edges
+    4. Return all reachable assets
+  - Cycle Detection:
+    1. Build adjacency set from relations
+    2. Convert to List-based adjacency map
+    3. Call GraphAlgorithms.findCycles()
+    4. Map cycle UUIDs back to asset UIDs
+  - Subgraph Extraction:
+    1. Bidirectional adjacency map
+    2. BFS from multiple roots
+    3. Filter relations to subgraph bounds
+  - Fields: assetRepository, relationRepository
+
+### Commands/DTOs
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/service/CreateAssetLinkCommand.java`
+  - Used by AssetService for creating links
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetSubgraphResult.java`
+  - Result of subgraph extraction
+
+- AssetCycleResult
+  - Contains cycle members (UIDs) and edges
+
+- AssetCycleEdge
+  - Edge info: sourceUid, targetUid, relationType
+
+### Controllers (REST API)
+- `/src/main/java/com/keplerops/groundcontrol/api/assets/AssetController.java` (Lines 29-293)
+  - Base path: /api/v1/assets
+  - Key endpoints:
+    * POST /links [Lines 154-171] - Create asset link
+    * GET /{id}/links [Lines 173-187] - Get links from asset
+    * DELETE /{id}/links/{linkId} [Lines 189-195] - Delete link
+    * GET /links/target [Lines 197-207] - Get links by target
+    * POST /cycles [Lines 269-277] - Detect cycles
+    * GET /impact-analysis/{id} [Lines 279-285] - IMPACT ANALYSIS
+    * GET /subgraph [Lines 287-292] - Extract subgraph
+  - Full list of methods:
+    * CRUD: create, list, getById, getByUid, update, delete, archive (Lines 44-101)
+    * Relations: createRelation, updateRelation, getRelations, deleteRelation (Lines 103-152)
+    * Links: createLink, getLinks, deleteLink, getLinksByTarget (Lines 154-207)
+    * External IDs: createExternalId, getExternalIds, updateExternalId, deleteExternalId, findByExternalId (Lines 209-267)
+    * Topology: detectCycles, impactAnalysis, extractSubgraph (Lines 269-292)
+  - Fields: assetService, topologyService, projectService
+
+### Response DTOs
+- `/src/main/java/com/keplerops/groundcontrol/api/assets/AssetLinkResponse.java`
+- `/src/main/java/com/keplerops/groundcontrol/api/assets/AssetLinkRequest.java`
+- `/src/main/java/com/keplerops/groundcontrol/api/assets/AssetResponse.java`
+- `/src/main/java/com/keplerops/groundcontrol/api/assets/AssetSubgraphResponse.java`
+- `/src/main/java/com/keplerops/groundcontrol/api/assets/SubgraphRequest.java`
+- ObservationResponse
+- ObservationController
+
+---
+
+## MIXED GRAPH (CROSS-ENTITY TRACEABILITY)
+
+### Models
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphNode.java`
+  - Record class
+  - Fields: id, domainId, entityType, projectIdentifier, uid, label, properties (Map)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphEdge.java`
+  - Record class
+  - Fields: id, edgeType, sourceId, targetId, sourceEntityType, targetEntityType, properties (Map)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphProjection.java`
+  - Record class
+  - Fields: nodes (List<GraphNode>), edges (List<GraphEdge>)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphEntityType.java`
+  - Enum with values: REQUIREMENT, OPERATIONAL_ASSET, OBSERVATION, RISK_SCENARIO, RISK_REGISTER_RECORD, RISK_ASSESSMENT_RESULT, TREATMENT_PLAN, METHODOLOGY_PROFILE, CONTROL, CONTROL_LINK, VERIFICATION_RESULT (11 types)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphIds.java`
+  - Graph ID utilities
+
+### Services
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/MixedGraphService.java` (Lines 22-179)
+  - Responsibilities: Cross-entity graph traversal and path finding
+  - Key methods:
+    * getVisualization(UUID projectId) → GraphProjection [Lines 32-34]
+    * extractSubgraph(UUID projectId, List<String> roots) → GraphProjection [Lines 36-39]
+    * traverse(UUID projectId, List<String> roots, int maxDepth, List<String> entityTypeNames) → GraphProjection [Lines 41-44]
+    * findPaths(UUID projectId, String sourceNodeId, String targetNodeId, int maxDepth, List<String> entityTypeNames) → List<GraphPathResult> [Lines 46-88]
+      - Algorithm: BFS between two nodes
+      - Returns single path or empty list
+      - Supports entity type filtering
+    * neighborhoodProjection(UUID projectId, List<String> rootNodeIds, int depth) → GraphProjection [Lines 90-128]
+      - Algorithm: BFS up to max depth
+      - Supports entity type filtering
+  - Helper methods:
+    * filterProjection(GraphProjection, Set<GraphEntityType>) → GraphProjection [Lines 130-142]
+    * parseEntityTypes(List<String>) → Set<GraphEntityType> [Lines 144-153]
+    * buildAdjacency(List<GraphEdge>) → Map<String, Set<String>> [Lines 155-166]
+    * buildEdgeLookup(List<GraphEdge>) → Map<String, GraphEdge> [Lines 168-174]
+    * undirectedKey(String, String) → String [Lines 176-178]
+  - Field: mixedGraphClient (MixedGraphClient)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/MixedGraphClient.java`
+  - Client for accessing mixed graph (not fully explored)
+  - Key method: getVisualization(UUID projectId) → GraphProjection
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphPathResult.java`
+  - Result of path finding
+  - Contains: path (List<String> of node IDs), edgeTypes (List<String>)
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphProjectionContributor.java`
+  - Interface for entities contributing to graph projection
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/RequirementGraphProjectionContributor.java`
+  - Implementation for requirement graph nodes/edges
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/AssetGraphProjectionContributor.java`
+  - Implementation for asset graph nodes/edges
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/RiskGraphProjectionContributor.java`
+  - Implementation for risk entity graph nodes/edges
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphProjectionRegistryService.java`
+  - Service for managing graph projection contributors
+
+- `/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java`
+  - Service for resolving link targets to entities
+
+### Controllers
+- `/src/main/java/com/keplerops/groundcontrol/api/requirements/RequirementGraphController.java`
+  - Not fully explored but handles graph endpoints
+
+---
+
+## SUMMARY STATISTICS
+
+**Total Enums:** 10
+- Requirement-side: ArtifactType, LinkType, SyncStatus, RelationType
+- Asset-side: AssetLinkType, AssetLinkTargetType, AssetRelationType
+- Graph: GraphEntityType
+
+**Total Model Classes:** 6
+- Requirement-side: TraceabilityLink, RequirementRelation, Requirement
+- Asset-side: AssetLink, AssetRelation, OperationalAsset
+
+**Total Repositories:** 5+
+- Requirement-side: TraceabilityLinkRepository, RequirementRelationRepository, RequirementRepository
+- Asset-side: AssetLinkRepository, AssetRelationRepository, OperationalAssetRepository, AssetExternalIdRepository
+
+**Total Services:** 8+
+- Requirement-side: TraceabilityService, AnalysisService, GraphAlgorithms (utility)
+- Asset-side: AssetService, AssetTopologyService
+- Graph: MixedGraphService, MixedGraphClient, supporting services
+
+**Total Controllers:** 3
+- AnalysisController (requirement analysis endpoints)
+- AssetController (asset management and analysis endpoints)
+- RequirementGraphController (requirement graph endpoints)
+
+**Total REST Endpoints:** 30+
+- Analysis endpoints: 10
+- Asset endpoints: 20+
+- Graph endpoints: TBD

--- a/backend/.serena/project.yml
+++ b/backend/.serena/project.yml
@@ -1,0 +1,152 @@
+# the name by which the project can be referenced within Serena
+project_name: "backend"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   java                julia               kotlin              lua                 markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- java
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions,
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/backend/bin/main/db/migration/V048__create_github_pr_sync.sql
+++ b/backend/bin/main/db/migration/V048__create_github_pr_sync.sql
@@ -1,0 +1,16 @@
+CREATE TABLE github_pr_sync (
+    id              UUID PRIMARY KEY,
+    repo            VARCHAR(200) NOT NULL,
+    pr_number       INTEGER      NOT NULL,
+    pr_title        VARCHAR(500) NOT NULL,
+    pr_state        VARCHAR(10)  NOT NULL,
+    pr_url          VARCHAR(2000) NOT NULL,
+    pr_body         TEXT DEFAULT '',
+    base_branch     VARCHAR(255) DEFAULT '',
+    head_branch     VARCHAR(255) DEFAULT '',
+    pr_labels       JSONB DEFAULT '[]'::jsonb,
+    last_fetched_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+    UNIQUE (repo, pr_number)
+);

--- a/backend/bin/main/db/migration/V049__create_verification_result.sql
+++ b/backend/bin/main/db/migration/V049__create_verification_result.sql
@@ -1,0 +1,21 @@
+CREATE TABLE verification_result (
+    id               UUID         PRIMARY KEY,
+    project_id       UUID         NOT NULL REFERENCES project(id),
+    target_id        UUID         REFERENCES traceability_link(id),
+    requirement_id   UUID         REFERENCES requirement(id),
+    prover           VARCHAR(100) NOT NULL,
+    property         TEXT,
+    result           VARCHAR(20)  NOT NULL,
+    assurance_level  VARCHAR(5)   NOT NULL,
+    evidence         TEXT,
+    verified_at      TIMESTAMPTZ  NOT NULL,
+    expires_at       TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ  NOT NULL,
+    updated_at       TIMESTAMPTZ  NOT NULL
+);
+
+CREATE INDEX idx_verification_result_project ON verification_result (project_id);
+CREATE INDEX idx_verification_result_requirement ON verification_result (requirement_id);
+CREATE INDEX idx_verification_result_target ON verification_result (target_id);
+CREATE INDEX idx_verification_result_result ON verification_result (result);
+CREATE INDEX idx_verification_result_prover ON verification_result (project_id, prover);

--- a/backend/bin/main/db/migration/V050__create_verification_result_audit.sql
+++ b/backend/bin/main/db/migration/V050__create_verification_result_audit.sql
@@ -1,0 +1,13 @@
+CREATE TABLE verification_result_audit (
+    id               UUID         NOT NULL,
+    rev              INTEGER      NOT NULL REFERENCES revinfo(rev),
+    revtype          SMALLINT     NOT NULL,
+    prover           VARCHAR(100),
+    property         TEXT,
+    result           VARCHAR(20),
+    assurance_level  VARCHAR(5),
+    evidence         TEXT,
+    verified_at      TIMESTAMPTZ,
+    expires_at       TIMESTAMPTZ,
+    PRIMARY KEY (id, rev)
+);

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/model/AssetLink.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/model/AssetLink.java
@@ -33,7 +33,7 @@ public class AssetLink extends BaseEntity {
     private OperationalAsset asset;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "target_type", nullable = false, length = 20)
+    @Column(name = "target_type", nullable = false, length = 40)
     private AssetLinkTargetType targetType;
 
     @Column(name = "target_entity_id")

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetLinkTargetType.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/state/AssetLinkTargetType.java
@@ -12,5 +12,8 @@ public enum AssetLinkTargetType {
     FINDING,
     EVIDENCE,
     AUDIT,
+    ISSUE,
+    CODE,
+    CONFIGURATION,
     EXTERNAL
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/repository/ControlLinkRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/repository/ControlLinkRepository.java
@@ -6,8 +6,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ControlLinkRepository extends JpaRepository<ControlLink, UUID> {
+
+    @Query("SELECT l FROM ControlLink l JOIN FETCH l.control WHERE l.control.project.id = :projectId")
+    List<ControlLink> findByProjectId(@Param("projectId") UUID projectId);
 
     List<ControlLink> findByControlId(UUID controlId);
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/AssetGraphProjectionContributor.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/AssetGraphProjectionContributor.java
@@ -139,7 +139,8 @@ public class AssetGraphProjectionContributor implements GraphProjectionContribut
                     case RISK_ASSESSMENT_RESULT -> GraphEntityType.RISK_ASSESSMENT_RESULT;
                     case TREATMENT_PLAN -> GraphEntityType.TREATMENT_PLAN;
                     case METHODOLOGY_PROFILE -> GraphEntityType.METHODOLOGY_PROFILE;
-                    case CONTROL, THREAT_MODEL_ENTRY, FINDING, EVIDENCE, AUDIT, EXTERNAL -> null;
+                    case CONTROL -> GraphEntityType.CONTROL;
+                    case THREAT_MODEL_ENTRY, FINDING, EVIDENCE, AUDIT, ISSUE, CODE, CONFIGURATION, EXTERNAL -> null;
                 };
         if (targetEntityType == null) {
             return null;

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/ControlGraphProjectionContributor.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/ControlGraphProjectionContributor.java
@@ -1,0 +1,96 @@
+package com.keplerops.groundcontrol.domain.graph.service;
+
+import com.keplerops.groundcontrol.domain.controls.repository.ControlLinkRepository;
+import com.keplerops.groundcontrol.domain.controls.repository.ControlRepository;
+import com.keplerops.groundcontrol.domain.controls.state.ControlLinkTargetType;
+import com.keplerops.groundcontrol.domain.graph.model.GraphEdge;
+import com.keplerops.groundcontrol.domain.graph.model.GraphEntityType;
+import com.keplerops.groundcontrol.domain.graph.model.GraphIds;
+import com.keplerops.groundcontrol.domain.graph.model.GraphNode;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ControlGraphProjectionContributor implements GraphProjectionContributor {
+
+    private final ControlRepository controlRepository;
+    private final ControlLinkRepository controlLinkRepository;
+
+    public ControlGraphProjectionContributor(
+            ControlRepository controlRepository, ControlLinkRepository controlLinkRepository) {
+        this.controlRepository = controlRepository;
+        this.controlLinkRepository = controlLinkRepository;
+    }
+
+    @Override
+    public List<GraphNode> contributeNodes(UUID projectId) {
+        return controlRepository.findByProjectIdOrderByCreatedAtDesc(projectId).stream()
+                .map(control -> {
+                    Map<String, Object> properties = new LinkedHashMap<>();
+                    properties.put("title", control.getTitle());
+                    properties.put("uid", control.getUid());
+                    properties.put("description", control.getDescription());
+                    properties.put("status", control.getStatus().name());
+                    properties.put(
+                            "controlFunction", control.getControlFunction().name());
+                    properties.put("owner", control.getOwner());
+                    properties.put("category", control.getCategory());
+                    properties.put("source", control.getSource());
+                    return new GraphNode(
+                            GraphIds.nodeId(GraphEntityType.CONTROL, control.getId()),
+                            control.getId().toString(),
+                            GraphEntityType.CONTROL,
+                            control.getProject().getIdentifier(),
+                            control.getUid(),
+                            control.getTitle(),
+                            properties);
+                })
+                .toList();
+    }
+
+    @Override
+    public List<GraphEdge> contributeEdges(UUID projectId) {
+        return controlLinkRepository.findByProjectId(projectId).stream()
+                .map(link -> toControlLinkEdge(
+                        link.getId(),
+                        link.getControl().getId(),
+                        link.getTargetType(),
+                        link.getTargetEntityId(),
+                        link.getLinkType().name()))
+                .filter(java.util.Objects::nonNull)
+                .toList();
+    }
+
+    private GraphEdge toControlLinkEdge(
+            UUID linkId, UUID controlId, ControlLinkTargetType targetType, UUID targetEntityId, String edgeType) {
+        if (targetEntityId == null) {
+            return null;
+        }
+        var targetEntityType =
+                switch (targetType) {
+                    case ASSET -> GraphEntityType.OPERATIONAL_ASSET;
+                    case REQUIREMENT -> GraphEntityType.REQUIREMENT;
+                    case RISK_SCENARIO -> GraphEntityType.RISK_SCENARIO;
+                    case RISK_REGISTER_RECORD -> GraphEntityType.RISK_REGISTER_RECORD;
+                    case RISK_ASSESSMENT_RESULT -> GraphEntityType.RISK_ASSESSMENT_RESULT;
+                    case TREATMENT_PLAN -> GraphEntityType.TREATMENT_PLAN;
+                    case METHODOLOGY_PROFILE -> GraphEntityType.METHODOLOGY_PROFILE;
+                    case OBSERVATION -> GraphEntityType.OBSERVATION;
+                    case EVIDENCE, FINDING, CODE, CONFIGURATION, OPERATIONAL_ARTIFACT, EXTERNAL -> null;
+                };
+        if (targetEntityType == null) {
+            return null;
+        }
+        return new GraphEdge(
+                linkId.toString(),
+                edgeType,
+                GraphIds.nodeId(GraphEntityType.CONTROL, controlId),
+                GraphIds.nodeId(targetEntityType, targetEntityId),
+                GraphEntityType.CONTROL,
+                targetEntityType,
+                Map.of());
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java
@@ -88,7 +88,8 @@ public class GraphTargetResolverService {
                     "Methodology profile");
             case CONTROL -> internalTarget(
                     targetEntityId, controlRepository.existsByIdAndProjectId(targetEntityId, projectId), "Control");
-            case THREAT_MODEL_ENTRY, FINDING, EVIDENCE, AUDIT, EXTERNAL -> externalTarget(targetIdentifier);
+            case THREAT_MODEL_ENTRY, FINDING, EVIDENCE, AUDIT, ISSUE, CODE, CONFIGURATION, EXTERNAL -> externalTarget(
+                    targetIdentifier);
         };
     }
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/RiskGraphProjectionContributor.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/RiskGraphProjectionContributor.java
@@ -255,7 +255,8 @@ public class RiskGraphProjectionContributor implements GraphProjectionContributo
                     case RISK_ASSESSMENT_RESULT -> GraphEntityType.RISK_ASSESSMENT_RESULT;
                     case TREATMENT_PLAN -> GraphEntityType.TREATMENT_PLAN;
                     case METHODOLOGY_PROFILE -> GraphEntityType.METHODOLOGY_PROFILE;
-                    case THREAT_MODEL, VULNERABILITY, CONTROL, FINDING, EVIDENCE, AUDIT_RECORD, EXTERNAL -> null;
+                    case CONTROL -> GraphEntityType.CONTROL;
+                    case THREAT_MODEL, VULNERABILITY, FINDING, EVIDENCE, AUDIT_RECORD, EXTERNAL -> null;
                 };
         if (targetEntityType == null) {
             return null;

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/RiskScenarioLink.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/RiskScenarioLink.java
@@ -34,7 +34,7 @@ public class RiskScenarioLink extends BaseEntity {
     private RiskScenario riskScenario;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "target_type", nullable = false, length = 20)
+    @Column(name = "target_type", nullable = false, length = 40)
     private RiskScenarioLinkTargetType targetType;
 
     @Column(name = "target_entity_id")

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetGraphProjectionContributorTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetGraphProjectionContributorTest.java
@@ -106,6 +106,32 @@ class AssetGraphProjectionContributorTest {
         });
     }
 
+    @Test
+    void controlTypedAssetLinkProducesGraphEdge() {
+        var project = new Project("ground-control", "Ground Control");
+        var projectId = UUID.randomUUID();
+        setField(project, "id", projectId);
+
+        var source = asset(project, "ASSET-1", "Gateway");
+        var controlTargetId = UUID.randomUUID();
+
+        var controlLink =
+                new AssetLink(source, AssetLinkTargetType.CONTROL, controlTargetId, null, AssetLinkType.GOVERNED_BY);
+        setField(controlLink, "id", UUID.randomUUID());
+
+        when(assetRelationRepository.findActiveByProjectId(projectId)).thenReturn(List.of());
+        when(observationRepository.findByProjectId(projectId)).thenReturn(List.of());
+        when(assetLinkRepository.findByProjectId(projectId)).thenReturn(List.of(controlLink));
+
+        var edges = contributor.contributeEdges(projectId);
+
+        assertThat(edges).hasSize(1);
+        assertThat(edges.get(0).edgeType()).isEqualTo("GOVERNED_BY");
+        assertThat(edges.get(0).targetId()).isEqualTo(GraphIds.nodeId(GraphEntityType.CONTROL, controlTargetId));
+        assertThat(edges.get(0).sourceEntityType()).isEqualTo(GraphEntityType.OPERATIONAL_ASSET);
+        assertThat(edges.get(0).targetEntityType()).isEqualTo(GraphEntityType.CONTROL);
+    }
+
     private OperationalAsset asset(Project project, String uid, String name) {
         var asset = new OperationalAsset(project, uid, name);
         setField(asset, "id", UUID.randomUUID());

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetGraphProjectionContributorTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetGraphProjectionContributorTest.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -130,6 +132,28 @@ class AssetGraphProjectionContributorTest {
         assertThat(edges.get(0).targetId()).isEqualTo(GraphIds.nodeId(GraphEntityType.CONTROL, controlTargetId));
         assertThat(edges.get(0).sourceEntityType()).isEqualTo(GraphEntityType.OPERATIONAL_ASSET);
         assertThat(edges.get(0).targetEntityType()).isEqualTo(GraphEntityType.CONTROL);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AssetLinkTargetType.class,
+            names = {"ISSUE", "CODE", "CONFIGURATION"})
+    void newExternalTargetTypesAreFilteredFromGraph(AssetLinkTargetType targetType) {
+        var project = new Project("ground-control", "Ground Control");
+        var projectId = UUID.randomUUID();
+        setField(project, "id", projectId);
+
+        var source = asset(project, "ASSET-1", "Gateway");
+        var link = new AssetLink(source, targetType, null, "ref-1", AssetLinkType.ASSOCIATED);
+        setField(link, "id", UUID.randomUUID());
+
+        when(assetRelationRepository.findActiveByProjectId(projectId)).thenReturn(List.of());
+        when(observationRepository.findByProjectId(projectId)).thenReturn(List.of());
+        when(assetLinkRepository.findByProjectId(projectId)).thenReturn(List.of(link));
+
+        var edges = contributor.contributeEdges(projectId);
+
+        assertThat(edges).isEmpty();
     }
 
     private OperationalAsset asset(Project project, String uid, String name) {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlGraphProjectionContributorTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlGraphProjectionContributorTest.java
@@ -1,0 +1,96 @@
+package com.keplerops.groundcontrol.unit.domain;
+
+import static com.keplerops.groundcontrol.TestUtil.setField;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.keplerops.groundcontrol.domain.controls.model.Control;
+import com.keplerops.groundcontrol.domain.controls.model.ControlLink;
+import com.keplerops.groundcontrol.domain.controls.repository.ControlLinkRepository;
+import com.keplerops.groundcontrol.domain.controls.repository.ControlRepository;
+import com.keplerops.groundcontrol.domain.controls.state.ControlFunction;
+import com.keplerops.groundcontrol.domain.controls.state.ControlLinkTargetType;
+import com.keplerops.groundcontrol.domain.controls.state.ControlLinkType;
+import com.keplerops.groundcontrol.domain.graph.model.GraphEntityType;
+import com.keplerops.groundcontrol.domain.graph.model.GraphIds;
+import com.keplerops.groundcontrol.domain.graph.service.ControlGraphProjectionContributor;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ControlGraphProjectionContributorTest {
+
+    @Mock
+    private ControlRepository controlRepository;
+
+    @Mock
+    private ControlLinkRepository controlLinkRepository;
+
+    @InjectMocks
+    private ControlGraphProjectionContributor contributor;
+
+    @Test
+    void contributesControlNodes() {
+        var project = new Project("ground-control", "Ground Control");
+        var projectId = UUID.randomUUID();
+        setField(project, "id", projectId);
+
+        var control = new Control(project, "CTL-001", "TLS Enforcement", ControlFunction.PREVENTIVE);
+        setField(control, "id", UUID.randomUUID());
+        control.setDescription("Enforce TLS 1.2+");
+        control.setOwner("security-team");
+        control.setCategory("network");
+        control.setSource("NIST 800-53");
+
+        when(controlRepository.findByProjectIdOrderByCreatedAtDesc(projectId)).thenReturn(List.of(control));
+
+        var nodes = contributor.contributeNodes(projectId);
+
+        assertThat(nodes).hasSize(1);
+        var node = nodes.get(0);
+        assertThat(node.entityType()).isEqualTo(GraphEntityType.CONTROL);
+        assertThat(node.uid()).isEqualTo("CTL-001");
+        assertThat(node.label()).isEqualTo("TLS Enforcement");
+        assertThat(node.id()).isEqualTo(GraphIds.nodeId(GraphEntityType.CONTROL, control.getId()));
+        assertThat(node.properties()).containsEntry("owner", "security-team");
+        assertThat(node.properties()).containsEntry("category", "network");
+        assertThat(node.properties()).containsEntry("controlFunction", "PREVENTIVE");
+    }
+
+    @Test
+    void contributesInternalLinkEdgesAndFiltersExternalLinks() {
+        var project = new Project("ground-control", "Ground Control");
+        var projectId = UUID.randomUUID();
+        setField(project, "id", projectId);
+
+        var control = new Control(project, "CTL-001", "TLS Enforcement", ControlFunction.PREVENTIVE);
+        setField(control, "id", UUID.randomUUID());
+
+        var assetTargetId = UUID.randomUUID();
+        var internalLink =
+                new ControlLink(control, ControlLinkTargetType.ASSET, assetTargetId, null, ControlLinkType.MITIGATES);
+        setField(internalLink, "id", UUID.randomUUID());
+
+        var externalLink =
+                new ControlLink(control, ControlLinkTargetType.EXTERNAL, null, "EXT-1", ControlLinkType.ASSOCIATED);
+        setField(externalLink, "id", UUID.randomUUID());
+
+        when(controlLinkRepository.findByProjectId(projectId)).thenReturn(List.of(internalLink, externalLink));
+
+        var edges = contributor.contributeEdges(projectId);
+
+        assertThat(edges).hasSize(1);
+        var edge = edges.get(0);
+        assertThat(edge.edgeType()).isEqualTo("MITIGATES");
+        assertThat(edge.sourceEntityType()).isEqualTo(GraphEntityType.CONTROL);
+        assertThat(edge.targetEntityType()).isEqualTo(GraphEntityType.OPERATIONAL_ASSET);
+        assertThat(edge.sourceId()).isEqualTo(GraphIds.nodeId(GraphEntityType.CONTROL, control.getId()));
+        assertThat(edge.targetId()).isEqualTo(GraphIds.nodeId(GraphEntityType.OPERATIONAL_ASSET, assetTargetId));
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlGraphProjectionContributorTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlGraphProjectionContributorTest.java
@@ -17,8 +17,13 @@ import com.keplerops.groundcontrol.domain.graph.service.ControlGraphProjectionCo
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -92,5 +97,62 @@ class ControlGraphProjectionContributorTest {
         assertThat(edge.targetEntityType()).isEqualTo(GraphEntityType.OPERATIONAL_ASSET);
         assertThat(edge.sourceId()).isEqualTo(GraphIds.nodeId(GraphEntityType.CONTROL, control.getId()));
         assertThat(edge.targetId()).isEqualTo(GraphIds.nodeId(GraphEntityType.OPERATIONAL_ASSET, assetTargetId));
+    }
+
+    static Stream<Arguments> internalTargetTypeMappings() {
+        return Stream.of(
+                Arguments.of(ControlLinkTargetType.ASSET, GraphEntityType.OPERATIONAL_ASSET),
+                Arguments.of(ControlLinkTargetType.REQUIREMENT, GraphEntityType.REQUIREMENT),
+                Arguments.of(ControlLinkTargetType.RISK_SCENARIO, GraphEntityType.RISK_SCENARIO),
+                Arguments.of(ControlLinkTargetType.RISK_REGISTER_RECORD, GraphEntityType.RISK_REGISTER_RECORD),
+                Arguments.of(ControlLinkTargetType.RISK_ASSESSMENT_RESULT, GraphEntityType.RISK_ASSESSMENT_RESULT),
+                Arguments.of(ControlLinkTargetType.TREATMENT_PLAN, GraphEntityType.TREATMENT_PLAN),
+                Arguments.of(ControlLinkTargetType.METHODOLOGY_PROFILE, GraphEntityType.METHODOLOGY_PROFILE),
+                Arguments.of(ControlLinkTargetType.OBSERVATION, GraphEntityType.OBSERVATION));
+    }
+
+    @ParameterizedTest
+    @MethodSource("internalTargetTypeMappings")
+    void mapsInternalTargetTypesToGraphEntityTypes(ControlLinkTargetType targetType, GraphEntityType expectedEntity) {
+        var project = new Project("ground-control", "Ground Control");
+        var projectId = UUID.randomUUID();
+        setField(project, "id", projectId);
+
+        var control = new Control(project, "CTL-001", "Test Control", ControlFunction.PREVENTIVE);
+        setField(control, "id", UUID.randomUUID());
+
+        var targetId = UUID.randomUUID();
+        var link = new ControlLink(control, targetType, targetId, null, ControlLinkType.ASSOCIATED);
+        setField(link, "id", UUID.randomUUID());
+
+        when(controlLinkRepository.findByProjectId(projectId)).thenReturn(List.of(link));
+
+        var edges = contributor.contributeEdges(projectId);
+
+        assertThat(edges).hasSize(1);
+        assertThat(edges.get(0).targetEntityType()).isEqualTo(expectedEntity);
+        assertThat(edges.get(0).targetId()).isEqualTo(GraphIds.nodeId(expectedEntity, targetId));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ControlLinkTargetType.class,
+            names = {"EVIDENCE", "FINDING", "CODE", "CONFIGURATION", "OPERATIONAL_ARTIFACT", "EXTERNAL"})
+    void filtersExternalTargetTypes(ControlLinkTargetType targetType) {
+        var project = new Project("ground-control", "Ground Control");
+        var projectId = UUID.randomUUID();
+        setField(project, "id", projectId);
+
+        var control = new Control(project, "CTL-001", "Test Control", ControlFunction.PREVENTIVE);
+        setField(control, "id", UUID.randomUUID());
+
+        var link = new ControlLink(control, targetType, null, "ext-ref", ControlLinkType.ASSOCIATED);
+        setField(link, "id", UUID.randomUUID());
+
+        when(controlLinkRepository.findByProjectId(projectId)).thenReturn(List.of(link));
+
+        var edges = contributor.contributeEdges(projectId);
+
+        assertThat(edges).isEmpty();
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GraphTargetResolverServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GraphTargetResolverServiceTest.java
@@ -86,7 +86,8 @@ class GraphTargetResolverServiceTest {
     @ParameterizedTest
     @EnumSource(
             value = AssetLinkTargetType.class,
-            names = {"THREAT_MODEL_ENTRY", "FINDING", "EVIDENCE", "AUDIT", "EXTERNAL"})
+            names = {"THREAT_MODEL_ENTRY", "FINDING", "EVIDENCE", "AUDIT", "ISSUE", "CODE", "CONFIGURATION", "EXTERNAL"
+            })
     void validateAssetTargetAcceptsExternalTargets(AssetLinkTargetType targetType) {
         var validated = graphTargetResolverService.validateAssetTarget(projectId, targetType, null, "EXT-1");
 
@@ -201,8 +202,14 @@ class GraphTargetResolverServiceTest {
                                     : java.util.Optional.empty());
             case CONTROL -> when(controlRepository.existsByIdAndProjectId(targetId, projectId))
                     .thenReturn(exists);
-            case THREAT_MODEL_ENTRY, FINDING, EVIDENCE, AUDIT, EXTERNAL -> throw new IllegalArgumentException(
-                    "Not an internal target type");
+            case THREAT_MODEL_ENTRY,
+                    FINDING,
+                    EVIDENCE,
+                    AUDIT,
+                    ISSUE,
+                    CODE,
+                    CONFIGURATION,
+                    EXTERNAL -> throw new IllegalArgumentException("Not an internal target type");
         }
     }
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -175,6 +175,11 @@ ESC runs on **pure logic classes** with no String constructor parameters and no 
 - `domain/verification/state/` — `VerificationStatus`, `AssuranceLevel` enums (simple value enums, L0)
 - Future pure domain logic classes that follow the same pattern
 
+Other `state/` packages contain simple value enums (L0) that are **not** ESC-verified:
+- `domain/assets/state/` — `AssetType`, `AssetLinkTargetType`, `AssetLinkType`, `AssetRelationType`, `ObservationCategory`
+- `domain/controls/state/` — `ControlFunction`, `ControlStatus`, `ControlLinkTargetType`, `ControlLinkType`
+- `domain/riskscenarios/state/` — risk scenario link and status enums
+
 ### What ESC cannot verify (and why)
 
 - `domain/requirements/model/` — JPA entities (Hibernate no-arg constructor produces `NullField` false positives)

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -121,6 +121,9 @@ export const ASSET_LINK_TARGET_TYPES = [
   "FINDING",
   "EVIDENCE",
   "AUDIT",
+  "ISSUE",
+  "CODE",
+  "CONFIGURATION",
   "EXTERNAL",
 ];
 export const ASSET_LINK_TYPES = [


### PR DESCRIPTION
## Summary

- Add `ISSUE`, `CODE`, `CONFIGURATION` to `AssetLinkTargetType` enum for first-class traceability from operational assets to issues, code files, and configuration artifacts
- Fix CONTROL graph edge projection in `AssetGraphProjectionContributor` and `RiskGraphProjectionContributor` (previously silently dropped)
- Create `ControlGraphProjectionContributor` to project Control entities as graph nodes with ControlLink edges
- Add `findByProjectId` query to `ControlLinkRepository` for graph projection
- Fix stale JPA `@Column(length=20)` annotations on `AssetLink.targetType` and `RiskScenarioLink.targetType` (DB widened to VARCHAR(40) in V043)
- Update MCP `ASSET_LINK_TARGET_TYPES` constant with new values
- Document non-ESC-verified state packages in CODING_STANDARDS.md and ADR-012

Closes #499

## Requirement UIDs

- GC-M017: Asset-Centric Traceability and Impact Context

## ADR Impact

- ADR-012: Updated ESC scope documentation to clarify non-verified state packages

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason
- [x] Requirement transitioned to ACTIVE
- [x] IMPLEMENTS traceability links created for all substantive files
- [x] TESTS traceability links created for all test files

## Traceability

- IMPLEMENTS: AssetLinkTargetType.java, AssetGraphProjectionContributor.java, ControlGraphProjectionContributor.java, GraphTargetResolverService.java, RiskGraphProjectionContributor.java, ControlLinkRepository.java, mcp/ground-control/lib.js
- TESTS: GraphTargetResolverServiceTest.java, AssetGraphProjectionContributorTest.java, ControlGraphProjectionContributorTest.java

## Test plan

- [x] `GraphTargetResolverServiceTest` validates new external target types (ISSUE, CODE, CONFIGURATION)
- [x] `AssetGraphProjectionContributorTest` verifies CONTROL-typed AssetLink produces graph edge
- [x] `ControlGraphProjectionContributorTest` verifies control node/edge contributions
- [x] All 1160+ tests pass via `make check`
- [x] Pre-commit hooks pass (including policy guardrails)