### PR TITLE
Add pluggable verifier adapter interface (GC-F005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.106.0] - 2026-04-08
+
+### Added
+
+- Pluggable verifier adapter interface (`VerifierAdapter`, `VerificationRequest`,
+  `VerificationOutcome`) enabling integration with OpenJML, TLA+/TLC, OPA/Rego,
+  Frama-C, and manual review processes (GC-F005, ADR-014 §6)
+
 ## [0.105.0] - 2026-04-06
 
 ### Added

--- a/architecture/adrs/014-pluggable-verification-architecture.md
+++ b/architecture/adrs/014-pluggable-verification-architecture.md
@@ -132,7 +132,7 @@ TLA+ is adopted for verifying Ground Control's own design-level properties:
 
 TLA+ specs live in `specs/tla/` at the repository root, versioned with code. TLC model checking runs as part of the verification pipeline.
 
-Implementation is staged. The repository now carries versioned TLA+ specs and policy sync tooling that keeps verification-oriented ADR and quality-gate metadata aligned, while the `VerificationResult` domain entity and verifier adapters remain future implementation work.
+Implementation is staged. The repository now carries versioned TLA+ specs and policy sync tooling that keeps verification-oriented ADR and quality-gate metadata aligned. The common `VerificationResult` domain entity is implemented; verifier execution/orchestration adapters remain future work.
 
 ### 5. Separation of concerns
 
@@ -152,23 +152,31 @@ domain/
     verification/           # New domain area
         model/
             VerificationResult.java
-            VerifierType.java         # Enum of known provers
             VerificationStatus.java   # PROVEN, REFUTED, TIMEOUT, UNKNOWN, ERROR
+            AssuranceLevel.java       # L0-L3
         service/
-            VerificationService.java  # Stores results, queries verification status
+            VerificationResultService.java  # Stores results, resolves target/requirement, queries status
+            VerifierAdapter.java            # Port: execute a verifier and return a common result payload
         repository/
             VerificationResultRepository.java
 
 infrastructure/
     verifiers/              # Adapter layer for external provers
