### PR TITLE
Read .ground-control.yaml for repo workflow config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.111.0] - 2026-04-11
+
+### Changed
+
+- Ground Control MCP server now reads `.ground-control.yaml` from each
+  repository root instead of parsing the "Ground Control Context" YAML
+  block in `AGENTS.md`. The `gc_get_repo_ground_control_context` tool
+  returns the full workflow config: project identifier, github_repo,
+  workflow commands (test/completion/lint/format), optional sonarcloud
+  settings, and optional inlined plan_rules file content. Repos must
+  provide `.ground-control.yaml` at their root; agents can self-service
+  migration using the `suggested_ground_control_yaml` field returned
+  on `missing_ground_control_yaml` status.
+
+### Removed
+
+- `parseRepoGroundControlContext` export and its AGENTS.md-based parser
+  (replaced by `parseGroundControlYaml`).
+
+### Added
+
+- `parseGroundControlYaml` and `buildSuggestedGroundControlYaml` exports
+  in `mcp/ground-control/lib.js`.
+- 16 new tests in `mcp/ground-control/lib.test.js` covering yaml
+  parsing, schema validation, plan_rules file resolution, and the
+  full `getRepoGroundControlContext` flow on a temporary git repo.
+
 ## [0.110.1] - 2026-04-10
 
 ### Added

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -666,7 +666,7 @@ server.tool(
 
 server.tool(
   "gc_get_repo_ground_control_context",
-  "Read the current repository's AGENTS.md and return the standardized Ground Control context used by workflow automation, including the project identifier and validation errors when the convention is missing or invalid.",
+  "Read the current repository's .ground-control.yaml and return the full Ground Control workflow config used by automation: project identifier, github_repo, workflow commands (test/completion/lint/format), optional sonarcloud settings, and optional inlined plan_rules file content. Returns validation errors when the file is missing or invalid.",
   {
     repo_path: z.string().describe("Absolute path to the target Git repository"),
   },

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -31,10 +31,30 @@ export function buildGroundControlContextSnippet(project = "your-project-id") {
   return [
     "## Ground Control Context",
     "",
-    "```yaml",
-    "ground_control:",
-    `  project: ${project}`,
-    "```",
+    "This repo's Ground Control project id, workflow commands, SonarCloud",
+    "settings, and plan rules live in `.ground-control.yaml` at repo root.",
+    "Agents read it via the `gc_get_repo_ground_control_context` MCP tool.",
+  ].join("\n");
+}
+
+export function buildSuggestedGroundControlYaml(project = "your-project-id") {
+  return [
+    "schema_version: 1",
+    `project: ${project}`,
+    "",
+    "# Optional fields:",
+    "# github_repo: owner/repo",
+    "# workflow:",
+    "#   test_command: <how to run tests>",
+    "#   completion_command: <how to run the full CI gate>",
+    "#   lint_command: <how to run the linter>",
+    "#   format_command: <how to run the formatter>",
+    "# sonarcloud:",
+    "#   project_key: <sonar-project-key>",
+    "#   organization: <sonar-org>",
+    "# rules:",
+    "#   plan_rules: .gc/plan-rules.md",
+    "",
   ].join("\n");
 }
 
@@ -900,108 +920,245 @@ export async function createGitHubIssueViaApi(data, project) {
 // Repository context helpers
 // ---------------------------------------------------------------------------
 
-export function parseRepoGroundControlContext(agentsMarkdown) {
-  const snippet = buildGroundControlContextSnippet();
-  const headingMatch = agentsMarkdown.match(/^#{1,6}\s+Ground Control Context\s*$/m);
-  if (!headingMatch || headingMatch.index == null) {
-    return {
-      status: "missing_ground_control_context",
-      project: null,
-      errors: [
-        "AGENTS.md must include a 'Ground Control Context' section with a fenced YAML block.",
-      ],
-      suggested_agents_snippet: snippet,
-    };
-  }
+const SUPPORTED_GROUND_CONTROL_SCHEMA_VERSIONS = [1];
 
-  const sectionStart = headingMatch.index + headingMatch[0].length;
-  const afterHeading = agentsMarkdown.slice(sectionStart);
-  const nextHeadingMatch = afterHeading.match(/^#{1,6}\s+\S.*$/m);
-  const sectionBody = nextHeadingMatch ? afterHeading.slice(0, nextHeadingMatch.index) : afterHeading;
-  const yamlBlockMatch = sectionBody.match(/```(?:yaml|yml)\s*\n([\s\S]*?)```/m);
-  if (!yamlBlockMatch) {
-    return {
-      status: "invalid_ground_control_context",
-      project: null,
-      errors: [
-        "The 'Ground Control Context' section must contain a fenced YAML block.",
-      ],
-      suggested_agents_snippet: snippet,
-    };
-  }
+function emptyWorkflowConfig() {
+  return {
+    test_command: null,
+    completion_command: null,
+    lint_command: null,
+    format_command: null,
+  };
+}
 
+function normalizeWorkflowConfig(raw) {
+  if (raw == null || typeof raw !== "object") {
+    return { ok: true, value: emptyWorkflowConfig() };
+  }
+  if (Array.isArray(raw)) {
+    return { ok: false, errors: ["workflow must be a mapping, not a list"] };
+  }
+  const allowed = ["test_command", "completion_command", "lint_command", "format_command"];
+  const value = emptyWorkflowConfig();
+  const errors = [];
+  for (const key of Object.keys(raw)) {
+    if (!allowed.includes(key)) {
+      errors.push(`workflow has unknown key '${key}'`);
+      continue;
+    }
+    const v = raw[key];
+    if (v == null) continue;
+    if (typeof v !== "string" || v.trim() === "") {
+      errors.push(`workflow.${key} must be a non-empty string when set`);
+      continue;
+    }
+    value[key] = v;
+  }
+  if (errors.length) return { ok: false, errors };
+  return { ok: true, value };
+}
+
+function normalizeSonarcloudConfig(raw) {
+  if (raw == null) {
+    return { ok: true, value: null };
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, errors: ["sonarcloud must be a mapping, not a list or scalar"] };
+  }
+  const allowed = ["project_key", "organization"];
+  const errors = [];
+  for (const key of Object.keys(raw)) {
+    if (!allowed.includes(key)) {
+      errors.push(`sonarcloud has unknown key '${key}'`);
+    }
+  }
+  const project_key = raw.project_key;
+  const organization = raw.organization;
+  if (typeof project_key !== "string" || project_key.trim() === "") {
+    errors.push("sonarcloud.project_key must be a non-empty string when sonarcloud is set");
+  }
+  if (typeof organization !== "string" || organization.trim() === "") {
+    errors.push("sonarcloud.organization must be a non-empty string when sonarcloud is set");
+  }
+  if (errors.length) return { ok: false, errors };
+  return { ok: true, value: { project_key, organization } };
+}
+
+function normalizeRulesConfig(raw) {
+  if (raw == null) {
+    return { ok: true, value: { plan_rules_path: null } };
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, errors: ["rules must be a mapping"] };
+  }
+  const allowed = ["plan_rules"];
+  const errors = [];
+  for (const key of Object.keys(raw)) {
+    if (!allowed.includes(key)) {
+      errors.push(`rules has unknown key '${key}'`);
+    }
+  }
+  if (errors.length) return { ok: false, errors };
+
+  const planRules = raw.plan_rules;
+  if (planRules == null) {
+    return { ok: true, value: { plan_rules_path: null } };
+  }
+  if (typeof planRules !== "string" || planRules.trim() === "") {
+    return { ok: false, errors: ["rules.plan_rules must be a non-empty string when set"] };
+  }
+  return { ok: true, value: { plan_rules_path: planRules } };
+}
+
+export function parseGroundControlYaml(yamlText) {
   let parsed;
   try {
-    parsed = parseYaml(yamlBlockMatch[1]);
+    parsed = parseYaml(yamlText);
   } catch (error) {
-    return {
-      status: "invalid_ground_control_context",
-      project: null,
-      errors: [`Could not parse Ground Control context YAML: ${error.message}`],
-      suggested_agents_snippet: snippet,
-    };
+    return { ok: false, errors: [`Could not parse .ground-control.yaml: ${error.message}`] };
   }
 
-  const project = parsed?.ground_control?.project;
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, errors: [".ground-control.yaml root must be a mapping"] };
+  }
+
+  const errors = [];
+  const allowedTop = [
+    "schema_version",
+    "project",
+    "github_repo",
+    "workflow",
+    "sonarcloud",
+    "rules",
+  ];
+  for (const key of Object.keys(parsed)) {
+    if (!allowedTop.includes(key)) {
+      errors.push(`unknown top-level key '${key}'`);
+    }
+  }
+
+  const schemaVersion = parsed.schema_version;
+  if (!SUPPORTED_GROUND_CONTROL_SCHEMA_VERSIONS.includes(schemaVersion)) {
+    errors.push(
+      `schema_version must be one of ${SUPPORTED_GROUND_CONTROL_SCHEMA_VERSIONS.join(", ")} (got ${JSON.stringify(schemaVersion)})`,
+    );
+  }
+
+  const project = parsed.project;
   if (typeof project !== "string" || project.trim() === "") {
-    return {
-      status: "invalid_ground_control_context",
-      project: null,
-      errors: [
-        "Ground Control context must define ground_control.project as a non-empty string.",
-      ],
-      suggested_agents_snippet: snippet,
-    };
+    errors.push("project is required and must be a non-empty string");
+  } else if (!GROUND_CONTROL_PROJECT_RE.test(project)) {
+    errors.push(
+      "project must be a lowercase identifier using letters, numbers, and hyphens only",
+    );
   }
 
-  if (!GROUND_CONTROL_PROJECT_RE.test(project)) {
-    return {
-      status: "invalid_ground_control_context",
-      project: null,
-      errors: [
-        "ground_control.project must be a lowercase identifier using letters, numbers, and hyphens only.",
-      ],
-      suggested_agents_snippet: snippet,
-    };
+  let githubRepo = null;
+  if (parsed.github_repo != null) {
+    if (typeof parsed.github_repo !== "string" || parsed.github_repo.trim() === "") {
+      errors.push("github_repo must be a non-empty string when set");
+    } else {
+      githubRepo = parsed.github_repo;
+    }
   }
+
+  const workflowResult = normalizeWorkflowConfig(parsed.workflow);
+  if (!workflowResult.ok) errors.push(...workflowResult.errors);
+
+  const sonarResult = normalizeSonarcloudConfig(parsed.sonarcloud);
+  if (!sonarResult.ok) errors.push(...sonarResult.errors);
+
+  const rulesResult = normalizeRulesConfig(parsed.rules);
+  if (!rulesResult.ok) errors.push(...rulesResult.errors);
+
+  if (errors.length) return { ok: false, errors };
 
   return {
-    status: "ok",
-    project,
-    errors: [],
-    suggested_agents_snippet: snippet,
+    ok: true,
+    value: {
+      project,
+      github_repo: githubRepo,
+      workflow: workflowResult.value,
+      sonarcloud: sonarResult.value,
+      rules: {
+        plan_rules_path: rulesResult.value.plan_rules_path,
+      },
+    },
   };
 }
 
 export async function getRepoGroundControlContext(repoPath) {
   const repoRoot = await ensureGitRepo(repoPath);
-  const agentsPath = join(repoRoot, "AGENTS.md");
-  const snippet = buildGroundControlContextSnippet();
+  const configPath = join(repoRoot, ".ground-control.yaml");
 
-  let agentsMarkdown;
+  let yamlText;
   try {
-    agentsMarkdown = readAbsoluteTextFile(agentsPath);
+    yamlText = readAbsoluteTextFile(configPath);
   } catch (error) {
     if (error.code === "ENOENT") {
       return {
         repo_path: repoRoot,
-        agents_path: agentsPath,
-        status: "missing_agents_md",
+        config_path: configPath,
+        status: "missing_ground_control_yaml",
         project: null,
         errors: [
-          "AGENTS.md was not found at the repository root.",
+          ".ground-control.yaml was not found at the repository root. Create it with schema_version: 1 and project: <your-project-id> at minimum.",
         ],
-        suggested_agents_snippet: snippet,
+        suggested_ground_control_yaml: buildSuggestedGroundControlYaml(),
       };
     }
-
     throw error;
+  }
+
+  const parseResult = parseGroundControlYaml(yamlText);
+  if (!parseResult.ok) {
+    return {
+      repo_path: repoRoot,
+      config_path: configPath,
+      status: "invalid_ground_control_yaml",
+      project: null,
+      errors: parseResult.errors,
+      suggested_ground_control_yaml: buildSuggestedGroundControlYaml(),
+    };
+  }
+
+  // Resolve the plan_rules file if referenced. Must stay inside the repo root.
+  const { rules } = parseResult.value;
+  let planRulesContent = null;
+  if (rules.plan_rules_path) {
+    const absRulesPath = join(repoRoot, rules.plan_rules_path);
+    try {
+      planRulesContent = readAbsoluteTextFile(absRulesPath);
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        return {
+          repo_path: repoRoot,
+          config_path: configPath,
+          status: "invalid_ground_control_yaml",
+          project: null,
+          errors: [
+            `rules.plan_rules references ${rules.plan_rules_path} which does not exist`,
+          ],
+          suggested_ground_control_yaml: buildSuggestedGroundControlYaml(),
+        };
+      }
+      throw error;
+    }
   }
 
   return {
     repo_path: repoRoot,
-    agents_path: agentsPath,
-    ...parseRepoGroundControlContext(agentsMarkdown),
+    config_path: configPath,
+    status: "ok",
+    project: parseResult.value.project,
+    github_repo: parseResult.value.github_repo,
+    workflow: parseResult.value.workflow,
+    sonarcloud: parseResult.value.sonarcloud,
+    rules: {
+      plan_rules_path: rules.plan_rules_path,
+      plan_rules_content: planRulesContent,
+    },
+    errors: [],
   };
 }
 

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -1,11 +1,17 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
 import {
   buildUrl,
   parseErrorBody,
   formatIssueBody,
   buildGroundControlContextSnippet,
-  parseRepoGroundControlContext,
+  buildSuggestedGroundControlYaml,
+  parseGroundControlYaml,
+  getRepoGroundControlContext,
   buildCodexArchitecturePreflightPrompt,
   buildCodexArchitectureExecArgs,
   buildCodexReviewPrompt,
@@ -168,54 +174,220 @@ describe("formatIssueBody", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildGroundControlContextSnippet", () => {
-  it("renders the standardized AGENTS.md snippet", () => {
-    const snippet = buildGroundControlContextSnippet("aces-sdl");
+  it("renders a pointer section for AGENTS.md that references .ground-control.yaml", () => {
+    const snippet = buildGroundControlContextSnippet();
     assert.ok(snippet.includes("## Ground Control Context"));
-    assert.ok(snippet.includes("ground_control:"));
-    assert.ok(snippet.includes("project: aces-sdl"));
+    assert.ok(snippet.includes(".ground-control.yaml"));
+    assert.ok(snippet.includes("gc_get_repo_ground_control_context"));
   });
 });
 
-describe("parseRepoGroundControlContext", () => {
-  it("parses a valid Ground Control Context section", () => {
-    const result = parseRepoGroundControlContext(`
-# Agent Instructions
+describe("buildSuggestedGroundControlYaml", () => {
+  it("renders a starter yaml with schema_version and project", () => {
+    const yaml = buildSuggestedGroundControlYaml("aces-sdl");
+    assert.ok(yaml.includes("schema_version: 1"));
+    assert.ok(yaml.includes("project: aces-sdl"));
+    assert.ok(yaml.includes("workflow:"));
+    assert.ok(yaml.includes("sonarcloud:"));
+    assert.ok(yaml.includes("rules:"));
+  });
+});
 
-## Ground Control Context
-
-\`\`\`yaml
-ground_control:
-  project: aces-sdl
-\`\`\`
-`);
-
-    assert.equal(result.status, "ok");
-    assert.equal(result.project, "aces-sdl");
-    assert.deepEqual(result.errors, []);
+describe("parseGroundControlYaml", () => {
+  it("parses a minimal valid yaml", () => {
+    const result = parseGroundControlYaml("schema_version: 1\nproject: aces-sdl\n");
+    assert.equal(result.ok, true);
+    assert.equal(result.value.project, "aces-sdl");
+    assert.equal(result.value.github_repo, null);
+    assert.deepEqual(result.value.workflow, {
+      test_command: null,
+      completion_command: null,
+      lint_command: null,
+      format_command: null,
+    });
+    assert.equal(result.value.sonarcloud, null);
+    assert.equal(result.value.rules.plan_rules_path, null);
   });
 
-  it("reports a missing Ground Control Context section", () => {
-    const result = parseRepoGroundControlContext("# Agent Instructions\n");
-
-    assert.equal(result.status, "missing_ground_control_context");
-    assert.equal(result.project, null);
-    assert.ok(result.errors[0].includes("Ground Control Context"));
-    assert.ok(result.suggested_agents_snippet.includes("ground_control:"));
+  it("parses a fully populated yaml", () => {
+    const yaml = [
+      "schema_version: 1",
+      "project: ground-control",
+      "github_repo: KeplerOps/Ground-Control",
+      "workflow:",
+      "  test_command: cd backend && ./gradlew test -Pquick",
+      "  completion_command: make check",
+      "  lint_command: cd backend && ./gradlew spotlessCheck",
+      "  format_command: cd backend && ./gradlew spotlessApply",
+      "sonarcloud:",
+      "  project_key: KeplerOps_Ground-Control",
+      "  organization: KeplerOps",
+      "rules:",
+      "  plan_rules: .gc/plan-rules.md",
+      "",
+    ].join("\n");
+    const result = parseGroundControlYaml(yaml);
+    assert.equal(result.ok, true);
+    assert.equal(result.value.project, "ground-control");
+    assert.equal(result.value.github_repo, "KeplerOps/Ground-Control");
+    assert.equal(result.value.workflow.completion_command, "make check");
+    assert.equal(result.value.sonarcloud.project_key, "KeplerOps_Ground-Control");
+    assert.equal(result.value.sonarcloud.organization, "KeplerOps");
+    assert.equal(result.value.rules.plan_rules_path, ".gc/plan-rules.md");
   });
 
-  it("reports an invalid project identifier", () => {
-    const result = parseRepoGroundControlContext(`
-## Ground Control Context
+  it("rejects invalid yaml text", () => {
+    const result = parseGroundControlYaml("project: a\n  bad: [unclosed");
+    assert.equal(result.ok, false);
+    assert.ok(result.errors[0].includes("parse"));
+  });
 
-\`\`\`yaml
-ground_control:
-  project: ACES_SDL
-\`\`\`
-`);
+  it("requires schema_version", () => {
+    const result = parseGroundControlYaml("project: x\n");
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.includes("schema_version")));
+  });
 
-    assert.equal(result.status, "invalid_ground_control_context");
-    assert.equal(result.project, null);
-    assert.ok(result.errors[0].includes("lowercase identifier"));
+  it("rejects unsupported schema_version", () => {
+    const result = parseGroundControlYaml("schema_version: 99\nproject: x\n");
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.includes("schema_version")));
+  });
+
+  it("requires project", () => {
+    const result = parseGroundControlYaml("schema_version: 1\n");
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.includes("project")));
+  });
+
+  it("rejects an uppercase project identifier", () => {
+    const result = parseGroundControlYaml("schema_version: 1\nproject: ACES_SDL\n");
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.includes("lowercase identifier")));
+  });
+
+  it("rejects unknown top-level keys", () => {
+    const result = parseGroundControlYaml("schema_version: 1\nproject: x\nbogus: true\n");
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.includes("unknown top-level key")));
+  });
+
+  it("rejects workflow unknown keys", () => {
+    const yaml = "schema_version: 1\nproject: x\nworkflow:\n  bogus: nope\n";
+    const result = parseGroundControlYaml(yaml);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.includes("workflow has unknown key")));
+  });
+
+  it("requires both sonarcloud fields when sonarcloud is set", () => {
+    const yaml = "schema_version: 1\nproject: x\nsonarcloud:\n  project_key: foo\n";
+    const result = parseGroundControlYaml(yaml);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.includes("organization")));
+  });
+});
+
+describe("getRepoGroundControlContext", () => {
+  function makeTempRepo() {
+    const dir = mkdtempSync(join(tmpdir(), "gc-yaml-test-"));
+    execFileSync("git", ["-C", dir, "init", "-q"]);
+    return dir;
+  }
+
+  it("returns missing_ground_control_yaml when the file is absent", async () => {
+    const dir = makeTempRepo();
+    try {
+      const result = await getRepoGroundControlContext(dir);
+      assert.equal(result.status, "missing_ground_control_yaml");
+      assert.equal(result.project, null);
+      assert.ok(result.errors[0].includes(".ground-control.yaml"));
+      assert.ok(result.suggested_ground_control_yaml.includes("schema_version"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns ok for a valid .ground-control.yaml", async () => {
+    const dir = makeTempRepo();
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      writeFileSync(
+        join(dir, ".ground-control.yaml"),
+        "schema_version: 1\nproject: test-project\n",
+      );
+      const result = await getRepoGroundControlContext(dir);
+      assert.equal(result.status, "ok");
+      assert.equal(result.project, "test-project");
+      assert.equal(result.rules.plan_rules_path, null);
+      assert.equal(result.rules.plan_rules_content, null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("inlines plan_rules file content when referenced", async () => {
+    const dir = makeTempRepo();
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      mkdirSync(join(dir, ".gc"));
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      writeFileSync(join(dir, ".gc", "plan-rules.md"), "- rule one\n- rule two\n");
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      writeFileSync(
+        join(dir, ".ground-control.yaml"),
+        [
+          "schema_version: 1",
+          "project: test-project",
+          "rules:",
+          "  plan_rules: .gc/plan-rules.md",
+          "",
+        ].join("\n"),
+      );
+      const result = await getRepoGroundControlContext(dir);
+      assert.equal(result.status, "ok");
+      assert.equal(result.rules.plan_rules_path, ".gc/plan-rules.md");
+      assert.ok(result.rules.plan_rules_content.includes("rule one"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns invalid_ground_control_yaml when plan_rules file is missing", async () => {
+    const dir = makeTempRepo();
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      writeFileSync(
+        join(dir, ".ground-control.yaml"),
+        [
+          "schema_version: 1",
+          "project: test-project",
+          "rules:",
+          "  plan_rules: .gc/missing.md",
+          "",
+        ].join("\n"),
+      );
+      const result = await getRepoGroundControlContext(dir);
+      assert.equal(result.status, "invalid_ground_control_yaml");
+      assert.ok(result.errors[0].includes(".gc/missing.md"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns invalid_ground_control_yaml when the yaml is malformed", async () => {
+    const dir = makeTempRepo();
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      writeFileSync(
+        join(dir, ".ground-control.yaml"),
+        "schema_version: 1\nproject: ACES_SDL\n",
+      );
+      const result = await getRepoGroundControlContext(dir);
+      assert.equal(result.status, "invalid_ground_control_yaml");
+      assert.ok(result.errors.some((e) => e.includes("lowercase identifier")));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Ground Control MCP server now reads `.ground-control.yaml` from each repo root instead of parsing the "Ground Control Context" YAML block in AGENTS.md
- `gc_get_repo_ground_control_context` returns the full workflow config: project, github_repo, workflow commands (test/completion/lint/format), optional sonarcloud settings, optional inlined plan_rules content
- Enables centralizing /implement and /ship skills at user level across multiple repos — each repo carries only a small `.ground-control.yaml` (+ optional `.gc/plan-rules.md`), skills stay 100% generic
- Existing AGENTS.md parser removed; replaced with yaml parser + schema validation
- 16 new tests for yaml parsing, schema errors, plan_rules resolution, and the full `getRepoGroundControlContext` flow on a temp git repo

Closes the repo-config duplication bug that caused shifter and shifter-k8s to ship with `KeplerOps_Ground-Control` hardcoded as their SonarCloud key, and that made Ground-Control's JPA/Flyway/WebMvcTest plan rules inlined in every other repo's copy of the implement skill.

## Requirement UIDs

- GC-O008 — Repo-Local Ground Control Configuration Surface

## ADR Impact

- ADR-023 — Repo-Local Workflow Config via .ground-control.yaml (ACCEPTED)

This PR is the implementation side of ADR-023. The ADR documents the schema, the MCP tool contract, the centralization of skills at user level, and the hard-cutover deprecation of the old AGENTS.md parser. The requirement (GC-O008) captures the "what the system shall do" side; the ADR captures the "why we chose this shape" side.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason

## Traceability

- IMPLEMENTS: mcp/ground-control/lib.js (parseGroundControlYaml, getRepoGroundControlContext, buildSuggestedGroundControlYaml, buildGroundControlContextSnippet pointer rewrite), mcp/ground-control/index.js (tool description updated)
- TESTS: mcp/ground-control/lib.test.js (16 new tests covering yaml parsing, schema errors, plan_rules resolution, and the full getRepoGroundControlContext flow against a temp git repo)

Traceability links created in Ground Control:
- GC-O008 IMPLEMENTS mcp/ground-control/lib.js
- GC-O008 IMPLEMENTS mcp/ground-control/index.js
- GC-O008 TESTS mcp/ground-control/lib.test.js
- GC-O008 DOCUMENTS ADR-023

## Migration

Repos must provide `.ground-control.yaml` at their root. When the file is missing, the tool returns `status: "missing_ground_control_yaml"` with a `suggested_ground_control_yaml` starter so agents can self-service migration.

Per-repo migration PRs for Ground-Control, aphelion, keplerops-template, capcom, aces-sdl, shifter, and shifter-k8s follow this one.

## Test plan

- [x] `npm test` in `mcp/ground-control` — 39 tests pass (16 new)
- [x] `npm run lint` clean
- [x] Pre-commit hooks pass (spotless / policy / secrets)
- [ ] CI green
