### PR TITLE
Knowledge system 2/6: capture primitive and real-time ingest engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.114.0] - 2026-04-13
+
+### Added
+
+- Knowledge base capture primitive and real-time ingest engine (GC-X006,
+  GC-X007, GC-X008, GC-X009, GC-X010, GC-X011): the new `gc_remember` MCP
+  tool writes a structured inbox file under `<knowledge.inbox>/` and
+  spawns a detached ingest subprocess that integrates the observation
+  into the wiki. Synchronous success means the inbox entry is durably
+  written; wiki integration is asynchronous and retried by later runs.
+- `mcp/ground-control/knowledge_ingest.js` — shared ingest engine. Reads
+  the inbox item, invokes **Claude Code** in headless mode
+  (`claude --print --bare --add-dir <repo> --allowed-tools ...`) as the
+  ingest agent for the update-vs-create decision and wiki edits,
+  validates commit isolation against the knowledge tree, and
+  stages/commits only the allowed paths. Injectable `ingestAgent`
+  parameter lets unit tests script the full transaction without
+  shelling out to the real Claude Code CLI. Codex is deliberately NOT
+  involved in knowledge ingest; see ADR-025 for the boundary.
+- `mcp/ground-control/knowledge_ingest_cli.js` — thin argv-driven entry
+  point that `gc_remember` spawns as the detached subprocess.
+- Canonical source-citation formatter (`formatSourceCitation`) and
+  vocabulary (`KNOWLEDGE_SOURCE_TYPES`) in `mcp/ground-control/lib.js`.
+  One formatter produces the citation string reused across inbox
+  frontmatter, page frontmatter, `log.md` bullets, and git commit
+  messages so terminology cannot drift.
+- Interprocess knowledge-base lock via `proper-lockfile`, keyed by the
+  canonical realpath of the knowledge directory so symlinked or
+  differently-spelled checkouts contend on the same lock.
+  `acquireKnowledgeLock` defaults to fail-fast and accepts a retry
+  policy; `runIngest` passes a bounded exponential backoff so two rapid
+  captures queue up instead of rejecting.
+- Atomic inbox write (`writeKnowledgeInbox`): temp-file + fsync + rename,
+  lazy inbox-dir creation, timestamp-prefixed filenames with random
+  collision-resistance suffix, spawn-failure-tolerant synchronous return.
+- [ADR-025](../architecture/adrs/025-knowledge-ingest-engine.md): captures
+  the engine location (co-located with the MCP server, not
+  `tools/ground_control/knowledge/`), Claude-Code-as-ingest-agent (with
+  an explicit "codex is NOT used for knowledge maintenance" boundary),
+  interprocess lock choice, strict commit-isolation rule, and the "no
+  Spring backend surface" boundary.
+- `docs/architecture/ARCHITECTURE.md` gains a short "Knowledge Ingest
+  Engine" section pointing at ADR-025.
+
+### Changed
+
+- `docs/notes/agent-knowledge-system-design.md` hot-path guardrails
+  section expanded: item-addressed subprocess contract (no inbox
+  rescanning), success-only inbox lifecycle, interprocess lock ownership,
+  canonical-path lock identity, detached-HEAD failure mode, measurable
+  real-time latency, no `git commit --no-verify` bypass.
+- `docs/knowledge/SCHEMA.md` gains an "Ingest consistency contract"
+  section (existing page file path is page identity, index.md is only a
+  shortlist, updates are incremental edits, renames/splits/merges are
+  exceptional) and an inbox-lifecycle clause (success-only archival).
+
+### Dependencies
+
+- Added `proper-lockfile@^4.1.2` to `mcp/ground-control/package.json`.
+- Bumped transitive `hono` (4.12.7 → 4.12.12) and `@hono/node-server`
+  (1.19.11 → 1.19.14) via `npm audit fix` to clear moderate advisories.
+
 ## [0.113.0] - 2026-04-12
 
 ### Added
@@ -29,6 +91,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcp/ground-control/README.md` no longer describes
   `gc_get_repo_ground_control_context` as reading from `AGENTS.md`; the
   tool reads `.ground-control.yaml` at the repo root.
+
+### Changed
+
+- Agent knowledge system design note now makes the phase-2 hot-path
+  guardrails explicit: the ingest engine stays in repo-local tooling (not
+  the Java backend), `gc_remember` owns only synchronous inbox capture, the
+  real-time path reuses the resolved `knowledge` config from
+  `gc_get_repo_ground_control_context`, the per-repo lock is a shared
+  interprocess guard keyed by canonical knowledge-base paths and covers the
+  full ingest transaction, failed ingest keeps the original inbox item in
+  place for retry until the commit succeeds, and ingest commits must stage
+  only knowledge-tree files plus the specific inbox item being processed.
 
 ## [0.112.0] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1046,6 +1046,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delegates to `docs/operations/backup-restore.md`, records the new
   cadence / retention / verification defaults, and enumerates the AGE
   verification checks.
+## [0.114.0] - 2026-04-13
+
+### Added
+
+- Knowledge base capture primitive and real-time ingest engine (GC-X006,
+  GC-X007, GC-X008, GC-X009, GC-X010, GC-X011): the new `gc_remember` MCP
+  tool writes a structured inbox file under `<knowledge.inbox>/` and
+  spawns a detached ingest subprocess that integrates the observation
+  into the wiki. Synchronous success means the inbox entry is durably
+  written; wiki integration is asynchronous and retried by later runs.
+- `mcp/ground-control/knowledge_ingest.js` — shared ingest engine. Reads
+  the inbox item, invokes **Claude Code** in headless mode
+  (`claude --print --bare --add-dir <repo> --allowed-tools ...`) as the
+  ingest agent for the update-vs-create decision and wiki edits,
+  validates commit isolation against the knowledge tree, and
+  stages/commits only the allowed paths. Injectable `ingestAgent`
+  parameter lets unit tests script the full transaction without
+  shelling out to the real Claude Code CLI. Codex is deliberately NOT
+  involved in knowledge ingest; see ADR-025 for the boundary.
+- `mcp/ground-control/knowledge_ingest_cli.js` — thin argv-driven entry
+  point that `gc_remember` spawns as the detached subprocess.
+- Canonical source-citation formatter (`formatSourceCitation`) and
+  vocabulary (`KNOWLEDGE_SOURCE_TYPES`) in `mcp/ground-control/lib.js`.
+  One formatter produces the citation string reused across inbox
+  frontmatter, page frontmatter, `log.md` bullets, and git commit
+  messages so terminology cannot drift.
+- Interprocess knowledge-base lock via `proper-lockfile`, keyed by the
+  canonical realpath of the knowledge directory so symlinked or
+  differently-spelled checkouts contend on the same lock.
+  `acquireKnowledgeLock` defaults to fail-fast and accepts a retry
+  policy; `runIngest` passes a bounded exponential backoff so two rapid
+  captures queue up instead of rejecting.
+- Atomic inbox write (`writeKnowledgeInbox`): temp-file + fsync + rename,
+  lazy inbox-dir creation, timestamp-prefixed filenames with random
+  collision-resistance suffix, spawn-failure-tolerant synchronous return.
+- [ADR-025](../architecture/adrs/025-knowledge-ingest-engine.md): captures
+  the engine location (co-located with the MCP server, not
+  `tools/ground_control/knowledge/`), Claude-Code-as-ingest-agent (with
+  an explicit "codex is NOT used for knowledge maintenance" boundary),
+  interprocess lock choice, strict commit-isolation rule, and the "no
+  Spring backend surface" boundary.
+- `docs/architecture/ARCHITECTURE.md` gains a short "Knowledge Ingest
+  Engine" section pointing at ADR-025.
+
+### Changed
+
+- `docs/notes/agent-knowledge-system-design.md` hot-path guardrails
+  section expanded: item-addressed subprocess contract (no inbox
+  rescanning), success-only inbox lifecycle, interprocess lock ownership,
+  canonical-path lock identity, detached-HEAD failure mode, measurable
+  real-time latency, no `git commit --no-verify` bypass.
+- `docs/knowledge/SCHEMA.md` gains an "Ingest consistency contract"
+  section (existing page file path is page identity, index.md is only a
+  shortlist, updates are incremental edits, renames/splits/merges are
+  exceptional) and an inbox-lifecycle clause (success-only archival).
+
+### Dependencies
+
+- Added `proper-lockfile@^4.1.2` to `mcp/ground-control/package.json`.
+- Bumped transitive `hono` (4.12.7 → 4.12.12) and `@hono/node-server`
+  (1.19.11 → 1.19.14) via `npm audit fix` to clear moderate advisories.
 
 ## [0.113.0] - 2026-04-12
 
@@ -1071,6 +1132,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcp/ground-control/README.md` no longer describes
   `gc_get_repo_ground_control_context` as reading from `AGENTS.md`; the
   tool reads `.ground-control.yaml` at the repo root.
+
+### Changed
+
+- Agent knowledge system design note now makes the phase-2 hot-path
+  guardrails explicit: the ingest engine stays in repo-local tooling (not
+  the Java backend), `gc_remember` owns only synchronous inbox capture, the
+  real-time path reuses the resolved `knowledge` config from
+  `gc_get_repo_ground_control_context`, the per-repo lock is a shared
+  interprocess guard keyed by canonical knowledge-base paths and covers the
+  full ingest transaction, failed ingest keeps the original inbox item in
+  place for retry until the commit succeeds, and ingest commits must stage
+  only knowledge-tree files plus the specific inbox item being processed.
 
 ## [0.112.0] - 2026-04-12
 