-        VerifierAdapter.java          # Interface: verify(target, property) -> result
-        OpenJmlAdapter.java           # Calls OpenJML ESC on Java source
+        OpenJmlAdapter.java          # Calls OpenJML ESC on Java source
         TlcAdapter.java              # Calls TLC on TLA+ specs
         OpaAdapter.java              # Calls OPA on Rego policies
         # Future: FramaCAdapter, VerusAdapter, DafnyAdapter, KeyAdapter
 ```
 
 The `infrastructure/verifiers/` package follows the ports-and-adapters pattern: `domain/` defines what a verification result looks like; `infrastructure/` knows how to invoke specific provers.
+
+Adapter guardrails:
+
+- The canonical verifier selector is the existing `VerificationResult.prover` string. Do not introduce a `VerifierType` enum or a second registry schema that can drift from persisted data and API/MCP contracts.
+- Adapter implementations are execution boundaries only. They must not depend on controllers or repositories, and they must not persist `VerificationResult` entities directly. Project resolution, target/requirement resolution, and result persistence stay in the domain service layer.
+- Tool-specific output belongs in the existing `evidence` JSONB/TEXT map so the common schema stays stable. Do not add per-verifier tables, nullable columns, or parallel DTO hierarchies unless a shared query or workflow requirement proves the need.
+- Manual review participates through the same adapter contract and common result schema. It is not a special-case bypass around validation, auditing, or persistence.
+- External verifier integrations must follow existing infrastructure patterns: validated configuration, bounded execution, structured logs, and no shell-string command construction or secret-rich log output.
 
 ## Consequences
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/VerificationOutcome.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/VerificationOutcome.java
@@ -1,0 +1,21 @@
+package com.keplerops.groundcontrol.domain.verification.service;
+
+import com.keplerops.groundcontrol.domain.verification.state.AssuranceLevel;
+import com.keplerops.groundcontrol.domain.verification.state.VerificationStatus;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Result returned by a {@link VerifierAdapter} after executing verification.
+ *
+ * <p>Fields map directly to {@link CreateVerificationResultCommand} so consumers can persist the
+ * outcome via {@link VerificationResultService#create}.
+ */
+public record VerificationOutcome(
+        String prover,
+        VerificationStatus result,
+        AssuranceLevel assuranceLevel,
+        String property,
+        Map<String, Object> evidence,
+        Instant verifiedAt,
+        Instant expiresAt) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/VerificationRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/VerificationRequest.java
@@ -1,0 +1,13 @@
+package com.keplerops.groundcontrol.domain.verification.service;
+
+import com.keplerops.groundcontrol.domain.verification.state.AssuranceLevel;
+import java.util.Map;
+
+/**
+ * Input to a {@link VerifierAdapter}. Describes what to verify and at what assurance level.
+ *
+ * <p>The {@code options} map carries adapter-specific configuration (tool flags, model configs,
+ * reviewer info) so the common contract stays stable across all verifier backends.
+ */
+public record VerificationRequest(
+        String targetPath, String property, AssuranceLevel assuranceLevel, Map<String, Object> options) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/VerifierAdapter.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/verification/service/VerifierAdapter.java
@@ -1,0 +1,39 @@
+package com.keplerops.groundcontrol.domain.verification.service;
+
+/**
+ * Port interface for pluggable verification tool integration (ADR-014 section 6).
+ *
+ * <p>Each adapter wraps a single external verifier (OpenJML, TLA+/TLC, OPA/Rego, Frama-C, manual
+ * review, etc.) behind a common contract. Adapters are execution boundaries only — they must not
+ * depend on repositories or persist {@link
+ * com.keplerops.groundcontrol.domain.verification.model.VerificationResult} entities directly.
+ * Result persistence stays in {@link VerificationResultService}.
+ *
+ * <p>Infrastructure implementations live in {@code infrastructure/verifiers/} and register as
+ * Spring components. The canonical verifier selector is the {@link #proverName()} string, which
+ * must match the {@code prover} field persisted on VerificationResult.
+ */
+public interface VerifierAdapter {
+
+    /**
+     * Canonical prover identifier stored in {@code VerificationResult.prover}.
+     *
+     * <p>Examples: {@code "openjml-esc"}, {@code "tlaplus-tlc"}, {@code "opa"}, {@code "frama-c"},
+     * {@code "manual-review"}.
+     */
+    String proverName();
+
+    /** Whether this adapter is configured and ready to execute verifications. */
+    boolean isAvailable();
+
+    /**
+     * Execute a verification and return the outcome.
+     *
+     * <p>Tool-specific output belongs in {@link VerificationOutcome#evidence()}. Implementations
+     * must not shell out with string-concatenated commands or log secrets/proof artifacts.
+     *
+     * @param request what to verify
+     * @return the verification outcome
+     */
+    VerificationOutcome verify(VerificationRequest request);
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/VerifierAdapterContractTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/VerifierAdapterContractTest.java
@@ -1,0 +1,237 @@
+package com.keplerops.groundcontrol.unit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keplerops.groundcontrol.domain.verification.service.VerificationOutcome;
+import com.keplerops.groundcontrol.domain.verification.service.VerificationRequest;
+import com.keplerops.groundcontrol.domain.verification.service.VerifierAdapter;
+import com.keplerops.groundcontrol.domain.verification.state.AssuranceLevel;
+import com.keplerops.groundcontrol.domain.verification.state.VerificationStatus;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for {@link VerifierAdapter}. Uses a minimal stub to verify the interface is
+ * expressive enough for all tool categories listed in GC-F005: OpenJML, TLA+/TLC, OPA/Rego,
+ * Frama-C, and manual review.
+ */
+class VerifierAdapterContractTest {
+
+    private static final Instant NOW = Instant.parse("2026-04-08T12:00:00Z");
+
+    /** Minimal stub that returns a configurable outcome. */
+    static class StubAdapter implements VerifierAdapter {
+
+        private final String prover;
+        private final boolean available;
+        private final VerificationOutcome fixedOutcome;
+
+        StubAdapter(String prover, boolean available, VerificationOutcome fixedOutcome) {
+            this.prover = prover;
+            this.available = available;
+            this.fixedOutcome = fixedOutcome;
+        }
+
+        @Override
+        public String proverName() {
+            return prover;
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return available;
+        }
+
+        @Override
+        public VerificationOutcome verify(VerificationRequest request) {
+            return fixedOutcome;
+        }
+    }
+
+    @Nested
+    class OpenJml {
+
+        @Test
+        void handlesEscVerification() {
+            var outcome = new VerificationOutcome(
+                    "openjml-esc",
+                    VerificationStatus.PROVEN,
+                    AssuranceLevel.L1,
+                    "requires x > 0",
+                    Map.of("solver", "z3", "duration_ms", 450),
+                    NOW,
+                    null);
+            var adapter = new StubAdapter("openjml-esc", true, outcome);
+
+            var request = new VerificationRequest(
+                    "src/main/java/com/example/Foo.java", "requires x > 0", AssuranceLevel.L1, Map.of("mode", "esc"));
+
+            var result = adapter.verify(request);
+
+            assertThat(adapter.proverName()).isEqualTo("openjml-esc");
+            assertThat(adapter.isAvailable()).isTrue();
+            assertThat(result.prover()).isEqualTo("openjml-esc");
+            assertThat(result.result()).isEqualTo(VerificationStatus.PROVEN);
+            assertThat(result.assuranceLevel()).isEqualTo(AssuranceLevel.L1);
+            assertThat(result.property()).isEqualTo("requires x > 0");
+            assertThat(result.evidence()).containsEntry("solver", "z3");
+        }
+    }
+
+    @Nested
+    class TlaPlusTlc {
+
+        @Test
+        void handlesModelChecking() {
+            var outcome = new VerificationOutcome(
+                    "tlaplus-tlc",
+                    VerificationStatus.PROVEN,
+                    AssuranceLevel.L2,
+                    "TypeInvariant",
+                    Map.of("states_explored", 42_000, "diameter", 15),
+                    NOW,
+                    NOW.plusSeconds(86400));
+            var adapter = new StubAdapter("tlaplus-tlc", true, outcome);
+
+            var request = new VerificationRequest(
+                    "specs/tla/RequirementLifecycle.tla",
+                    "TypeInvariant",
+                    AssuranceLevel.L2,
+                    Map.of("model", "MC_RequirementLifecycle.cfg"));
+
+            var result = adapter.verify(request);
+
+            assertThat(result.prover()).isEqualTo("tlaplus-tlc");
+            assertThat(result.result()).isEqualTo(VerificationStatus.PROVEN);
+            assertThat(result.assuranceLevel()).isEqualTo(AssuranceLevel.L2);
+            assertThat(result.evidence()).containsEntry("states_explored", 42_000);
+            assertThat(result.expiresAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class OpaRego {
+
+        @Test
+        void handlesPolicyVerification() {
+            var outcome = new VerificationOutcome(
+                    "opa",
+                    VerificationStatus.PROVEN,
+                    AssuranceLevel.L1,
+                    "allow_admin_access",
+                    Map.of("decisions", 5, "bindings", Map.of("role", "admin")),
+                    NOW,
+                    null);
+            var adapter = new StubAdapter("opa", true, outcome);
+
+            var request = new VerificationRequest(
+                    "policies/authz.rego",
+                    "allow_admin_access",
+                    AssuranceLevel.L1,
+                    Map.of("input", Map.of("user", "alice", "role", "admin")));
+
+            var result = adapter.verify(request);
+
+            assertThat(result.prover()).isEqualTo("opa");
+            assertThat(result.result()).isEqualTo(VerificationStatus.PROVEN);
+            assertThat(result.evidence()).containsKey("decisions");
+        }
+    }
+
+    @Nested
+    class FramaC {
+
+        @Test
+        void handlesCSourceVerification() {
+            var outcome = new VerificationOutcome(
+                    "frama-c",
+                    VerificationStatus.REFUTED,
+                    AssuranceLevel.L3,
+                    "assigns \\nothing",
+                    Map.of("plugin", "wp", "counterexample", "buffer overflow at line 42"),
+                    NOW,
+                    null);
+            var adapter = new StubAdapter("frama-c", true, outcome);
+
+            var request = new VerificationRequest(
+                    "src/crypto/aes.c", "assigns \\nothing", AssuranceLevel.L3, Map.of("plugin", "wp"));
+
+            var result = adapter.verify(request);
+
+            assertThat(result.prover()).isEqualTo("frama-c");
+            assertThat(result.result()).isEqualTo(VerificationStatus.REFUTED);
+            assertThat(result.assuranceLevel()).isEqualTo(AssuranceLevel.L3);
+            assertThat(result.evidence()).containsEntry("plugin", "wp");
+        }
+    }
+
+    @Nested
+    class ManualReview {
+
+        @Test
+        void handlesManualReviewProcess() {
+            var outcome = new VerificationOutcome(
+                    "manual-review",
+                    VerificationStatus.PROVEN,
+                    AssuranceLevel.L0,
+                    "Security review of auth module",
+                    Map.of("reviewer", "jane.doe", "checklist_passed", true, "notes", "LGTM"),
+                    NOW,
+                    NOW.plusSeconds(7 * 86400));
+            var adapter = new StubAdapter("manual-review", true, outcome);
+
+            var request = new VerificationRequest(
+                    "src/main/java/com/example/AuthService.java",
+                    "Security review of auth module",
+                    AssuranceLevel.L0,
+                    Map.of("reviewer", "jane.doe", "checklist", "security-review-v2"));
+
+            var result = adapter.verify(request);
+
+            assertThat(result.prover()).isEqualTo("manual-review");
+            assertThat(result.result()).isEqualTo(VerificationStatus.PROVEN);
+            assertThat(result.evidence()).containsEntry("reviewer", "jane.doe");
+            assertThat(result.expiresAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    class Availability {
+
+        @Test
+        void unavailableAdapterReportsCorrectly() {
+            var adapter = new StubAdapter("openjml-esc", false, null);
+
+            assertThat(adapter.isAvailable()).isFalse();
+            assertThat(adapter.proverName()).isEqualTo("openjml-esc");
+        }
+    }
+
+    @Nested
+    class OutcomeMapping {
+
+        @Test
+        void outcomeFieldsMapToCreateCommand() {
+            var outcome = new VerificationOutcome(
+                    "tlaplus-tlc",
+                    VerificationStatus.TIMEOUT,
+                    AssuranceLevel.L2,
+                    "Liveness",
+                    Map.of("timeout_seconds", 300),
+                    NOW,
+                    NOW.plusSeconds(3600));
+
+            // Verify all fields needed by CreateVerificationResultCommand are present
+            assertThat(outcome.prover()).isNotNull();
+            assertThat(outcome.result()).isNotNull();
+            assertThat(outcome.assuranceLevel()).isNotNull();
+            assertThat(outcome.verifiedAt()).isNotNull();
+            // Nullable fields
+            assertThat(outcome.property()).isEqualTo("Liveness");
+            assertThat(outcome.evidence()).isNotEmpty();
+            assertThat(outcome.expiresAt()).isNotNull();
+        }
+    }
+}

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -122,7 +122,7 @@ Environment variables use the `GC_` prefix (e.g., `GC_DATABASE_URL`, `GC_SERVER_
 - Production deployment infrastructure (local Docker Compose + EC2 via CDK)
 - Multi-tenancy
 - Search
