### PR TITLE
Add reverse traceability lookup and self-referential enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.110.0] - 2026-04-10
+
+### Added
+
+- Reverse traceability lookup: `GET /api/v1/requirements/traceability/by-artifact`
+  endpoint and `gc_get_traceability_by_artifact` MCP tool for querying which
+  requirements link to a given artifact (GC-O002)
+- Self-referential traceability enforcement in `check_live_policy.mjs`: automated
+  reverse traceability check that verifies substantive code files are linked to
+  requirements, with baseline regression prevention
+
 ## [0.109.0] - 2026-04-09
 
 ### Added

--- a/architecture/adrs/011-requirements-data-model.md
+++ b/architecture/adrs/011-requirements-data-model.md
@@ -11,6 +11,7 @@ Accepted
 ## Revision
 
 2026-03-09 — Implementation details updated to reflect ADR-013 (Java/Spring Boot rewrite). Core decisions unchanged.
+2026-04-10 — Traceability identifier conventions updated to match the implemented service, ADR reverse-lookup, and GitHub sync contracts.
 
 ## Context
 
@@ -143,22 +144,24 @@ See also [ADR-014](014-pluggable-verification-architecture.md) for `Verification
 **Unique constraint**: `(source_id, target_id, relation_type)`
 **Validation**: `source != target` (no self-loops, enforced in service layer). Cycle detection is an analysis-time check, not a save-time constraint.
 
-#### TraceabilityLink (planned)
+#### TraceabilityLink
 
-Connects requirements to external artifacts. The `artifactIdentifier` uses a typed prefix convention:
-- `github:#42` — GitHub issue
-- `file:backend/src/.../Requirement.java` — code file
-- `adr:011` — architecture decision record
-- `test:backend/src/test/.../RequirementTest.java` — test file
-- `tla:specs/tla/RequirementStateMachine.tla` — TLA+ specification
-- `proof:verification/results/access-control.json` — verification result
+Connects requirements to external artifacts. `artifactIdentifier` is interpreted in the context of `artifactType`; it is not a globally-prefixed mini-schema.
+
+Canonical conventions:
+- `GITHUB_ISSUE`, `PULL_REQUEST` — raw decimal number stored as a string (for example `"42"`), so sync services can parse and refresh URL/title/state
+- `ADR`, `RISK_SCENARIO`, `CONTROL` — the Ground Control UID (for example `"ADR-021"`, `"RS-001"`, `"CTRL-001"`), so reverse lookup resolves by domain UID
+- `CODE_FILE`, `TEST`, `CONFIG`, `POLICY`, `SPEC`, `PROOF`, `DOCUMENTATION` — repo-relative path or other stable repo-local identifier
+- `artifactUrl` and `artifactTitle` are denormalized display/sync fields, not identity keys
+
+Do not introduce alternate encodings for the same artifact (`#42`, `owner/repo#42`, `file:...`, `adr:021`) in new data. Self-referential dogfooding must reuse this existing link model rather than adding a GC-specific traceability abstraction.
 
 | Field | Type | Constraints | Notes |
 |-------|------|-------------|-------|
 | id | UUID | PK, generated | |
 | requirement | FK -> Requirement | Not null | |
 | artifactType | Enum (ArtifactType) | Not null | github_issue, code_file, adr, config, policy, test, spec, proof, documentation |
-| artifactIdentifier | String(500) | Not null | Typed prefix convention |
+| artifactIdentifier | String(500) | Not null | Stable identifier scoped by `artifactType` |
 | artifactUrl | String(2000) | Default "" | |
 | artifactTitle | String(255) | Default "" | |
 | linkType | Enum (LinkType) | Not null | implements, tests, documents, constrains, verifies |
@@ -209,7 +212,7 @@ Audit trail for each import/sync operation.
 - AGE-as-query-layer avoids consistency issues while enabling powerful graph queries
 - Envers provides automatic audit trail with minimal configuration
 - Service-layer write ownership prevents mutation spaghetti without premature package splitting
