### PR TITLE
Document architecture model artifacts as traceable artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.110.1] - 2026-04-10
+
+### Added
+
+- Architecture model artifacts design note documenting how C4 models,
+  architecture tests, and fitness functions are supported as traceable
+  artifacts using existing TraceabilityLink and VerificationResult
+  infrastructure (GC-J002)
+
 ## [0.110.0] - 2026-04-10
 
 ### Added

--- a/architecture/design/README.md
+++ b/architecture/design/README.md
@@ -16,3 +16,4 @@ For architecture decisions, see [ADRs](../adrs/).
 |----------|-------|-------------|
 | [Phase 1: Requirements Management](../notes/phase1-requirements-design.md) | 1 | Data model, app structure, key patterns for the requirements management system |
 | [Phase 2: Cloud Database](../notes/phase2-cloud-database-design.md) | 2 | RDS deployment, Terraform structure, security model, developer workflow |
+| [Architecture Model Artifacts](../notes/architecture-model-artifacts.md) | 5 | Guardrails for modeling C4 diagrams, architecture tests, and fitness functions as traceable artifacts without introducing a parallel artifact domain |

--- a/architecture/notes/architecture-model-artifacts.md
+++ b/architecture/notes/architecture-model-artifacts.md
@@ -1,0 +1,69 @@
+# Architecture Model Artifacts
+
+## Context
+
+`GC-J002` adds support for C4 architecture models, architecture tests, and fitness functions as managed, versioned artifacts in the traceability graph.
+
+The repository already has two relevant primitives:
+
+- `TraceabilityLink` in the requirements domain for requirement-to-artifact links
+- `VerificationResult` in the verification domain for execution outcomes tied to a traceability target
+
+Those existing primitives are the default implementation path. `GC-J002` should not introduce a parallel artifact model unless a later requirement explicitly needs architecture artifacts to become first-class internal entities.
+
+## Guardrails
+
+### 1. Reuse existing artifact and verification surfaces
+
+- Treat architecture artifacts as repo-versioned artifacts identified by stable repo-relative paths or existing Ground Control UIDs.
+- Use `TraceabilityLink` for requirement linkage and reverse lookup.
+- Use `VerificationResult` for recorded outcomes of architecture tests or formal fitness checks.
+- Keep Git as the version store for artifact content. Ground Control stores metadata and traceability, not duplicate file bodies or version histories.
+
+### 2. Keep architecture artifacts external unless they need first-class graph semantics
+
+The mixed graph currently materializes first-class internal entities (`REQUIREMENT`, `CONTROL`, `RISK_SCENARIO`, `VERIFICATION_RESULT`, etc.). External artifacts remain requirement-anchored traceability targets.
+
+Do not add:
+
+- a new `GraphEntityType` for architecture artifacts
+- a new artifact aggregate root or repository
+- a second graph-projection path for files already represented by traceability links
+
+If a future requirement needs architecture artifacts to have their own lifecycle, metadata schema, or graph edges independent of a requirement anchor, that is a new ADR-worthy decision.
+
+### 3. Classify artifacts by existing semantics, not by new labels
+
+Prefer the existing taxonomy:
+
+- C4 model source files: `ArtifactType.SPEC` with repo-relative `artifactIdentifier`
+- Rendered/static architecture diagrams with no executable source semantics: `ArtifactType.DOCUMENTATION`
+- Architecture tests: `ArtifactType.TEST` with `LinkType.TESTS`
+- Fitness functions implemented as executable tests: `ArtifactType.TEST` with `LinkType.TESTS`
+- Fitness functions implemented as policies or rules: `ArtifactType.POLICY` or `ArtifactType.CONFIG` with `LinkType.CONSTRAINS`
+- Formal architecture verification artifacts/results: `ArtifactType.SPEC` or `ArtifactType.PROOF` with `LinkType.VERIFIES`, plus `VerificationResult` when an execution outcome is recorded
+
+Do not add `ARCHITECTURE_MODEL`, `ARCHITECTURE_TEST`, or `FITNESS_FUNCTION` enum values unless the existing taxonomy proves materially insufficient across API, MCP, frontend, and persistence layers.
+
+### 4. Reuse the existing cross-cutting concerns
+
+- Validation: keep request-shape validation in DTOs and business-rule validation in domain services via `DomainValidationException`
+- Exception mapping: reuse `GlobalExceptionHandler`; do not introduce a feature-specific error envelope
+- Write ownership: keep requirement-artifact writes in `TraceabilityService`; keep verification persistence in `VerificationResultService`
+- Persistence: if a new audited entity ever becomes unavoidable, follow `BaseEntity` + JPA + Flyway + Envers patterns rather than ad hoc tables
+- Logging: use existing structured SLF4J event-style logs with stable keys, and rely on `RequestLoggingFilter` for request correlation
+- Architecture enforcement: preserve `api -> domain <- infrastructure` and existing ArchUnit rules
+
+## Implementation Gotchas
+
+- `artifactIdentifier` matching is exact. Competing encodings for the same file or artifact will fragment reverse lookup and sync behavior.
+- If new `ArtifactType` values are introduced, the implementation must update backend enums, API docs, MCP enum contracts, frontend enum mirrors, and tests together. Avoid that unless there is no fit in the current taxonomy.
+- `VerificationResult.target` already points at a `TraceabilityLink`. Do not bypass that relationship with direct file/path foreign keys or a second verification target schema.
+- A C4 DSL/parser abstraction is not justified up front. Start with stable file-path traceability and only generalize if multiple concrete model formats actually need shared behavior.
+
+## Non-Goals
+
+- No blob storage or database-backed content store for architecture artifacts
+- No generic artifact registry spanning all repo files
+- No new workflow engine for architecture checks separate from existing traceability and verification flows
+- No attempt to parse, render, or normalize every architecture modeling format as part of `GC-J002`


### PR DESCRIPTION
## Requirement UIDs

GC-J002

## Summary

- Add design note documenting how C4 architecture models, architecture tests, and fitness functions map to existing TraceabilityLink and VerificationResult infrastructure
- Existing ArtifactType taxonomy (SPEC, TEST, DOCUMENTATION, POLICY, CONFIG, PROOF) already supports all architecture artifact classes — no new code needed
- Index the design note in architecture/design/README.md

## ADR Impact

No ADR required. Existing ADR-011 (requirements data model) and ADR-014 (pluggable verification architecture) already cover the design direction.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason

## Traceability

- IMPLEMENTS: GC-J002 (ArtifactType, LinkType, TraceabilityLink, TraceabilityService, VerificationResult, VerificationResultService)
- TESTS: GC-J002 (ArchitectureTest — ArchUnit fitness functions)

## Test plan

- [x] `make check` passes (no code changes)
- [x] `make policy` passes
- [x] Design note correctly maps each artifact class to existing enums