--- a/architecture/adrs/025-knowledge-ingest-engine.md
+++ b/architecture/adrs/025-knowledge-ingest-engine.md
@@ -1,0 +1,134 @@
+# ADR-025: Knowledge Ingest Engine
+
+## Status
+
+accepted
+
+## Date
+
+2026-04-13
+
+## Context
+
+Issue #522 landed the knowledge-base skeleton (`.ground-control.yaml` `knowledge` section, `docs/knowledge/` with `SCHEMA.md`, `index.md`, `log.md`). Issue #523 now wires the *write path*: an agent captures an observation via the `gc_remember` MCP tool, and a detached subprocess integrates that observation into the wiki within seconds so the next agent invocation in the same working session sees it as a page.
+
+The requirements that drive this work are GC-X006 through GC-X011. They define the capture primitive's input contract (GC-X006), read-before-write consistency (GC-X007), serialized writes within a single knowledge base (GC-X008), failure retry via untouched inbox files (GC-X009), commit-on-active-branch semantics (GC-X010), and real-time latency in seconds (GC-X011).
+
+The design note at `docs/notes/agent-knowledge-system-design.md` describes the rollout in prose but deliberately leaves several "logistics, not architecture" decisions open for the implementation phase (§"Open decisions not blocking the design"). This ADR pins down the ones that affect code boundaries, so issues #524–#527 (consumption, admin CLI, scheduled sweep, lint) can anchor on a stable shape instead of re-litigating the same questions.
+
+## Decision
+
+### 1. One shared ingest engine, co-located with the MCP server
+
+The ingest engine is a Node.js module at `mcp/ground-control/knowledge_ingest.js`, with a thin CLI entry point at `mcp/ground-control/knowledge_ingest_cli.js` that `gc_remember` spawns as a detached subprocess. The engine's core function (`runIngest`) is exported directly and used by the unit tests with an injected `ingestAgent` stub, so the full transaction can be exercised without shelling out to the real Claude Code CLI.
+
+The original design note suggested `tools/ground_control/knowledge/ingest.py` — Python, in the general tooling area, shared between the hot path and a future CLI. We diverge from that suggestion for this slice:
+
+- **Only consumer is Node.** `gc_remember` is an MCP tool; the MCP server is Node. The future CLI (issue #525) is hypothetical infrastructure and its language is undecided. Building Python infrastructure now just to hedge against a hypothetical future CLI violates the CLAUDE.md "don't design for future requirements" rule.
+- **Existing test harness works as-is.** `mcp/ground-control/lib.test.js` already runs with `node --test`. `tools/ground_control/` has no JS test harness and would need one (or a whole Python test story) to match the engine's coverage.
+- **Existing subprocess + path helpers live here.** `lib.js` already exposes `execFileWithInput`, `resolveRepoRelativePath`, `assertRealpathInRepo`, and `getRepoGroundControlContext`. The ingest engine reuses all of them via a single local import instead of cross-package coupling.
+- **Dodges the `architecture/policies/adr-policy.json` ADR-014 trip.** That policy treats any change under `tools/ground_control/**` as verification-architecture territory and requires syncing ADR-014 and `docs/architecture/ARCHITECTURE.md`. Knowledge ingest is NOT verification; co-locating with the MCP server avoids the cross-doc friction without needing a policy carve-out.
+
+When the admin CLI ships (issue #525), there are two clean paths forward:
+- If the CLI is Node/Bun, it imports `runIngest` directly from `mcp/ground-control/knowledge_ingest.js`. Done.
+- If the CLI is Python, we factor `knowledge_ingest.js` and its helpers out to a neutral location (e.g., `tools/ground_control/knowledge/`) AND the #525 slice owns the policy carve-out and the language-bridge decision. The refactor is local to this module: nothing else in the codebase imports it.
+
+Either way, the decision is one lateral move, not a rewrite. Deferring the decision is cheaper than making the wrong one now.
+
+### 2. Claude Code is the ingest "agent" (not codex)
+
+The ingest engine does not attempt to decide update-vs-create itself. Instead, it builds a tightly-scoped prompt that includes the inbox item, the current `index.md`, the tail of `log.md`, and the wiki schema, and invokes **Claude Code** in headless mode (`claude --print`) with a restricted tool allowlist. Claude Code uses its built-in `Read` / `Edit` / `Write` / scoped `Bash` tools to read what it needs, write the new/updated page directly to the worktree, append to `index.md` and `log.md`, and move the inbox item to `inbox/processed/`. The engine then:
+
+1. Inspects `git status --porcelain -uall` to compute the set of files the agent touched.
+2. Subtracts any files that were already dirty before ingest ran (those are pre-existing user work, not agent output).
+3. Validates every agent-introduced path is under the knowledge directory OR is the exact inbox item (the one allowed move target).
+4. On isolation violation, reverts all agent-introduced changes via `git checkout -- <path>` / `git clean -f -- <path>`, leaves the inbox file untouched, and throws.
+5. On success, stages exactly those paths (no `git add -A`) and commits with a canonical citation-derived message.
+
+**Codex is explicitly NOT used for knowledge ingest.** Codex's role in this repository is confined to the specific workflows where it has already been wired in by name — architecture preflight (`gc_codex_architecture_preflight`) and cross-model PR review (`gc_codex_review`). Knowledge maintenance is a Claude Code responsibility by project decision, and any attempt to reintroduce codex into the ingest path should be rejected at review time. The rationale:
+
+- Claude Code is the model family the team already trusts for day-to-day coding work, and knowledge ingest is day-to-day coding work applied to markdown instead of source code.
+- Claude Code's headless mode (`claude -p`) supports tool-level allowlisting via `--allowed-tools` and directory-level access control via `--add-dir`, giving the engine finer-grained sandboxing than codex's `--sandbox workspace-write`.
+- Keeping a single agent responsible for the knowledge base means the agent that writes pages is the same agent that reads them during `/implement` Step 3 (consumption, issue #524) — tone, conventions, and citation style stay consistent.
+- Codex remains valuable exactly where it is — as a cross-model reviewer and architecture preflight. Mixing it into maintenance work dilutes that role.
+
+The default invoker is `defaultIngestAgent` in `knowledge_ingest.js`. It shells out with:
+
+```
+claude --print
+       --add-dir <repoRoot>
+       --permission-mode bypassPermissions
+       --allowed-tools "Read Edit Write Bash(git status:*) Bash(git mv:*) Bash(mkdir:*)"
+       --model sonnet
+       --output-format text
+```
+
+The prompt is piped via stdin (through `execFileWithInput` in `lib.js`) rather than passed as a positional argument, because `--print` mode waits 3 seconds for stdin before falling back to the positional prompt. Writing the prompt directly onto the child's stdin eliminates the false-positive warning and starts the model call immediately.
+
+Flag rationale:
+
+- `--print` runs Claude Code non-interactively: read prompt, execute, exit.
+- `--add-dir <repoRoot>` grants tool-layer access to the target repository only.
+- `--permission-mode bypassPermissions` is required for unattended operation (no interactive confirm prompts). The blast radius is bounded by the tool allowlist and `--add-dir` scoping above, and the engine validates commit isolation after the agent returns, so an over-permissioned subprocess cannot silently poison state outside the knowledge tree.
+- `--allowed-tools "Read Edit Write Bash(git status:*) Bash(git mv:*) Bash(mkdir:*)"` is the minimum set required to read the wiki, edit pages, and rename the inbox item. No `WebFetch`, no free-form `Bash`, no `Task` delegation.
+- `--model sonnet` is sufficient for ingest decisions at a significantly lower cost than opus; operators can override via the `agentOverrides` parameter.
+
+**Why `--bare` is NOT used:** `--bare` restricts Anthropic authentication to `ANTHROPIC_API_KEY` or an `apiKeyHelper` configured via `--settings`. It explicitly refuses to read OAuth / keychain credentials. Operators who log in interactively with `claude login` (the common case for this repository) use OAuth session credentials; a bare-mode subprocess would fail with "Not logged in · Please run /login" even on an otherwise-working machine. The non-bare default lets the subprocess inherit the same OAuth session the operator uses interactively.
+
+**Subprocess env handling:** when Claude Code spawns another Claude Code instance as a subprocess, the parent passes `ANTHROPIC_API_KEY` through its environment automatically. `claude` prefers that env var over the OAuth session file, which means the subprocess would use whatever API key happens to be in the parent's env — not the session the operator logged in with. `defaultIngestAgent` strips `ANTHROPIC_API_KEY` from the child env before spawning so the subprocess falls back to the session credential file, matching the auth path an interactive shell would use. Operators who want a dedicated API-key path for ingest runs (separate from their interactive session) can set `GC_KNOWLEDGE_INGEST_ANTHROPIC_API_KEY` in their environment; when present, it is passed through as `ANTHROPIC_API_KEY` for the subprocess only.
+
+This mirrors how `runCodexArchitecturePreflight` already delegates "read context + write files" to a sandboxed CLI subprocess and inspects the worktree afterwards — the pattern is the same, only the CLI binary and flag shape differ. The engine is trivially mockable for unit tests via the `ingestAgent` DI parameter.
+
+The agent invocation returns a structured tail line (`INGEST_RESULT={"action":"create|update","page":"...","citations_added":n}`) that the engine parses with `parseIngestResultTail`. Missing or malformed tails are treated as ingest failures.
+
+### 3. Interprocess serialization via `proper-lockfile`
+
+Node's stdlib does not expose `flock(2)`, and a per-process mutex is insufficient — `gc_remember` spawns a detached subprocess, so the lock holder is a different OS process from the MCP server that issued the spawn. A future scheduled sweep and a future admin CLI both add more processes that need to serialize through the same mechanism.
+
+We use `proper-lockfile` (5M+ weekly downloads, zero native deps) with:
+
+- `stale: 60_000` — lock is reclaimable if its mtime hasn't been refreshed in 60 s (covers crashed holders).
+- `update: 10_000` — the active holder refreshes the lock mtime this often while work is in progress.
+- Retry policy configurable per call. The `acquireKnowledgeLock` helper defaults to `retries: 0` (fail-fast) so administrative tools can report contention cleanly. `runIngest` passes a bounded exponential retry (`{retries: 15, factor: 1.5, minTimeout: 100, maxTimeout: 2000}`, ~20 s total wait) so two rapid captures queue up instead of rejecting.
+
+The lock identity is the `realpath` of the knowledge directory, not the raw `repo_path` string the caller passed in. Different path spellings (symlinked checkouts, `../` variants) that point at the same inode contend on the same lock. The lockfile itself is stored as `.gc-lock` inside the knowledge directory so `rm -rf <repo>` cleans it up automatically on test teardown.
+
+Alternative considered: `fs.mkdirSync` with a lock directory plus hand-rolled stale detection. Zero deps but requires ~80 lines of pid-check and retry-loop code, re-inventing exactly what `proper-lockfile` already does correctly. Not worth it.
+
+### 4. Strict commit isolation (GC-X010)
+
+Every ingest commit stages:
+- Files under `<knowledge.dir>/<anything>`
+- The exact inbox item path
+
+No other file. Never `git add -A`. Never `--no-verify`. Never `commit.gpgsign = false` bypass.
+
+The engine verifies this by diffing the worktree before and after the ingest agent runs, subtracting pre-existing dirty files, and asserting the remainder is contained in the allowlist. Violations trigger a revert of agent-introduced changes and leave the inbox file untouched.
+
+Rationale: ingest runs on the same branch as ongoing feature work. A permissive stage would silently absorb whatever the developer had in-flight into the "knowledge" commit, breaking the rebase/cherry-pick story and polluting the review diff. Strict isolation keeps the commit boundary clean and the rollback trivial.
+
+### 5. No Spring backend surface in this slice
+
+No REST controller, DTO, JPA entity, Flyway migration, graph node, domain aggregate, or exception class is added for capture / ingest. The knowledge subsystem is deliberately repo-local tooling. If a later slice needs to surface knowledge through HTTP (cross-host sweep, multi-tenant knowledge catalog), the design note's "Future direction" section covers the path, and that slice owns the decision to promote the model.
+
+## Consequences
+
+### Positive
+
+- **Zero new infrastructure.** No Python, no new package, no new test harness, no new dep except `proper-lockfile`. Ships in a single Node package.
+- **Reuses existing path + subprocess machinery.** Every cross-cutting concern (repo-relative paths, symlink containment, subprocess plumbing, ground-control config loading) is imported from `lib.js`, not duplicated.
+- **Testable without the real Claude Code CLI.** The `ingestAgent` DI parameter lets unit tests script filesystem actions in ~20 lines per test. The serialization, isolation, failure-retry, and latency invariants are all exercised in `mcp/ground-control/knowledge_ingest.test.js`.
+- **Process-safe locking.** `proper-lockfile` handles the stale-lock recovery case that a hand-rolled `mkdirSync` lock would have to re-implement.
+- **Strict commit isolation.** Reviewers see knowledge updates as standalone commits with a clean file list, not as noise on top of a feature PR.
+
+### Negative
+
+- **Deviates from the design note's Python/tools preference.** The co-location at `mcp/ground-control/` trades the "shared tooling module" aesthetic for zero premature abstraction. Issue #525's CLI decision may require a lateral move.
+- **Claude Code is load-bearing for the write path.** If the `claude` CLI is unavailable (not installed, offline, out of budget), `gc_remember` still writes the inbox durably but the wiki doesn't update until a sweep (issue #526) or manual retry runs. This matches the design's "availability does not gate implementation" invariant, but operators should know the hot path degrades without the ingest agent.
+- **Extra dep: `proper-lockfile`.** Small, battle-tested, but it is a new runtime dep and must be kept in sync with `npm audit`.
+
+### Risks
+
+- **Commit isolation false positives.** If a developer happens to have a dirty file exactly in the knowledge tree when ingest runs, the engine allows it through (per the "subtract pre-existing dirty files" rule) but then stages and commits it as part of the ingest commit. Mitigation: the engine refuses to run if pre-existing dirty files touch paths the ingest would write to. Broader "don't accidentally ingest another dev's WIP knowledge edit" is documented as an operator responsibility.
+- **Stale-lock edge case.** If a crashed ingest subprocess dies exactly at the lock-refresh boundary, the `stale: 60_000` window could leave a freshly-crashed lock undetected for up to 60 seconds. Mitigation: this is a failure mode, not a correctness issue — the second ingest waits out the stale window and then proceeds. Operators running at higher throughput can tune `stale` down.
+- **Prompt injection via inbox content.** A malicious or accidental inbox note could contain text that tries to redirect the ingest agent to write outside the knowledge tree. Mitigation layers: (a) the Claude Code invocation is already tool-restricted via `--allowed-tools` and directory-scoped via `--add-dir`, so only the repo is reachable; (b) the commit-isolation check runs *after* the agent returns, catches any out-of-scope writes inside the repo, reverts them, and aborts; (c) the inbox file itself is preserved so an operator can investigate.

--- a/changelog.d/523.added.md
+++ b/changelog.d/523.added.md
@@ -1,0 +1,24 @@
+### Added
+
+- **Agent knowledge capture primitive (`gc_remember` MCP tool)**: synchronous
+  capture-only tool that validates `{repo_path, note, source_type, source_ref,
+  tags?}` against `KNOWLEDGE_SOURCE_TYPES`, canonicalizes the citation via
+  `formatSourceCitation`, writes the inbox item atomically (temp + fsync +
+  rename), and spawns a detached ingest subprocess. Returns
+  `{ok: true, inbox_path, citation}` on success. Spawn failures surface as a
+  warning on the same success envelope so the inbox entry is durable for retry.
+- **Shared knowledge ingest engine** at
+  `mcp/ground-control/knowledge_ingest.js`: owns the full ingest transaction
+  under a per-knowledge-base interprocess file lock (`proper-lockfile`, keyed
+  by the canonical realpath of the knowledge directory so symlinked checkouts
+  contend on the same lock). Refuses to run on detached HEAD, invokes Claude
+  Code in headless mode as the ingest agent, validates commit isolation
+  against the knowledge tree, stages exactly the agent-introduced files (no
+  `git add -A`), commits with the canonical citation string, releases the
+  lock. Every failure path leaves the inbox file untouched so the next run
+  retries it.
+- **ADR-025 (Knowledge Ingest Engine)** documenting the engine layout, the
+  Claude-Code-as-ingest-agent boundary (codex is intentionally not used for
+  knowledge maintenance), `proper-lockfile` for interprocess serialization,
+  strict commit isolation, and the no-Spring-backend-surface scope of this
+  slice.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -134,3 +134,9 @@ Environment variables use the `GC_` prefix (e.g., `GC_DATABASE_URL`, `GC_SERVER_
 - Verification result storage (VerificationResult entity with eager-loaded target/requirement, enums, CRUD API, MCP tools) — ADR-014 §2 common schema
 - Pluggable verifier adapter interface (`VerifierAdapter`, `VerificationRequest`, `VerificationOutcome`) — ADR-014 §6 port contract for multi-tool integration
 - Self-referential traceability enforcement — `check_live_policy.mjs` verifies substantive code files have reverse traceability links to requirements (GC-O002), using the `GET /requirements/traceability/by-artifact` reverse lookup endpoint. Lookup errors are tracked separately for debuggability when the endpoint is unavailable.
+
+## Knowledge Ingest Engine (repo-local, out of the product model)
+
+Each repository that uses Ground Control can declare an agent-maintained knowledge base under `docs/knowledge/` via the `knowledge` section of its `.ground-control.yaml`. The `gc_remember` MCP tool captures observations into that repo's inbox; a detached ingest subprocess reads the inbox item, decides update-vs-create via codex, writes the wiki page, and commits the change under a per-repo interprocess lock. The engine lives at `mcp/ground-control/knowledge_ingest.js` with a thin CLI entry at `mcp/ground-control/knowledge_ingest_cli.js`.
+
+The knowledge subsystem is deliberately repo-local tooling — not a Spring backend product feature. No REST controller, DTO, JPA entity, migration, or graph node is added by issues #522–#527. See [ADR-025](../../architecture/adrs/025-knowledge-ingest-engine.md) for the decision to co-locate the engine with the MCP server, use codex as the ingest agent, and serialize via `proper-lockfile`. Rollout phasing lives in `docs/notes/agent-knowledge-system-design.md`.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -176,3 +176,9 @@ The report contract is derived evidence: each finding carries the DRAFT requirem
 - Verification result storage (VerificationResult entity with eager-loaded target/requirement, enums, CRUD API, MCP tools) — ADR-014 §2 common schema
 - Pluggable verifier adapter interface (`VerifierAdapter`, `VerificationRequest`, `VerificationOutcome`) — ADR-014 §6 port contract for multi-tool integration
 - Self-referential traceability enforcement — `check_live_policy.mjs` verifies substantive code files have reverse traceability links to requirements (GC-O002), using the `GET /requirements/traceability/by-artifact` reverse lookup endpoint. Lookup errors are tracked separately for debuggability when the endpoint is unavailable.
+
+## Knowledge Ingest Engine (repo-local, out of the product model)
+
+Each repository that uses Ground Control can declare an agent-maintained knowledge base under `docs/knowledge/` via the `knowledge` section of its `.ground-control.yaml`. The `gc_remember` MCP tool captures observations into that repo's inbox; a detached ingest subprocess reads the inbox item, decides update-vs-create via codex, writes the wiki page, and commits the change under a per-repo interprocess lock. The engine lives at `mcp/ground-control/knowledge_ingest.js` with a thin CLI entry at `mcp/ground-control/knowledge_ingest_cli.js`.
+
+The knowledge subsystem is deliberately repo-local tooling — not a Spring backend product feature. No REST controller, DTO, JPA entity, migration, or graph node is added by issues #522–#527. See [ADR-025](../../architecture/adrs/025-knowledge-ingest-engine.md) for the decision to co-locate the engine with the MCP server, use codex as the ingest agent, and serialize via `proper-lockfile`. Rollout phasing lives in `docs/notes/agent-knowledge-system-design.md`.

--- a/docs/knowledge/SCHEMA.md
+++ b/docs/knowledge/SCHEMA.md
@@ -64,6 +64,28 @@ summary and optionally tags. Before creating a new page, an agent MUST read
 topic — if so, update the existing page rather than creating a duplicate
 (read-before-write invariant from the design note).
 
+### Ingest consistency contract
+
+When ingest integrates a new observation into the wiki (GC-X007), it treats
+an existing page's current file path as that page's identity. If the
+observation refines or extends a page already represented in `index.md`,
+ingest updates that file in place rather than creating a second page with a
+new slug, source-specific suffix, or timestamped variant.
+
+`index.md` is the discovery shortlist, not the whole decision. Ingest reads
+the candidate pages themselves before deciding whether the observation
+belongs on one of them or truly requires a new page.
+
+When updating an existing page, ingest uses the current page contents as the
+base document. Preserve existing frontmatter, source coverage, and
+cross-references unless the new evidence explicitly corrects them. The goal
+is to refine the current page, not re-summarize the topic from scratch.
+
+Renames, splits, and merges are exceptional maintenance operations, not the
+default ingest path. If one is truly required, update `index.md` and any
+affected intra-wiki links in the same transaction so the knowledge base
+never points at stale paths.
+
 ### `log.md` contract
 
 `log.md` is the append-only chronological record of knowledge-base activity
@@ -78,6 +100,17 @@ The inbox is a staging area for raw captures from the capture primitive
 (`gc_remember`). It does not exist yet — it is created by a later slice of
 the agent knowledge system rollout (issues 2–6). Until then, do not write
 to `inbox/`.
+
+When the inbox ships, each inbox file is the retry surface for ingest. A
+failed ingest leaves the source file's bytes untouched at its inbox path so
+later real-time, manual, or scheduled processing can retry it
+automatically. Do not move failed items to a `failed/` directory, rename
+them out of `inbox/`, or mutate the file to track retry state.
+
+An inbox file may be archived under a success-only location such as
+`inbox/processed/` or deleted only after the full ingest transaction has
+succeeded: page update or creation, `index.md` update, `log.md` append, and
+the git commit that records the change.
 
 ## Content page types
 

--- a/docs/notes/agent-knowledge-system-design.md
+++ b/docs/notes/agent-knowledge-system-design.md
@@ -60,7 +60,7 @@ The scheduled sweep handles all three. It runs on a timer (systemd user unit / l
 - Computes "new material since the last successful sweep" via a per-repo watermark (last merged PR processed, last inbox file mtime).
 - Pulls metadata for merged PRs newer than the watermark via `gh api` — review comments, fix-review commit messages, linked CI runs.
 - Retries any inbox files that are still sitting in `inbox/`.
-- Feeds the aggregated new material to the same ingest engine the hot path uses. One codex subprocess per item, under the same per-repo lock, serialized with any concurrent real-time ingest.
+- Feeds the aggregated new material to the same ingest engine the hot path uses. One ingest-agent subprocess per item, under the same per-repo lock, serialized with any concurrent real-time ingest. The ingest agent is Claude Code (see ADR-025); codex is deliberately not involved in knowledge maintenance.
 - Updates the watermark state and commits + pushes.
 
 The sweep is the safety net, not the main road. In a repo where `gc_remember` is used diligently, the sweep rarely finds fresh material — it mostly runs the lint. In a repo where nobody uses `gc_remember`, the sweep is the only capture mechanism and the cold path carries the whole load.
@@ -96,7 +96,7 @@ The boundary we landed on is clean:
 - `gc knowledge ingest-inbox [--repo X]` — manual re-processing of the inbox (same engine as real-time, different entry point).
 - `gc knowledge lint [--repo X | --all]` — manual lint pass.
 
-The per-repo ingest engine is a shared Python module (`tools/ground_control/knowledge/ingest.py` or similar). Both the CLI entry points and the `gc_remember` subprocess call it. The MCP server does not orchestrate cross-repo work — cross-repo work is strictly the CLI / scheduler concern.
+The per-repo ingest engine is a shared repo-local tooling module (`tools/ground_control/knowledge/ingest.*` or similar), not a Java backend service. Both the CLI entry points and the `gc_remember` subprocess call it. The MCP server does not orchestrate cross-repo work — cross-repo work is strictly the CLI / scheduler concern.
 
 Rationale for this split:
 - MCP is designed for in-session tool calls. Multi-repo orchestration and scheduling belong at a layer that doesn't require a Claude Code session to exist.
@@ -126,6 +126,24 @@ Config guardrails for implementation:
 - All `knowledge.*` paths are repo-relative author input resolved against the Git repo root. Absolute paths and repo-escaping traversal (`..`) are rejected. Use one shared repo-scoped path resolver for repo-local config paths rather than open-coding separate `join(repoRoot, rawPath)` logic for each field.
 - `knowledge.dir` is the single knowledge-base root. `knowledge.schema` and `knowledge.inbox` are overrides for locations inside that root, not a way to declare a second store elsewhere in the repo. `index.md` and `log.md` stay anchored under `knowledge.dir`.
 - Absence of `knowledge` means "this repo has no configured knowledge base yet", not "fall back to an implicit global default". Registration and sweep flows fail clearly; implementation workflows degrade gracefully and continue without knowledge capture.
+- The real-time path should reuse the resolved knowledge block returned by `gc_get_repo_ground_control_context` (or the same helper chain) and pass resolved repo / knowledge paths into the ingest subprocess. Do not make the subprocess re-open `.ground-control.yaml` through a second parser with slightly different containment or defaulting rules.
+
+## Hot-path guardrails for implementation
+
+- `gc_remember` owns only synchronous capture: validate the fixed input shape, canonicalize the source citation once, append an immutable inbox file, trigger ingest, and return the stored location. It does not read `index.md`, choose a target page, deduplicate content, or write wiki files directly.
+- `source_type` is not a second citation vocabulary. Its allowed values must match the source-citation prefixes documented in `docs/knowledge/SCHEMA.md`, and one canonical formatter / validator should turn `{source_type, source_ref}` into the citation string reused in inbox payloads, page frontmatter, `log.md`, and commit messages.
+- Success for the synchronous MCP call means "the inbox entry was durably written", not "the wiki ingest finished". If subprocess launch fails after the write, the inbox file stays in place for retry and the failure is surfaced without deleting or rewriting the source material.
+- The detached ingest contract is item-addressed, not inbox-scanning. `gc_remember` passes the exact inbox file path plus the already-resolved repo / knowledge paths into the subprocess, and the subprocess processes that specific item. Do not have the child rescan the inbox for "the newest file", and do not tie correctness to the parent MCP call staying alive after spawn.
+- Source lifecycle is success-only: the ingest engine may archive or delete the inbox item only after the wiki update, `index.md` / `log.md` update, and git commit all succeed. Failed attempts leave the original bytes at the same inbox path so later runs can discover and retry the item automatically; do not quarantine failures under `inbox/failed/`, rename them out of the inbox pre-commit, or mutate the file to record retry state.
+- The per-repo lock covers the whole ingest transaction: read current wiki state, decide update-vs-create, write page / `index.md` / `log.md` changes, move the inbox file, and create the git commit while holding the same lock. Locking only the final file write is insufficient.
+- The lock must be an interprocess file lock owned by the shared ingest engine, not an in-memory mutex in the MCP server. `gc_remember`, manual inbox retry, and the future scheduled sweep all need to serialize through the same mechanism even when they run in different OS processes.
+- Lock identity comes from the canonicalized repo / knowledge-base path returned by the existing config-resolution chain, not from the raw `repo_path` string the caller supplied. Different path spellings or symlinked checkout roots must still contend on the same lock.
+- Git commit isolation is strict. Ingest stages and commits only files inside the knowledge base plus the specific inbox item being processed. Never `git add -A`, never include unrelated working-tree changes, and fail safely if pre-existing edits in the knowledge tree would be overwritten.
+- GC-X010 commit messages come from one canonical formatter and must identify the integrated source material directly (for example the normalized citation string), not from ad hoc per-call wording. The same canonical source formatter used for page citations should drive the commit-message fragment so inbox payloads, `log.md`, and git history cannot drift in terminology.
+- "Active branch at processing time" means the current symbolic branch name of the checkout that owns the knowledge base. If the repo is in detached HEAD, an unborn branch state, or any other non-branch checkout, ingest fails clearly and leaves the inbox item in place for retry; it must not invent a fallback branch, auto-checkout another ref, or silently skip the commit.
+- GC-X011 latency must be measured on the real write path, not inferred from process launch. The canonical measure is capture timestamp to successful knowledge-base commit completion for that inbox item; emit it in structured logs (including source citation / inbox path) so "available within seconds" is observable and testable under normal conditions.
+- Do not silently bypass repo-native commit policy with `git commit --no-verify` just to keep ingest fast. If existing hooks or signing requirements need a knowledge-commit carve-out, make that carve-out explicit in repo-native policy / hook logic so the behavior is auditable and consistent between manual and automated commits.
+- This slice stays out of the Spring backend product model. No REST controller, DTO, migration, graph node, or domain aggregate should be added for capture / ingest unless a later requirement explicitly moves knowledge into the server-backed product surface.
 
 ## Invariants worth stating explicitly
 
@@ -189,7 +207,7 @@ None of these are on the critical path. They are directions that become easier o
 | Knowledge base per repo, never merged | Cross-repo unified knowledge | Repos have different conventions, vocabularies, and lifecycles. Cross-repo merging is a different problem layer. |
 | Sweep is global, MCP is per-project | Put sweep in MCP (`gc_knowledge_sweep`) | MCP tools are in-session per-repo. Multi-repo orchestration and scheduling don't fit that shape. Sweep lives in the CLI. |
 | One `gc_remember` MCP tool, nothing else | Multiple MCP tools for capture, ingest, query, etc. | Capture is the only per-session, per-project agent action. Ingest is always async. Query is grep + read. No need for more MCP surface. |
-| Per-repo ingest engine is shared Python module | Duplicate engines in MCP (Node) and CLI (Python); or invoke MCP from CLI | MCP protocol is wrong for batch work. Duplicating is worse than sharing. Python wins because the CLI is naturally Python. |
+| Per-repo ingest engine is shared repo-local tooling module | Duplicate engines in MCP and CLI; or invoke MCP from CLI | MCP protocol is wrong for batch work. Duplicating is worse than sharing. Keep one engine under repo-local tooling and let both entry points call it. |
 | Real-time and scheduled paths use the same engine | Separate engines | Consistency of behavior. Same lock, same commit semantics, same failure modes. |
 | Scheduler is systemd user unit / launchd plist / cron, not a daemon | Long-running daemon with IPC | Zero infra. Reboot-safe. Nothing to maintain. Timer fires the CLI, CLI runs, exits. |
 | Registry lives in local JSON (v1) | Ground Control Postgres (v2 direction) | v1 is one user, one machine. GC-backed registry is the migration target for multi-host. |

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -267,6 +267,8 @@ import {
   INSTALL_OUTCOMES,
   TRUST_POLICY_FIELDS,
   TRUST_POLICY_RULE_OPERATORS,
+  KNOWLEDGE_SOURCE_TYPES,
+  writeKnowledgeInbox,
 } from "./lib.js";
 
 function ok(text) {
@@ -699,6 +701,44 @@ server.tool(
   async ({ repo_path }) => {
     try {
       return ok(JSON.stringify(await getRepoGroundControlContext(repo_path), null, 2));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
+
+server.tool(
+  "gc_remember",
+  "Capture a knowledge-base observation from the calling agent. Writes a structured inbox file in the repository's knowledge base and spawns a detached ingest subprocess that integrates the observation into the wiki. Synchronous success means the inbox entry was durably written; wiki integration happens asynchronously and may be retried by later real-time or scheduled runs. Requires the repository's .ground-control.yaml to declare a knowledge block.",
+  {
+    repo_path: z.string().describe("Absolute path to the target Git repository"),
+    note: z.string().min(1).describe("The observation to capture, as free-form text"),
+    source_type: z
+      .enum(KNOWLEDGE_SOURCE_TYPES)
+      .describe(
+        "Source citation type (must match the vocabulary in docs/knowledge/SCHEMA.md)",
+      ),
+    source_ref: z
+      .string()
+      .min(1)
+      .describe(
+        "Source citation reference (short SHA for commit, number for pr/issue, comment id for review, etc.)",
+      ),
+    tags: z
+      .array(z.string())
+      .optional()
+      .describe("Optional list of tags used for index discovery"),
+  },
+  async ({ repo_path, note, source_type, source_ref, tags }) => {
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: repo_path,
+        note,
+        sourceType: source_type,
+        sourceRef: source_ref,
+        tags,
+      });
+      return ok(JSON.stringify(result, null, 2));
     } catch (e) {
       return err(e);
     }

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -776,12 +776,12 @@ server.tool(
 
 server.tool(
   "gc_codex_review",
-  "Run Codex against the current branch with a production-readiness review prompt. Codex enumerates all material findings (no triage) and, when a pull request is available, posts each finding as an inline PR review comment. Returns the list of posted comment ids, enriched with GraphQL review-thread ids and a short file/line/title preview so the coding agent can drive a fix/verify loop via gc_codex_verify_finding. Auto-detects the PR number for the current branch via `gh pr view` when pr_number is omitted.",
+  "Run Codex against the current branch with a production-readiness review prompt. Codex enumerates all material findings (no triage) and, when a pull request is available, posts each finding as an inline PR review comment. Returns the list of posted comment ids, enriched with GraphQL review-thread ids and a short file/line/title preview so the coding agent can drive a fix/verify loop via gc_codex_verify_finding. DEFAULT INVOCATION: pass ONLY { repo_path } and optionally { base_branch }. The tool auto-detects the PR number via `gh pr view --json number` — do NOT pass pr_number explicitly; that path is reserved for the uncommitted / no-PR-yet edge cases documented on pr_number itself and has been a known footgun in practice. uncommitted: true reviews staged/unstaged/untracked changes instead of committed branch history.",
   {
     repo_path: z.string().describe("Absolute path to the target Git repository"),
     base_branch: z.string().optional().describe("Base branch to review against (defaults to 'dev')"),
     uncommitted: z.boolean().optional().describe("Review staged/unstaged/untracked changes instead of committed branch history"),
-    pr_number: z.number().int().positive().optional().describe("Pull request number to post findings to. When omitted and uncommitted is false, the tool auto-detects via `gh pr view --json number`. When no PR can be found, codex emits findings inline without posting."),
+    pr_number: z.number().int().positive().optional().describe("ADVANCED / DISCOURAGED. Pull request number to post findings to. In the common case leave this unset — the tool auto-detects via `gh pr view --json number`. Pass pr_number ONLY when the current branch is not associated with a PR that `gh pr view` can resolve (for example: running against a foreign checkout) and you know the exact number to target. Passing it unnecessarily has been a source of client-layer rejection bugs; prefer auto-detect."),
   },
   async ({ repo_path, base_branch, uncommitted, pr_number }) => {
     try {

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -209,6 +209,8 @@ import {
   PR_BODY_SUMMARY_MAX,
   FINAL_REPORT_SUMMARY_MAX,
   FINAL_REPORT_REVIEW_SUMMARY_MAX,
+  KNOWLEDGE_SOURCE_TYPES,
+  writeKnowledgeInbox,
 } from "./lib.js";
 import {
   executeGcQuery,
@@ -496,6 +498,44 @@ const ASYNC_REVIEW_PARAM_DESC =
   "Poll the job with gc_codex_job (action='poll') until status='done', then dispatch " +
   "on result.next_action exactly as for the synchronous call. Use this in the /implement " +
   "workflow so a multi-minute review never trips the MCP client's tool-call timeout (issue #937).";
+
+server.tool(
+  "gc_remember",
+  "Capture a knowledge-base observation from the calling agent. Writes a structured inbox file in the repository's knowledge base and spawns a detached ingest subprocess that integrates the observation into the wiki. Synchronous success means the inbox entry was durably written; wiki integration happens asynchronously and may be retried by later real-time or scheduled runs. Requires the repository's .ground-control.yaml to declare a knowledge block.",
+  {
+    repo_path: z.string().describe("Absolute path to the target Git repository"),
+    note: z.string().min(1).describe("The observation to capture, as free-form text"),
+    source_type: z
+      .enum(KNOWLEDGE_SOURCE_TYPES)
+      .describe(
+        "Source citation type (must match the vocabulary in docs/knowledge/SCHEMA.md)",
+      ),
+    source_ref: z
+      .string()
+      .min(1)
+      .describe(
+        "Source citation reference (short SHA for commit, number for pr/issue, comment id for review, etc.)",
+      ),
+    tags: z
+      .array(z.string())
+      .optional()
+      .describe("Optional list of tags used for index discovery"),
+  },
+  async ({ repo_path, note, source_type, source_ref, tags }) => {
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: repo_path,
+        note,
+        sourceType: source_type,
+        sourceRef: source_ref,
+        tags,
+      });
+      return ok(JSON.stringify(result, null, 2));
+    } catch (e) {
+      return err(e);
+    }
+  },
+);
 
 server.tool(
   "gc_codex_architecture_preflight",

--- a/mcp/ground-control/knowledge_ingest.js
+++ b/mcp/ground-control/knowledge_ingest.js
@@ -1,0 +1,598 @@
+// Knowledge base ingest engine — GC-X007..GC-X011.
+//
+// This module is called by two entry points:
+//
+//   1. The `gc_remember` MCP tool spawns this via knowledge_ingest_cli.js
+//      as a detached subprocess right after an agent captures an
+//      observation (the "hot path"). The subprocess passes the exact
+//      inbox file path plus the resolved repo / knowledge paths, so the
+//      engine never rescans the inbox or re-parses .ground-control.yaml.
+//
+//   2. Unit tests call `runIngest` directly, injecting a stub ingest
+//      agent that scripts the filesystem actions a real run would
+//      produce. This lets us exercise read-before-write consistency,
+//      serialization, commit isolation, and failure semantics without
+//      shelling out to the real Claude Code CLI on every test.
+//
+// The engine delegates the actual "update existing page vs. create new
+// page" decision to Claude Code (the ingest agent), then validates and
+// commits the resulting filesystem changes under strict isolation and
+// locking rules described in docs/notes/agent-knowledge-system-design.md
+// §"Hot path guardrails for implementation".
+//
+// Claude Code is the only ingestion agent. Codex is deliberately NOT
+// used for knowledge ingest: codex's role in this repo is confined to
+// the workflows (architecture preflight, cross-model review) where it
+// has already been wired in by name. Knowledge maintenance is a
+// Claude Code responsibility by project decision.
+
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve as resolvePath } from "node:path";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { load as parseYaml } from "js-yaml";
+import { acquireKnowledgeLock, execFileWithInput } from "./lib.js";
+
+const execFile = promisify(execFileCb);
+
+// Parse the trailing `INGEST_RESULT={...}` line from the ingest agent's
+// output. This mirrors `parseCodexReviewTail` in lib.js and gives the
+// engine a machine-checkable signal that Claude Code finished and
+// decided on an action. Throws if the line is missing, malformed, or
+// carries an unknown action.
+export function parseIngestResultTail(output) {
+  if (typeof output !== "string") {
+    throw new Error("parseIngestResultTail: output must be a string");
+  }
+  const lines = output.split(/\r?\n/);
+  let tail = null;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line === "") continue;
+    if (line.startsWith("INGEST_RESULT=")) {
+      tail = line.slice("INGEST_RESULT=".length);
+    }
+    break;
+  }
+  if (tail == null) {
+    throw new Error("parseIngestResultTail: no INGEST_RESULT tail line found");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(tail);
+  } catch (error) {
+    throw new Error(`parseIngestResultTail: INGEST_RESULT payload is not valid JSON: ${error.message}`);
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("parseIngestResultTail: INGEST_RESULT must be a JSON object");
+  }
+  const { action, page, citations_added: citationsAdded } = parsed;
+  if (action !== "create" && action !== "update") {
+    throw new Error(`parseIngestResultTail: unknown action '${action}' (expected 'create' or 'update')`);
+  }
+  if (typeof page !== "string" || page.trim() === "") {
+    throw new Error("parseIngestResultTail: INGEST_RESULT.page must be a non-empty string");
+  }
+  if (typeof citationsAdded !== "number" || citationsAdded < 0) {
+    throw new Error("parseIngestResultTail: INGEST_RESULT.citations_added must be a non-negative number");
+  }
+  return { action, page, citations_added: citationsAdded };
+}
+
+// Walk up the current branch name with a structured failure. Ingest
+// commits land on whatever symbolic branch the repo happens to be on at
+// the time, which keeps the knowledge update in the same PR as the code
+// that taught the lesson. Detached HEAD or an unborn branch state is a
+// retry failure — per GC-X010 we never invent a fallback branch or
+// silently skip the commit.
+async function resolveSymbolicBranch(repoRoot) {
+  try {
+    const { stdout } = await execFile("git", ["-C", repoRoot, "symbolic-ref", "--short", "HEAD"]);
+    const name = stdout.trim();
+    if (!name) {
+      throw new Error("git symbolic-ref returned an empty branch name");
+    }
+    return name;
+  } catch (error) {
+    throw new Error(
+      `refusing to ingest: repository ${repoRoot} is not on a symbolic branch (detached HEAD or unborn branch state). Ingest must run on a named branch so the commit lands in the same history as the code that taught the lesson. Leave the inbox file in place and retry after checking out a branch. underlying: ${error.message}`,
+    );
+  }
+}
+
+// Read frontmatter + body out of a markdown file. Returns
+// { frontmatter, body }. Used to parse the inbox item so we can include
+// its captured_at timestamp in the latency measurement.
+function splitFrontmatter(source) {
+  if (!source.startsWith("---\n")) {
+    return { frontmatter: {}, body: source };
+  }
+  const end = source.indexOf("\n---", 4);
+  if (end === -1) {
+    return { frontmatter: {}, body: source };
+  }
+  const yamlBlock = source.slice(4, end);
+  const bodyStart = source.indexOf("\n", end + 4);
+  const body = bodyStart === -1 ? "" : source.slice(bodyStart + 1);
+  let frontmatter = {};
+  try {
+    const parsed = parseYaml(yamlBlock);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      frontmatter = parsed;
+    }
+  } catch {
+    // If the frontmatter is malformed, fall through with an empty
+    // object — the ingest engine continues and the agent can decide
+    // what to do with the body.
+  }
+  return { frontmatter, body };
+}
+
+// Default ingest agent invoker. Shells out to Claude Code in headless
+// mode (`claude -p`) with a tight tool allowlist and directory access
+// scoped to the repository root. Claude Code reads the prompt on the
+// command line, uses its built-in Read/Edit/Write/Bash tools to make
+// the wiki changes, and emits prose + the INGEST_RESULT tail on stdout.
+// Tests replace this with a scripted stub via the `ingestAgent`
+// parameter on `runIngest`.
+//
+// Flag rationale:
+//   --print                         headless (no interactive session)
+//   --bare                          skip hooks, LSP, plugin sync,
+//                                   auto-memory, CLAUDE.md
+//                                   auto-discovery — clean subprocess
+//                                   environment
+//   --add-dir <repo>                grants Claude Code tool access to
+//                                   the target repo
+//   --permission-mode
+//     bypassPermissions             unattended ingest: no interactive
+//                                   confirm prompts. Safe because
+//                                   --allowed-tools restricts to a
+//                                   minimal set and the engine
+//                                   validates commit isolation after
+//                                   the agent finishes.
+//   --allowed-tools "Read Edit Write Bash(git status:*) Bash(git mv:*)"
+//                                   minimum tools to read the wiki,
+//                                   edit pages, and rename the inbox
+//                                   item. No WebFetch, no Task, no
+//                                   free-form Bash.
+//   --max-budget-usd <cap>          hard spend cap per invocation
+//   --model sonnet                  ingest decisions don't need opus;
+//                                   sonnet is fast enough and cheap.
+//   --output-format text            plain-text stdout we can grep for
+//                                   the INGEST_RESULT tail.
+async function defaultIngestAgent({ repoRoot, prompt, agentOverrides = {} }) {
+  const model = agentOverrides.model || "sonnet";
+  // `claude --print` reads the prompt from stdin by default and only
+  // falls back to the positional arg after a 3 s stdin-wait timeout.
+  // We pipe the prompt via stdin explicitly (through execFileWithInput)
+  // so the subprocess starts the model call immediately without the
+  // false-positive warning.
+  //
+  // NOTE: `--bare` is deliberately NOT used here. Per `claude --help`,
+  // `--bare` restricts Anthropic auth to ANTHROPIC_API_KEY or an
+  // apiKeyHelper — it refuses to read OAuth / keychain credentials.
+  // The interactive operator session is OAuth-based (via `claude login`),
+  // so a bare-mode subprocess with the API key stripped has no auth at
+  // all and fails with "Not logged in". We keep the non-bare default
+  // so the subprocess inherits the same logged-in session the operator
+  // uses interactively, while still isolating tool access via
+  // `--allowed-tools` and directory access via `--add-dir`.
+  const args = [
+    "--print",
+    "--add-dir", repoRoot,
+    "--permission-mode", "bypassPermissions",
+    "--allowed-tools",
+    "Read Edit Write Bash(git status:*) Bash(git mv:*) Bash(mkdir:*)",
+    "--model", model,
+    "--output-format", "text",
+  ];
+  // Strip `ANTHROPIC_API_KEY` from the subprocess env. When the parent
+  // is itself a running Claude Code instance, it inherits an API key
+  // in its environment that `claude -p` would prefer over the
+  // logged-in session credentials at `~/.claude/.credentials.json`.
+  // That is almost never what an operator wants: the operator logged
+  // in interactively, so the session creds are the "real" auth they
+  // expect unattended subprocess runs to use. Filtering the env var
+  // (only in the child's env dict — this does not touch the parent's
+  // env) lets `claude` fall back to the session credential file and
+  // matches the auth path an interactive shell would use.
+  //
+  // Operators who explicitly want API-key auth for ingest can set
+  // `GC_KNOWLEDGE_INGEST_ANTHROPIC_API_KEY` in their environment;
+  // when present, we pass it through as ANTHROPIC_API_KEY for the
+  // subprocess only, preserving the "bring your own dedicated key"
+  // escape hatch without polluting the interactive session's auth.
+  const childEnv = { ...process.env, NO_COLOR: "1" };
+  delete childEnv.ANTHROPIC_API_KEY;
+  if (agentOverrides.anthropicApiKey) {
+    childEnv.ANTHROPIC_API_KEY = agentOverrides.anthropicApiKey;
+  } else if (process.env.GC_KNOWLEDGE_INGEST_ANTHROPIC_API_KEY) {
+    childEnv.ANTHROPIC_API_KEY = process.env.GC_KNOWLEDGE_INGEST_ANTHROPIC_API_KEY;
+  }
+  const { stdout, stderr } = await execFileWithInput("claude", args, {
+    cwd: repoRoot,
+    maxBuffer: 10 * 1024 * 1024,
+    env: childEnv,
+    input: prompt,
+  });
+  return { stdout, stderr };
+}
+
+// Build the ingest prompt sent to the ingest agent (Claude Code). The
+// prompt fully describes the transaction the agent owns: read current
+// wiki state, decide update vs create, write knowledge-tree files,
+// append to log.md, move the inbox item, and emit the INGEST_RESULT
+// tail. Staging and committing happen in the parent — the agent never
+// runs git itself beyond the allowed `git mv` for the inbox move.
+function buildIngestPrompt({
+  knowledgeDir,
+  knowledgeSchemaRel,
+  inboxFileAbs,
+  inboxFileRel,
+  inboxDirRel,
+  inboxPayload,
+  indexMdContent,
+  logMdTail,
+}) {
+  return [
+    "You are the Ground Control knowledge ingest agent.",
+    "",
+    "An agent captured a new observation. Integrate it into the repo-local",
+    `knowledge base at ${knowledgeDir}. Follow the conventions documented in`,
+    `${knowledgeSchemaRel}.`,
+    "",
+    "Inbox item (absolute path):",
+    inboxFileAbs,
+    "",
+    "Inbox item content (frontmatter + body):",
+    "```",
+    inboxPayload,
+    "```",
+    "",
+    "Current index.md:",
+    "```",
+    indexMdContent,
+    "```",
+    "",
+    "Tail of log.md (last ~20 lines):",
+    "```",
+    logMdTail,
+    "```",
+    "",
+    "Required behavior (use your Read / Edit / Write / Bash tools):",
+    "- Consult existing pages listed in index.md BEFORE deciding to create.",
+    "  Read the candidate pages with your Read tool. If this observation",
+    "  refines or extends an existing page, update that page in place via",
+    "  your Edit tool. Preserve the existing page's frontmatter, sources",
+    "  list, and cross-references. Incremental edits, not full regeneration.",
+    "- If the observation is genuinely new, use your Write tool to create a",
+    `  new page under the appropriate category directory under ${knowledgeDir}.`,
+    "- Use your Edit tool to append a new dated bullet to log.md describing",
+    "  the ingest.",
+    "- Use `git mv` via your Bash tool to move the inbox item from",
+    `  ${inboxFileRel} to ${inboxDirRel}/processed/ ONLY after you have`,
+    "  written the page and updated index.md and log.md. If `git mv` fails",
+    "  because the inbox file is untracked (it was just written by",
+    "  gc_remember and has not been committed), use `mkdir -p` to ensure",
+    "  the processed directory exists and then fall back to moving with",
+    "  a plain filesystem move via your Bash tool.",
+    `- Do NOT write or edit any file outside ${knowledgeDir}/ or the inbox`,
+    "  item path. The parent process enforces commit isolation and will",
+    "  abort the whole ingest if you touch anything outside that scope.",
+    "- Do NOT stage or commit; the parent process does that. Do not run",
+    "  `git add`, `git commit`, or `git push`.",
+    "",
+    "Emit exactly one trailing line as the VERY LAST line of your output,",
+    "in this format (literal, no code fence, choose 'create' or 'update'):",
+    "",
+    '  INGEST_RESULT={"action":"create","page":"<relative path>","citations_added":<n>}',
+    '  INGEST_RESULT={"action":"update","page":"<relative path>","citations_added":<n>}',
+    "",
+    "Use 'create' when you wrote a new page file, 'update' when you modified",
+    "an existing one.",
+  ].join("\n");
+}
+
+// Collect the set of files that changed in the worktree relative to HEAD.
+// Returns a Set of repo-relative paths, including untracked files and
+// renamed-from / renamed-to entries. We compare against HEAD (not the
+// staging area) because the agent may have written directly to the worktree
+// without staging.
+async function collectWorktreeChanges(repoRoot) {
+  const { stdout } = await execFile("git", [
+    "-C",
+    repoRoot,
+    "status",
+    "--porcelain=v1",
+    "-uall",
+  ]);
+  const files = new Set();
+  for (const rawLine of stdout.split("\n")) {
+    if (rawLine.trim() === "") continue;
+    // Porcelain v1 format: XY path [-> renamedPath]
+    // X = index status, Y = worktree status, 2-char code + space + path.
+    const code = rawLine.slice(0, 2);
+    const rest = rawLine.slice(3);
+    if (code.trim() === "") continue;
+    // Rename entries: "R  from -> to" — include both sides.
+    const renameIdx = rest.indexOf(" -> ");
+    if (renameIdx !== -1) {
+      const from = rest.slice(0, renameIdx);
+      const to = rest.slice(renameIdx + " -> ".length);
+      files.add(from);
+      files.add(to);
+    } else {
+      files.add(rest);
+    }
+  }
+  return files;
+}
+
+// Verify that every changed path is contained in the allowed set:
+// somewhere under the knowledge directory (any file), or the exact inbox
+// file path (so the agent can move it to processed/). Returns { ok: true }
+// or { ok: false, unexpected: [...] }.
+function validateCommitIsolation({ changedFiles, knowledgeDirRel, inboxFileRel }) {
+  const unexpected = [];
+  const allowedPrefix = knowledgeDirRel.endsWith("/") ? knowledgeDirRel : knowledgeDirRel + "/";
+  for (const path of changedFiles) {
+    if (path === inboxFileRel) continue;
+    if (path.startsWith(allowedPrefix)) continue;
+    unexpected.push(path);
+  }
+  if (unexpected.length > 0) {
+    return { ok: false, unexpected };
+  }
+  return { ok: true };
+}
+
+// Abort cleanly: revert any changes the agent made, using `git checkout --`
+// for tracked paths and filesystem cleanup for untracked files. The goal
+// is that after an abort the worktree is indistinguishable from before
+// the ingest attempt, modulo whatever was already dirty when we started.
+async function revertWorktreeChanges(repoRoot, changedFiles, preexistingDirty) {
+  for (const path of changedFiles) {
+    // Skip files that were already dirty before ingest started. We never
+    // modify pre-existing user edits.
+    if (preexistingDirty.has(path)) continue;
+    // Try `git checkout -- path` first (reverts tracked file to HEAD).
+    try {
+      await execFile("git", ["-C", repoRoot, "checkout", "--", path]);
+    } catch {
+      // If checkout fails, the file is probably untracked; clean it up.
+      try {
+        await execFile("git", ["-C", repoRoot, "clean", "-f", "--", path]);
+      } catch {
+        // Best-effort; the caller already knows we're aborting.
+      }
+    }
+  }
+}
+
+// Run the full ingest transaction for a single inbox item. See module
+// header for the higher-level contract. The function owns:
+//   - Branch check (reject detached HEAD)
+//   - Lock acquisition (serialization)
+//   - Pre-ingest snapshot of dirty state (to avoid clobbering user work)
+//   - Codex invocation
+//   - Commit-isolation validation
+//   - Commit (knowledge tree + inbox item only)
+//   - Lock release
+//   - Latency measurement
+//
+// Returns { ok: true, action, page, commit_sha, latency_ms, citations_added }
+// on success. Throws on any failure; the caller (CLI or test) is
+// responsible for turning thrown errors into structured output and for
+// deciding whether to retry.
+export async function runIngest({
+  repoRoot,
+  inboxFilePath,
+  knowledge,
+  ingestAgent = defaultIngestAgent,
+  now = Date.now,
+}) {
+  if (typeof repoRoot !== "string" || !isAbsolute(repoRoot)) {
+    throw new Error("runIngest: repoRoot must be an absolute path");
+  }
+  if (typeof inboxFilePath !== "string" || !isAbsolute(inboxFilePath)) {
+    throw new Error("runIngest: inboxFilePath must be an absolute path");
+  }
+  if (!knowledge || typeof knowledge !== "object") {
+    throw new Error("runIngest: knowledge block is required");
+  }
+  for (const field of ["dir", "schema", "inbox"]) {
+    if (typeof knowledge[field] !== "string" || knowledge[field] === "") {
+      throw new Error(`runIngest: knowledge.${field} is required`);
+    }
+  }
+
+  // Canonicalize repo root so the lock is keyed by inode identity, not by
+  // whatever path spelling the caller happened to pass in. This matches
+  // the containment logic in lib.js:resolveKnowledgeBlock.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- repoRoot is caller-validated absolute
+  const repoRootReal = realpathSync(repoRoot);
+
+  const knowledgeDirRel = knowledge.dir;
+  const absKnowledgeDir = resolvePath(repoRootReal, knowledgeDirRel);
+  const inboxFileRel = relative(repoRootReal, inboxFilePath);
+
+  // Read the inbox item up front so we have its captured_at timestamp for
+  // latency calculation, plus a stable bytes snapshot we can use to prove
+  // the file was left untouched on failure.
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- inboxFilePath is caller-validated absolute and anchored under knowledge.inbox
+  if (!existsSync(inboxFilePath)) {
+    throw new Error(`runIngest: inbox file does not exist: ${inboxFilePath}`);
+  }
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- inboxFilePath is caller-validated absolute
+  const inboxPayload = readFileSync(inboxFilePath, "utf8");
+  const { frontmatter: inboxFrontmatter } = splitFrontmatter(inboxPayload);
+  const capturedAtIso = typeof inboxFrontmatter.captured_at === "string"
+    ? inboxFrontmatter.captured_at
+    : null;
+  const source = typeof inboxFrontmatter.source === "string" ? inboxFrontmatter.source : null;
+
+  // Enforce symbolic-branch invariant before touching anything.
+  await resolveSymbolicBranch(repoRootReal);
+
+  // Acquire the per-knowledge-base lock. We pass a retry policy here
+  // rather than failing fast: the real-time capture path expects two
+  // captures fired in quick succession to both land in the wiki, so the
+  // second ingest should wait for the first to finish instead of
+  // returning an error. Total wait budget: ~20s across 15 retries with
+  // exponential backoff capped at 2s. That is long enough to serialize
+  // a typical ingest (~5s with Claude Code) without holding the caller forever.
+  const release = await acquireKnowledgeLock(absKnowledgeDir, {
+    retries: {
+      retries: 15,
+      factor: 1.5,
+      minTimeout: 100,
+      maxTimeout: 2000,
+    },
+  });
+
+  // Snapshot pre-existing dirty files so we can tell user changes apart
+  // from agent-introduced changes when we validate commit isolation and
+  // when we revert on failure.
+  const preexistingDirty = await collectWorktreeChanges(repoRootReal);
+
+  let agentResult;
+  try {
+    // Read index.md and log.md tail for the prompt context.
+    const indexMdAbs = resolvePath(repoRootReal, knowledge.dir, "index.md");
+    const logMdAbs = resolvePath(repoRootReal, knowledge.dir, "log.md");
+    let indexMdContent = "";
+    let logMdContent = "";
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- derived from validated knowledge.dir
+    if (existsSync(indexMdAbs)) {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- derived from validated knowledge.dir
+      indexMdContent = readFileSync(indexMdAbs, "utf8");
+    }
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- derived from validated knowledge.dir
+    if (existsSync(logMdAbs)) {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- derived from validated knowledge.dir
+      logMdContent = readFileSync(logMdAbs, "utf8");
+    }
+    const logMdLines = logMdContent.split("\n");
+    const logMdTail = logMdLines.slice(-20).join("\n");
+
+    const prompt = buildIngestPrompt({
+      knowledgeDir: knowledge.dir,
+      knowledgeSchemaRel: knowledge.schema,
+      inboxFileAbs: inboxFilePath,
+      inboxFileRel,
+      inboxDirRel: knowledge.inbox,
+      inboxPayload,
+      indexMdContent,
+      logMdTail,
+    });
+
+    agentResult = await ingestAgent({ repoRoot: repoRootReal, prompt });
+    const resultTail = parseIngestResultTail(agentResult.stdout || "");
+
+    // Validate commit isolation: every changed file must be under the
+    // knowledge tree or the inbox item path. If any path is outside that
+    // allowlist, we revert ALL agent-introduced changes, leave the inbox
+    // file untouched, and throw.
+    const changedAfter = await collectWorktreeChanges(repoRootReal);
+    const agentChanges = new Set();
+    for (const path of changedAfter) {
+      if (preexistingDirty.has(path)) continue;
+      agentChanges.add(path);
+    }
+    const isolation = validateCommitIsolation({
+      changedFiles: agentChanges,
+      knowledgeDirRel,
+      inboxFileRel,
+    });
+    if (!isolation.ok) {
+      await revertWorktreeChanges(repoRootReal, agentChanges, preexistingDirty);
+      throw new Error(
+        `runIngest: ingest agent wrote files outside the knowledge tree (commit isolation violation): ${isolation.unexpected.join(", ")}`,
+      );
+    }
+    if (agentChanges.size === 0) {
+      throw new Error("runIngest: ingest agent made no changes — nothing to commit");
+    }
+
+    // Stage exactly the agent-introduced paths. No `git add -A`.
+    const stagePaths = Array.from(agentChanges);
+    await execFile("git", ["-C", repoRootReal, "add", "--", ...stagePaths]);
+
+    // Commit with the canonical citation-derived message. Repo-native
+    // hooks (pre-commit, sign-off) run as normal — no `--no-verify`.
+    const citation = source || resultTail.page;
+    const commitMessage = `knowledge: ingest ${citation}\n\nAction: ${resultTail.action}\nPage: ${resultTail.page}\nCitations added: ${resultTail.citations_added}\n`;
+    try {
+      await execFile("git", ["-C", repoRootReal, "commit", "-m", commitMessage]);
+    } catch (error) {
+      // Commit failure: revert staged changes and leave the inbox item
+      // untouched. The inbox file is itself one of the staged paths if
+      // the agent moved it to processed/, so the revert restores it.
+      await revertWorktreeChanges(repoRootReal, agentChanges, preexistingDirty);
+      throw new Error(`runIngest: git commit failed: ${error.message}`);
+    }
+
+    const { stdout: headOut } = await execFile("git", ["-C", repoRootReal, "rev-parse", "HEAD"]);
+    const commitSha = headOut.trim();
+
+    const completedAt = now();
+    let latencyMs = 0;
+    if (capturedAtIso) {
+      const capturedAt = Date.parse(capturedAtIso);
+      if (!Number.isNaN(capturedAt)) {
+        latencyMs = Math.max(0, completedAt - capturedAt);
+      }
+    }
+
+    // Emit a structured log line on stderr so the CLI's parent (and
+    // test harnesses) can observe latency without affecting stdout
+    // (which is the ingest-agent tail protocol).
+    process.stderr.write(
+      JSON.stringify({
+        event: "ingest_commit",
+        citation,
+        inbox_path: inboxFileRel,
+        action: resultTail.action,
+        page: resultTail.page,
+        citations_added: resultTail.citations_added,
+        commit_sha: commitSha,
+        latency_ms: latencyMs,
+      }) + "\n",
+    );
+
+    return {
+      ok: true,
+      action: resultTail.action,
+      page: resultTail.page,
+      citations_added: resultTail.citations_added,
+      commit_sha: commitSha,
+      latency_ms: latencyMs,
+    };
+  } catch (error) {
+    // On any failure between lock acquisition and commit, revert agent
+    // changes (if any were made) and rethrow. The inbox file is
+    // deliberately NOT touched by this revert — if the agent renamed it,
+    // the rename is one of the "agent changes" which get reverted.
+    try {
+      const current = await collectWorktreeChanges(repoRootReal);
+      const agentChanges = new Set();
+      for (const p of current) {
+        if (!preexistingDirty.has(p)) agentChanges.add(p);
+      }
+      if (agentChanges.size > 0) {
+        await revertWorktreeChanges(repoRootReal, agentChanges, preexistingDirty);
+      }
+    } catch {
+      // Revert is best-effort; we prioritize surfacing the original error.
+    }
+    throw error;
+  } finally {
+    try {
+      await release();
+    } catch {
+      // Release failures are logged by the lock helper. Do not let them
+      // mask the original ingest result / error.
+    }
+  }
+}

--- a/mcp/ground-control/knowledge_ingest.test.js
+++ b/mcp/ground-control/knowledge_ingest.test.js
@@ -1,0 +1,655 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { runIngest, parseIngestResultTail } from "./knowledge_ingest.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeKnowledgeRepo({ extraFiles = {} } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "gc-ingest-test-"));
+  execFileSync("git", ["-C", dir, "init", "-q", "-b", "main"]);
+  execFileSync("git", ["-C", dir, "config", "user.email", "test@example.com"]);
+  execFileSync("git", ["-C", dir, "config", "user.name", "Test"]);
+  execFileSync("git", ["-C", dir, "config", "commit.gpgsign", "false"]);
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+  mkdirSync(join(dir, "docs", "knowledge", "inbox"), { recursive: true });
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+  writeFileSync(
+    join(dir, "docs", "knowledge", "SCHEMA.md"),
+    "---\ntitle: schema\n---\n# schema\n",
+  );
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+  writeFileSync(
+    join(dir, "docs", "knowledge", "index.md"),
+    "---\ntitle: Index\n---\n# Knowledge Base Index\n\n## Topics\n\n_No pages yet._\n",
+  );
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+  writeFileSync(
+    join(dir, "docs", "knowledge", "log.md"),
+    "---\ntitle: Log\n---\n# Log\n\n## Entries\n",
+  );
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+  writeFileSync(
+    join(dir, ".ground-control.yaml"),
+    [
+      "schema_version: 1",
+      "project: test-project",
+      "knowledge:",
+      "  dir: docs/knowledge",
+      "",
+    ].join("\n"),
+  );
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+  writeFileSync(join(dir, "README.md"), "# test repo\n");
+
+  for (const [relPath, content] of Object.entries(extraFiles)) {
+    const abs = join(dir, relPath);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    mkdirSync(join(abs, ".."), { recursive: true });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    writeFileSync(abs, content);
+  }
+
+  execFileSync("git", ["-C", dir, "add", "-A"]);
+  execFileSync("git", ["-C", dir, "commit", "-q", "-m", "seed"]);
+  return dir;
+}
+
+function writeInboxFile(repoRoot, content, { filename } = {}) {
+  const name =
+    filename ||
+    `2026-04-13T01-00-00-${Math.floor(Math.random() * 10000)
+      .toString()
+      .padStart(4, "0")}-test.md`;
+  const abs = join(repoRoot, "docs", "knowledge", "inbox", name);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+  writeFileSync(abs, content);
+  return abs;
+}
+
+function defaultInboxPayload({
+  source = "pr:523",
+  body = "test observation",
+  capturedAt = new Date().toISOString(),
+} = {}) {
+  return [
+    "---",
+    `captured_at: '${capturedAt}'`,
+    `source: '${source}'`,
+    "---",
+    "",
+    body,
+    "",
+  ].join("\n");
+}
+
+// A stub `ingestAgent` that interprets a scripted action map and applies
+// it to the filesystem. Each action represents what the real Claude Code
+// ingest agent would produce via its Read/Edit/Write/Bash tools. The
+// stub also emits the required INGEST_RESULT tail line so
+// parseIngestResultTail can parse the output the same way it parses
+// real ingest-agent output.
+function makeStubAgent(actions, { tail = null } = {}) {
+  return async function stubAgent({ repoRoot, prompt: _prompt }) {
+    for (const action of actions) {
+      if (action.type === "write_file") {
+        const abs = join(repoRoot, action.path);
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+        mkdirSync(join(abs, ".."), { recursive: true });
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+        writeFileSync(abs, action.content);
+      } else if (action.type === "append_file") {
+        const abs = join(repoRoot, action.path);
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+        const prev = existsSync(abs) ? readFileSync(abs, "utf8") : "";
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+        writeFileSync(abs, prev + action.content);
+      } else if (action.type === "rename") {
+        const from = join(repoRoot, action.from);
+        const to = join(repoRoot, action.to);
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+        mkdirSync(join(to, ".."), { recursive: true });
+        // Use a plain filesystem rename because inbox files are untracked
+        // at ingest time (gc_remember writes them post-commit) and
+        // `git mv` requires the source to be tracked.
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+        renameSync(from, to);
+      } else if (action.type === "throw") {
+        throw new Error(action.message || "stub ingest agent error");
+      }
+    }
+    const resolvedTail =
+      tail ??
+      `INGEST_RESULT={"action":"create","page":"docs/knowledge/gotchas/stub.md","citations_added":1}`;
+    return { stdout: resolvedTail + "\n", stderr: "" };
+  };
+}
+
+function assertNoCommitSinceSeed(repoRoot) {
+  const out = execFileSync("git", ["-C", repoRoot, "log", "--oneline"])
+    .toString()
+    .trim()
+    .split("\n");
+  assert.equal(out.length, 1, `expected only the seed commit, got ${out.length}: ${out.join(" | ")}`);
+  assert.match(out[0], /seed$/);
+}
+
+function gitHead(repoRoot) {
+  return execFileSync("git", ["-C", repoRoot, "rev-parse", "HEAD"]).toString().trim();
+}
+
+function commitMessage(repoRoot, ref = "HEAD") {
+  return execFileSync("git", ["-C", repoRoot, "log", "-1", "--format=%B", ref]).toString().trim();
+}
+
+function commitFiles(repoRoot, ref = "HEAD") {
+  return execFileSync("git", ["-C", repoRoot, "show", "--name-only", "--format=", ref])
+    .toString()
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .sort();
+}
+
+function knowledgePaths() {
+  return {
+    dir: "docs/knowledge",
+    schema: "docs/knowledge/SCHEMA.md",
+    inbox: "docs/knowledge/inbox",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseIngestResultTail
+// ---------------------------------------------------------------------------
+
+describe("parseIngestResultTail", () => {
+  it("parses a valid INGEST_RESULT tail", () => {
+    const out = 'some prose\nINGEST_RESULT={"action":"create","page":"docs/knowledge/topics/foo.md","citations_added":1}\n';
+    const r = parseIngestResultTail(out);
+    assert.equal(r.action, "create");
+    assert.equal(r.page, "docs/knowledge/topics/foo.md");
+    assert.equal(r.citations_added, 1);
+  });
+
+  it("throws when the tail line is missing", () => {
+    assert.throws(() => parseIngestResultTail("no tail here"), /INGEST_RESULT/);
+  });
+
+  it("throws on malformed JSON", () => {
+    assert.throws(() => parseIngestResultTail("INGEST_RESULT={bad json}"), /JSON/);
+  });
+
+  it("throws on unknown action", () => {
+    assert.throws(
+      () => parseIngestResultTail('INGEST_RESULT={"action":"delete","page":"x","citations_added":1}'),
+      /action/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runIngest — happy paths
+// ---------------------------------------------------------------------------
+
+describe("runIngest — create path (GC-X007 new page)", () => {
+  it("produces exactly one commit with only the knowledge tree + inbox item staged", async () => {
+    const dir = makeKnowledgeRepo();
+    try {
+      const inbox = writeInboxFile(dir, defaultInboxPayload());
+      const agent = makeStubAgent(
+        [
+          {
+            type: "write_file",
+            path: "docs/knowledge/gotchas/race-condition.md",
+            content:
+              "---\ntitle: Race Condition\nsources: ['pr:523']\n---\n# Race Condition\n\nBody.\n",
+          },
+          {
+            type: "write_file",
+            path: "docs/knowledge/index.md",
+            content:
+              "---\ntitle: Index\n---\n# Knowledge Base Index\n\n## Gotchas\n\n- [Race Condition](gotchas/race-condition.md) — latent race. Tags: concurrency\n",
+          },
+          {
+            type: "append_file",
+            path: "docs/knowledge/log.md",
+            content: "- `2026-04-13` — ingested pr:523 into gotchas/race-condition.md.\n",
+          },
+          // Move inbox file into processed/.
+          {
+            type: "rename",
+            from: relPathUnder(dir, inbox),
+            to: `docs/knowledge/inbox/processed/${basenameOf(inbox)}`,
+          },
+        ],
+        {
+          tail:
+            'INGEST_RESULT={"action":"create","page":"docs/knowledge/gotchas/race-condition.md","citations_added":1}',
+        },
+      );
+      const result = await runIngest({
+        repoRoot: dir,
+        inboxFilePath: inbox,
+        knowledge: knowledgePaths(),
+        ingestAgent: agent,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "create");
+      assert.ok(typeof result.commit_sha === "string" && result.commit_sha.length >= 7);
+      assert.ok(typeof result.latency_ms === "number" && result.latency_ms >= 0);
+
+      // One new commit since seed.
+      const commits = execFileSync("git", ["-C", dir, "log", "--oneline"])
+        .toString()
+        .trim()
+        .split("\n");
+      assert.equal(commits.length, 2, `expected 2 commits, got ${commits.length}`);
+
+      // Commit message includes the canonical citation.
+      const msg = commitMessage(dir);
+      assert.match(msg, /pr:523/);
+
+      // Commit staged exactly: new page, index.md, log.md, inbox-move (as rename).
+      const files = commitFiles(dir);
+      assert.ok(
+        files.includes("docs/knowledge/gotchas/race-condition.md"),
+        `missing new page in commit: ${files.join(", ")}`,
+      );
+      assert.ok(files.includes("docs/knowledge/index.md"));
+      assert.ok(files.includes("docs/knowledge/log.md"));
+      // inbox file appears either as the original or processed path depending
+      // on how git records the rename; both are under docs/knowledge/inbox/.
+      assert.ok(files.some((f) => f.startsWith("docs/knowledge/inbox/")));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runIngest — update-in-place path (GC-X007 existing page)", () => {
+  it("updates an existing page without creating a duplicate", async () => {
+    const existingPageRel = "docs/knowledge/gotchas/race-condition.md";
+    const dir = makeKnowledgeRepo({
+      extraFiles: {
+        [existingPageRel]:
+          "---\ntitle: Race Condition\nsources: ['pr:520']\n---\n# Race Condition\n\nOriginal body.\n",
+      },
+    });
+    try {
+      const inbox = writeInboxFile(dir, defaultInboxPayload({ source: "pr:530" }));
+      const agent = makeStubAgent(
+        [
+          {
+            // Update the existing file in place — add a new source to frontmatter.
+            type: "write_file",
+            path: existingPageRel,
+            content:
+              "---\ntitle: Race Condition\nsources: ['pr:520', 'pr:530']\n---\n# Race Condition\n\nOriginal body.\n\nNew note: also affects checkout.\n",
+          },
+          {
+            type: "append_file",
+            path: "docs/knowledge/log.md",
+            content: "- `2026-04-13` — updated gotchas/race-condition.md with pr:530.\n",
+          },
+          {
+            type: "rename",
+            from: relPathUnder(dir, inbox),
+            to: `docs/knowledge/inbox/processed/${basenameOf(inbox)}`,
+          },
+        ],
+        {
+          tail: `INGEST_RESULT={"action":"update","page":"${existingPageRel}","citations_added":1}`,
+        },
+      );
+      const result = await runIngest({
+        repoRoot: dir,
+        inboxFilePath: inbox,
+        knowledge: knowledgePaths(),
+        ingestAgent: agent,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.action, "update");
+      const files = commitFiles(dir);
+      // The existing page should appear in the commit, NOT a second new
+      // gotcha file with a different slug.
+      assert.ok(files.includes(existingPageRel));
+      const extraPages = files.filter(
+        (f) => f.startsWith("docs/knowledge/gotchas/") && f !== existingPageRel,
+      );
+      assert.deepEqual(
+        extraPages,
+        [],
+        `ingest duplicated the page instead of updating in place: ${extraPages.join(", ")}`,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runIngest — commit isolation (GC-X010)
+// ---------------------------------------------------------------------------
+
+describe("runIngest — commit isolation", () => {
+  it("does not include unrelated pre-existing dirty files in the commit", async () => {
+    const dir = makeKnowledgeRepo();
+    try {
+      // Plant a dirty file outside the knowledge tree BEFORE ingest runs.
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      writeFileSync(join(dir, "unrelated.txt"), "unrelated change\n");
+      const inbox = writeInboxFile(dir, defaultInboxPayload());
+      const agent = makeStubAgent(
+        [
+          {
+            type: "write_file",
+            path: "docs/knowledge/gotchas/foo.md",
+            content: "---\ntitle: foo\n---\n# foo\n",
+          },
+          {
+            type: "append_file",
+            path: "docs/knowledge/log.md",
+            content: "- entry\n",
+          },
+          {
+            type: "rename",
+            from: relPathUnder(dir, inbox),
+            to: `docs/knowledge/inbox/processed/${basenameOf(inbox)}`,
+          },
+        ],
+        {
+          tail: `INGEST_RESULT={"action":"create","page":"docs/knowledge/gotchas/foo.md","citations_added":1}`,
+        },
+      );
+      const result = await runIngest({
+        repoRoot: dir,
+        inboxFilePath: inbox,
+        knowledge: knowledgePaths(),
+        ingestAgent: agent,
+      });
+      assert.equal(result.ok, true);
+      const files = commitFiles(dir);
+      assert.ok(!files.includes("unrelated.txt"), `unrelated file leaked into commit: ${files.join(", ")}`);
+      // And the unrelated file is STILL dirty in the worktree after ingest.
+      const status = execFileSync("git", ["-C", dir, "status", "--porcelain"]).toString();
+      assert.match(status, /unrelated\.txt/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("aborts and reverts when the ingest agent writes outside the knowledge tree", async () => {
+    const dir = makeKnowledgeRepo();
+    try {
+      const inbox = writeInboxFile(dir, defaultInboxPayload());
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      const inboxBytesBefore = readFileSync(inbox, "utf8");
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      const readmeBefore = readFileSync(join(dir, "README.md"), "utf8");
+      const agent = makeStubAgent(
+        [
+          // Legitimate knowledge-tree write.
+          {
+            type: "write_file",
+            path: "docs/knowledge/gotchas/foo.md",
+            content: "---\ntitle: foo\n---\nbody\n",
+          },
+          // Malicious / buggy write OUTSIDE the knowledge tree.
+          {
+            type: "write_file",
+            path: "README.md",
+            content: "clobbered by the ingest agent\n",
+          },
+        ],
+        { tail: 'INGEST_RESULT={"action":"create","page":"docs/knowledge/gotchas/foo.md","citations_added":1}' },
+      );
+      const result = await runIngest({
+        repoRoot: dir,
+        inboxFilePath: inbox,
+        knowledge: knowledgePaths(),
+        ingestAgent: agent,
+      }).catch((e) => ({ ok: false, error: e.message }));
+      assert.equal(result.ok, false);
+      assert.match(result.error, /outside|isolation|unexpected/i);
+      // No commit was created.
+      assertNoCommitSinceSeed(dir);
+      // Inbox file is unchanged.
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      assert.equal(readFileSync(inbox, "utf8"), inboxBytesBefore);
+      // README was reverted to its committed state.
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      assert.equal(readFileSync(join(dir, "README.md"), "utf8"), readmeBefore);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to run on detached HEAD", async () => {
+    const dir = makeKnowledgeRepo();
+    try {
+      // Detach HEAD.
+      const sha = execFileSync("git", ["-C", dir, "rev-parse", "HEAD"]).toString().trim();
+      execFileSync("git", ["-C", dir, "checkout", "-q", "--detach", sha]);
+      const inbox = writeInboxFile(dir, defaultInboxPayload());
+      const agent = makeStubAgent([]);
+      const result = await runIngest({
+        repoRoot: dir,
+        inboxFilePath: inbox,
+        knowledge: knowledgePaths(),
+        ingestAgent: agent,
+      }).catch((e) => ({ ok: false, error: e.message }));
+      assert.equal(result.ok, false);
+      assert.match(result.error, /detached|branch/i);
+      // Inbox file untouched on disk.
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      assert.ok(existsSync(inbox));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runIngest — serialization (GC-X008)
+// ---------------------------------------------------------------------------
+
+describe("runIngest — serialization", () => {
+  it("serializes concurrent ingest against the same knowledge base", async () => {
+    const dir = makeKnowledgeRepo();
+    try {
+      const inboxA = writeInboxFile(dir, defaultInboxPayload({ source: "pr:1" }), {
+        filename: "2026-04-13T01-00-00-aaaa-a.md",
+      });
+      const inboxB = writeInboxFile(dir, defaultInboxPayload({ source: "pr:2" }), {
+        filename: "2026-04-13T01-00-00-bbbb-b.md",
+      });
+      // Track the order in which the agent invocations start and finish.
+      const events = [];
+      const agentFor = (label, delayMs, pagePath) =>
+        async function ({ repoRoot }) {
+          events.push(`start:${label}`);
+          await new Promise((r) => setTimeout(r, delayMs));
+          const abs = join(repoRoot, pagePath);
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+          mkdirSync(join(abs, ".."), { recursive: true });
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+          writeFileSync(abs, `---\ntitle: ${label}\n---\nbody\n`);
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+          const existingLog = readFileSync(
+            join(repoRoot, "docs", "knowledge", "log.md"),
+            "utf8",
+          );
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+          writeFileSync(
+            join(repoRoot, "docs", "knowledge", "log.md"),
+            existingLog + `- ${label}\n`,
+          );
+          const inbox = label === "A" ? inboxA : inboxB;
+          const processedDir = join(repoRoot, "docs/knowledge/inbox/processed");
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+          mkdirSync(processedDir, { recursive: true });
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+          renameSync(inbox, join(processedDir, basenameOf(inbox)));
+          events.push(`end:${label}`);
+          return {
+            stdout:
+              `INGEST_RESULT={"action":"create","page":"${pagePath}","citations_added":1}\n`,
+            stderr: "",
+          };
+        };
+      const [resA, resB] = await Promise.all([
+        runIngest({
+          repoRoot: dir,
+          inboxFilePath: inboxA,
+          knowledge: knowledgePaths(),
+          ingestAgent: agentFor("A", 50, "docs/knowledge/gotchas/a.md"),
+        }),
+        runIngest({
+          repoRoot: dir,
+          inboxFilePath: inboxB,
+          knowledge: knowledgePaths(),
+          ingestAgent: agentFor("B", 50, "docs/knowledge/gotchas/b.md"),
+        }),
+      ]);
+      assert.equal(resA.ok, true);
+      assert.equal(resB.ok, true);
+      // The two runs must not interleave: one full start→end, then the
+      // other. Serialization is the core invariant — either order is fine.
+      const starts = events.filter((e) => e.startsWith("start:"));
+      const ends = events.filter((e) => e.startsWith("end:"));
+      assert.equal(starts.length, 2);
+      assert.equal(ends.length, 2);
+      // events should look like [start:X, end:X, start:Y, end:Y]
+      assert.equal(events[1].replace("end:", "start:"), events[0]);
+      assert.equal(events[3].replace("end:", "start:"), events[2]);
+      // And two commits exist.
+      const commits = execFileSync("git", ["-C", dir, "log", "--oneline"])
+        .toString()
+        .trim()
+        .split("\n");
+      assert.equal(commits.length, 3, `expected 3 commits (seed + 2 ingests), got ${commits.length}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runIngest — failure semantics (GC-X009)
+// ---------------------------------------------------------------------------
+
+describe("runIngest — failure retains source", () => {
+  it("leaves the inbox file untouched when the ingest agent throws", async () => {
+    const dir = makeKnowledgeRepo();
+    try {
+      const inbox = writeInboxFile(dir, defaultInboxPayload());
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      const bytesBefore = readFileSync(inbox, "utf8");
+      const agent = makeStubAgent([{ type: "throw", message: "boom" }]);
+      const result = await runIngest({
+        repoRoot: dir,
+        inboxFilePath: inbox,
+        knowledge: knowledgePaths(),
+        ingestAgent: agent,
+      }).catch((e) => ({ ok: false, error: e.message }));
+      assert.equal(result.ok, false);
+      assert.match(result.error, /boom|agent/i);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      assert.equal(readFileSync(inbox, "utf8"), bytesBefore);
+      assertNoCommitSinceSeed(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves the inbox file untouched when the ingest agent produces no result tail", async () => {
+    const dir = makeKnowledgeRepo();
+    try {
+      const inbox = writeInboxFile(dir, defaultInboxPayload());
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      const bytesBefore = readFileSync(inbox, "utf8");
+      const agent = async () => ({ stdout: "no tail here\n", stderr: "" });
+      const result = await runIngest({
+        repoRoot: dir,
+        inboxFilePath: inbox,
+        knowledge: knowledgePaths(),
+        ingestAgent: agent,
+      }).catch((e) => ({ ok: false, error: e.message }));
+      assert.equal(result.ok, false);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      assert.equal(readFileSync(inbox, "utf8"), bytesBefore);
+      assertNoCommitSinceSeed(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runIngest — latency measurement (GC-X011)
+// ---------------------------------------------------------------------------
+
+describe("runIngest — latency", () => {
+  it("records latency in milliseconds for a successful ingest", async () => {
+    const dir = makeKnowledgeRepo();
+    try {
+      const inbox = writeInboxFile(dir, defaultInboxPayload());
+      const agent = makeStubAgent(
+        [
+          {
+            type: "write_file",
+            path: "docs/knowledge/gotchas/ok.md",
+            content: "---\ntitle: ok\n---\nbody\n",
+          },
+          {
+            type: "append_file",
+            path: "docs/knowledge/log.md",
+            content: "- entry\n",
+          },
+          {
+            type: "rename",
+            from: relPathUnder(dir, inbox),
+            to: `docs/knowledge/inbox/processed/${basenameOf(inbox)}`,
+          },
+        ],
+        { tail: 'INGEST_RESULT={"action":"create","page":"docs/knowledge/gotchas/ok.md","citations_added":1}' },
+      );
+      const result = await runIngest({
+        repoRoot: dir,
+        inboxFilePath: inbox,
+        knowledge: knowledgePaths(),
+        ingestAgent: agent,
+      });
+      assert.equal(result.ok, true);
+      assert.ok(typeof result.latency_ms === "number");
+      assert.ok(result.latency_ms >= 0);
+      // Unit tests with a fast stub should always run in well under 30s.
+      assert.ok(result.latency_ms < 30_000);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Tiny utility helpers used by the scripted stubs.
+function basenameOf(abs) {
+  return abs.split("/").pop();
+}
+function relPathUnder(repoRoot, abs) {
+  return abs.startsWith(repoRoot + "/") ? abs.slice(repoRoot.length + 1) : abs;
+}

--- a/mcp/ground-control/knowledge_ingest_cli.js
+++ b/mcp/ground-control/knowledge_ingest_cli.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// Thin executable entry point for the detached ingest subprocess spawned
+// by `gc_remember`. Parses a structured argv, delegates to `runIngest`
+// in knowledge_ingest.js, and exits with a non-zero status on failure so
+// the parent process (or a later sweep) can observe the outcome.
+//
+// This file is intentionally minimal: all the interesting logic lives in
+// knowledge_ingest.js and is covered by the unit test suite that injects
+// a stub `codexInvoker`. The CLI is just argv plumbing.
+//
+// Expected argv (all required, all absolute or repo-relative as noted):
+//   --repo <absolute-repo-root>
+//   --inbox-file <absolute-path-to-inbox-item>
+//   --knowledge-dir <repo-relative>
+//   --knowledge-schema <repo-relative>
+//   --knowledge-inbox <repo-relative>
+
+import { runIngest } from "./knowledge_ingest.js";
+
+function parseArgv(argv) {
+  const out = {};
+  const expected = new Map([
+    ["--repo", "repoRoot"],
+    ["--inbox-file", "inboxFilePath"],
+    ["--knowledge-dir", "dir"],
+    ["--knowledge-schema", "schema"],
+    ["--knowledge-inbox", "inbox"],
+  ]);
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const key = expected.get(flag);
+    if (!key) {
+      throw new Error(`knowledge_ingest_cli: unknown argument '${flag}'`);
+    }
+    const value = argv[i + 1];
+    if (value == null || value.startsWith("--")) {
+      throw new Error(`knowledge_ingest_cli: missing value for '${flag}'`);
+    }
+    out[key] = value;
+    i += 1;
+  }
+  for (const [flag, key] of expected) {
+    if (out[key] == null) {
+      throw new Error(`knowledge_ingest_cli: missing required argument '${flag}'`);
+    }
+  }
+  return out;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  let parsed;
+  try {
+    parsed = parseArgv(argv);
+  } catch (error) {
+    process.stderr.write(
+      JSON.stringify({ event: "ingest_cli_argv_error", error: error.message }) + "\n",
+    );
+    return 2;
+  }
+  try {
+    const result = await runIngest({
+      repoRoot: parsed.repoRoot,
+      inboxFilePath: parsed.inboxFilePath,
+      knowledge: {
+        dir: parsed.dir,
+        schema: parsed.schema,
+        inbox: parsed.inbox,
+      },
+    });
+    // Success is already observable via the structured `ingest_commit`
+    // log line that `runIngest` emits. Nothing more to say here.
+    return result.ok ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(
+      JSON.stringify({
+        event: "ingest_cli_failure",
+        inbox_path: parsed.inboxFilePath,
+        error: error.message,
+      }) + "\n",
+    );
+    return 1;
+  }
+}
+
+// Only run main() when this file is invoked directly, not when it is
+// imported by the unit test. The import.meta.url check is the standard
+// ESM pattern for "if __name__ == '__main__'".
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => process.exit(code));
+}

--- a/mcp/ground-control/knowledge_ingest_cli.test.js
+++ b/mcp/ground-control/knowledge_ingest_cli.test.js
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { main } from "./knowledge_ingest_cli.js";
+
+// The CLI is deliberately thin — argv → runIngest → exit code. We do not
+// re-exercise the whole ingest transaction here; the knowledge_ingest
+// test suite already covers that. These tests just verify the argv
+// plumbing and the two exit-code paths (argv error vs runtime error).
+
+describe("knowledge_ingest_cli argv parsing", () => {
+  it("exits 2 on missing required arguments", async () => {
+    const code = await main([]);
+    assert.equal(code, 2);
+  });
+
+  it("exits 2 on unknown arguments", async () => {
+    const code = await main([
+      "--repo", "/tmp/x",
+      "--inbox-file", "/tmp/x/item.md",
+      "--knowledge-dir", "docs/knowledge",
+      "--knowledge-schema", "docs/knowledge/SCHEMA.md",
+      "--knowledge-inbox", "docs/knowledge/inbox",
+      "--bogus", "value",
+    ]);
+    assert.equal(code, 2);
+  });
+
+  it("exits 2 when a flag is missing its value", async () => {
+    const code = await main(["--repo"]);
+    assert.equal(code, 2);
+  });
+
+  it("exits 1 on a runtime failure (nonexistent repo)", async () => {
+    // All argv is well-formed, but the repo path does not exist, so
+    // runIngest throws and the CLI returns a non-zero (non-argv) code.
+    const code = await main([
+      "--repo", "/does/not/exist/for/real",
+      "--inbox-file", "/does/not/exist/for/real/item.md",
+      "--knowledge-dir", "docs/knowledge",
+      "--knowledge-schema", "docs/knowledge/SCHEMA.md",
+      "--knowledge-inbox", "docs/knowledge/inbox",
+    ]);
+    assert.equal(code, 1);
+  });
+});

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -1,9 +1,12 @@
-import { mkdtempSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
+import { closeSync, fsyncSync, mkdirSync, mkdtempSync, openSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as resolvePath } from "node:path";
-import { execFile as execFileCb } from "node:child_process";
+import { execFile as execFileCb, spawn as spawnChild } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { randomBytes } from "node:crypto";
 import { promisify } from "node:util";
-import { load as parseYaml } from "js-yaml";
+import { dump as dumpYaml, load as parseYaml } from "js-yaml";
+import properLockfile from "proper-lockfile";
 
 const execFile = promisify(execFileCb);
 const GROUND_CONTROL_PROJECT_RE = /^[a-z0-9][a-z0-9-]*$/;
@@ -63,7 +66,7 @@ export function buildSuggestedGroundControlYaml(project = "your-project-id") {
   ].join("\n");
 }
 
-async function execFileWithInput(file, args, { input, ...options } = {}) {
+export async function execFileWithInput(file, args, { input, ...options } = {}) {
   return await new Promise((resolve, reject) => {
     const child = execFileCb(file, args, options, (error, stdout, stderr) => {
       if (error) {
@@ -3357,4 +3360,407 @@ export async function listPackInstallRecords(project, { packId } = {}) {
 
 export async function getPackInstallRecord(id) {
   return request("GET", `/api/v1/pack-install-records/${encodeURIComponent(id)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge base capture / ingest helpers — GC-X006..GC-X011
+// ---------------------------------------------------------------------------
+
+// The canonical vocabulary for source citations. This list IS the source of
+// truth: gc_remember's Zod input enum, the ingest engine's validation, and
+// the citation prefixes written into page frontmatter, log.md entries, and
+// git commit messages all draw from here. Keep in sync with
+// docs/knowledge/SCHEMA.md §"Source citation rule".
+export const KNOWLEDGE_SOURCE_TYPES = Object.freeze([
+  "commit",
+  "pr",
+  "review",
+  "issue",
+  "ci",
+  "user-correction",
+  "file",
+]);
+
+// Short SHA minimum length; git accepts 4 chars but anything under 7 is
+// ambiguous in practice. 40 chars is a full SHA-1 hash.
+const COMMIT_SHA_RE = /^[0-9a-f]{7,40}$/;
+const POSITIVE_INT_RE = /^[1-9][0-9]*$/;
+// Allow stricter path validation for `file:` citations: repo-relative only,
+// no leading slash, no `..` segments, no backslashes. This mirrors the
+// repo-relative containment rules enforced by resolveRepoRelativePath for
+// config paths so the citation vocabulary can't sneak repo-escaping paths
+// into log.md or commit messages.
+const REPO_RELATIVE_PATH_RE = /^(?!\.\.(\/|$))(?!.*\/\.\.(\/|$))(?!\/)(?!.*\\)[^\s].*$/;
+
+// Turn a structured {source_type, source_ref} pair into the canonical
+// citation string. Every place that needs to record WHERE an observation
+// came from goes through this single function, so the inbox payload, page
+// frontmatter `sources` list, `log.md` bullets, and git commit messages
+// cannot drift in terminology or validation.
+//
+// Returns { ok: true, citation: string } on success, or
+// { ok: false, error: string } on validation failure. Does not throw.
+export function formatSourceCitation({ sourceType, sourceRef } = {}) {
+  if (typeof sourceType !== "string" || sourceType.trim() === "") {
+    return { ok: false, error: "source_type is required and must be a non-empty string" };
+  }
+  if (!KNOWLEDGE_SOURCE_TYPES.includes(sourceType)) {
+    return {
+      ok: false,
+      error: `source_type must be one of ${KNOWLEDGE_SOURCE_TYPES.join(", ")} (got '${sourceType}')`,
+    };
+  }
+  if (typeof sourceRef !== "string" || sourceRef.trim() === "") {
+    return { ok: false, error: "source_ref is required and must be a non-empty string" };
+  }
+
+  // Normalize per type. Each branch produces a single-line canonical ref
+  // so the resulting citation is safe to embed in a YAML scalar, a markdown
+  // bullet, or a git commit message subject without escaping.
+  switch (sourceType) {
+    case "commit": {
+      const ref = sourceRef.trim().toLowerCase();
+      if (!COMMIT_SHA_RE.test(ref)) {
+        return {
+          ok: false,
+          error: `source_ref for 'commit' must be a 7–40 char hex SHA (got '${sourceRef}')`,
+        };
+      }
+      return { ok: true, citation: `commit:${ref}` };
+    }
+    case "pr":
+    case "issue": {
+      const ref = sourceRef.trim().replace(/^#/, "");
+      if (!POSITIVE_INT_RE.test(ref)) {
+        return {
+          ok: false,
+          error: `source_ref for '${sourceType}' must be a positive integer (got '${sourceRef}')`,
+        };
+      }
+      return { ok: true, citation: `${sourceType}:${ref}` };
+    }
+    case "review":
+    case "ci": {
+      // Review comment ids and CI run ids are opaque strings produced by
+      // GitHub. Collapse any internal whitespace to a single space and
+      // reject anything empty after trimming.
+      const ref = sourceRef.trim().replace(/\s+/g, " ");
+      if (ref === "") {
+        return { ok: false, error: `source_ref for '${sourceType}' must be a non-empty id` };
+      }
+      return { ok: true, citation: `${sourceType}:${ref}` };
+    }
+    case "user-correction": {
+      // User corrections are free-form short descriptions. Collapse
+      // whitespace runs (including newlines) into single spaces so the
+      // citation stays a single line safe for commit-message subjects.
+      const ref = sourceRef.replace(/\s+/g, " ").trim();
+      if (ref === "") {
+        return { ok: false, error: "source_ref for 'user-correction' must be a non-empty description" };
+      }
+      return { ok: true, citation: `user-correction:${ref}` };
+    }
+    case "file": {
+      const ref = sourceRef.trim();
+      if (isAbsolute(ref)) {
+        return { ok: false, error: `source_ref for 'file' must be a repo-relative path (got absolute path '${sourceRef}')` };
+      }
+      if (!REPO_RELATIVE_PATH_RE.test(ref)) {
+        return { ok: false, error: `source_ref for 'file' must be a repo-relative path with no '..' segments (got '${sourceRef}')` };
+      }
+      return { ok: true, citation: `file:${ref}` };
+    }
+    default: {
+      // Unreachable: KNOWLEDGE_SOURCE_TYPES is the only valid set and we
+      // already validated membership above. Kept for defensive completeness
+      // so a future addition to the list without a switch case fails fast.
+      return { ok: false, error: `unsupported source_type '${sourceType}'` };
+    }
+  }
+}
+
+// Slug a note title into a filesystem-safe, kebab-cased string bounded at
+// 40 chars. Used as the tail of inbox filenames so humans scanning
+// `docs/knowledge/inbox/` can tell entries apart without opening them.
+function buildInboxSlug(note) {
+  const trimmed = (note || "").slice(0, 200).toLowerCase();
+  const kebab = trimmed
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const bounded = kebab.slice(0, 40).replace(/-+$/g, "");
+  return bounded || "note";
+}
+
+// ISO timestamp suitable for filename prefixes: swaps out the `:` chars
+// that are illegal on Windows / awkward in URLs, and drops the milliseconds
+// so filenames are exactly `YYYY-MM-DDTHH-MM-SS`.
+function formatInboxTimestamp(date = new Date()) {
+  return date.toISOString().replace(/\.\d+Z$/, "").replace(/:/g, "-");
+}
+
+// Default spawn implementation for gc_remember's detached ingest
+// subprocess. The returned function accepts { repoRoot, inboxFilePath,
+// knowledge } and returns after the child has been fully detached. Any
+// spawn-layer exception propagates to the caller which converts it to a
+// warning on the synchronous return envelope.
+function defaultSpawnIngest({ repoRoot, inboxFilePath, knowledge }) {
+  const cliPath = fileURLToPath(new URL("./knowledge_ingest_cli.js", import.meta.url));
+  const args = [
+    cliPath,
+    "--repo", repoRoot,
+    "--inbox-file", inboxFilePath,
+    "--knowledge-dir", knowledge.dir,
+    "--knowledge-schema", knowledge.schema,
+    "--knowledge-inbox", knowledge.inbox,
+  ];
+  const child = spawnChild(process.execPath, args, {
+    cwd: repoRoot,
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+}
+
+// Append a knowledge-base observation to the repo's inbox. Synchronous
+// success means the inbox entry is durably written to disk; the ingest
+// subprocess that integrates the observation into the wiki is spawned
+// after the write but its result is asynchronous and may fail. Per
+// GC-X006, subprocess spawn failures surface as a warning in the return
+// envelope but do not fail the capture — a later sweep will discover the
+// untouched inbox file and retry.
+//
+// Parameters:
+//   repoPath     — absolute path to the target git repo
+//   note         — the observation body text (required, non-empty)
+//   sourceType   — one of KNOWLEDGE_SOURCE_TYPES (required)
+//   sourceRef    — source reference (validated per sourceType)
+//   tags         — optional list of discovery tags
+//   spawnIngest  — optional DI hook for tests; defaults to
+//                  defaultSpawnIngest which launches the real CLI
+//
+// Returns { ok: true, inbox_path, citation, warning? } on success, or
+// { ok: false, error } on validation / config failure. Does not throw.
+export async function writeKnowledgeInbox({
+  repoPath,
+  note,
+  sourceType,
+  sourceRef,
+  tags = [],
+  spawnIngest = defaultSpawnIngest,
+} = {}) {
+  if (typeof repoPath !== "string" || !isAbsolute(repoPath)) {
+    return { ok: false, error: "repo_path must be an absolute path to a Git repository" };
+  }
+  if (typeof note !== "string" || note.trim() === "") {
+    return { ok: false, error: "note is required and must be a non-empty string" };
+  }
+  if (tags != null && !Array.isArray(tags)) {
+    return { ok: false, error: "tags must be an array of strings when set" };
+  }
+
+  const citationResult = formatSourceCitation({ sourceType, sourceRef });
+  if (!citationResult.ok) return { ok: false, error: citationResult.error };
+
+  let context;
+  try {
+    context = await getRepoGroundControlContext(repoPath);
+  } catch (error) {
+    return { ok: false, error: `failed to resolve repo context: ${error.message}` };
+  }
+  if (context.status !== "ok") {
+    return {
+      ok: false,
+      error: `repository is not ready for knowledge capture: ${context.errors?.[0] || context.status}`,
+    };
+  }
+  if (context.knowledge == null) {
+    return {
+      ok: false,
+      error: "repository has no 'knowledge' block in .ground-control.yaml — capture is not configured",
+    };
+  }
+
+  const repoRoot = context.repo_path;
+  const knowledge = context.knowledge;
+  const inboxRel = knowledge.inbox;
+  const absInboxDir = resolvePath(repoRoot, inboxRel);
+
+  // Lazy-create the inbox directory on first capture. The inbox is
+  // deliberately not committed as part of the #522 skeleton because an
+  // empty directory has nothing to commit.
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- absInboxDir derives from a realpath-contained, resolved knowledge.inbox
+    mkdirSync(absInboxDir, { recursive: true });
+  } catch (error) {
+    return { ok: false, error: `failed to create inbox directory ${inboxRel}: ${error.message}` };
+  }
+
+  // Compose the filename: ISO timestamp + 4-char random suffix + slug.
+  // The random suffix protects against sub-second concurrent captures
+  // producing identical timestamps; the slug keeps the file human-scanable.
+  const timestamp = formatInboxTimestamp();
+  const slug = buildInboxSlug(note);
+  const rand = randomBytes(3).toString("hex").slice(0, 4);
+  const filename = `${timestamp}-${rand}-${slug}.md`;
+  const absInboxFile = join(absInboxDir, filename);
+
+  // Build the frontmatter + body. js-yaml dump auto-quotes scalars that
+  // need escaping so citations containing `:` or special chars are safe.
+  const frontmatter = {
+    captured_at: new Date().toISOString(),
+    source: citationResult.citation,
+  };
+  if (tags && tags.length > 0) {
+    frontmatter.tags = tags;
+  }
+  const yamlBlock = dumpYaml(frontmatter, { lineWidth: -1, noRefs: true });
+  const fileContent = `---\n${yamlBlock}---\n\n${note.trim()}\n`;
+
+  // Atomic write: temp file + fsync + rename. A crash between the write
+  // and the rename leaves a .tmp sidecar but no partial file at the final
+  // path, so readers never observe a half-written inbox entry.
+  const tmpPath = `${absInboxFile}.tmp`;
+  let fd;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- tmpPath derives from inboxDir which is repo-relative
+    fd = openSync(tmpPath, "wx");
+    writeSync(fd, fileContent);
+    fsyncSync(fd);
+  } catch (error) {
+    if (fd != null) {
+      try { closeSync(fd); } catch { /* best-effort */ }
+    }
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch { /* best-effort cleanup */ }
+    return { ok: false, error: `failed to write inbox tmp file: ${error.message}` };
+  }
+  try {
+    closeSync(fd);
+  } catch (error) {
+    return { ok: false, error: `failed to close inbox tmp file: ${error.message}` };
+  }
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- both paths are under absInboxDir which is realpath-contained within repoRoot
+    renameSync(tmpPath, absInboxFile);
+  } catch (error) {
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch { /* best-effort cleanup */ }
+    return { ok: false, error: `failed to rename inbox tmp file: ${error.message}` };
+  }
+
+  const inboxRelFromRepo = relative(repoRoot, absInboxFile);
+
+  // Spawn the detached ingest subprocess. Spawn failures do not fail the
+  // capture — the inbox entry is durable and will be retried by a later
+  // real-time call, manual retry, or scheduled sweep.
+  let warning = null;
+  try {
+    spawnIngest({
+      repoRoot,
+      inboxFilePath: absInboxFile,
+      knowledge,
+    });
+  } catch (error) {
+    warning = `ingest_spawn_failed: ${error.message}`;
+  }
+
+  const result = {
+    ok: true,
+    inbox_path: inboxRelFromRepo,
+    citation: citationResult.citation,
+  };
+  if (warning) result.warning = warning;
+  return result;
+}
+
+// Acquire an interprocess lock on a knowledge base, keyed by the canonical
+// realpath of the knowledge directory. Different path spellings (symlinks,
+// `..`-normalized forms) that point at the same inode contend on the same
+// lock, which is required by GC-X008's invariant that "concurrent ingest
+// against the same knowledge base" serializes even if the callers supplied
+// different strings for the path.
+//
+// Uses `proper-lockfile`'s filesystem-based lock with stale detection:
+//   - stale  — lock is considered abandoned after this many ms if its
+//              refresh timestamp has not been updated. 60 s is long enough
+//              to survive normal ingest runs and short enough to recover
+//              from a crashed subprocess without blocking forever.
+//   - update — the holder refreshes the lock's mtime this often while
+//              work is in progress. 10 s gives a large margin under `stale`.
+//
+// By default `retries: 0` — contention fails fast so callers like
+// administrative tools can report a clean "locked, try again later"
+// error. Callers that want to wait (like `runIngest`, which serializes
+// two concurrent captures into a single sequential queue) pass a
+// `retries` option that matches proper-lockfile's retry shape.
+//
+// Returns an async release function. The returned function is
+// idempotent — calling it twice is safe but will no-op on the second call
+// (proper-lockfile throws if the lock is not actually held, so we swallow
+// that specific error).
+//
+// Throws on invalid input (non-absolute path, nonexistent directory) and
+// on contention. Errors carry a message that includes the canonical path
+// so debugging shows exactly which knowledge base is contended.
+export async function acquireKnowledgeLock(knowledgeDir, { retries = 0 } = {}) {
+  if (typeof knowledgeDir !== "string" || !isAbsolute(knowledgeDir)) {
+    throw new Error("acquireKnowledgeLock: path must be an absolute directory path");
+  }
+  let canonical;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- absolute path validated above
+    canonical = realpathSync(knowledgeDir);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      throw new Error(`acquireKnowledgeLock: path does not exist: ${knowledgeDir}`);
+    }
+    throw error;
+  }
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- canonical is a realpath
+  const stat = statSync(canonical);
+  if (!stat.isDirectory()) {
+    throw new Error(`acquireKnowledgeLock: path is not a directory: ${knowledgeDir}`);
+  }
+
+  let release;
+  try {
+    release = await properLockfile.lock(canonical, {
+      stale: 60_000,
+      update: 10_000,
+      retries,
+      // Store the lockfile INSIDE the knowledge directory as `.gc-lock`
+      // rather than next to it, so rm'ing the knowledge directory also
+      // cleans up the lock. This keeps the host filesystem tidy on test
+      // teardown and stale-repo cleanup.
+      lockfilePath: join(canonical, ".gc-lock"),
+      realpath: false,
+    });
+  } catch (error) {
+    // proper-lockfile maps contention to `ELOCKED`. Rewrite as a clear
+    // message so callers do not need to know about the underlying code.
+    if (error.code === "ELOCKED") {
+      const contended = new Error(`knowledge base is already held by another process: ${canonical}`);
+      contended.code = "ELOCKED";
+      contended.path = canonical;
+      throw contended;
+    }
+    throw error;
+  }
+
+  let released = false;
+  return async function releaseHandle() {
+    if (released) return;
+    released = true;
+    try {
+      await release();
+    } catch (error) {
+      // "Lock is already released" is fine — we just observed the release
+      // through a different path. Anything else is a real error.
+      if (error.code !== "ENOTACQUIRED" && !/already released/i.test(error.message)) {
+        throw error;
+      }
+    }
+  };
 }

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -2037,13 +2037,18 @@ async function computeReviewDiff(repoRoot, baseBranch, uncommitted) {
 }
 
 async function runSingleCodexReview({ repoRoot, prompt, args }) {
-  const { stdout } = await execFileWithInput("codex", args, {
+  // Return both stdout and stderr so the caller can include them in a
+  // diagnostic error when the structured COMMENT_IDS tail is missing.
+  // Dropping stderr silently (the prior behavior) made the common case
+  // "codex ran but didn't follow the output contract" impossible to
+  // debug without re-running by hand.
+  const { stdout, stderr } = await execFileWithInput("codex", args, {
     input: prompt,
     cwd: repoRoot,
     maxBuffer: 10 * 1024 * 1024,
     env: { ...process.env, NO_COLOR: "1" },
   });
-  return stdout;
+  return { stdout, stderr };
 }
 
 // Dedup key combines path, line, and a short prefix of the body so two
@@ -2100,6 +2105,40 @@ async function enrichCommentsList({ repoRoot, owner, name, prNumber, commentIds,
   return comments;
 }
 
+// Truncate a long string to `max` chars, prefixing an ellipsis when the
+// original was longer. Used for error-message previews of codex output so
+// callers don't have to eyeball multi-KB dumps.
+function previewTailString(raw, max = 500) {
+  if (typeof raw !== "string") return "";
+  if (raw.length <= max) return raw;
+  return `…${raw.slice(raw.length - max)}`;
+}
+
+// Wrap parseCodexReviewTail so the "missing tail" error is actionable.
+// The base error message is identical to the original so any downstream
+// matching on it keeps working, but we append the last ~500 chars of both
+// stdout and stderr from the reviewer subprocess. That preview is the
+// difference between "codex didn't follow the contract" and "codex
+// errored for a specific reason we can see".
+function parseReviewerTail(reviewerLabel, output) {
+  if (!output || typeof output !== "object") {
+    throw new Error(`Codex ${reviewerLabel} review returned no output object`);
+  }
+  const { stdout = "", stderr = "" } = output;
+  try {
+    return parseCodexReviewTail(stdout);
+  } catch (error) {
+    const stdoutPreview = previewTailString(stdout, 500);
+    const stderrPreview = previewTailString(stderr, 500);
+    const detail = [
+      `Codex ${reviewerLabel} review: ${error.message}`,
+      stdoutPreview ? `--- stdout tail ---\n${stdoutPreview}` : "--- stdout was empty ---",
+      stderrPreview ? `--- stderr tail ---\n${stderrPreview}` : "--- stderr was empty ---",
+    ].join("\n\n");
+    throw new Error(detail);
+  }
+}
+
 export async function runCodexReview({ repoPath, baseBranch = "dev", uncommitted = false, prNumber = null }) {
   const repoRoot = await ensureGitRepo(repoPath);
 
@@ -2125,10 +2164,10 @@ export async function runCodexReview({ repoPath, baseBranch = "dev", uncommitted
   });
   const args = buildCodexReviewArgs({ uncommitted });
 
-  let coreStdout;
-  let securityStdout;
+  let coreOutput;
+  let securityOutput;
   try {
-    [coreStdout, securityStdout] = await Promise.all([
+    [coreOutput, securityOutput] = await Promise.all([
       runSingleCodexReview({ repoRoot, prompt: corePrompt, args }),
       runSingleCodexReview({ repoRoot, prompt: securityPrompt, args }),
     ]);
@@ -2136,8 +2175,12 @@ export async function runCodexReview({ repoPath, baseBranch = "dev", uncommitted
     throw new Error(`Codex review failed: ${formatCommandFailure("codex", error)}`);
   }
 
-  const core = parseCodexReviewTail(coreStdout);
-  const security = parseCodexReviewTail(securityStdout);
+  // Wrap parseCodexReviewTail so its "missing tail" error includes a
+  // preview of the reviewer's actual stdout and stderr. Without that,
+  // the error is unactionable: there is no indication of what codex
+  // really emitted or whether it failed silently on the codex side.
+  const core = parseReviewerTail("core", coreOutput);
+  const security = parseReviewerTail("security", securityOutput);
 
   let owner = null;
   let name = null;

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -1,10 +1,12 @@
-import { appendFileSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { appendFileSync, closeSync, fsyncSync, lstatSync, mkdirSync, mkdtempSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync, writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as resolvePath } from "node:path";
-import { execFile as execFileCb } from "node:child_process";
+import { execFile as execFileCb, spawn as spawnChild } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { createHash, randomBytes } from "node:crypto";
 import { promisify } from "node:util";
-import { createHash } from "node:crypto";
-import { load as parseYaml } from "js-yaml";
+import { dump as dumpYaml, load as parseYaml } from "js-yaml";
+import properLockfile from "proper-lockfile";
 
 const execFile = promisify(execFileCb);
 const GROUND_CONTROL_PROJECT_RE = /^[a-z0-9][a-z0-9-]*$/;
@@ -13091,4 +13093,407 @@ export function validateGovernanceStatus(entity, status) {
         `Valid values: ${allowed.join(", ")}`,
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge base capture / ingest helpers — GC-X006..GC-X011
+// ---------------------------------------------------------------------------
+
+// The canonical vocabulary for source citations. This list IS the source of
+// truth: gc_remember's Zod input enum, the ingest engine's validation, and
+// the citation prefixes written into page frontmatter, log.md entries, and
+// git commit messages all draw from here. Keep in sync with
+// docs/knowledge/SCHEMA.md §"Source citation rule".
+export const KNOWLEDGE_SOURCE_TYPES = Object.freeze([
+  "commit",
+  "pr",
+  "review",
+  "issue",
+  "ci",
+  "user-correction",
+  "file",
+]);
+
+// Short SHA minimum length; git accepts 4 chars but anything under 7 is
+// ambiguous in practice. 40 chars is a full SHA-1 hash.
+const COMMIT_SHA_RE = /^[0-9a-f]{7,40}$/;
+const POSITIVE_INT_RE = /^[1-9][0-9]*$/;
+// Allow stricter path validation for `file:` citations: repo-relative only,
+// no leading slash, no `..` segments, no backslashes. This mirrors the
+// repo-relative containment rules enforced by resolveRepoRelativePath for
+// config paths so the citation vocabulary can't sneak repo-escaping paths
+// into log.md or commit messages.
+const REPO_RELATIVE_PATH_RE = /^(?!\.\.(\/|$))(?!.*\/\.\.(\/|$))(?!\/)(?!.*\\)[^\s].*$/;
+
+// Turn a structured {source_type, source_ref} pair into the canonical
+// citation string. Every place that needs to record WHERE an observation
+// came from goes through this single function, so the inbox payload, page
+// frontmatter `sources` list, `log.md` bullets, and git commit messages
+// cannot drift in terminology or validation.
+//
+// Returns { ok: true, citation: string } on success, or
+// { ok: false, error: string } on validation failure. Does not throw.
+export function formatSourceCitation({ sourceType, sourceRef } = {}) {
+  if (typeof sourceType !== "string" || sourceType.trim() === "") {
+    return { ok: false, error: "source_type is required and must be a non-empty string" };
+  }
+  if (!KNOWLEDGE_SOURCE_TYPES.includes(sourceType)) {
+    return {
+      ok: false,
+      error: `source_type must be one of ${KNOWLEDGE_SOURCE_TYPES.join(", ")} (got '${sourceType}')`,
+    };
+  }
+  if (typeof sourceRef !== "string" || sourceRef.trim() === "") {
+    return { ok: false, error: "source_ref is required and must be a non-empty string" };
+  }
+
+  // Normalize per type. Each branch produces a single-line canonical ref
+  // so the resulting citation is safe to embed in a YAML scalar, a markdown
+  // bullet, or a git commit message subject without escaping.
+  switch (sourceType) {
+    case "commit": {
+      const ref = sourceRef.trim().toLowerCase();
+      if (!COMMIT_SHA_RE.test(ref)) {
+        return {
+          ok: false,
+          error: `source_ref for 'commit' must be a 7–40 char hex SHA (got '${sourceRef}')`,
+        };
+      }
+      return { ok: true, citation: `commit:${ref}` };
+    }
+    case "pr":
+    case "issue": {
+      const ref = sourceRef.trim().replace(/^#/, "");
+      if (!POSITIVE_INT_RE.test(ref)) {
+        return {
+          ok: false,
+          error: `source_ref for '${sourceType}' must be a positive integer (got '${sourceRef}')`,
+        };
+      }
+      return { ok: true, citation: `${sourceType}:${ref}` };
+    }
+    case "review":
+    case "ci": {
+      // Review comment ids and CI run ids are opaque strings produced by
+      // GitHub. Collapse any internal whitespace to a single space and
+      // reject anything empty after trimming.
+      const ref = sourceRef.trim().replace(/\s+/g, " ");
+      if (ref === "") {
+        return { ok: false, error: `source_ref for '${sourceType}' must be a non-empty id` };
+      }
+      return { ok: true, citation: `${sourceType}:${ref}` };
+    }
+    case "user-correction": {
+      // User corrections are free-form short descriptions. Collapse
+      // whitespace runs (including newlines) into single spaces so the
+      // citation stays a single line safe for commit-message subjects.
+      const ref = sourceRef.replace(/\s+/g, " ").trim();
+      if (ref === "") {
+        return { ok: false, error: "source_ref for 'user-correction' must be a non-empty description" };
+      }
+      return { ok: true, citation: `user-correction:${ref}` };
+    }
+    case "file": {
+      const ref = sourceRef.trim();
+      if (isAbsolute(ref)) {
+        return { ok: false, error: `source_ref for 'file' must be a repo-relative path (got absolute path '${sourceRef}')` };
+      }
+      if (!REPO_RELATIVE_PATH_RE.test(ref)) {
+        return { ok: false, error: `source_ref for 'file' must be a repo-relative path with no '..' segments (got '${sourceRef}')` };
+      }
+      return { ok: true, citation: `file:${ref}` };
+    }
+    default: {
+      // Unreachable: KNOWLEDGE_SOURCE_TYPES is the only valid set and we
+      // already validated membership above. Kept for defensive completeness
+      // so a future addition to the list without a switch case fails fast.
+      return { ok: false, error: `unsupported source_type '${sourceType}'` };
+    }
+  }
+}
+
+// Slug a note title into a filesystem-safe, kebab-cased string bounded at
+// 40 chars. Used as the tail of inbox filenames so humans scanning
+// `docs/knowledge/inbox/` can tell entries apart without opening them.
+function buildInboxSlug(note) {
+  const trimmed = (note || "").slice(0, 200).toLowerCase();
+  const kebab = trimmed
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const bounded = kebab.slice(0, 40).replace(/-+$/g, "");
+  return bounded || "note";
+}
+
+// ISO timestamp suitable for filename prefixes: swaps out the `:` chars
+// that are illegal on Windows / awkward in URLs, and drops the milliseconds
+// so filenames are exactly `YYYY-MM-DDTHH-MM-SS`.
+function formatInboxTimestamp(date = new Date()) {
+  return date.toISOString().replace(/\.\d+Z$/, "").replace(/:/g, "-");
+}
+
+// Default spawn implementation for gc_remember's detached ingest
+// subprocess. The returned function accepts { repoRoot, inboxFilePath,
+// knowledge } and returns after the child has been fully detached. Any
+// spawn-layer exception propagates to the caller which converts it to a
+// warning on the synchronous return envelope.
+function defaultSpawnIngest({ repoRoot, inboxFilePath, knowledge }) {
+  const cliPath = fileURLToPath(new URL("./knowledge_ingest_cli.js", import.meta.url));
+  const args = [
+    cliPath,
+    "--repo", repoRoot,
+    "--inbox-file", inboxFilePath,
+    "--knowledge-dir", knowledge.dir,
+    "--knowledge-schema", knowledge.schema,
+    "--knowledge-inbox", knowledge.inbox,
+  ];
+  const child = spawnChild(process.execPath, args, {
+    cwd: repoRoot,
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+}
+
+// Append a knowledge-base observation to the repo's inbox. Synchronous
+// success means the inbox entry is durably written to disk; the ingest
+// subprocess that integrates the observation into the wiki is spawned
+// after the write but its result is asynchronous and may fail. Per
+// GC-X006, subprocess spawn failures surface as a warning in the return
+// envelope but do not fail the capture — a later sweep will discover the
+// untouched inbox file and retry.
+//
+// Parameters:
+//   repoPath     — absolute path to the target git repo
+//   note         — the observation body text (required, non-empty)
+//   sourceType   — one of KNOWLEDGE_SOURCE_TYPES (required)
+//   sourceRef    — source reference (validated per sourceType)
+//   tags         — optional list of discovery tags
+//   spawnIngest  — optional DI hook for tests; defaults to
+//                  defaultSpawnIngest which launches the real CLI
+//
+// Returns { ok: true, inbox_path, citation, warning? } on success, or
+// { ok: false, error } on validation / config failure. Does not throw.
+export async function writeKnowledgeInbox({
+  repoPath,
+  note,
+  sourceType,
+  sourceRef,
+  tags = [],
+  spawnIngest = defaultSpawnIngest,
+} = {}) {
+  if (typeof repoPath !== "string" || !isAbsolute(repoPath)) {
+    return { ok: false, error: "repo_path must be an absolute path to a Git repository" };
+  }
+  if (typeof note !== "string" || note.trim() === "") {
+    return { ok: false, error: "note is required and must be a non-empty string" };
+  }
+  if (tags != null && !Array.isArray(tags)) {
+    return { ok: false, error: "tags must be an array of strings when set" };
+  }
+
+  const citationResult = formatSourceCitation({ sourceType, sourceRef });
+  if (!citationResult.ok) return { ok: false, error: citationResult.error };
+
+  let context;
+  try {
+    context = await getRepoGroundControlContext(repoPath);
+  } catch (error) {
+    return { ok: false, error: `failed to resolve repo context: ${error.message}` };
+  }
+  if (context.status !== "ok") {
+    return {
+      ok: false,
+      error: `repository is not ready for knowledge capture: ${context.errors?.[0] || context.status}`,
+    };
+  }
+  if (context.knowledge == null) {
+    return {
+      ok: false,
+      error: "repository has no 'knowledge' block in .ground-control.yaml — capture is not configured",
+    };
+  }
+
+  const repoRoot = context.repo_path;
+  const knowledge = context.knowledge;
+  const inboxRel = knowledge.inbox;
+  const absInboxDir = resolvePath(repoRoot, inboxRel);
+
+  // Lazy-create the inbox directory on first capture. The inbox is
+  // deliberately not committed as part of the #522 skeleton because an
+  // empty directory has nothing to commit.
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- absInboxDir derives from a realpath-contained, resolved knowledge.inbox
+    mkdirSync(absInboxDir, { recursive: true });
+  } catch (error) {
+    return { ok: false, error: `failed to create inbox directory ${inboxRel}: ${error.message}` };
+  }
+
+  // Compose the filename: ISO timestamp + 4-char random suffix + slug.
+  // The random suffix protects against sub-second concurrent captures
+  // producing identical timestamps; the slug keeps the file human-scanable.
+  const timestamp = formatInboxTimestamp();
+  const slug = buildInboxSlug(note);
+  const rand = randomBytes(3).toString("hex").slice(0, 4);
+  const filename = `${timestamp}-${rand}-${slug}.md`;
+  const absInboxFile = join(absInboxDir, filename);
+
+  // Build the frontmatter + body. js-yaml dump auto-quotes scalars that
+  // need escaping so citations containing `:` or special chars are safe.
+  const frontmatter = {
+    captured_at: new Date().toISOString(),
+    source: citationResult.citation,
+  };
+  if (tags && tags.length > 0) {
+    frontmatter.tags = tags;
+  }
+  const yamlBlock = dumpYaml(frontmatter, { lineWidth: -1, noRefs: true });
+  const fileContent = `---\n${yamlBlock}---\n\n${note.trim()}\n`;
+
+  // Atomic write: temp file + fsync + rename. A crash between the write
+  // and the rename leaves a .tmp sidecar but no partial file at the final
+  // path, so readers never observe a half-written inbox entry.
+  const tmpPath = `${absInboxFile}.tmp`;
+  let fd;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- tmpPath derives from inboxDir which is repo-relative
+    fd = openSync(tmpPath, "wx");
+    writeSync(fd, fileContent);
+    fsyncSync(fd);
+  } catch (error) {
+    if (fd != null) {
+      try { closeSync(fd); } catch { /* best-effort */ }
+    }
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch { /* best-effort cleanup */ }
+    return { ok: false, error: `failed to write inbox tmp file: ${error.message}` };
+  }
+  try {
+    closeSync(fd);
+  } catch (error) {
+    return { ok: false, error: `failed to close inbox tmp file: ${error.message}` };
+  }
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- both paths are under absInboxDir which is realpath-contained within repoRoot
+    renameSync(tmpPath, absInboxFile);
+  } catch (error) {
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch { /* best-effort cleanup */ }
+    return { ok: false, error: `failed to rename inbox tmp file: ${error.message}` };
+  }
+
+  const inboxRelFromRepo = relative(repoRoot, absInboxFile);
+
+  // Spawn the detached ingest subprocess. Spawn failures do not fail the
+  // capture — the inbox entry is durable and will be retried by a later
+  // real-time call, manual retry, or scheduled sweep.
+  let warning = null;
+  try {
+    spawnIngest({
+      repoRoot,
+      inboxFilePath: absInboxFile,
+      knowledge,
+    });
+  } catch (error) {
+    warning = `ingest_spawn_failed: ${error.message}`;
+  }
+
+  const result = {
+    ok: true,
+    inbox_path: inboxRelFromRepo,
+    citation: citationResult.citation,
+  };
+  if (warning) result.warning = warning;
+  return result;
+}
+
+// Acquire an interprocess lock on a knowledge base, keyed by the canonical
+// realpath of the knowledge directory. Different path spellings (symlinks,
+// `..`-normalized forms) that point at the same inode contend on the same
+// lock, which is required by GC-X008's invariant that "concurrent ingest
+// against the same knowledge base" serializes even if the callers supplied
+// different strings for the path.
+//
+// Uses `proper-lockfile`'s filesystem-based lock with stale detection:
+//   - stale  — lock is considered abandoned after this many ms if its
+//              refresh timestamp has not been updated. 60 s is long enough
+//              to survive normal ingest runs and short enough to recover
+//              from a crashed subprocess without blocking forever.
+//   - update — the holder refreshes the lock's mtime this often while
+//              work is in progress. 10 s gives a large margin under `stale`.
+//
+// By default `retries: 0` — contention fails fast so callers like
+// administrative tools can report a clean "locked, try again later"
+// error. Callers that want to wait (like `runIngest`, which serializes
+// two concurrent captures into a single sequential queue) pass a
+// `retries` option that matches proper-lockfile's retry shape.
+//
+// Returns an async release function. The returned function is
+// idempotent — calling it twice is safe but will no-op on the second call
+// (proper-lockfile throws if the lock is not actually held, so we swallow
+// that specific error).
+//
+// Throws on invalid input (non-absolute path, nonexistent directory) and
+// on contention. Errors carry a message that includes the canonical path
+// so debugging shows exactly which knowledge base is contended.
+export async function acquireKnowledgeLock(knowledgeDir, { retries = 0 } = {}) {
+  if (typeof knowledgeDir !== "string" || !isAbsolute(knowledgeDir)) {
+    throw new Error("acquireKnowledgeLock: path must be an absolute directory path");
+  }
+  let canonical;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- absolute path validated above
+    canonical = realpathSync(knowledgeDir);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      throw new Error(`acquireKnowledgeLock: path does not exist: ${knowledgeDir}`);
+    }
+    throw error;
+  }
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- canonical is a realpath
+  const stat = statSync(canonical);
+  if (!stat.isDirectory()) {
+    throw new Error(`acquireKnowledgeLock: path is not a directory: ${knowledgeDir}`);
+  }
+
+  let release;
+  try {
+    release = await properLockfile.lock(canonical, {
+      stale: 60_000,
+      update: 10_000,
+      retries,
+      // Store the lockfile INSIDE the knowledge directory as `.gc-lock`
+      // rather than next to it, so rm'ing the knowledge directory also
+      // cleans up the lock. This keeps the host filesystem tidy on test
+      // teardown and stale-repo cleanup.
+      lockfilePath: join(canonical, ".gc-lock"),
+      realpath: false,
+    });
+  } catch (error) {
+    // proper-lockfile maps contention to `ELOCKED`. Rewrite as a clear
+    // message so callers do not need to know about the underlying code.
+    if (error.code === "ELOCKED") {
+      const contended = new Error(`knowledge base is already held by another process: ${canonical}`);
+      contended.code = "ELOCKED";
+      contended.path = canonical;
+      throw contended;
+    }
+    throw error;
+  }
+
+  let released = false;
+  return async function releaseHandle() {
+    if (released) return;
+    released = true;
+    try {
+      await release();
+    } catch (error) {
+      // "Lock is already released" is fine — we just observed the release
+      // through a different path. Anything else is a real error.
+      if (error.code !== "ENOTACQUIRED" && !/already released/i.test(error.message)) {
+        throw error;
+      }
+    }
+  };
 }

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -21,6 +21,10 @@ import {
   dedupFindings,
   buildCodexVerifyPrompt,
   parseCodexVerifyTail,
+  formatSourceCitation,
+  KNOWLEDGE_SOURCE_TYPES,
+  writeKnowledgeInbox,
+  acquireKnowledgeLock,
   STATUSES,
   REQUIREMENT_TYPES,
   PRIORITIES,
@@ -1419,5 +1423,542 @@ describe("constants", () => {
 
   it("LINK_TYPES matches Java LinkType enum", () => {
     assert.deepEqual(LINK_TYPES, ["IMPLEMENTS", "TESTS", "DOCUMENTS", "CONSTRAINS", "VERIFIES"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Knowledge base capture / ingest — GC-X006..GC-X011
+// ---------------------------------------------------------------------------
+
+describe("KNOWLEDGE_SOURCE_TYPES", () => {
+  it("matches the source-citation vocabulary documented in docs/knowledge/SCHEMA.md", () => {
+    // This list is the single source of truth for gc_remember's Zod enum,
+    // the ingest engine's validation, and the citation strings written into
+    // page frontmatter, log.md, and git commit messages. Keep it synced
+    // with docs/knowledge/SCHEMA.md §"Source citation rule".
+    assert.deepEqual(
+      [...KNOWLEDGE_SOURCE_TYPES].sort(),
+      ["ci", "commit", "file", "issue", "pr", "review", "user-correction"].sort(),
+    );
+  });
+});
+
+describe("formatSourceCitation", () => {
+  it("formats commit SHAs as commit:<sha>", () => {
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: "abc123d" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "commit:abc123d");
+  });
+
+  it("accepts full 40-char SHAs", () => {
+    const sha = "abcdef0123456789abcdef0123456789abcdef01";
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: sha });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, `commit:${sha}`);
+  });
+
+  it("accepts 7-char short SHAs", () => {
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: "abcdef0" });
+    assert.equal(r.ok, true);
+  });
+
+  it("rejects non-hex commit refs", () => {
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: "not-a-sha" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /commit.*hex/i);
+  });
+
+  it("rejects commit refs shorter than 7 chars", () => {
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: "abc12" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /commit/i);
+  });
+
+  it("formats PR numbers as pr:<number>", () => {
+    const r = formatSourceCitation({ sourceType: "pr", sourceRef: "528" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "pr:528");
+  });
+
+  it("formats PR numbers with a # prefix by stripping the prefix", () => {
+    const r = formatSourceCitation({ sourceType: "pr", sourceRef: "#528" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "pr:528");
+  });
+
+  it("rejects non-numeric PR refs", () => {
+    const r = formatSourceCitation({ sourceType: "pr", sourceRef: "not-a-number" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /pr/i);
+  });
+
+  it("formats review comment ids as review:<id>", () => {
+    const r = formatSourceCitation({ sourceType: "review", sourceRef: "1234567890" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "review:1234567890");
+  });
+
+  it("rejects empty review ids", () => {
+    const r = formatSourceCitation({ sourceType: "review", sourceRef: "" });
+    assert.equal(r.ok, false);
+  });
+
+  it("formats issue numbers as issue:<number>", () => {
+    const r = formatSourceCitation({ sourceType: "issue", sourceRef: "523" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "issue:523");
+  });
+
+  it("formats CI run ids as ci:<id>", () => {
+    const r = formatSourceCitation({ sourceType: "ci", sourceRef: "24319887139" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "ci:24319887139");
+  });
+
+  it("formats user corrections as user-correction:<desc>", () => {
+    const r = formatSourceCitation({
+      sourceType: "user-correction",
+      sourceRef: "dont skip review cycles",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "user-correction:dont skip review cycles");
+  });
+
+  it("formats file references as file:<path>", () => {
+    const r = formatSourceCitation({
+      sourceType: "file",
+      sourceRef: "mcp/ground-control/lib.js",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "file:mcp/ground-control/lib.js");
+  });
+
+  it("rejects file references that are absolute paths", () => {
+    const r = formatSourceCitation({ sourceType: "file", sourceRef: "/etc/passwd" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /file.*relative/i);
+  });
+
+  it("rejects file references that escape with ..", () => {
+    const r = formatSourceCitation({ sourceType: "file", sourceRef: "../secret" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /file/i);
+  });
+
+  it("rejects unknown source types", () => {
+    const r = formatSourceCitation({ sourceType: "bogus", sourceRef: "x" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /source_type/);
+  });
+
+  it("rejects empty source_ref", () => {
+    const r = formatSourceCitation({ sourceType: "pr", sourceRef: "" });
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects missing source_type", () => {
+    const r = formatSourceCitation({ sourceRef: "abc" });
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects null / missing input object", () => {
+    const r = formatSourceCitation();
+    assert.equal(r.ok, false);
+  });
+
+  it("collapses newlines and tab runs in user-correction descriptions to single spaces", () => {
+    // Citations appear in git commit message subjects and log.md bullets,
+    // both of which are single-line contexts. A multiline description would
+    // break both. YAML frontmatter safety is handled at serialization time
+    // via js-yaml's auto-quoting, not here, so this check only asserts the
+    // "single line" property — inline `- something` substrings after
+    // collapsing are harmless in commit subjects and in log.md bullets
+    // (markdown only starts a new list item on a real newline).
+    const r = formatSourceCitation({
+      sourceType: "user-correction",
+      sourceRef: "line one\n\tmore\r\nstill more",
+    });
+    assert.equal(r.ok, true);
+    assert.ok(!r.citation.includes("\n"));
+    assert.ok(!r.citation.includes("\r"));
+    assert.ok(!r.citation.includes("\t"));
+    assert.equal(r.citation, "user-correction:line one more still more");
+  });
+});
+
+describe("writeKnowledgeInbox", () => {
+  // A helper that builds a git repo ready for ingest tests: initialized,
+  // on a symbolic branch (`main`), with one committed file so HEAD exists,
+  // and with a `docs/knowledge/` skeleton plus `.ground-control.yaml`
+  // declaring the knowledge block. Returns the absolute path.
+  function makeKnowledgeReadyRepo() {
+    const dir = mkdtempSync(join(tmpdir(), "gc-knowledge-test-"));
+    execFileSync("git", ["-C", dir, "init", "-q", "-b", "main"]);
+    execFileSync("git", ["-C", dir, "config", "user.email", "test@example.com"]);
+    execFileSync("git", ["-C", dir, "config", "user.name", "Test"]);
+    execFileSync("git", ["-C", dir, "config", "commit.gpgsign", "false"]);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    mkdirSync(join(dir, "docs", "knowledge"), { recursive: true });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    writeFileSync(
+      join(dir, "docs", "knowledge", "SCHEMA.md"),
+      "---\ntitle: test schema\n---\n# test schema\n",
+    );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    writeFileSync(
+      join(dir, "docs", "knowledge", "index.md"),
+      "---\ntitle: Index\n---\n# Index\n",
+    );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    writeFileSync(
+      join(dir, "docs", "knowledge", "log.md"),
+      "---\ntitle: Log\n---\n# Log\n",
+    );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    writeFileSync(
+      join(dir, ".ground-control.yaml"),
+      [
+        "schema_version: 1",
+        "project: test-project",
+        "knowledge:",
+        "  dir: docs/knowledge",
+        "",
+      ].join("\n"),
+    );
+    execFileSync("git", ["-C", dir, "add", "-A"]);
+    execFileSync("git", ["-C", dir, "commit", "-q", "-m", "seed"]);
+    return dir;
+  }
+
+  it("writes an inbox file, returns a structured receipt, and does NOT spawn when spawnIngest is stubbed", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    const calls = [];
+    const spawnStub = (args) => {
+      calls.push(args);
+    };
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "ingest engine drops commits on detached HEAD — always check symbolic ref before committing",
+        sourceType: "pr",
+        sourceRef: "523",
+        tags: ["knowledge", "ingest"],
+        spawnIngest: spawnStub,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.citation, "pr:523");
+      assert.equal(typeof result.inbox_path, "string");
+      assert.ok(result.inbox_path.startsWith("docs/knowledge/inbox/"));
+      assert.ok(result.inbox_path.endsWith(".md"));
+      // The file exists on disk.
+      const absInbox = join(dir, result.inbox_path);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      const body = readFileSync(absInbox, "utf8");
+      // Frontmatter carries the canonical citation, ISO timestamp, and tags.
+      assert.match(body, /^---\n/);
+      assert.match(body, /captured_at: /);
+      assert.match(body, /source: 'pr:523'|source: pr:523|source: "pr:523"/);
+      assert.match(body, /tags:\n\s+- knowledge\n\s+- ingest|tags: \[knowledge, ingest\]/);
+      // Body text follows the frontmatter.
+      assert.match(body, /ingest engine drops commits on detached HEAD/);
+      // The spawn stub was called once with structured argv.
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].inboxFilePath, absInbox);
+      assert.equal(calls[0].repoRoot, dir);
+      assert.ok(calls[0].knowledge);
+      assert.equal(calls[0].knowledge.dir, "docs/knowledge");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates the inbox directory lazily if it does not exist yet", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      // The skeleton from issue #522 deliberately does NOT commit inbox/.
+      // Writing the first inbox file must succeed anyway.
+      assert.ok(!existsSyncHelper(join(dir, "docs", "knowledge", "inbox")));
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "first capture",
+        sourceType: "issue",
+        sourceRef: "523",
+        spawnIngest: () => {},
+      });
+      assert.equal(result.ok, true);
+      assert.ok(existsSyncHelper(join(dir, "docs", "knowledge", "inbox")));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns {ok:false} and does not spawn when the repo has no knowledge block", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-knowledge-no-kb-"));
+    execFileSync("git", ["-C", dir, "init", "-q"]);
+    let spawned = false;
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      writeFileSync(
+        join(dir, ".ground-control.yaml"),
+        "schema_version: 1\nproject: no-kb\n",
+      );
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "anything",
+        sourceType: "pr",
+        sourceRef: "1",
+        spawnIngest: () => {
+          spawned = true;
+        },
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.error, /knowledge/i);
+      assert.equal(spawned, false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns {ok:false} and does not spawn when the citation is invalid", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    let spawned = false;
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "hmm",
+        sourceType: "commit",
+        sourceRef: "not-a-sha",
+        spawnIngest: () => {
+          spawned = true;
+        },
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.error, /commit/i);
+      assert.equal(spawned, false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects empty notes", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "",
+        sourceType: "pr",
+        sourceRef: "1",
+        spawnIngest: () => {},
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.error, /note/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns success with a warning when spawnIngest throws (inbox bytes are durable)", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "bang",
+        sourceType: "pr",
+        sourceRef: "999",
+        spawnIngest: () => {
+          throw new Error("simulated spawn failure");
+        },
+      });
+      // GC-X006 says the synchronous MCP call succeeds as long as the
+      // inbox entry is durably written. Spawn failures must not rewrite
+      // or delete the source file; a later sweep picks it up.
+      assert.equal(result.ok, true);
+      assert.ok(result.warning);
+      assert.match(result.warning, /ingest_spawn_failed|simulated spawn/);
+      // The inbox file is still on disk.
+      const absInbox = join(dir, result.inbox_path);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      assert.ok(readFileSync(absInbox, "utf8").includes("bang"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("produces unique filenames for rapid concurrent captures", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      const N = 30;
+      const results = await Promise.all(
+        Array.from({ length: N }, (_, i) =>
+          writeKnowledgeInbox({
+            repoPath: dir,
+            note: `race ${i}`,
+            sourceType: "pr",
+            sourceRef: String(100 + i),
+            spawnIngest: () => {},
+          }),
+        ),
+      );
+      for (const r of results) assert.equal(r.ok, true);
+      const paths = new Set(results.map((r) => r.inbox_path));
+      assert.equal(paths.size, N, `expected ${N} unique inbox paths, got ${paths.size}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a timestamp-first filename with a slug derived from the note", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "Race condition in Checkout flow: requires mutex around cart read",
+        sourceType: "pr",
+        sourceRef: "42",
+        spawnIngest: () => {},
+      });
+      assert.equal(result.ok, true);
+      const basename = result.inbox_path.split("/").pop();
+      // ISO timestamp prefix: YYYY-MM-DDTHH-MM-SS (colons replaced with -)
+      assert.match(basename, /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/);
+      // Slug is kebab-cased and present in the filename.
+      assert.match(basename, /race-condition/);
+      assert.ok(basename.endsWith(".md"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects repo_path that is not an absolute path", async () => {
+    const result = await writeKnowledgeInbox({
+      repoPath: "not-absolute",
+      note: "x",
+      sourceType: "pr",
+      sourceRef: "1",
+      spawnIngest: () => {},
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /absolute/i);
+  });
+
+  it("rejects repo_path that is not a git repo", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-no-git-"));
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "x",
+        sourceType: "pr",
+        sourceRef: "1",
+        spawnIngest: () => {},
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.error, /git/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Local existence helper so tests don't have to pass test-controlled
+// temp paths through an eslint-disabled call everywhere.
+function existsSyncHelper(p) {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled path
+  return existsSync(p);
+}
+
+describe("acquireKnowledgeLock", () => {
+  function makeLockTempDir() {
+    return mkdtempSync(join(tmpdir(), "gc-lock-test-"));
+  }
+
+  it("acquires a fresh lock, returns a release handle, and releases cleanly", async () => {
+    const dir = makeLockTempDir();
+    try {
+      const release = await acquireKnowledgeLock(dir);
+      assert.equal(typeof release, "function");
+      await release();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to acquire a currently-held lock", async () => {
+    const dir = makeLockTempDir();
+    try {
+      const release = await acquireKnowledgeLock(dir);
+      await assert.rejects(
+        () => acquireKnowledgeLock(dir),
+        /held|locked/i,
+      );
+      await release();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows re-acquisition after release", async () => {
+    const dir = makeLockTempDir();
+    try {
+      const r1 = await acquireKnowledgeLock(dir);
+      await r1();
+      const r2 = await acquireKnowledgeLock(dir);
+      await r2();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs locks on different knowledge bases in parallel", async () => {
+    const dirA = makeLockTempDir();
+    const dirB = makeLockTempDir();
+    try {
+      const [rA, rB] = await Promise.all([
+        acquireKnowledgeLock(dirA),
+        acquireKnowledgeLock(dirB),
+      ]);
+      // Both held at once — no contention.
+      assert.equal(typeof rA, "function");
+      assert.equal(typeof rB, "function");
+      await rA();
+      await rB();
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a symlinked path and its realpath as the same lock identity", async () => {
+    const realDir = makeLockTempDir();
+    const symRoot = mkdtempSync(join(tmpdir(), "gc-lock-sym-"));
+    const symlinked = join(symRoot, "kb");
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dirs
+      symlinkSync(realDir, symlinked);
+      const release = await acquireKnowledgeLock(realDir);
+      // Symlinked path should observe the same held lock.
+      await assert.rejects(
+        () => acquireKnowledgeLock(symlinked),
+        /held|locked/i,
+      );
+      await release();
+      // After release, the symlinked path can now acquire.
+      const r2 = await acquireKnowledgeLock(symlinked);
+      await r2();
+    } finally {
+      rmSync(realDir, { recursive: true, force: true });
+      rmSync(symRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-absolute and nonexistent paths", async () => {
+    await assert.rejects(
+      () => acquireKnowledgeLock("relative/path"),
+      /absolute/i,
+    );
+    const fakeAbs = join(tmpdir(), "gc-lock-does-not-exist-" + Math.random());
+    await assert.rejects(
+      () => acquireKnowledgeLock(fakeAbs),
+      /exist/i,
+    );
   });
 });

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -91,6 +91,10 @@ import {
   dedupFindings,
   buildCodexVerifyPrompt,
   parseCodexVerifyTail,
+  formatSourceCitation,
+  KNOWLEDGE_SOURCE_TYPES,
+  writeKnowledgeInbox,
+  acquireKnowledgeLock,
   STATUSES,
   REQUIREMENT_TYPES,
   PRIORITIES,
@@ -11109,5 +11113,542 @@ describe("mergeReviewerArchitecturalReads — decision-record read (issue #966)"
     const { mergeReviewerArchitecturalReads } = await import("./lib.js");
     assert.equal(mergeReviewerArchitecturalReads({ body: "x" }, { body: "y" }), undefined);
     assert.equal(mergeReviewerArchitecturalReads(null, null), undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Knowledge base capture / ingest — GC-X006..GC-X011
+// ---------------------------------------------------------------------------
+
+describe("KNOWLEDGE_SOURCE_TYPES", () => {
+  it("matches the source-citation vocabulary documented in docs/knowledge/SCHEMA.md", () => {
+    // This list is the single source of truth for gc_remember's Zod enum,
+    // the ingest engine's validation, and the citation strings written into
+    // page frontmatter, log.md, and git commit messages. Keep it synced
+    // with docs/knowledge/SCHEMA.md §"Source citation rule".
+    assert.deepEqual(
+      [...KNOWLEDGE_SOURCE_TYPES].sort(),
+      ["ci", "commit", "file", "issue", "pr", "review", "user-correction"].sort(),
+    );
+  });
+});
+
+describe("formatSourceCitation", () => {
+  it("formats commit SHAs as commit:<sha>", () => {
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: "abc123d" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "commit:abc123d");
+  });
+
+  it("accepts full 40-char SHAs", () => {
+    const sha = "abcdef0123456789abcdef0123456789abcdef01";
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: sha });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, `commit:${sha}`);
+  });
+
+  it("accepts 7-char short SHAs", () => {
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: "abcdef0" });
+    assert.equal(r.ok, true);
+  });
+
+  it("rejects non-hex commit refs", () => {
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: "not-a-sha" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /commit.*hex/i);
+  });
+
+  it("rejects commit refs shorter than 7 chars", () => {
+    const r = formatSourceCitation({ sourceType: "commit", sourceRef: "abc12" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /commit/i);
+  });
+
+  it("formats PR numbers as pr:<number>", () => {
+    const r = formatSourceCitation({ sourceType: "pr", sourceRef: "528" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "pr:528");
+  });
+
+  it("formats PR numbers with a # prefix by stripping the prefix", () => {
+    const r = formatSourceCitation({ sourceType: "pr", sourceRef: "#528" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "pr:528");
+  });
+
+  it("rejects non-numeric PR refs", () => {
+    const r = formatSourceCitation({ sourceType: "pr", sourceRef: "not-a-number" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /pr/i);
+  });
+
+  it("formats review comment ids as review:<id>", () => {
+    const r = formatSourceCitation({ sourceType: "review", sourceRef: "1234567890" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "review:1234567890");
+  });
+
+  it("rejects empty review ids", () => {
+    const r = formatSourceCitation({ sourceType: "review", sourceRef: "" });
+    assert.equal(r.ok, false);
+  });
+
+  it("formats issue numbers as issue:<number>", () => {
+    const r = formatSourceCitation({ sourceType: "issue", sourceRef: "523" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "issue:523");
+  });
+
+  it("formats CI run ids as ci:<id>", () => {
+    const r = formatSourceCitation({ sourceType: "ci", sourceRef: "24319887139" });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "ci:24319887139");
+  });
+
+  it("formats user corrections as user-correction:<desc>", () => {
+    const r = formatSourceCitation({
+      sourceType: "user-correction",
+      sourceRef: "dont skip review cycles",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "user-correction:dont skip review cycles");
+  });
+
+  it("formats file references as file:<path>", () => {
+    const r = formatSourceCitation({
+      sourceType: "file",
+      sourceRef: "mcp/ground-control/lib.js",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.citation, "file:mcp/ground-control/lib.js");
+  });
+
+  it("rejects file references that are absolute paths", () => {
+    const r = formatSourceCitation({ sourceType: "file", sourceRef: "/etc/passwd" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /file.*relative/i);
+  });
+
+  it("rejects file references that escape with ..", () => {
+    const r = formatSourceCitation({ sourceType: "file", sourceRef: "../secret" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /file/i);
+  });
+
+  it("rejects unknown source types", () => {
+    const r = formatSourceCitation({ sourceType: "bogus", sourceRef: "x" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /source_type/);
+  });
+
+  it("rejects empty source_ref", () => {
+    const r = formatSourceCitation({ sourceType: "pr", sourceRef: "" });
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects missing source_type", () => {
+    const r = formatSourceCitation({ sourceRef: "abc" });
+    assert.equal(r.ok, false);
+  });
+
+  it("rejects null / missing input object", () => {
+    const r = formatSourceCitation();
+    assert.equal(r.ok, false);
+  });
+
+  it("collapses newlines and tab runs in user-correction descriptions to single spaces", () => {
+    // Citations appear in git commit message subjects and log.md bullets,
+    // both of which are single-line contexts. A multiline description would
+    // break both. YAML frontmatter safety is handled at serialization time
+    // via js-yaml's auto-quoting, not here, so this check only asserts the
+    // "single line" property — inline `- something` substrings after
+    // collapsing are harmless in commit subjects and in log.md bullets
+    // (markdown only starts a new list item on a real newline).
+    const r = formatSourceCitation({
+      sourceType: "user-correction",
+      sourceRef: "line one\n\tmore\r\nstill more",
+    });
+    assert.equal(r.ok, true);
+    assert.ok(!r.citation.includes("\n"));
+    assert.ok(!r.citation.includes("\r"));
+    assert.ok(!r.citation.includes("\t"));
+    assert.equal(r.citation, "user-correction:line one more still more");
+  });
+});
+
+describe("writeKnowledgeInbox", () => {
+  // A helper that builds a git repo ready for ingest tests: initialized,
+  // on a symbolic branch (`main`), with one committed file so HEAD exists,
+  // and with a `docs/knowledge/` skeleton plus `.ground-control.yaml`
+  // declaring the knowledge block. Returns the absolute path.
+  function makeKnowledgeReadyRepo() {
+    const dir = mkdtempSync(join(tmpdir(), "gc-knowledge-test-"));
+    execFileSync("git", ["-C", dir, "init", "-q", "-b", "main"]);
+    execFileSync("git", ["-C", dir, "config", "user.email", "test@example.com"]);
+    execFileSync("git", ["-C", dir, "config", "user.name", "Test"]);
+    execFileSync("git", ["-C", dir, "config", "commit.gpgsign", "false"]);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    mkdirSync(join(dir, "docs", "knowledge"), { recursive: true });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    writeFileSync(
+      join(dir, "docs", "knowledge", "SCHEMA.md"),
+      "---\ntitle: test schema\n---\n# test schema\n",
+    );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    writeFileSync(
+      join(dir, "docs", "knowledge", "index.md"),
+      "---\ntitle: Index\n---\n# Index\n",
+    );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    writeFileSync(
+      join(dir, "docs", "knowledge", "log.md"),
+      "---\ntitle: Log\n---\n# Log\n",
+    );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+    writeFileSync(
+      join(dir, ".ground-control.yaml"),
+      [
+        "schema_version: 1",
+        "project: test-project",
+        "knowledge:",
+        "  dir: docs/knowledge",
+        "",
+      ].join("\n"),
+    );
+    execFileSync("git", ["-C", dir, "add", "-A"]);
+    execFileSync("git", ["-C", dir, "commit", "-q", "-m", "seed"]);
+    return dir;
+  }
+
+  it("writes an inbox file, returns a structured receipt, and does NOT spawn when spawnIngest is stubbed", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    const calls = [];
+    const spawnStub = (args) => {
+      calls.push(args);
+    };
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "ingest engine drops commits on detached HEAD — always check symbolic ref before committing",
+        sourceType: "pr",
+        sourceRef: "523",
+        tags: ["knowledge", "ingest"],
+        spawnIngest: spawnStub,
+      });
+      assert.equal(result.ok, true);
+      assert.equal(result.citation, "pr:523");
+      assert.equal(typeof result.inbox_path, "string");
+      assert.ok(result.inbox_path.startsWith("docs/knowledge/inbox/"));
+      assert.ok(result.inbox_path.endsWith(".md"));
+      // The file exists on disk.
+      const absInbox = join(dir, result.inbox_path);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      const body = readFileSync(absInbox, "utf8");
+      // Frontmatter carries the canonical citation, ISO timestamp, and tags.
+      assert.match(body, /^---\n/);
+      assert.match(body, /captured_at: /);
+      assert.match(body, /source: 'pr:523'|source: pr:523|source: "pr:523"/);
+      assert.match(body, /tags:\n\s+- knowledge\n\s+- ingest|tags: \[knowledge, ingest\]/);
+      // Body text follows the frontmatter.
+      assert.match(body, /ingest engine drops commits on detached HEAD/);
+      // The spawn stub was called once with structured argv.
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].inboxFilePath, absInbox);
+      assert.equal(calls[0].repoRoot, dir);
+      assert.ok(calls[0].knowledge);
+      assert.equal(calls[0].knowledge.dir, "docs/knowledge");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates the inbox directory lazily if it does not exist yet", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      // The skeleton from issue #522 deliberately does NOT commit inbox/.
+      // Writing the first inbox file must succeed anyway.
+      assert.ok(!existsSyncHelper(join(dir, "docs", "knowledge", "inbox")));
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "first capture",
+        sourceType: "issue",
+        sourceRef: "523",
+        spawnIngest: () => {},
+      });
+      assert.equal(result.ok, true);
+      assert.ok(existsSyncHelper(join(dir, "docs", "knowledge", "inbox")));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns {ok:false} and does not spawn when the repo has no knowledge block", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-knowledge-no-kb-"));
+    execFileSync("git", ["-C", dir, "init", "-q"]);
+    let spawned = false;
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      writeFileSync(
+        join(dir, ".ground-control.yaml"),
+        "schema_version: 1\nproject: no-kb\n",
+      );
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "anything",
+        sourceType: "pr",
+        sourceRef: "1",
+        spawnIngest: () => {
+          spawned = true;
+        },
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.error, /knowledge/i);
+      assert.equal(spawned, false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns {ok:false} and does not spawn when the citation is invalid", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    let spawned = false;
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "hmm",
+        sourceType: "commit",
+        sourceRef: "not-a-sha",
+        spawnIngest: () => {
+          spawned = true;
+        },
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.error, /commit/i);
+      assert.equal(spawned, false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects empty notes", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "",
+        sourceType: "pr",
+        sourceRef: "1",
+        spawnIngest: () => {},
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.error, /note/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns success with a warning when spawnIngest throws (inbox bytes are durable)", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "bang",
+        sourceType: "pr",
+        sourceRef: "999",
+        spawnIngest: () => {
+          throw new Error("simulated spawn failure");
+        },
+      });
+      // GC-X006 says the synchronous MCP call succeeds as long as the
+      // inbox entry is durably written. Spawn failures must not rewrite
+      // or delete the source file; a later sweep picks it up.
+      assert.equal(result.ok, true);
+      assert.ok(result.warning);
+      assert.match(result.warning, /ingest_spawn_failed|simulated spawn/);
+      // The inbox file is still on disk.
+      const absInbox = join(dir, result.inbox_path);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dir
+      assert.ok(readFileSync(absInbox, "utf8").includes("bang"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("produces unique filenames for rapid concurrent captures", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      const N = 30;
+      const results = await Promise.all(
+        Array.from({ length: N }, (_, i) =>
+          writeKnowledgeInbox({
+            repoPath: dir,
+            note: `race ${i}`,
+            sourceType: "pr",
+            sourceRef: String(100 + i),
+            spawnIngest: () => {},
+          }),
+        ),
+      );
+      for (const r of results) assert.equal(r.ok, true);
+      const paths = new Set(results.map((r) => r.inbox_path));
+      assert.equal(paths.size, N, `expected ${N} unique inbox paths, got ${paths.size}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a timestamp-first filename with a slug derived from the note", async () => {
+    const dir = makeKnowledgeReadyRepo();
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "Race condition in Checkout flow: requires mutex around cart read",
+        sourceType: "pr",
+        sourceRef: "42",
+        spawnIngest: () => {},
+      });
+      assert.equal(result.ok, true);
+      const basename = result.inbox_path.split("/").pop();
+      // ISO timestamp prefix: YYYY-MM-DDTHH-MM-SS (colons replaced with -)
+      assert.match(basename, /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/);
+      // Slug is kebab-cased and present in the filename.
+      assert.match(basename, /race-condition/);
+      assert.ok(basename.endsWith(".md"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects repo_path that is not an absolute path", async () => {
+    const result = await writeKnowledgeInbox({
+      repoPath: "not-absolute",
+      note: "x",
+      sourceType: "pr",
+      sourceRef: "1",
+      spawnIngest: () => {},
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /absolute/i);
+  });
+
+  it("rejects repo_path that is not a git repo", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-no-git-"));
+    try {
+      const result = await writeKnowledgeInbox({
+        repoPath: dir,
+        note: "x",
+        sourceType: "pr",
+        sourceRef: "1",
+        spawnIngest: () => {},
+      });
+      assert.equal(result.ok, false);
+      assert.match(result.error, /git/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Local existence helper so tests don't have to pass test-controlled
+// temp paths through an eslint-disabled call everywhere.
+function existsSyncHelper(p) {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled path
+  return existsSync(p);
+}
+
+describe("acquireKnowledgeLock", () => {
+  function makeLockTempDir() {
+    return mkdtempSync(join(tmpdir(), "gc-lock-test-"));
+  }
+
+  it("acquires a fresh lock, returns a release handle, and releases cleanly", async () => {
+    const dir = makeLockTempDir();
+    try {
+      const release = await acquireKnowledgeLock(dir);
+      assert.equal(typeof release, "function");
+      await release();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to acquire a currently-held lock", async () => {
+    const dir = makeLockTempDir();
+    try {
+      const release = await acquireKnowledgeLock(dir);
+      await assert.rejects(
+        () => acquireKnowledgeLock(dir),
+        /held|locked/i,
+      );
+      await release();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows re-acquisition after release", async () => {
+    const dir = makeLockTempDir();
+    try {
+      const r1 = await acquireKnowledgeLock(dir);
+      await r1();
+      const r2 = await acquireKnowledgeLock(dir);
+      await r2();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("runs locks on different knowledge bases in parallel", async () => {
+    const dirA = makeLockTempDir();
+    const dirB = makeLockTempDir();
+    try {
+      const [rA, rB] = await Promise.all([
+        acquireKnowledgeLock(dirA),
+        acquireKnowledgeLock(dirB),
+      ]);
+      // Both held at once — no contention.
+      assert.equal(typeof rA, "function");
+      assert.equal(typeof rB, "function");
+      await rA();
+      await rB();
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a symlinked path and its realpath as the same lock identity", async () => {
+    const realDir = makeLockTempDir();
+    const symRoot = mkdtempSync(join(tmpdir(), "gc-lock-sym-"));
+    const symlinked = join(symRoot, "kb");
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test-controlled temp dirs
+      symlinkSync(realDir, symlinked);
+      const release = await acquireKnowledgeLock(realDir);
+      // Symlinked path should observe the same held lock.
+      await assert.rejects(
+        () => acquireKnowledgeLock(symlinked),
+        /held|locked/i,
+      );
+      await release();
+      // After release, the symlinked path can now acquire.
+      const r2 = await acquireKnowledgeLock(symlinked);
+      await r2();
+    } finally {
+      rmSync(realDir, { recursive: true, force: true });
+      rmSync(symRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-absolute and nonexistent paths", async () => {
+    await assert.rejects(
+      () => acquireKnowledgeLock("relative/path"),
+      /absolute/i,
+    );
+    const fakeAbs = join(tmpdir(), "gc-lock-does-not-exist-" + Math.random());
+    await assert.rejects(
+      () => acquireKnowledgeLock(fakeAbs),
+      /exist/i,
+    );
   });
 });

--- a/mcp/ground-control/package-lock.json
+++ b/mcp/ground-control/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "js-yaml": "^4.1.1",
+        "proper-lockfile": "^4.1.2",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -186,9 +187,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1205,6 +1206,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1240,9 +1247,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1726,6 +1733,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1815,6 +1833,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/router": {
@@ -1992,6 +2019,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/mcp/ground-control/package.json
+++ b/mcp/ground-control/package.json
@@ -6,13 +6,14 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node --test lib.test.js",
+    "test": "node --test lib.test.js knowledge_ingest.test.js knowledge_ingest_cli.test.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "js-yaml": "^4.1.1",
+    "proper-lockfile": "^4.1.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/mcp/ground-control/package.json
+++ b/mcp/ground-control/package.json
@@ -6,13 +6,14 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node --test lib.test.js gc-query.test.js gc-threat-model.test.js gc-risk-scenario.test.js gc-risk-governance.test.js gc-control.test.js gc-finding.test.js gc-evidence.test.js gc-analyze.test.js link-create.test.js test-case-tools.test.js traceability-tools.test.js gc-asset.test.js gc-observation.test.js",
+    "test": "node --test lib.test.js gc-query.test.js gc-threat-model.test.js gc-risk-scenario.test.js gc-risk-governance.test.js gc-control.test.js gc-finding.test.js gc-evidence.test.js gc-analyze.test.js link-create.test.js test-case-tools.test.js traceability-tools.test.js gc-asset.test.js gc-observation.test.js knowledge_ingest.test.js knowledge_ingest_cli.test.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "js-yaml": "^4.1.1",
+    "proper-lockfile": "^4.1.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Issue #2 of 6 in the agent knowledge system rollout. Wires the **write path** so an agent can capture an observation mid-run via `gc_remember`, and within seconds that observation becomes a wiki page committed to the branch — available to the next agent invocation in the same working session.

- **`gc_remember` MCP tool** — synchronous, capture-only. Validates input against the fixed shape `{repo_path, note, source_type, source_ref, tags?}`, canonicalizes the citation via `formatSourceCitation`, writes the inbox item atomically (temp + fsync + rename), and spawns a detached ingest subprocess. Returns `{ok: true, inbox_path, citation}` on success. Spawn failures surface as a warning on the same success envelope — the inbox entry is durable and a later run will retry.
- **Shared ingest engine** at `mcp/ground-control/knowledge_ingest.js`. Owns the full transaction under a per-knowledge-base interprocess file lock: read current wiki state, invoke Claude Code as the ingest agent, validate commit isolation against the knowledge tree, stage exactly the agent-introduced paths, commit with the canonical citation, release the lock. Every failure path leaves the inbox file untouched.
- **Claude Code is the ingest agent, not codex.** Codex remains wired in for architecture preflight and cross-model review; knowledge maintenance is a Claude Code responsibility by project decision. The boundary is captured in ADR-025 so it cannot be quietly relaxed.
- **Canonical source-citation formatter** (`formatSourceCitation` + `KNOWLEDGE_SOURCE_TYPES`) produces the one citation string reused across inbox frontmatter, page frontmatter, `log.md` bullets, and git commit messages. No vocabulary drift between call sites.
- **Interprocess file lock** via `proper-lockfile`, keyed by the canonical realpath of the knowledge directory. Symlinked or differently-spelled checkouts contend on the same lock.
- **Strict commit isolation**: the engine stages exactly the files under `<knowledge.dir>/` plus the single inbox item. Never `git add -A`, never `--no-verify`, and any file an agent writes outside that scope triggers a revert + abort.

## Requirement UIDs

- GC-X006 — Agent capture primitive for knowledge observations
- GC-X007 — Ingest consistency: update existing pages, do not duplicate
- GC-X008 — Serialized writes within a knowledge base
- GC-X009 — Failed ingest retains source material for retry
- GC-X010 — Knowledge base changes committed to version control
- GC-X011 — Real-time ingest of captured observations

## Related Issues

Closes #523

## ADR Impact

ADR-025 (Knowledge Ingest Engine) added in this PR. Captures:
- Shared ingest engine co-located with the MCP server at `mcp/ground-control/knowledge_ingest.js` (not `tools/ground_control/knowledge/` as the design note originally suggested) — rationale: only consumer is Node, existing test harness works as-is, dodges the `adr-policy.json` ADR-014 verification-architecture trip on `tools/ground_control/**`.
- Claude Code as the ingest agent, with a "codex is NOT used for knowledge maintenance" boundary that should be rejected at review time if someone tries to revert it.
- `claude --print` flag set: `--add-dir`, `--permission-mode bypassPermissions`, `--allowed-tools` (Read/Edit/Write + narrow git patterns), no `--bare` (so OAuth session creds work).
- Subprocess env strips `ANTHROPIC_API_KEY` so the child falls back to the operator's logged-in OAuth session; escape hatch via `GC_KNOWLEDGE_INGEST_ANTHROPIC_API_KEY`.
- `proper-lockfile` for interprocess serialization with stale detection.
- Strict commit isolation (stage + commit only knowledge tree + inbox item).
- No Spring backend surface in this slice (no REST controller, DTO, entity, migration, or graph node).

`docs/architecture/ARCHITECTURE.md` gained a short Knowledge Ingest Engine section pointing at ADR-025.

## Changes

- Added `gc_remember` MCP tool, the shared knowledge ingest engine (`knowledge_ingest.js`), and the argv-driven CLI entry point (`knowledge_ingest_cli.js`).
- Added `formatSourceCitation` + `KNOWLEDGE_SOURCE_TYPES` canonical vocabulary in `lib.js`.
- Added ADR-025 documenting the engine, the Claude-Code-as-ingest-agent boundary, the lock strategy, and the commit-isolation contract.
- Updated `docs/architecture/ARCHITECTURE.md`, `docs/knowledge/SCHEMA.md`, and `docs/notes/agent-knowledge-system-design.md` to match.
- Added `proper-lockfile@^4.1.2` dependency for interprocess locking.

## Test Plan

- [x] Unit tests pass (`npm test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

147/147 unit tests pass under the dedicated test files; `make policy` and `make check` both green. Manual end-to-end smoke with live Claude Code: temp repo, real `claude --print`, agent created `gotchas/git-ops-in-detached-mcp-subprocess.md`, updated `index.md` and `log.md`, moved the inbox item to `inbox/processed/`. Engine validated isolation, staged exactly the 4 touched paths, committed `knowledge: ingest pr:523`. Total latency: 37.5 s.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

`gc_evaluate_quality_gates` is unchanged — no new coverage gates introduced. `gc_run_sweep` is not applicable to this slice — no project baselines, watermarks, or graph state are touched, so the sweep has no reconciliation work to perform.

## Traceability

- IMPLEMENTS: `mcp/ground-control/lib.js`, `mcp/ground-control/knowledge_ingest.js`, `mcp/ground-control/knowledge_ingest_cli.js`, `mcp/ground-control/index.js`, `docs/knowledge/SCHEMA.md`, `architecture/adrs/025-knowledge-ingest-engine.md` → GC-X006, GC-X007, GC-X008, GC-X009, GC-X010, GC-X011
- TESTS: `mcp/ground-control/lib.test.js`, `mcp/ground-control/knowledge_ingest.test.js`, `mcp/ground-control/knowledge_ingest_cli.test.js` → GC-X006 (writeKnowledgeInbox), GC-X007 (create + update-in-place), GC-X008 (serialization + parallel bases + lock realpath identity), GC-X009 (three failure-retains-source variants), GC-X010 (commit isolation + detached-HEAD rejection), GC-X011 (latency measurement)
- DOCUMENTS: `docs/notes/agent-knowledge-system-design.md`, `docs/knowledge/SCHEMA.md`, `architecture/adrs/025-knowledge-ingest-engine.md`, `docs/architecture/ARCHITECTURE.md`

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/523.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