-- TraceabilityLink's typed prefix convention accommodates verification artifacts (TLA+ specs, proof results) alongside code and documentation
+- Artifact-type-scoped identifiers keep reverse lookup and sync flows simple while accommodating code, docs, ADRs, and verification artifacts without a second schema layer
 
 ### Negative
 
@@ -222,6 +225,7 @@ Audit trail for each import/sync operation.
 - AGE extension availability varies across PostgreSQL hosting providers (mitigated: core analysis works without AGE via JPA)
 - StrictDoc format may have edge cases not covered by the parser (mitigated: import is a one-time migration)
 - DAG traversal via JPA adjacency list is O(depth x branching_factor) per query (mitigated: AGE provides O(1)-ish traversal for production use)
+- Multiple textual encodings for the same artifact fragment uniqueness and break sync or reverse lookup (mitigated: keep canonical identifier conventions per `artifactType` and route writes through the existing service layer)
 
 ## Related ADRs
 

--- a/architecture/adrs/014-pluggable-verification-architecture.md
+++ b/architecture/adrs/014-pluggable-verification-architecture.md
@@ -184,7 +184,7 @@ Adapter guardrails:
 
 - Platform can verify software in any language — not limited to Java
 - Graph-based traceability works across verification tools: the differentiator is preserved and strengthened
-- Reverse traceability lookup (`GET /requirements/traceability/by-artifact`) enables automated enforcement that code is linked to requirements, closing the bidirectional traceability loop and supporting self-referential validation (GC-O002)
+- Reverse traceability lookup (`GET /requirements/traceability/by-artifact`) enables automated enforcement that code is linked to requirements, closing the bidirectional traceability loop and supporting self-referential validation (GC-O002). Lookup errors are tracked separately from untraced files for operational debuggability.
 - Security use case is viable: threat model -> security requirement -> formal property -> language-specific proof -> graph-stored evidence
 - Design-level verification via TLA+ is immediately actionable, high-ROI, and proven at AWS scale
 - No rearchitecting needed when adding new prover backends

--- a/architecture/adrs/014-pluggable-verification-architecture.md
+++ b/architecture/adrs/014-pluggable-verification-architecture.md
@@ -184,6 +184,7 @@ Adapter guardrails:
 
 - Platform can verify software in any language — not limited to Java
 - Graph-based traceability works across verification tools: the differentiator is preserved and strengthened
+- Reverse traceability lookup (`GET /requirements/traceability/by-artifact`) enables automated enforcement that code is linked to requirements, closing the bidirectional traceability loop and supporting self-referential validation (GC-O002)
 - Security use case is viable: threat model -> security requirement -> formal property -> language-specific proof -> graph-stored evidence
 - Design-level verification via TLA+ is immediately actionable, high-ROI, and proven at AWS scale
 - No rearchitecting needed when adding new prover backends

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/requirements/RequirementController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/requirements/RequirementController.java
@@ -10,6 +10,7 @@ import com.keplerops.groundcontrol.domain.requirements.service.RequirementFilter
 import com.keplerops.groundcontrol.domain.requirements.service.RequirementService;
 import com.keplerops.groundcontrol.domain.requirements.service.TraceabilityService;
 import com.keplerops.groundcontrol.domain.requirements.service.UpdateRequirementCommand;
+import com.keplerops.groundcontrol.domain.requirements.state.ArtifactType;
 import com.keplerops.groundcontrol.domain.requirements.state.ChangeCategory;
 import com.keplerops.groundcontrol.domain.requirements.state.Priority;
 import com.keplerops.groundcontrol.domain.requirements.state.RequirementType;