-- Verification result tracking — future: infrastructure verifier adapters (ADR-014 §6 infrastructure/verifiers/ layer)
+- Concrete verifier adapter implementations in `infrastructure/verifiers/` (ADR-014 §6). The `VerifierAdapter` port interface and request/outcome contracts are defined in the domain layer; future work is implementing adapters for each prover (OpenJML, TLA+/TLC, OPA/Rego, Frama-C, manual review).
 - Traceability Matrix view (`/traceability`) and Audit Timeline view (`/audit`) in the frontend
 - Apache AGE is optional — the app gracefully degrades to JPA-only analysis when AGE is unavailable
 
@@ -130,3 +130,4 @@ Environment variables use the `GC_` prefix (e.g., `GC_DATABASE_URL`, `GC_SERVER_
 
 - `specs/tla/` for design-level verification artifacts and state-machine specs, aligned with ADR-014
 - Verification result storage (VerificationResult entity with eager-loaded target/requirement, enums, CRUD API, MCP tools) — ADR-014 §2 common schema
+- Pluggable verifier adapter interface (`VerifierAdapter`, `VerificationRequest`, `VerificationOutcome`) — ADR-014 §6 port contract for multi-tool integration


### PR DESCRIPTION
## Summary

- Define `VerifierAdapter` port interface in the domain layer enabling pluggable integration with multiple verification tools (ADR-014 §6)
- Add `VerificationRequest` and `VerificationOutcome` records as the common input/output contract
- Contract tests prove the interface handles all 5 tool categories: OpenJML, TLA+/TLC, OPA/Rego, Frama-C, and manual review
- Update ADR-014 with binding adapter guardrails from Codex architecture preflight
- Update ARCHITECTURE.md to reflect the adapter interface is now defined

## Requirement UIDs

- GC-F005: Verifier Adapter Interface

## ADR Impact

- ADR-014: Updated with adapter guardrails (execution port only, no VerifierType enum, manual review same contract)

## Ground Control Checks

- [x] `make check` passes
- [x] `make policy` passes
- [x] `pre-commit run --all-files` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason

## Traceability

- IMPLEMENTS: `VerifierAdapter.java`, `VerificationRequest.java`, `VerificationOutcome.java`
- TESTS: `VerifierAdapterContractTest.java`
- DOCUMENTS: ADR-014 (created by Codex preflight)

## Test plan

- [x] Contract test covers all 5 verification tool categories (OpenJML, TLA+/TLC, OPA/Rego, Frama-C, manual review)
- [x] ArchUnit confirms no domain->infrastructure dependency violations
- [x] All pre-commit hooks pass including OpenJML ESC