@@ -191,6 +192,14 @@ public class RequirementController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteRelation(@PathVariable UUID id, @PathVariable UUID relationId) {
         requirementService.deleteRelation(id, relationId);
+    }
+
+    @GetMapping("/traceability/by-artifact")
+    public List<TraceabilityLinkResponse> findTraceabilityByArtifact(
+            @RequestParam ArtifactType artifactType, @RequestParam String artifactIdentifier) {
+        return traceabilityService.findByArtifact(artifactType, artifactIdentifier).stream()
+                .map(TraceabilityLinkResponse::from)
+                .toList();
     }
 
     @GetMapping("/{id}/traceability")

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityService.java
@@ -5,6 +5,7 @@ import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.requirements.model.TraceabilityLink;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
+import com.keplerops.groundcontrol.domain.requirements.state.ArtifactType;
 import com.keplerops.groundcontrol.domain.requirements.state.LinkType;
 import com.keplerops.groundcontrol.domain.requirements.state.Status;
 import java.util.List;
@@ -80,6 +81,12 @@ public class TraceabilityService {
             throw new NotFoundException("Requirement not found: " + requirementId);
         }
         return traceabilityLinkRepository.findByRequirementId(requirementId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TraceabilityLink> findByArtifact(ArtifactType artifactType, String artifactIdentifier) {
+        return traceabilityLinkRepository.findByArtifactTypeAndArtifactIdentifierWithRequirement(
+                artifactType, artifactIdentifier);
     }
 
     public void deleteLink(UUID linkId) {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTest.java
@@ -436,6 +436,37 @@ class RequirementControllerTest {
             mockMvc.perform(delete("/api/v1/requirements/" + reqId + "/traceability/" + linkId))
                     .andExpect(status().isNoContent());
         }
+
+        @Test
+        void findByArtifact_returnsMatchingLinks() throws Exception {
+            var req = createRequirement("REQ-001");
+            var link = new TraceabilityLink(req, ArtifactType.CODE_FILE, "backend/src/Main.java", LinkType.IMPLEMENTS);
+            setField(link, "id", UUID.randomUUID());
+            setField(link, "createdAt", Instant.now());
+            setField(link, "updatedAt", Instant.now());
+            when(traceabilityService.findByArtifact(ArtifactType.CODE_FILE, "backend/src/Main.java"))
+                    .thenReturn(List.of(link));
+
+            mockMvc.perform(get("/api/v1/requirements/traceability/by-artifact")
+                            .param("artifactType", "CODE_FILE")
+                            .param("artifactIdentifier", "backend/src/Main.java"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].artifactType", is("CODE_FILE")))
+                    .andExpect(jsonPath("$[0].artifactIdentifier", is("backend/src/Main.java")))
+                    .andExpect(jsonPath("$[0].linkType", is("IMPLEMENTS")));
+        }
+
+        @Test
+        void findByArtifact_returnsEmptyWhenNoMatch() throws Exception {
+            when(traceabilityService.findByArtifact(ArtifactType.CODE_FILE, "nonexistent.java"))
+                    .thenReturn(List.of());
+
+            mockMvc.perform(get("/api/v1/requirements/traceability/by-artifact")
+                            .param("artifactType", "CODE_FILE")
+                            .param("artifactIdentifier", "nonexistent.java"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.length()", is(0)));
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TraceabilityServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TraceabilityServiceTest.java
@@ -182,6 +182,35 @@ class TraceabilityServiceTest {
     }
 
     @Nested
+    class FindByArtifact {
+
+        @Test
+        void returnsMatchingLinks() {
+            var req = makeRequirement("REQ-001");
+            var link = new TraceabilityLink(req, ArtifactType.CODE_FILE, "backend/src/Main.java", LinkType.IMPLEMENTS);
+            setField(link, "id", UUID.randomUUID());
+            when(traceabilityLinkRepository.findByArtifactTypeAndArtifactIdentifierWithRequirement(
+                            ArtifactType.CODE_FILE, "backend/src/Main.java"))
+                    .thenReturn(List.of(link));
+
+            var result = service.findByArtifact(ArtifactType.CODE_FILE, "backend/src/Main.java");
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getArtifactIdentifier()).isEqualTo("backend/src/Main.java");
+            assertThat(result.get(0).getLinkType()).isEqualTo(LinkType.IMPLEMENTS);
+        }
+
+        @Test
+        void returnsEmptyWhenNoMatch() {
+            when(traceabilityLinkRepository.findByArtifactTypeAndArtifactIdentifierWithRequirement(
+                            ArtifactType.CODE_FILE, "nonexistent.java"))
+                    .thenReturn(List.of());
+
+            var result = service.findByArtifact(ArtifactType.CODE_FILE, "nonexistent.java");
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
     class DeleteLink {
 
         @Test

--- a/docs/API.md
+++ b/docs/API.md
@@ -38,7 +38,15 @@ http://localhost:8000/api/v1/
 |--------|------|------|--------|---------|
 | POST | `/requirements/{id}/traceability` | TraceabilityLinkRequest | 201 | Create traceability link |
 | GET | `/requirements/{id}/traceability` | — | 200 | List traceability links |
+| GET | `/requirements/traceability/by-artifact` | — | 200 | Reverse lookup: find links by artifact |
 | DELETE | `/requirements/{id}/traceability/{linkId}` | — | 204 | Delete traceability link |
+
+`GET /requirements/traceability/by-artifact` accepts query parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `artifactType` | enum | GITHUB_ISSUE, PULL_REQUEST, CODE_FILE, ADR, CONFIG, POLICY, TEST, SPEC, PROOF, DOCUMENTATION, RISK_SCENARIO, CONTROL |
+| `artifactIdentifier` | string | Artifact identifier (e.g. repo-relative path, issue number, ADR UID) |
 
 ### Audit History
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -109,7 +109,7 @@ Environment variables use the `GC_` prefix (e.g., `GC_DATABASE_URL`, `GC_SERVER_
 
 **Domain entities:** Requirement, RequirementRelation, TraceabilityLink, GitHubIssueSync, RequirementImport — all JPA with Envers auditing.
 
-**Services:** RequirementService (9 methods), TraceabilityService, ImportService (StrictDoc parser + idempotent import), GitHubIssueSyncService (CLI-based GitHub sync), AnalysisService (cycle/orphan/coverage/impact/cross-wave), AgeGraphService (Apache AGE graph materialization + Cypher queries).
+**Services:** RequirementService (9 methods), TraceabilityService (forward and reverse artifact lookup), ImportService (StrictDoc parser + idempotent import), GitHubIssueSyncService (CLI-based GitHub sync), AnalysisService (cycle/orphan/coverage/impact/cross-wave), AgeGraphService (Apache AGE graph materialization + Cypher queries).
 
 **API:** RequirementController (9 REST endpoints), AnalysisController (5 endpoints), ImportController, SyncController, GraphController. GlobalExceptionHandler maps domain exceptions to HTTP error envelopes.
 
@@ -133,3 +133,4 @@ Environment variables use the `GC_` prefix (e.g., `GC_DATABASE_URL`, `GC_SERVER_
 - `specs/tla/` for design-level verification artifacts and state-machine specs, aligned with ADR-014
 - Verification result storage (VerificationResult entity with eager-loaded target/requirement, enums, CRUD API, MCP tools) — ADR-014 §2 common schema
 - Pluggable verifier adapter interface (`VerifierAdapter`, `VerificationRequest`, `VerificationOutcome`) — ADR-014 §6 port contract for multi-tool integration
+- Self-referential traceability enforcement — `check_live_policy.mjs` verifies substantive code files have reverse traceability links to requirements (GC-O002), using the `GET /requirements/traceability/by-artifact` reverse lookup endpoint

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -133,4 +133,4 @@ Environment variables use the `GC_` prefix (e.g., `GC_DATABASE_URL`, `GC_SERVER_
 - `specs/tla/` for design-level verification artifacts and state-machine specs, aligned with ADR-014
 - Verification result storage (VerificationResult entity with eager-loaded target/requirement, enums, CRUD API, MCP tools) — ADR-014 §2 common schema
 - Pluggable verifier adapter interface (`VerifierAdapter`, `VerificationRequest`, `VerificationOutcome`) — ADR-014 §6 port contract for multi-tool integration
-- Self-referential traceability enforcement — `check_live_policy.mjs` verifies substantive code files have reverse traceability links to requirements (GC-O002), using the `GET /requirements/traceability/by-artifact` reverse lookup endpoint
+- Self-referential traceability enforcement — `check_live_policy.mjs` verifies substantive code files have reverse traceability links to requirements (GC-O002), using the `GET /requirements/traceability/by-artifact` reverse lookup endpoint. Lookup errors are tracked separately for debuggability when the endpoint is unavailable.

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -17,6 +17,7 @@ import {
   createRelation,
   getRelations,
   getTraceabilityLinks,
+  getTraceabilityByArtifact,
   createTraceabilityLink,
   detectCycles,
   findOrphans,
@@ -550,6 +551,24 @@ server.tool(
     try {
       const links = await getTraceabilityLinks(id);
       if (Array.isArray(links) && links.length === 0) return ok("No traceability links found.");
+      return ok(JSON.stringify(links, null, 2));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+server.tool(
+  "gc_get_traceability_by_artifact",
+  "Find all traceability links for a given artifact (reverse lookup: from code/test/ADR to requirements).",
+  {
+    artifact_type: z.enum(ARTIFACT_TYPES).describe("Type of artifact"),
+    artifact_identifier: z.string().describe("Artifact identifier (e.g. file path, issue number)"),
+  },
+  async ({ artifact_type, artifact_identifier }) => {
+    try {
+      const links = await getTraceabilityByArtifact(artifact_type, artifact_identifier);
+      if (Array.isArray(links) && links.length === 0) return ok("No traceability links found for this artifact.");
       return ok(JSON.stringify(links, null, 2));
     } catch (e) {
       return err(e);

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -745,6 +745,12 @@ export async function deleteTraceabilityLink(reqId, linkId) {
   await request("DELETE", `/api/v1/requirements/${encodeURIComponent(reqId)}/traceability/${encodeURIComponent(linkId)}`);
 }
 
+export async function getTraceabilityByArtifact(artifactType, artifactIdentifier) {
+  return request("GET", "/api/v1/requirements/traceability/by-artifact", {
+    params: { artifactType, artifactIdentifier },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Graph functions
 // ---------------------------------------------------------------------------

--- a/tools/ground_control/check_live_policy.mjs
+++ b/tools/ground_control/check_live_policy.mjs
@@ -1,7 +1,8 @@
+import { execFileSync } from "node:child_process";
 import process from "node:process";
 
-import { evaluateQualityGates, runSweep } from "../../mcp/ground-control/lib.js";
-import { gateActualValue, gateName, readGateField, readJson, summarizeSweep } from "./common.mjs";
+import { evaluateQualityGates, getTraceabilityByArtifact, runSweep } from "../../mcp/ground-control/lib.js";
+import { gateActualValue, gateName, readGateField, readJson, repoRoot, summarizeSweep } from "./common.mjs";
 
 const config = await readJson("tools/ground_control/policy.json");
 const baselineConfig = await readJson("tools/ground_control/sweep-baseline.json");
@@ -40,6 +41,47 @@ for (const [linkType, count] of Object.entries(current.coverageGaps)) {
   if (count > allowed) {
     regressions.push(`coverage gap regressed for ${linkType}: baseline=${allowed} current=${count}`);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Reverse traceability: verify substantive files are linked to requirements
+// ---------------------------------------------------------------------------
+
+const TRACKED_PATTERNS = [
+  /^backend\/src\/main\/java\/.*\.java$/,
+  /^mcp\/ground-control\/(lib|index)\.js$/,
+  /^tools\/policy\/checks\.py$/,
+  /^tools\/ground_control\/.*\.mjs$/,
+];
+
+try {
+  const allFiles = execFileSync("git", ["ls-files"], { cwd: repoRoot, encoding: "utf8" })
+    .split("\n")
+    .filter(Boolean);
+  const substantiveFiles = allFiles.filter((f) => TRACKED_PATTERNS.some((p) => p.test(f)));
+
+  let untracedCount = 0;
+  for (const file of substantiveFiles) {
+    try {
+      const links = await getTraceabilityByArtifact("CODE_FILE", file);
+      if (!Array.isArray(links) || links.length === 0) {
+        untracedCount += 1;
+      }
+    } catch {
+      untracedCount += 1;
+    }
+  }
+
+  const untracedBaseline = baseline.untracedFiles;
+  if (untracedBaseline !== undefined && untracedCount > untracedBaseline) {
+    regressions.push(`untraced files regressed: baseline=${untracedBaseline} current=${untracedCount}`);
+  }
+
+  console.log(
+    `Reverse traceability: ${substantiveFiles.length - untracedCount}/${substantiveFiles.length} files traced.`,
+  );
+} catch (e) {
+  console.warn(`Reverse traceability check skipped: ${e.message}`);
 }
 
 if (regressions.length > 0) {

--- a/tools/ground_control/check_live_policy.mjs
+++ b/tools/ground_control/check_live_policy.mjs
@@ -61,6 +61,7 @@ try {
   const substantiveFiles = allFiles.filter((f) => TRACKED_PATTERNS.some((p) => p.test(f)));
 
   let untracedCount = 0;
+  let errorCount = 0;
   for (const file of substantiveFiles) {
     try {
       const links = await getTraceabilityByArtifact("CODE_FILE", file);
@@ -69,6 +70,7 @@ try {
       }
     } catch {
       untracedCount += 1;
+      errorCount += 1;
     }
   }
 
@@ -77,9 +79,9 @@ try {
     regressions.push(`untraced files regressed: baseline=${untracedBaseline} current=${untracedCount}`);
   }
 
-  console.log(
-    `Reverse traceability: ${substantiveFiles.length - untracedCount}/${substantiveFiles.length} files traced.`,
-  );
+  const traced = substantiveFiles.length - untracedCount;
+  const errorNote = errorCount > 0 ? ` (${errorCount} lookup errors)` : "";
+  console.log(`Reverse traceability: ${traced}/${substantiveFiles.length} files traced.${errorNote}`);
 } catch (e) {
   console.warn(`Reverse traceability check skipped: ${e.message}`);
 }

--- a/tools/ground_control/sweep-baseline.json
+++ b/tools/ground_control/sweep-baseline.json
@@ -13,6 +13,7 @@
       "DOCUMENTS": 245,
       "CONSTRAINS": 254,
       "VERIFIES": 267
-    }
+    },
+    "untracedFiles": 559
   }
 }


### PR DESCRIPTION
## Requirement UIDs

GC-O002

## Summary

- Add `GET /api/v1/requirements/traceability/by-artifact` reverse traceability lookup endpoint and `gc_get_traceability_by_artifact` MCP tool, exposing the existing repository query method
- Add automated reverse traceability enforcement to `check_live_policy.mjs` that verifies substantive code files are linked to requirements, with baseline regression prevention
- Update ADR-011 (artifact identifier conventions), ADR-014 (reverse traceability as verification mechanism), and architecture docs

## ADR Impact

- ADR-011: Updated by Codex preflight to lock artifact identifier conventions
- ADR-014: Updated to document reverse traceability as a verification mechanism

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason

## Traceability

- IMPLEMENTS: GC-O002 (TraceabilityService, RequirementController, TraceabilityLinkRepository, lib.js, index.js, check_live_policy.mjs, sweep-baseline.json)
- TESTS: GC-O002 (RequirementControllerTest)

## Test plan

- [ ] `make check` passes (build + unit tests + static analysis)
- [ ] `make policy` passes (ADR guard, controller contracts, migration policy)
- [ ] New `findByArtifact_returnsMatchingLinks` and `findByArtifact_returnsEmptyWhenNoMatch` @WebMvcTest cases pass
- [ ] Reverse lookup endpoint returns correct results for CODE_FILE artifact types
- [ ] Live policy check correctly counts untraced files and compares against baseline