### PR TITLE
Enforce GC-P021 backup policy defaults (ADR-025)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,71 @@ jobs:
           fi
           echo "instance_id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
 
+      # GC-P021: refresh /opt/gc ops scripts + cron files before every deploy.
+      # The EC2 resource has ignore_changes=[user_data], so Terraform cannot
+      # rewrite /opt/gc on updates; SSM is the only path that keeps the live
+      # instance aligned with the repo. install-ops-scripts.sh is idempotent
+      # and enforces the GC-P021 cadence / retention floors on input.
+      - name: Refresh ops scripts via SSM (GC-P021)
+        id: ssm-install-ops
+        run: |
+          INSTALL_B64=$(base64 -w0 deploy/scripts/install-ops-scripts.sh)
+          CMD="export GC_BACKUP_BUCKET='groundcontrol-backups-catalyst-dev'; export GC_BACKUP_CRON='0 3,11,19 * * *'; export GC_LOCAL_RETENTION_COUNT=4; echo '${INSTALL_B64}' | base64 -d | bash"
+          jq -n --arg cmd "$CMD" '{commands: [$cmd]}' > /tmp/ssm-install-ops.json
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --parameters file:///tmp/ssm-install-ops.json \
+            --timeout-seconds 300 \
+            --query 'Command.CommandId' \
+            --output text)
+          echo "command_id=$COMMAND_ID" >> "$GITHUB_OUTPUT"
+        env:
+          INSTANCE_ID: ${{ steps.ec2.outputs.instance_id }}
+
+      - name: Wait for ops-script refresh to complete
+        run: |
+          for i in $(seq 1 60); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query 'Status' \
+              --output text 2>/dev/null || echo "Pending")
+            case "$STATUS" in
+              Success)
+                echo "install-ops-scripts succeeded"
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "$INSTANCE_ID" \
+                  --query 'StandardOutputContent' \
+                  --output text
+                exit 0
+                ;;
+              Failed|TimedOut|Cancelled)
+                echo "install-ops-scripts failed with status: $STATUS"
+                echo "--- stdout ---"
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "$INSTANCE_ID" \
+                  --query 'StandardOutputContent' \
+                  --output text
+                echo "--- stderr ---"
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "$INSTANCE_ID" \
+                  --query 'StandardErrorContent' \
+                  --output text
+                exit 1
+                ;;
+            esac
+            sleep 5
+          done
+          echo "Timed out waiting for install-ops-scripts"
+          exit 1
+        env:
+          COMMAND_ID: ${{ steps.ssm-install-ops.outputs.command_id }}
+          INSTANCE_ID: ${{ steps.ec2.outputs.instance_id }}
+
       - name: Deploy via SSM
         id: ssm
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,22 @@ repos:
       - id: detect-private-key
         exclude: ^backend/src/test/
 
+  # Bash syntax check for deploy/operator scripts
+  - repo: local
+    hooks:
+      - id: bash-syntax
+        name: bash -n (deploy + ops scripts)
+        entry: bash -c 'for f in "$@"; do bash -n "$f" || exit 1; done' --
+        language: system
+        files: ^(deploy/scripts/.*\.sh|scripts/(assert-backup-policy|test-backup-restore-locally)\.sh)$
+
+      - id: assert-backup-policy
+        name: assert GC-P021 backup policy defaults
+        entry: scripts/assert-backup-policy.sh
+        language: system
+        files: ^(deploy/terraform/modules/(backup|compute)/|deploy/scripts/(backup|test-restore)\.sh|deploy/terraform/environments/dev/terraform\.tfvars\.example|scripts/assert-backup-policy\.sh)
+        pass_filenames: false
+
   # Java formatting (Spotless via Gradle — auto-fix mode)
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         name: assert GC-P021 backup policy defaults
         entry: scripts/assert-backup-policy.sh
         language: system
-        files: ^(deploy/terraform/modules/(backup|compute)/|deploy/scripts/(backup|test-restore)\.sh|deploy/terraform/environments/dev/terraform\.tfvars\.example|scripts/assert-backup-policy\.sh)
+        files: ^(\.github/workflows/ci\.yml|deploy/terraform/modules/(backup|compute)/|deploy/terraform/environments/dev/(variables\.tf|terraform\.tfvars\.example)|deploy/scripts/(backup|test-restore|install-ops-scripts)\.sh|scripts/assert-backup-policy\.sh)
         pass_filenames: false
 
   # Java formatting (Spotless via Gradle — auto-fix mode)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `deploy/scripts/install-ops-scripts.sh` — canonical, idempotent
+  installer for `/opt/gc/{backup,restore,test-restore,watchdog}.sh` and
+  `/etc/cron.d/gc-{backup,restore-test,watchdog}`. Enforces the GC-P021
+  cadence (≥ 3×/day) and retention (≥ 4) floors on input; exits non-zero
+  on any out-of-spec value. Runs on the instance in two paths: first
+  boot (written by user-data) and every main-branch deploy (pushed via
+  `aws ssm send-command` by the CI `deploy` job).
+- CI `deploy` job now refreshes `/opt/gc` scripts via SSM before
+  invoking `/opt/gc/deploy.sh` so the live instance picks up script
+  changes even though `ignore_changes = [user_data]` prevents Terraform
+  from replacing user-data. Closes the rollout gap flagged in Codex
+  review of #534.
+- `scripts/assert-backup-policy.sh` now additionally validates:
+  - the dev env root `variables.tf` defaults (not just the module
+    defaults, so the forwarded `module.backup` inputs stay compliant),
+  - `install-ops-scripts.sh` contains every GC-P021 sentinel and the
+    `GC-P021` anchor,
+  - the CI workflow wires `install-ops-scripts.sh` into the deploy
+    job,
+  - executing the installer against an ephemeral prefix — rejecting
+    non-compliant inputs and writing the expected artifacts with the
+    expected substitutions.
 - GC-P021 backup policy enforcement (ADR-025): backup cadence raised to
   3× / day (`0 3,11,19 * * *` UTC) and local dump retention raised to 4
   files, guaranteeing ≥ 24 h of local retention with a one-run margin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.114.0] - 2026-04-19
+
+### Added
+
+- GC-P021 backup policy enforcement (ADR-025): backup cadence raised to
+  3× / day (`0 3,11,19 * * *` UTC) and local dump retention raised to 4
+  files, guaranteeing ≥ 24 h of local retention with a one-run margin
+  on top of the 30-day S3 lifecycle. Defaults live in
+  `deploy/terraform/modules/backup/variables.tf`; overrides below these
+  thresholds are blocked by the new structural guardrail.
+- Daily restore verification (`0 5 * * *` UTC) replaces the prior
+  weekly run. `deploy/scripts/test-restore.sh` and the user-data
+  inlined copy now additionally assert the AGE extension is present,
+  core Ground Control tables (`project`, `requirement`,
+  `requirement_relation`, `traceability_link`, `document`, `section`,
+  `threat_model`) exist in the restored database, `flyway_schema_history`
+  contains V010, and `create_graph('requirements_verify')` succeeds
+  against the restored catalog — proving AGE is operationally usable
+  after restore, not just installed.
+- `docs/operations/backup-restore.md` — standalone operator runbook
+  covering the three recovery scenarios (in-place, volume survives,
+  full rebuild), AGE graph rematerialization after S3 dump restore,
+  credential rotation, and post-restore verification. Written for an
+  operator with AWS + Tailscale credentials but no prior exposure to
+  the stack.
+- `scripts/assert-backup-policy.sh` — structural guardrail that fails
+  pre-commit / `make policy` if the GC-P021 cadence, retention, cron, or
+  verification sentinels are altered away from the accepted defaults.
+- `scripts/test-backup-restore-locally.sh` + `make test-backup-restore-local`
+  — self-contained end-to-end local exerciser. Stands up a fresh
+  `apache/age` container, replays every Flyway migration, takes a
+  pg_dump, and invokes `test-restore.sh` against the dump; asserts
+  every sentinel check appears in the output.
+- `.pre-commit-config.yaml` now runs `bash -n` across
+  `deploy/scripts/*.sh` plus the two new ops scripts, and invokes
+  `scripts/assert-backup-policy.sh` on any change to the backup module,
+  user-data template, backup/restore scripts, or the example tfvars.
+- ADR-025 (Backup Policy) documents the decision to retain
+  pg_dump + EBS rather than switching to pgBackRest, the GC-P021
+  clause-to-change mapping, and the AGE-derivative-from-relational
+  invariant that makes the decision safe.
+
+### Changed
+
+- `deploy/scripts/backup.sh` and `deploy/scripts/test-restore.sh`
+  headers now reference GC-P021 so the policy anchor is visible at the
+  script level. `test-restore.sh` accepts env overrides
+  (`BACKUP_DIR`, `TEST_CONTAINER`, `TEST_PORT`, `DB_IMAGE`,
+  `POSTGRES_*`, `SKIP_ENV_FILE=1`) so it runs locally without the
+  production `/opt/gc/.env`. The readiness loop now requires three
+  consecutive successful `SELECT 1` calls to outlast the apache/age
+  image's post-init restart window.
+- `docs/deployment/DEPLOYMENT.md` Backup and Recovery section now
+  delegates to `docs/operations/backup-restore.md`, records the new
+  cadence / retention / verification defaults, and enumerates the AGE
+  verification checks.
+
 ## [0.113.0] - 2026-04-12
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: rapid build test test-cov format lint check integration verify policy policy-tests policy-live \
+       assert-backup-policy test-backup-restore-local \
        ground-control-mcp-install sync-ground-control-policy scaffold-controller scaffold-audited-entity \
        scaffold-l2-state-machine sync-packs trigger-pack-sync dev clean up down docker-build smoke frontend-install frontend-dev \
        frontend-build frontend-lint frontend-format frontend-test deploy deploy-infra
@@ -39,8 +40,14 @@ verify: ## Full CI-equivalent verification
 policy-tests: ## Run unit tests for repo policy tooling
 	python3 -m unittest discover -s tools/tests -p 'test_*.py'
 
-policy: policy-tests ## Run repo-native policy checks shared by Claude and Codex
+policy: policy-tests assert-backup-policy ## Run repo-native policy checks shared by Claude and Codex
 	python3 bin/policy --skip-pr-body
+
+assert-backup-policy: ## Assert GC-P021 backup cadence / retention / verification defaults are intact
+	bash scripts/assert-backup-policy.sh
+
+test-backup-restore-local: ## Run the self-contained local backup/restore verification loop (requires Docker)
+	bash scripts/test-backup-restore-locally.sh
 
 ground-control-mcp-install: ## Install dependencies for the repo-local Ground Control MCP helpers
 	npm --prefix mcp/ground-control ci

--- a/architecture/adrs/025-backup-policy.md
+++ b/architecture/adrs/025-backup-policy.md
@@ -106,14 +106,30 @@ raise the defaults so GC-P021 is met:
    AWS console access, Tailscale credentials, and no prior exposure to
    Ground Control internals; it is executable end-to-end without
    consulting other documents.
-6. **Drift protection** — `scripts/assert-backup-policy.sh` is a
-   structural check over the Terraform module and the two `test-restore`
-   copies. It runs in pre-commit and `make policy` and fails loudly if the
-   cadence, retention, cron, or verification checks are altered away from
-   the GC-P021 defaults. `scripts/test-backup-restore-locally.sh` stands
-   up a fresh apache/age container, replays every Flyway migration,
-   dumps, and exercises `test-restore.sh` against the dump; operators can
-   run it locally to prove the loop works end-to-end.
+6. **Script rollout** — because `deploy/terraform/modules/compute/main.tf`
+   declares `ignore_changes = [ami, user_data]`, Terraform cannot rewrite
+   `/opt/gc/*.sh` on the live instance on updates. The CI `deploy` job
+   closes that gap: after `terraform apply` and before running
+   `/opt/gc/deploy.sh`, it `aws ssm send-command`s the contents of
+   `deploy/scripts/install-ops-scripts.sh` to the running instance with
+   the GC-P021 env vars (`GC_BACKUP_BUCKET`, `GC_BACKUP_CRON`,
+   `GC_LOCAL_RETENTION_COUNT`). The installer is idempotent, enforces
+   the ≥ 3×/day cadence and ≥ 4-file retention floors on input, and
+   rewrites `/opt/gc/{backup,restore,test-restore,watchdog}.sh` plus the
+   three `/etc/cron.d/gc-*` entries on every deploy. First-boot
+   provisioning uses the same installer, keeping one source of truth.
+7. **Drift protection** — `scripts/assert-backup-policy.sh` is a
+   structural check over the Terraform module and env vars, the inlined
+   user-data copy, the canonical `deploy/scripts/test-restore.sh`, and
+   the installer. It also executes the installer against an ephemeral
+   prefix to prove (a) it refuses non-compliant inputs and (b) it
+   writes the expected files and substitutions. It runs in pre-commit
+   and `make policy` and fails the build if cadence, retention, cron,
+   verification, or CI-workflow wiring drifts away from the GC-P021
+   defaults. `scripts/test-backup-restore-locally.sh` is a second
+   guardrail: it stands up a fresh apache/age container, replays every
+   Flyway migration, dumps, and exercises `test-restore.sh` against the
+   dump end-to-end, asserting every sentinel check.
 
 ## Consequences
 

--- a/architecture/adrs/025-backup-policy.md
+++ b/architecture/adrs/025-backup-policy.md
@@ -1,0 +1,170 @@
+# ADR-025: Backup Policy (GC-P021)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-19
+
+## Context
+
+GC-P021 is a non-functional policy that the production Ground Control
+deployment must meet:
+
+> The Ground Control production deployment shall have its persistent data
+> backed up at least three times per day, with at least twenty-four (24)
+> hours of backup retention. Backups shall cover all persistent state
+> required to restore the system to an operational condition. Restoration
+> from backup shall be verified on a recurring basis and documented such
+> that recovery can be performed without prior knowledge of the live
+> system.
+
+ADR-018 established the AWS EC2 deployment with two independent backup
+layers:
+
+1. **Logical** — `pg_dump -Fc` via cron on the EC2 host → local dump on the
+   `/data` volume + S3 (`groundcontrol-backups-catalyst-dev`, versioned,
+   SSE-S3, public-access-blocked, 30-day lifecycle).
+2. **Block-level** — AWS Data Lifecycle Manager daily EBS snapshots of the
+   `/data` volume, 7-day retention.
+
+Restore tooling:
+
+- `/opt/gc/restore.sh` — restore-in-place from a local dump or S3 key,
+  with a pre-restore safety backup.
+- `/opt/gc/test-restore.sh` — throwaway-container restore of the latest
+  dump, invoked weekly (Sunday 05:00 UTC) via cron.
+
+The defaults under ADR-018 were:
+
+- Backup cadence: `0 3 * * *` (once daily at 03:00 UTC).
+- Local retention: 3 dump files.
+- Verification cadence: weekly.
+- Verification checks: count of public-schema tables and Flyway migration
+  rows only.
+
+These satisfy GC-P009 ("configurable automated backups with defined
+retention and tested restore") but do not satisfy GC-P021:
+
+- Cadence is 1×/day, not 3×/day.
+- Verification is weekly and does not exercise Apache AGE — the restored
+  database could be silently missing the AGE extension or its catalog and
+  the existing checks would still pass.
+- Recovery documentation is embedded in `docs/deployment/DEPLOYMENT.md`
+  and mixes local-dev with prod instructions; it does not meet the
+  "recovery without prior knowledge" bar.
+
+Issue #533 proposed replacing the logical backup path with **pgBackRest**
+(block-level Postgres backup with WAL archiving). Two reasons make that
+path the wrong choice for this deployment:
+
+1. **Apache AGE data is derivative.** The authoritative state for
+   requirements, relations, documents, sections, threat models, risk, and
+   traceability lives in relational tables governed by Envers auditing.
+   `AgeGraphService.materializeGraph()` rebuilds the AGE graph from those
+   tables (see
+   `backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java`).
+   Preserving the AGE graph at byte-for-byte fidelity is not required — a
+   post-restore `materializeGraph` call re-derives it from restored
+   relational data.
+2. **Operational cost outweighs the benefit.** The deployment is a single
+   `t3a.small` (2 vCPU / 2 GB RAM). Enabling pgBackRest's archive-command
+   and WAL shipping adds a continuous Postgres workload and new
+   sidecar/host process for a single-tenant dev tool. GC-P021 does not ask
+   for PITR finer than the backup cadence, so the additional machinery
+   buys nothing we need.
+
+## Decision
+
+Retain the ADR-018 two-layer backup architecture (pg_dump + EBS) and
+raise the defaults so GC-P021 is met:
+
+1. **Cadence** — `backup_cron` default changes from `0 3 * * *` to
+   `0 3,11,19 * * *` (8-hour interval, 3×/day). Override is still allowed
+   but the variable description records that any override must remain
+   ≥ 3×/day to stay compliant.
+2. **Retention** — `local_retention_count` default raises from 3 to 4
+   dump files, guaranteeing > 24 h retention at 3×/day cadence with a
+   one-run margin. S3 lifecycle stays at 30 days (cost-governed, already
+   ≥ 24 h).
+3. **Verification cadence** — the restore-test cron changes from weekly
+   (`0 5 * * 0`) to daily (`0 5 * * *`).
+4. **Verification depth** — `deploy/scripts/test-restore.sh` and the
+   inlined copy in `deploy/terraform/modules/compute/user-data.sh.tftpl`
+   now additionally assert:
+   - AGE extension is present (`pg_extension` row).
+   - Core Ground Control tables are present (`project`, `requirement`,
+     `requirement_relation`, `traceability_link`, `document`, `section`,
+     `threat_model`).
+   - V010 (`create_age_graph`) appears in `flyway_schema_history`.
+   - `create_graph('requirements_verify')` succeeds against the restored
+     catalog — this proves AGE is operationally usable, not just installed.
+5. **Documentation** — a new standalone runbook lives at
+   `docs/operations/backup-restore.md`. It is written for an operator with
+   AWS console access, Tailscale credentials, and no prior exposure to
+   Ground Control internals; it is executable end-to-end without
+   consulting other documents.
+6. **Drift protection** — `scripts/assert-backup-policy.sh` is a
+   structural check over the Terraform module and the two `test-restore`
+   copies. It runs in pre-commit and `make policy` and fails loudly if the
+   cadence, retention, cron, or verification checks are altered away from
+   the GC-P021 defaults. `scripts/test-backup-restore-locally.sh` stands
+   up a fresh apache/age container, replays every Flyway migration,
+   dumps, and exercises `test-restore.sh` against the dump; operators can
+   run it locally to prove the loop works end-to-end.
+
+## Consequences
+
+### Positive
+
+- Zero architecture churn — reuses the existing backup/restore tooling.
+- Verification now catches AGE-specific regressions that the previous
+  table-count check would have missed silently.
+- Daily verification shrinks the blind window between "backup taken" and
+  "backup proven restorable" from up to 7 days to at most 24 h.
+- The standalone runbook lets any operator execute recovery cold.
+- The structural assertions prevent accidental regression of the
+  GC-P021-critical defaults in future Terraform or script changes.
+
+### Negative
+
+- Not true PITR — effective RPO is the cadence interval (~8 h). GC-P021
+  does not require finer PITR, but teams that grow tighter RPO needs must
+  revisit this ADR.
+- 3× more S3 PUTs and roughly 3× S3 storage for local + S3 copies.
+  At ~500 MB per dump × 30-day retention this is still pennies per month,
+  but the ADR records the trade-off for future cost review.
+- pg_dump runs against the live container; at current data volume
+  (low-single-digit GB) it completes in seconds, but a future order-of-
+  magnitude growth may require moving to online physical backup.
+
+### Risks
+
+- **AGE extension drift** — if a future Postgres or AGE image upgrade
+  changes the catalog layout, a dump taken pre-upgrade may fail to
+  restore post-upgrade. Mitigation: verification runs against the same
+  `apache/age:release_PG16_1.6.0` image tag pinned in
+  `docker-compose.yml`, `deploy/docker/docker-compose.prod.yml`, and the
+  `user-data.sh.tftpl` inline `test-restore.sh`. A version upgrade touches
+  all three and invalidates this ADR; a new ADR is required at that time.
+- **Verification container cold-start flakiness** — the apache/age image
+  briefly restarts after its first boot. `test-restore.sh` now waits for
+  three consecutive successful `SELECT 1` calls before restoring. If the
+  restart window ever exceeds the 120-second wait, verification fails
+  loudly rather than silently — acceptable behaviour.
+- **Backup cron failures that silently fall under retention** — at 4-file
+  local retention and 3 runs/day, two consecutive failed backups still
+  leave ≥ 24 h of valid dumps. Three consecutive failures would drop
+  retention below the policy; operators rely on
+  `/var/log/gc-backup.log` + the daily restore-test failure to catch
+  this.
+
+## Related
+
+- [ADR-005 Apache AGE](005-apache-age-graph.md)
+- [ADR-018 AWS EC2 Deployment](018-aws-ec2-deployment.md)
+- GC-P009 — the enabling capability (see Ground Control requirement catalog)
+- GC-P021 — the policy this ADR records, filed as issue [#533](https://github.com/KeplerOps/Ground-Control/issues/533)
+- [docs/operations/backup-restore.md](../../docs/operations/backup-restore.md) — the operator runbook

--- a/architecture/adrs/README.md
+++ b/architecture/adrs/README.md
@@ -41,5 +41,6 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [022](022-content-pack-distribution-architecture.md) | Content Pack Distribution Architecture | Accepted |
 | [023](023-plugin-architecture.md) | Plugin Architecture | Accepted |
 | [024](024-threat-model-entry-boundary.md) | Threat Model Entry Boundary | Accepted |
+| [025](025-backup-policy.md) | Backup Policy (GC-P021) | Accepted |
 
 Prior ADRs from the old project frame are archived in `archive/architecture/adrs/`.

--- a/deploy/scripts/backup.sh
+++ b/deploy/scripts/backup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Ground Control database backup — pg_dump to local + S3
-# Runs via cron. Schedule and retention are configurable via Terraform.
+# Ground Control database backup — pg_dump to local + S3 (GC-P021).
+# Runs via cron. Cadence (>= 3/day) and local retention (>= 24h) are
+# enforced by deploy/terraform/modules/backup/variables.tf defaults;
+# scripts/assert-backup-policy.sh asserts those defaults stay in place.
 set -euo pipefail
 
 # Source env for DB credentials

--- a/deploy/scripts/install-ops-scripts.sh
+++ b/deploy/scripts/install-ops-scripts.sh
@@ -1,0 +1,393 @@
+#!/bin/bash
+# Install /opt/gc/{backup,restore,test-restore,watchdog}.sh and the three
+# /etc/cron.d entries that drive GC-P021. Canonical installer.
+#
+# Runs on the EC2 instance in two paths:
+#   1. First boot — user-data writes this file and calls it.
+#   2. Every main-branch deploy — the CI `deploy` job base64-transports
+#      this file via SSM SendCommand so the live instance picks up new
+#      scripts even though `ignore_changes = [user_data]` on the EC2
+#      resource prevents Terraform from rewriting user-data.
+#
+# Idempotent; safe to re-run. Exits non-zero if the requested parameters
+# violate GC-P021 floors.
+#
+# Required env:
+#   GC_BACKUP_BUCKET              S3 bucket that holds pg-dumps/
+#   GC_BACKUP_CRON                cron expression; must be >= 3/day
+#   GC_LOCAL_RETENTION_COUNT      integer >= 4 (>= 24h at 3x/day)
+#
+# Canonical-sync guardrail:
+#   scripts/assert-backup-policy.sh greps this file and the
+#   deploy/scripts/*.sh copies for the same GC-P021 sentinels
+#   (AGE_EXT, CORE TABLES PRESENT, V010 PRESENT, GRAPH MATERIALIZABLE,
+#   create_graph('requirements_verify')). Any drift fails pre-commit.
+set -euo pipefail
+
+: "${GC_BACKUP_BUCKET:?GC_BACKUP_BUCKET is required}"
+: "${GC_BACKUP_CRON:?GC_BACKUP_CRON is required}"
+: "${GC_LOCAL_RETENTION_COUNT:?GC_LOCAL_RETENTION_COUNT is required}"
+
+case "${GC_LOCAL_RETENTION_COUNT}" in
+  ''|*[!0-9]*)
+    echo "ERROR: GC_LOCAL_RETENTION_COUNT must be a non-negative integer (got '${GC_LOCAL_RETENTION_COUNT}')" >&2
+    exit 1
+    ;;
+esac
+if [ "${GC_LOCAL_RETENTION_COUNT}" -lt 4 ]; then
+  echo "ERROR: GC_LOCAL_RETENTION_COUNT=${GC_LOCAL_RETENTION_COUNT} is below the GC-P021 floor (4)" >&2
+  exit 1
+fi
+
+# GC-P021 requires >= 3 backups/day. Validate the cron minute/hour fields
+# declare at least three distinct run times per day.
+cron_minute="$(echo "${GC_BACKUP_CRON}" | awk '{print $1}')"
+cron_hour="$(echo "${GC_BACKUP_CRON}" | awk '{print $2}')"
+runs_per_day="$(python3 - "${cron_minute}" "${cron_hour}" <<'PY'
+import sys
+
+minute, hour = sys.argv[1], sys.argv[2]
+
+def enumerate_field(expr, low, high):
+    if expr == "*":
+        return set(range(low, high + 1))
+    out = set()
+    for part in expr.split(","):
+        step = 1
+        if "/" in part:
+            part, step_str = part.split("/", 1)
+            step = int(step_str)
+        if part == "*":
+            lo, hi = low, high
+        elif "-" in part:
+            lo_str, hi_str = part.split("-", 1)
+            lo, hi = int(lo_str), int(hi_str)
+        else:
+            lo = hi = int(part)
+        out.update(range(lo, hi + 1, step))
+    return out
+
+minutes = enumerate_field(minute, 0, 59)
+hours = enumerate_field(hour, 0, 23)
+print(len(minutes) * len(hours))
+PY
+)"
+if [ "${runs_per_day}" -lt 3 ]; then
+  echo "ERROR: GC_BACKUP_CRON='${GC_BACKUP_CRON}' fires ${runs_per_day} time(s)/day; GC-P021 floor is 3" >&2
+  exit 1
+fi
+
+GC_INSTALL_PREFIX="${GC_INSTALL_PREFIX:-}"
+GC_OPT_DIR="${GC_INSTALL_PREFIX}/opt/gc"
+GC_CRON_DIR="${GC_INSTALL_PREFIX}/etc/cron.d"
+install -d "${GC_OPT_DIR}"
+install -d "${GC_CRON_DIR}"
+
+# --- ${GC_OPT_DIR}/backup.sh --------------------------------------------------
+cat > ${GC_OPT_DIR}/backup.sh <<'BACKUPEOF'
+#!/bin/bash
+# Ground Control database backup — pg_dump to local + S3 (GC-P021).
+# Rewritten by deploy/scripts/install-ops-scripts.sh; do not edit by hand.
+set -euo pipefail
+
+set -a
+# shellcheck source=/dev/null
+source /opt/gc/.env
+set +a
+
+BACKUP_DIR=/data/backups
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+DUMP_FILE="${BACKUP_DIR}/gc-${TIMESTAMP}.dump"
+
+docker compose -f /opt/gc/docker-compose.yml exec -T db \
+  pg_dump -Fc -U "${POSTGRES_USER}" "${POSTGRES_DB}" > "${DUMP_FILE}"
+
+aws s3 cp "${DUMP_FILE}" "s3://__GC_BACKUP_BUCKET__/pg-dumps/gc-${TIMESTAMP}.dump"
+
+# Retention: keep at least GC-P021's 24h floor.
+ls -t "${BACKUP_DIR}"/gc-*.dump 2>/dev/null | tail -n +$((__GC_LOCAL_RETENTION_COUNT__ + 1)) | xargs -r rm
+
+echo "$(date): Backup complete — ${DUMP_FILE}"
+BACKUPEOF
+sed -i \
+  -e "s|__GC_BACKUP_BUCKET__|${GC_BACKUP_BUCKET}|g" \
+  -e "s|__GC_LOCAL_RETENTION_COUNT__|${GC_LOCAL_RETENTION_COUNT}|g" \
+  ${GC_OPT_DIR}/backup.sh
+chmod +x ${GC_OPT_DIR}/backup.sh
+
+# --- ${GC_OPT_DIR}/restore.sh -------------------------------------------------
+cat > ${GC_OPT_DIR}/restore.sh <<'RESTOREEOF'
+#!/bin/bash
+# Ground Control database restore — from local dump or S3 (GC-P021 recovery).
+# Rewritten by deploy/scripts/install-ops-scripts.sh; do not edit by hand.
+set -euo pipefail
+
+set -a
+# shellcheck source=/dev/null
+source /opt/gc/.env
+set +a
+
+BACKUP_DIR=/data/backups
+COMPOSE_FILE=/opt/gc/docker-compose.yml
+BUCKET="${BACKUP_BUCKET:-__GC_BACKUP_BUCKET__}"
+SKIP_CONFIRM="${SKIP_CONFIRM:-false}"
+
+usage() {
+  echo "Usage: restore.sh [--list | --from-file <path> | --from-s3 <key>] [--yes]"
+  echo ""
+  echo "Options:"
+  echo "  --list            List available backups (local and S3)"
+  echo "  --from-file PATH  Restore from a local pg_dump file"
+  echo "  --from-s3 KEY     Download from S3 and restore (e.g. pg-dumps/gc-20260329-030000.dump)"
+  echo "  --yes             Skip confirmation prompt"
+}
+
+list_backups() {
+  echo "=== Local backups ==="
+  ls -lht "${BACKUP_DIR}"/gc-*.dump 2>/dev/null || echo "  (none)"
+  echo ""
+  echo "=== S3 backups ==="
+  aws s3 ls "s3://${BUCKET}/pg-dumps/" 2>/dev/null || echo "  (none)"
+}
+
+verify_restore() {
+  echo "Verifying database health..."
+  docker compose -f "${COMPOSE_FILE}" exec -T db \
+    pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" > /dev/null
+  TABLE_COUNT=$(docker compose -f "${COMPOSE_FILE}" exec -T db \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -A \
+    -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")
+  echo "Verified: ${TABLE_COUNT} public tables present."
+}
+
+do_restore() {
+  local DUMP_FILE="$1"
+  [ -f "${DUMP_FILE}" ] || { echo "ERROR: File not found: ${DUMP_FILE}"; exit 1; }
+
+  echo "Creating pre-restore safety backup..."
+  /opt/gc/backup.sh
+
+  if [ "${SKIP_CONFIRM}" != "true" ]; then
+    read -p "Restore from ${DUMP_FILE}? This will REPLACE the current database. [y/N] " -r
+    [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
+  fi
+
+  echo "Restoring from ${DUMP_FILE}..."
+  docker compose -f "${COMPOSE_FILE}" exec -T db \
+    pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --clean --if-exists < "${DUMP_FILE}"
+
+  verify_restore
+  echo "Restore complete."
+}
+
+[ $# -eq 0 ] && { usage; exit 1; }
+
+MODE=""
+FILE_ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --list) MODE="list"; shift ;;
+    --from-file)
+      [ $# -ge 2 ] || { echo "ERROR: --from-file requires a path"; usage; exit 1; }
+      MODE="file"; FILE_ARG="$2"; shift 2 ;;
+    --from-s3)
+      [ $# -ge 2 ] || { echo "ERROR: --from-s3 requires an S3 key"; usage; exit 1; }
+      MODE="s3"; FILE_ARG="$2"; shift 2 ;;
+    --yes) SKIP_CONFIRM="true"; shift ;;
+    *) usage; exit 1 ;;
+  esac
+done
+
+case "${MODE}" in
+  list) list_backups ;;
+  file) do_restore "${FILE_ARG}" ;;
+  s3)
+    LOCAL_PATH="${BACKUP_DIR}/$(basename "${FILE_ARG}")"
+    echo "Downloading s3://${BUCKET}/${FILE_ARG}..."
+    aws s3 cp "s3://${BUCKET}/${FILE_ARG}" "${LOCAL_PATH}"
+    do_restore "${LOCAL_PATH}"
+    ;;
+  *) usage; exit 1 ;;
+esac
+RESTOREEOF
+sed -i "s|__GC_BACKUP_BUCKET__|${GC_BACKUP_BUCKET}|g" ${GC_OPT_DIR}/restore.sh
+chmod +x ${GC_OPT_DIR}/restore.sh
+
+# --- ${GC_OPT_DIR}/test-restore.sh --------------------------------------------
+cat > ${GC_OPT_DIR}/test-restore.sh <<'TESTRESTOREEOF'
+#!/bin/bash
+# Ground Control restore test (GC-P021 recurring restore verification).
+# Rewritten by deploy/scripts/install-ops-scripts.sh; do not edit by hand.
+#
+# Validates a pg_dump produced by /opt/gc/backup.sh by restoring it into
+# a throwaway apache/age:release_PG16_1.6.0 container and running the
+# operational-readiness checks below. Any failure exits non-zero so the
+# cron-wrapped run produces a loud log line.
+#
+# Checks (all must pass):
+#   1. public schema contains at least one table
+#   2. flyway_schema_history has recorded migrations
+#   3. flyway_schema_history contains V010 (create_age_graph)
+#   4. AGE extension is loaded in the restored database
+#   5. Core Ground Control tables are present (catches truncated dumps)
+#   6. create_graph() succeeds against the restored catalog
+set -euo pipefail
+
+if [ "${SKIP_ENV_FILE:-0}" != "1" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source /opt/gc/.env
+  set +a
+fi
+
+BACKUP_DIR="${BACKUP_DIR:-/data/backups}"
+TEST_CONTAINER="${TEST_CONTAINER:-gc-restore-test}"
+TEST_PORT="${TEST_PORT:-15432}"
+DB_IMAGE="${DB_IMAGE:-apache/age:release_PG16_1.6.0}"
+
+: "${POSTGRES_USER:?POSTGRES_USER must be set (via /opt/gc/.env or env override)}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}"
+: "${POSTGRES_DB:?POSTGRES_DB must be set}"
+
+DUMP_FILE="${1:-$(ls -t "${BACKUP_DIR}"/gc-*.dump 2>/dev/null | head -1)}"
+[ -n "${DUMP_FILE}" ] || { echo "ERROR: No backup file found"; exit 1; }
+[ -f "${DUMP_FILE}" ] || { echo "ERROR: File not found: ${DUMP_FILE}"; exit 1; }
+
+echo "Testing restore of: ${DUMP_FILE}"
+
+cleanup() {
+  echo "Cleaning up test container..."
+  docker stop "${TEST_CONTAINER}" 2>/dev/null || true
+  docker rm -f "${TEST_CONTAINER}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+docker rm -f "${TEST_CONTAINER}" 2>/dev/null || true
+
+echo "Starting temporary PostgreSQL container on port ${TEST_PORT}..."
+docker run -d --name "${TEST_CONTAINER}" \
+  -e POSTGRES_DB="${POSTGRES_DB}" \
+  -e POSTGRES_USER="${POSTGRES_USER}" \
+  -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+  -p "${TEST_PORT}:5432" \
+  "${DB_IMAGE}" >/dev/null
+
+echo "Waiting for test database..."
+ready=0
+for i in $(seq 1 120); do
+  if docker exec "${TEST_CONTAINER}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" > /dev/null 2>&1 \
+     && docker exec "${TEST_CONTAINER}" \
+          psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -q -t -A \
+          -c "SELECT 1" > /dev/null 2>&1; then
+    ready=$((ready + 1))
+    [ "${ready}" -ge 3 ] && break
+  else
+    ready=0
+  fi
+  [ "$i" -eq 120 ] && { echo "FAIL: Test database did not become ready"; exit 1; }
+  sleep 1
+done
+
+echo "Restoring into test container..."
+docker exec -i "${TEST_CONTAINER}" \
+  pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --clean --if-exists < "${DUMP_FILE}"
+
+psql_scalar() {
+  docker exec "${TEST_CONTAINER}" \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -A -v ON_ERROR_STOP=1 \
+    -c "$1"
+}
+
+echo "Running verification queries..."
+
+TABLE_COUNT="$(psql_scalar "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")"
+if [ "${TABLE_COUNT}" -gt 0 ]; then
+  echo "PASS: ${TABLE_COUNT} public tables in restored database"
+else
+  echo "FAIL: No tables found after restore"
+  exit 1
+fi
+
+MIGRATION_COUNT="$(psql_scalar "SELECT count(*) FROM flyway_schema_history;" 2>/dev/null || echo "0")"
+if [ "${MIGRATION_COUNT}" -gt 0 ]; then
+  echo "PASS: ${MIGRATION_COUNT} Flyway migrations recorded"
+else
+  echo "FAIL: flyway_schema_history empty or missing"
+  exit 1
+fi
+
+V010_PRESENT="$(psql_scalar "SELECT count(*) FROM flyway_schema_history WHERE version = '010';")"
+if [ "${V010_PRESENT}" -ge 1 ]; then
+  echo "PASS: V010 PRESENT in flyway_schema_history"
+else
+  echo "FAIL: V010 (create_age_graph) missing from flyway_schema_history"
+  exit 1
+fi
+
+AGE_EXT="$(psql_scalar "SELECT extname FROM pg_extension WHERE extname = 'age';")"
+if [ "${AGE_EXT}" = "age" ]; then
+  echo "PASS: AGE extension present"
+else
+  echo "FAIL: AGE extension not installed in restored database"
+  exit 1
+fi
+
+CORE_TABLES="project requirement requirement_relation traceability_link document section threat_model"
+missing=""
+for t in ${CORE_TABLES}; do
+  exists="$(psql_scalar "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name='${t}';")"
+  if [ "${exists}" -lt 1 ]; then
+    missing="${missing} ${t}"
+  fi
+done
+if [ -z "${missing}" ]; then
+  echo "PASS: CORE TABLES PRESENT (${CORE_TABLES})"
+else
+  echo "FAIL: core Ground Control tables missing:${missing}"
+  exit 1
+fi
+
+docker exec "${TEST_CONTAINER}" \
+  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -q -c \
+  "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public; SELECT create_graph('requirements_verify'); SELECT drop_graph('requirements_verify', true);"
+echo "PASS: GRAPH MATERIALIZABLE via create_graph('requirements_verify')"
+
+echo ""
+echo "$(date): Restore test PASSED — ${DUMP_FILE}"
+TESTRESTOREEOF
+chmod +x ${GC_OPT_DIR}/test-restore.sh
+
+# --- ${GC_OPT_DIR}/watchdog.sh ------------------------------------------------
+cat > ${GC_OPT_DIR}/watchdog.sh <<'WATCHEOF'
+#!/bin/bash
+# Ground Control backend watchdog — cron restarts backend on health failure.
+# Rewritten by deploy/scripts/install-ops-scripts.sh; do not edit by hand.
+set -uo pipefail
+
+HEALTH=$(curl -sf http://localhost:8000/actuator/health 2>/dev/null || echo "DOWN")
+
+if echo "${HEALTH}" | grep -q '"status":"UP"'; then
+  exit 0
+fi
+
+echo "$(date): Health check failed (${HEALTH}), restarting backend..." >> /var/log/gc-watchdog.log
+cd /opt/gc && docker compose restart backend
+WATCHEOF
+chmod +x ${GC_OPT_DIR}/watchdog.sh
+
+# --- Cron files ---------------------------------------------------------
+# Cron entries reference the production install path (/opt/gc) regardless of
+# GC_INSTALL_PREFIX. The prefix only affects where the cron *files* land so
+# tests can assert on content without needing /etc/cron.d write access.
+cat > "${GC_CRON_DIR}/gc-backup" <<EOF
+${GC_BACKUP_CRON} root /opt/gc/backup.sh >> /var/log/gc-backup.log 2>&1
+EOF
+cat > "${GC_CRON_DIR}/gc-restore-test" <<'EOF'
+0 5 * * * root /opt/gc/test-restore.sh >> /var/log/gc-restore-test.log 2>&1
+EOF
+cat > "${GC_CRON_DIR}/gc-watchdog" <<'EOF'
+*/5 * * * * root /opt/gc/watchdog.sh
+EOF
+chmod 644 "${GC_CRON_DIR}/gc-backup" "${GC_CRON_DIR}/gc-restore-test" "${GC_CRON_DIR}/gc-watchdog"
+
+echo "$(date): install-ops-scripts.sh installed /opt/gc + /etc/cron.d (bucket=${GC_BACKUP_BUCKET}, cron='${GC_BACKUP_CRON}', retention=${GC_LOCAL_RETENTION_COUNT})"

--- a/deploy/scripts/test-restore.sh
+++ b/deploy/scripts/test-restore.sh
@@ -1,23 +1,54 @@
 #!/bin/bash
-# Ground Control restore test — validates backup integrity without production impact
-# Spins up a temporary PostgreSQL container, restores, verifies, and tears down.
+# Ground Control restore test (GC-P021: verify backups on a recurring basis).
+#
+# Validates a pg_dump produced by deploy/scripts/backup.sh by restoring it
+# into a throwaway apache/age:release_PG16_1.6.0 container and running the
+# operational-readiness checks below. Any failure exits non-zero so the
+# cron-wrapped run produces a loud log line and a systemd/cron failure
+# email.
+#
+# Checks (all must pass):
+#   1. public schema contains at least one table
+#   2. flyway_schema_history has recorded migrations
+#   3. flyway_schema_history contains V010 (create_age_graph)
+#   4. AGE extension is loaded in the restored database
+#   5. Core Ground Control tables are present (catches truncated dumps)
+#   6. create_graph() succeeds against the restored catalog
+#      (proves AGE is operationally usable, not just installed)
+#
+# Overridable via environment for local dev:
+#   BACKUP_DIR         default /data/backups
+#   TEST_CONTAINER     default gc-restore-test
+#   TEST_PORT          default 15432
+#   DB_IMAGE           default apache/age:release_PG16_1.6.0
+#   SKIP_ENV_FILE=1    skip sourcing /opt/gc/.env (local dev)
+#   POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB — only required when
+#                      SKIP_ENV_FILE=1
 set -euo pipefail
 
-set -a; source /opt/gc/.env; set +a
+if [ "${SKIP_ENV_FILE:-0}" != "1" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source /opt/gc/.env
+  set +a
+fi
 
-BACKUP_DIR=/data/backups
-TEST_CONTAINER="gc-restore-test"
-TEST_PORT=15432
-DB_IMAGE="apache/age:release_PG16_1.6.0"
+BACKUP_DIR="${BACKUP_DIR:-/data/backups}"
+TEST_CONTAINER="${TEST_CONTAINER:-gc-restore-test}"
+TEST_PORT="${TEST_PORT:-15432}"
+DB_IMAGE="${DB_IMAGE:-apache/age:release_PG16_1.6.0}"
 
-# Use argument or latest local dump
+: "${POSTGRES_USER:?POSTGRES_USER must be set (via /opt/gc/.env or env override)}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}"
+: "${POSTGRES_DB:?POSTGRES_DB must be set}"
+
+# Use argument or latest local dump.
 DUMP_FILE="${1:-$(ls -t "${BACKUP_DIR}"/gc-*.dump 2>/dev/null | head -1)}"
 [ -n "${DUMP_FILE}" ] || { echo "ERROR: No backup file found"; exit 1; }
 [ -f "${DUMP_FILE}" ] || { echo "ERROR: File not found: ${DUMP_FILE}"; exit 1; }
 
 echo "Testing restore of: ${DUMP_FILE}"
 
-# Always clean up on exit
 cleanup() {
   echo "Cleaning up test container..."
   docker stop "${TEST_CONTAINER}" 2>/dev/null || true
@@ -25,7 +56,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Remove any leftover test container
 docker rm -f "${TEST_CONTAINER}" 2>/dev/null || true
 
 echo "Starting temporary PostgreSQL container on port ${TEST_PORT}..."
@@ -34,14 +64,24 @@ docker run -d --name "${TEST_CONTAINER}" \
   -e POSTGRES_USER="${POSTGRES_USER}" \
   -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
   -p "${TEST_PORT}:5432" \
-  "${DB_IMAGE}"
+  "${DB_IMAGE}" >/dev/null
 
 echo "Waiting for test database..."
-for i in $(seq 1 30); do
-  if docker exec "${TEST_CONTAINER}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" > /dev/null 2>&1; then
-    break
+# Two-phase wait: pg_isready handles initial boot, then require three
+# consecutive successful `SELECT 1` queries to confirm we are past the
+# apache/age image's post-init restart window.
+ready=0
+for i in $(seq 1 120); do
+  if docker exec "${TEST_CONTAINER}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" > /dev/null 2>&1 \
+     && docker exec "${TEST_CONTAINER}" \
+          psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -q -t -A \
+          -c "SELECT 1" > /dev/null 2>&1; then
+    ready=$((ready + 1))
+    [ "${ready}" -ge 3 ] && break
+  else
+    ready=0
   fi
-  [ "$i" -eq 30 ] && { echo "FAIL: Test database did not become ready"; exit 1; }
+  [ "$i" -eq 120 ] && { echo "FAIL: Test database did not become ready"; exit 1; }
   sleep 1
 done
 
@@ -49,12 +89,17 @@ echo "Restoring into test container..."
 docker exec -i "${TEST_CONTAINER}" \
   pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --clean --if-exists < "${DUMP_FILE}"
 
+# psql helper — runs as the restored-DB superuser, returns exit 1 on query error
+# so failures abort the script via set -e.
+psql_scalar() {
+  docker exec "${TEST_CONTAINER}" \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -A -v ON_ERROR_STOP=1 \
+    -c "$1"
+}
+
 echo "Running verification queries..."
 
-TABLE_COUNT=$(docker exec "${TEST_CONTAINER}" \
-  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -A \
-  -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")
-
+TABLE_COUNT="$(psql_scalar "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")"
 if [ "${TABLE_COUNT}" -gt 0 ]; then
   echo "PASS: ${TABLE_COUNT} public tables in restored database"
 else
@@ -62,15 +107,55 @@ else
   exit 1
 fi
 
-MIGRATION_COUNT=$(docker exec "${TEST_CONTAINER}" \
-  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -A \
-  -c "SELECT count(*) FROM flyway_schema_history;" 2>/dev/null || echo "0")
-
+MIGRATION_COUNT="$(psql_scalar "SELECT count(*) FROM flyway_schema_history;" 2>/dev/null || echo "0")"
 if [ "${MIGRATION_COUNT}" -gt 0 ]; then
   echo "PASS: ${MIGRATION_COUNT} Flyway migrations recorded"
 else
-  echo "WARN: No Flyway migration history"
+  echo "FAIL: flyway_schema_history empty or missing"
+  exit 1
 fi
+
+# 3. Flyway V010 present (marks the AGE graph bootstrap migration).
+V010_PRESENT="$(psql_scalar "SELECT count(*) FROM flyway_schema_history WHERE version = '010';")"
+if [ "${V010_PRESENT}" -ge 1 ]; then
+  echo "PASS: V010 PRESENT in flyway_schema_history"
+else
+  echo "FAIL: V010 (create_age_graph) missing from flyway_schema_history"
+  exit 1
+fi
+
+# 4. AGE extension loaded on the restored cluster.
+AGE_EXT="$(psql_scalar "SELECT extname FROM pg_extension WHERE extname = 'age';")"
+if [ "${AGE_EXT}" = "age" ]; then
+  echo "PASS: AGE extension present"
+else
+  echo "FAIL: AGE extension not installed in restored database"
+  exit 1
+fi
+
+# 5. Core Ground Control tables present.
+CORE_TABLES="project requirement requirement_relation traceability_link document section threat_model"
+missing=""
+for t in ${CORE_TABLES}; do
+  exists="$(psql_scalar "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name='${t}';")"
+  if [ "${exists}" -lt 1 ]; then
+    missing="${missing} ${t}"
+  fi
+done
+if [ -z "${missing}" ]; then
+  echo "PASS: CORE TABLES PRESENT (${CORE_TABLES})"
+else
+  echo "FAIL: core Ground Control tables missing:${missing}"
+  exit 1
+fi
+
+# 6. Graph materializable — proves AGE is loadable and create_graph() works
+#    against the restored catalog. Uses a throwaway graph name so we never
+#    touch a real `requirements` graph that may exist in the dump.
+docker exec "${TEST_CONTAINER}" \
+  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -q -c \
+  "LOAD 'age'; SET search_path = ag_catalog, \"\$user\", public; SELECT create_graph('requirements_verify'); SELECT drop_graph('requirements_verify', true);"
+echo "PASS: GRAPH MATERIALIZABLE via create_graph('requirements_verify')"
 
 echo ""
 echo "$(date): Restore test PASSED — ${DUMP_FILE}"

--- a/deploy/terraform/environments/dev/terraform.tfvars.example
+++ b/deploy/terraform/environments/dev/terraform.tfvars.example
@@ -12,11 +12,13 @@ tailscale_hostname = "gc-dev"
 # S3 backup bucket
 backup_bucket_name = "groundcontrol-backups-catalyst-dev"
 
-# Backup schedule (cron expression, default: daily at 03:00 UTC)
-# backup_cron = "0 3 * * *"
+# Backup schedule (cron expression) — GC-P021 requires at least 3x/day.
+# Default: 03:00, 11:00, 19:00 UTC.
+# backup_cron = "0 3,11,19 * * *"
 
-# Number of local backup dumps to keep (default: 3)
-# local_retention_count = 3
+# Number of local backup dumps to keep — GC-P021 requires >= 24h retention.
+# At 3 backups/day, 4 gives ~32h. Do not set below 4.
+# local_retention_count = 4
 
 # Embedding provider (set to "openai" to enable, then put the API key in SSM)
 # gc_embedding_provider = "openai"

--- a/deploy/terraform/environments/dev/variables.tf
+++ b/deploy/terraform/environments/dev/variables.tf
@@ -41,15 +41,25 @@ variable "backup_bucket_name" {
 }
 
 variable "backup_cron" {
-  description = "Cron expression for automated pg_dump backup schedule"
+  description = <<-EOT
+    Cron expression for automated pg_dump backup. GC-P021 requires at least
+    three backups per day; this env default matches the upstream backup
+    module default (`0 3,11,19 * * *`). Overrides must stay >= 3x/day to
+    remain compliant — the scripts/assert-backup-policy.sh guardrail fails
+    the build otherwise.
+  EOT
   type        = string
-  default     = "0 3 * * *"
+  default     = "0 3,11,19 * * *"
 }
 
 variable "local_retention_count" {
-  description = "Number of local pg_dump files to retain on the EC2 instance"
+  description = <<-EOT
+    Number of local pg_dump files to retain on the EC2 instance. GC-P021
+    requires at least 24 hours of retention; at 3 backups/day the minimum
+    compliant value is 4. Do not set below 4.
+  EOT
   type        = number
-  default     = 3
+  default     = 4
 }
 
 variable "gc_embedding_provider" {

--- a/deploy/terraform/modules/backup/variables.tf
+++ b/deploy/terraform/modules/backup/variables.tf
@@ -22,13 +22,21 @@ variable "snapshot_retention_count" {
 }
 
 variable "backup_cron" {
-  description = "Cron expression for automated pg_dump backup (default: daily at 03:00 UTC)"
+  description = <<-EOT
+    Cron expression for automated pg_dump backup. GC-P021 requires at least
+    three backups per day; the default (03:00, 11:00, 19:00 UTC) gives an
+    approximate 8-hour RPO. Overrides must stay >= 3x/day to remain compliant.
+  EOT
   type        = string
-  default     = "0 3 * * *"
+  default     = "0 3,11,19 * * *"
 }
 
 variable "local_retention_count" {
-  description = "Number of local pg_dump files to retain on the EC2 instance"
+  description = <<-EOT
+    Number of local pg_dump files to retain on the EC2 instance. GC-P021
+    requires at least 24 hours of retention; at 3 backups/day the minimum
+    compliant value is 4 (>= ~32 hours, one-run margin). Do not lower below 4.
+  EOT
   type        = number
-  default     = 3
+  default     = 4
 }

--- a/deploy/terraform/modules/compute/user-data.sh.tftpl
+++ b/deploy/terraform/modules/compute/user-data.sh.tftpl
@@ -275,27 +275,32 @@ RESTOREEOF
 sed -i "s|BUCKET_PLACEHOLDER|${backup_bucket}|" /opt/gc/restore.sh
 chmod +x /opt/gc/restore.sh
 
-# --- Restore test script ---
+# --- Restore test script (GC-P021 recurring restore verification) ---
 cat > /opt/gc/test-restore.sh <<'TESTRESTOREEOF'
 #!/bin/bash
-# Ground Control restore test — validates backup integrity without production impact
+# Ground Control restore test (GC-P021: verify backups on a recurring basis).
+# Canonical source: deploy/scripts/test-restore.sh — keep this copy in sync.
 set -euo pipefail
 
-set -a; source /opt/gc/.env; set +a
+if [ "$${SKIP_ENV_FILE:-0}" != "1" ]; then
+  set -a; source /opt/gc/.env; set +a
+fi
 
-BACKUP_DIR=/data/backups
-TEST_CONTAINER="gc-restore-test"
-TEST_PORT=15432
-DB_IMAGE="apache/age:release_PG16_1.6.0"
+BACKUP_DIR="$${BACKUP_DIR:-/data/backups}"
+TEST_CONTAINER="$${TEST_CONTAINER:-gc-restore-test}"
+TEST_PORT="$${TEST_PORT:-15432}"
+DB_IMAGE="$${DB_IMAGE:-apache/age:release_PG16_1.6.0}"
 
-# Use argument or latest local dump
+: "$${POSTGRES_USER:?POSTGRES_USER must be set (via /opt/gc/.env or env override)}"
+: "$${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}"
+: "$${POSTGRES_DB:?POSTGRES_DB must be set}"
+
 DUMP_FILE="$${1:-$$(ls -t "$${BACKUP_DIR}"/gc-*.dump 2>/dev/null | head -1)}"
 [ -n "$${DUMP_FILE}" ] || { echo "ERROR: No backup file found"; exit 1; }
 [ -f "$${DUMP_FILE}" ] || { echo "ERROR: File not found: $${DUMP_FILE}"; exit 1; }
 
 echo "Testing restore of: $${DUMP_FILE}"
 
-# Always clean up on exit
 cleanup() {
   echo "Cleaning up test container..."
   docker stop "$${TEST_CONTAINER}" 2>/dev/null || true
@@ -303,7 +308,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Remove any leftover test container
 docker rm -f "$${TEST_CONTAINER}" 2>/dev/null || true
 
 echo "Starting temporary PostgreSQL container on port $${TEST_PORT}..."
@@ -312,14 +316,24 @@ docker run -d --name "$${TEST_CONTAINER}" \
   -e POSTGRES_USER="$${POSTGRES_USER}" \
   -e POSTGRES_PASSWORD="$${POSTGRES_PASSWORD}" \
   -p "$${TEST_PORT}:5432" \
-  "$${DB_IMAGE}"
+  "$${DB_IMAGE}" >/dev/null
 
 echo "Waiting for test database..."
-for i in $$(seq 1 30); do
-  if docker exec "$${TEST_CONTAINER}" pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}" > /dev/null 2>&1; then
-    break
+# Two-phase wait: pg_isready handles initial boot, then require three
+# consecutive successful `SELECT 1` queries to confirm we are past the
+# apache/age image's post-init restart window.
+ready=0
+for i in $$(seq 1 120); do
+  if docker exec "$${TEST_CONTAINER}" pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}" > /dev/null 2>&1 \
+     && docker exec "$${TEST_CONTAINER}" \
+          psql -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}" -q -t -A \
+          -c "SELECT 1" > /dev/null 2>&1; then
+    ready=$$((ready + 1))
+    [ "$${ready}" -ge 3 ] && break
+  else
+    ready=0
   fi
-  [ "$$i" -eq 30 ] && { echo "FAIL: Test database did not become ready"; exit 1; }
+  [ "$$i" -eq 120 ] && { echo "FAIL: Test database did not become ready"; exit 1; }
   sleep 1
 done
 
@@ -327,12 +341,15 @@ echo "Restoring into test container..."
 docker exec -i "$${TEST_CONTAINER}" \
   pg_restore -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}" --clean --if-exists < "$${DUMP_FILE}"
 
+psql_scalar() {
+  docker exec "$${TEST_CONTAINER}" \
+    psql -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}" -t -A -v ON_ERROR_STOP=1 \
+    -c "$$1"
+}
+
 echo "Running verification queries..."
 
-TABLE_COUNT=$$(docker exec "$${TEST_CONTAINER}" \
-  psql -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}" -t -A \
-  -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")
-
+TABLE_COUNT="$$(psql_scalar "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")"
 if [ "$${TABLE_COUNT}" -gt 0 ]; then
   echo "PASS: $${TABLE_COUNT} public tables in restored database"
 else
@@ -340,15 +357,49 @@ else
   exit 1
 fi
 
-MIGRATION_COUNT=$$(docker exec "$${TEST_CONTAINER}" \
-  psql -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}" -t -A \
-  -c "SELECT count(*) FROM flyway_schema_history;" 2>/dev/null || echo "0")
-
+MIGRATION_COUNT="$$(psql_scalar "SELECT count(*) FROM flyway_schema_history;" 2>/dev/null || echo "0")"
 if [ "$${MIGRATION_COUNT}" -gt 0 ]; then
   echo "PASS: $${MIGRATION_COUNT} Flyway migrations recorded"
 else
-  echo "WARN: No Flyway migration history"
+  echo "FAIL: flyway_schema_history empty or missing"
+  exit 1
 fi
+
+V010_PRESENT="$$(psql_scalar "SELECT count(*) FROM flyway_schema_history WHERE version = '010';")"
+if [ "$${V010_PRESENT}" -ge 1 ]; then
+  echo "PASS: V010 PRESENT in flyway_schema_history"
+else
+  echo "FAIL: V010 (create_age_graph) missing from flyway_schema_history"
+  exit 1
+fi
+
+AGE_EXT="$$(psql_scalar "SELECT extname FROM pg_extension WHERE extname = 'age';")"
+if [ "$${AGE_EXT}" = "age" ]; then
+  echo "PASS: AGE extension present"
+else
+  echo "FAIL: AGE extension not installed in restored database"
+  exit 1
+fi
+
+CORE_TABLES="project requirement requirement_relation traceability_link document section threat_model"
+missing=""
+for t in $${CORE_TABLES}; do
+  exists="$$(psql_scalar "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name='$${t}';")"
+  if [ "$${exists}" -lt 1 ]; then
+    missing="$${missing} $${t}"
+  fi
+done
+if [ -z "$${missing}" ]; then
+  echo "PASS: CORE TABLES PRESENT ($${CORE_TABLES})"
+else
+  echo "FAIL: core Ground Control tables missing:$${missing}"
+  exit 1
+fi
+
+docker exec "$${TEST_CONTAINER}" \
+  psql -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}" -v ON_ERROR_STOP=1 -q -c \
+  "LOAD 'age'; SET search_path = ag_catalog, \"\$$user\", public; SELECT create_graph('requirements_verify'); SELECT drop_graph('requirements_verify', true);"
+echo "PASS: GRAPH MATERIALIZABLE via create_graph('requirements_verify')"
 
 echo ""
 echo "$$(date): Restore test PASSED — $${DUMP_FILE}"
@@ -396,8 +447,8 @@ chmod +x /opt/gc/deploy.sh
 echo "${backup_cron} root /opt/gc/backup.sh >> /var/log/gc-backup.log 2>&1" > /etc/cron.d/gc-backup
 # Watchdog every 5 minutes
 echo "*/5 * * * * root /opt/gc/watchdog.sh" > /etc/cron.d/gc-watchdog
-# Weekly restore test (Sunday 05:00 UTC)
-echo "0 5 * * 0 root /opt/gc/test-restore.sh >> /var/log/gc-restore-test.log 2>&1" > /etc/cron.d/gc-restore-test
+# Daily restore test at 05:00 UTC (GC-P021 recurring verification)
+echo "0 5 * * * root /opt/gc/test-restore.sh >> /var/log/gc-restore-test.log 2>&1" > /etc/cron.d/gc-restore-test
 chmod 644 /etc/cron.d/gc-backup /etc/cron.d/gc-watchdog /etc/cron.d/gc-restore-test
 
 echo "=== Ground Control initialization complete ==="

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -136,7 +136,7 @@ Ground Control runs on a single EC2 instance in the `catalyst-dev` AWS account, 
 - **Instance**: `t3a.small` (2 vCPU, 2 GB RAM) running Amazon Linux 2023
 - **Access**: Tailscale only — zero public ingress. `http://gc-dev:8000` via MagicDNS
 - **Storage**: Root EBS (8 GB gp3) + data EBS (20 GB gp3, encrypted) at `/data`
-- **Backup**: EBS snapshots (daily, 7-day retention) + pg_dump to S3 (daily, 30-day retention)
+- **Backup**: EBS snapshots (daily, 7-day retention) + pg_dump to S3 (3×/day, 30-day retention) — see [ADR-025](../../architecture/adrs/025-backup-policy.md) for policy rationale (GC-P021)
 - **Cost**: ~$17/mo on-demand
 
 ### Prerequisites
@@ -238,98 +238,53 @@ ssh gc-dev 'docker compose -f /opt/gc/docker-compose.yml exec -T db \
 
 Ground Control uses two complementary backup strategies: **logical backups** (pg_dump to S3) for portable, table-level restore and **block-level backups** (EBS snapshots) for fast full-volume recovery. Both run automatically and are configurable via Terraform.
 
+The authoritative operator runbook is **[docs/operations/backup-restore.md](../operations/backup-restore.md)** — it walks a cold operator through every recovery scenario without assuming prior exposure to the stack. The ADR behind the current policy is [ADR-025](../../architecture/adrs/025-backup-policy.md).
+
 #### Backup Configuration
 
 | Parameter | Default | Terraform Variable | Description |
 |-----------|---------|-------------------|-------------|
-| Backup schedule | `0 3 * * *` (daily 03:00 UTC) | `backup_cron` | Cron expression for pg_dump frequency |
+| Backup schedule | `0 3,11,19 * * *` (03:00 / 11:00 / 19:00 UTC, 3×/day) | `backup_cron` | Cron expression for pg_dump frequency. GC-P021 requires ≥ 3×/day; do not lower. |
 | S3 retention | 30 days | `s3_retention_days` | How long S3 dumps are kept |
-| Local dump retention | 3 files | `local_retention_count` | Number of pg_dump files kept on EC2 |
+| Local dump retention | 4 files | `local_retention_count` | Number of pg_dump files kept on EC2. GC-P021 requires ≥ 24 h; at 3×/day this means ≥ 4 files. |
 | EBS snapshot retention | 7 snapshots | `snapshot_retention_count` | Number of daily EBS snapshots kept |
 | EBS snapshot schedule | Daily 04:00 UTC | DLM policy (fixed) | Block-level volume snapshots |
+| Restore-test schedule | Daily 05:00 UTC | fixed in `user-data.sh.tftpl` | Automated verification of the newest dump |
 
-To change backup frequency, set the Terraform variable and redeploy:
-
-```hcl
-# terraform.tfvars — example: backup every 6 hours
-backup_cron = "0 */6 * * *"
-```
+To change backup frequency, set the Terraform variable and redeploy.
+Any override must remain ≥ 3×/day to stay GC-P021 compliant — the
+`scripts/assert-backup-policy.sh` gate (run by pre-commit and
+`make policy`) will fail the build otherwise.
 
 #### Point-in-Time Restore
 
-Point-in-time restore granularity equals the backup frequency. Each pg_dump is a consistent database snapshot at the moment it was taken. To restore to a specific point in time, select the backup with the closest timestamp before your target time. Reducing the `backup_cron` interval increases granularity (e.g., `0 */6 * * *` gives 6-hour RPO).
+Point-in-time restore granularity equals the backup frequency. Each pg_dump is a consistent database snapshot at the moment it was taken. To restore to a specific point in time, select the backup with the closest timestamp before your target time. The default `0 3,11,19 * * *` schedule gives an RPO of approximately 8 hours.
 
-#### Manual Backup
+#### Manual Backup / Restore / Verification
 
-```bash
-ssh gc-dev /opt/gc/backup.sh
-```
-
-#### List Available Backups
+Quick reference (full procedures live in the operator runbook):
 
 ```bash
-ssh gc-dev /opt/gc/restore.sh --list
+ssh gc-dev /opt/gc/backup.sh                                  # ad-hoc backup
+ssh gc-dev /opt/gc/restore.sh --list                          # enumerate backups
+ssh gc-dev /opt/gc/restore.sh --from-s3 pg-dumps/gc-...dump   # restore
+ssh gc-dev /opt/gc/test-restore.sh                            # verify newest dump
+ssh gc-dev cat /var/log/gc-restore-test.log                   # daily verification log
+scripts/test-backup-restore-locally.sh                        # self-contained local loop
 ```
 
-#### Restore from Local Dump
+For restore-from-EBS-snapshot, credential rotation, full-loss rebuild,
+or AGE graph rematerialization, follow the operator runbook rather than
+ad-hoc commands.
 
-```bash
-ssh gc-dev /opt/gc/restore.sh --from-file /data/backups/gc-20260329-030000.dump
-```
+**Automated verification checks** (executed daily at 05:00 UTC):
 
-The restore script automatically creates a safety backup before restoring and prompts for confirmation. Use `--yes` to skip the confirmation prompt.
-
-#### Restore from S3
-
-```bash
-ssh gc-dev /opt/gc/restore.sh --from-s3 pg-dumps/gc-20260329-030000.dump
-```
-
-Downloads the dump from S3, creates a safety backup, and restores.
-
-#### Restore from EBS Snapshot
-
-For full-volume recovery (restores everything including PostgreSQL data directory):
-
-1. Find the snapshot: `aws ec2 describe-snapshots --filters "Name=tag:Service,Values=ground-control" --query 'Snapshots[*].{ID:SnapshotId,Time:StartTime}' --output table`
-2. Create a new volume from the snapshot: `aws ec2 create-volume --snapshot-id <snap-id> --availability-zone us-east-2a --volume-type gp3`
-3. Stop the instance: `aws ec2 stop-instances --instance-ids <instance-id>`
-4. Detach old data volume: `aws ec2 detach-volume --volume-id <old-vol-id>`
-5. Attach new volume at same device: `aws ec2 attach-volume --volume-id <new-vol-id> --instance-id <instance-id> --device /dev/xvdf`
-6. Start the instance: `aws ec2 start-instances --instance-ids <instance-id>`
-
-#### Restore Testing
-
-A restore test script validates backup integrity without impacting the production database. It spins up a temporary PostgreSQL container, restores the latest backup, runs verification queries, and tears down automatically.
-
-**Manual test:**
-
-```bash
-# Test latest backup
-ssh gc-dev /opt/gc/test-restore.sh
-
-# Test a specific backup file
-ssh gc-dev /opt/gc/test-restore.sh /data/backups/gc-20260329-030000.dump
-```
-
-**Automated test:** Runs weekly (Sunday 05:00 UTC) via cron. Check results:
-
-```bash
-ssh gc-dev cat /var/log/gc-restore-test.log
-```
-
-**Verification checks performed:**
 - PostgreSQL responds to `pg_isready`
 - Public tables exist in the restored database
-- Flyway migration history is present
-
-#### Post-Restore Verification Checklist
-
-After any restore to the production database:
-
-1. Database responds: `docker compose -f /opt/gc/docker-compose.yml exec db pg_isready -U gc -d ground_control`
-2. Application is healthy: `curl http://gc-dev:8000/actuator/health`
-3. Spot check data: `curl http://gc-dev:8000/api/v1/analysis/dashboard-stats?project=ground-control`
+- `flyway_schema_history` contains migrations, including V010 (`create_age_graph`)
+- The Apache AGE extension is installed
+- Core Ground Control tables exist (`project`, `requirement`, `requirement_relation`, `traceability_link`, `document`, `section`, `threat_model`)
+- `create_graph('requirements_verify')` succeeds — proves AGE is operationally usable against restored data
 
 ### Monitoring
 

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -349,7 +349,38 @@ For IAM / ECR / Tailscale rotation see
 | `/etc/cron.d/gc-backup` | Cron declaration for scheduled backups |
 | `/etc/cron.d/gc-restore-test` | Cron declaration for daily verification |
 | `/etc/cron.d/gc-watchdog` | 5-minute health-check watchdog (restarts backend on failure) |
-| `deploy/terraform/modules/compute/user-data.sh.tftpl` | Source of truth for every `/opt/gc/*` script (written at first boot) |
-| `deploy/scripts/*.sh` | Repo-side copies used for local testing and review |
+| `deploy/scripts/install-ops-scripts.sh` | Canonical installer for `/opt/gc/*.sh` and `/etc/cron.d/gc-*`. Runs on the instance in two paths: first boot (written by `user-data.sh.tftpl`) and every main-branch deploy (pushed via SSM SendCommand by the CI `deploy` job, sidestepping `ignore_changes = [user_data]`). Enforces the GC-P021 cadence (≥ 3×/day) and retention (≥ 4) floors on input. |
+| `deploy/terraform/modules/compute/user-data.sh.tftpl` | First-boot bootstrap (Docker, Tailscale, EBS volume, initial docker compose up). Writes `/opt/gc/install-ops-scripts.sh` and calls it once at first boot. |
+| `deploy/scripts/*.sh` | Reference copies used by local testing (`scripts/test-backup-restore-locally.sh` invokes `deploy/scripts/test-restore.sh`). Kept consistent with the installer heredocs by `scripts/assert-backup-policy.sh`. |
 | `scripts/test-backup-restore-locally.sh` | Self-contained local end-to-end test of the restore loop |
 | `scripts/assert-backup-policy.sh` | Pre-commit / `make policy` guardrail preventing drift away from GC-P021 defaults |
+
+### Manually rolling out script updates to an existing instance
+
+If you changed any `/opt/gc/*` script in this repo and need it on the
+running `gc-dev` instance immediately (not on the next main-branch
+deploy), run the installer via SSM:
+
+```bash
+INSTANCE_ID=$(aws ec2 describe-instances \
+  --profile catalyst-dev --region us-east-2 \
+  --filters "Name=tag:Name,Values=groundcontrol-ec2" "Name=instance-state-name,Values=running" \
+  --query 'Reservations[0].Instances[0].InstanceId' --output text)
+
+B64=$(base64 -w0 deploy/scripts/install-ops-scripts.sh)
+CMD="export GC_BACKUP_BUCKET='groundcontrol-backups-catalyst-dev'; \
+     export GC_BACKUP_CRON='0 3,11,19 * * *'; \
+     export GC_LOCAL_RETENTION_COUNT=4; \
+     echo '${B64}' | base64 -d | bash"
+jq -n --arg cmd "$CMD" '{commands:[$cmd]}' > /tmp/install.json
+
+aws ssm send-command \
+  --profile catalyst-dev --region us-east-2 \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name AWS-RunShellScript \
+  --parameters file:///tmp/install.json \
+  --timeout-seconds 300
+```
+
+The CI `deploy` job performs the same step on every main-branch push;
+this manual path is only needed for off-cycle rollouts.

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -1,0 +1,355 @@
+# Backup and Restore Runbook
+
+This runbook gets Ground Control back to an operational state after data
+loss or host failure. It assumes:
+
+- You have AWS CLI or console access to account `516608939870`
+  (`us-east-2`). The AWS CLI profile this project uses is `catalyst-dev`.
+- You are enrolled in the Tailscale tailnet that owns `gc-dev`.
+- You have SSH access to `gc-dev` via Tailscale SSH (no SSH key is
+  required — Tailscale authenticates the connection).
+- You have **no prior exposure** to Ground Control internals. Everything
+  you need is either in this document or linked inline.
+
+If any prerequisite above is missing, stop and request it from the
+repository owner before continuing.
+
+Anchors:
+
+- Policy: Ground Control requirement GC-P021 (filed as GitHub
+  issue [#533](https://github.com/KeplerOps/Ground-Control/issues/533));
+  this runbook satisfies its "documented such that recovery can be
+  performed without prior knowledge" clause.
+- Architecture context: [ADR-018](../../architecture/adrs/018-aws-ec2-deployment.md),
+  [ADR-025](../../architecture/adrs/025-backup-policy.md).
+
+---
+
+## 1. What is backed up
+
+Ground Control runs on one EC2 instance (tag `Name=groundcontrol-ec2`)
+in `us-east-2`. Two backup layers protect the data:
+
+| Layer | What | Where | Cadence | Retention |
+|-------|------|-------|---------|-----------|
+| pg_dump (logical) | Custom-format Postgres dump of the `ground_control` database | EBS `/data/backups/` on the instance **and** `s3://groundcontrol-backups-catalyst-dev/pg-dumps/` | 03:00, 11:00, 19:00 UTC (3×/day) | ≥ 24 h local (4 dump files), 30 days S3 |
+| EBS snapshot (block) | Full `/data` volume including Postgres data directory and local dumps | AWS EBS snapshots tagged `Service=ground-control` | Daily 04:00 UTC | 7 snapshots |
+
+The relational tables are the authoritative source of truth. The Apache
+AGE graph stored in `ag_catalog` is derivative — it is rebuilt from the
+relational tables by
+`POST /api/v1/admin/graph/materialize`
+(code: `AgeGraphService.materializeGraph()`).
+
+Secrets the running application needs are stored in AWS SSM Parameter
+Store under `/gc/dev/*` (not on the instance, not in backups). See
+[§ 7 Rotating credentials](#7-rotating-credentials).
+
+---
+
+## 2. Locating resources
+
+Run these from any machine with AWS CLI and the `catalyst-dev` profile.
+
+```bash
+# The live EC2 instance.
+aws ec2 describe-instances \
+  --profile catalyst-dev --region us-east-2 \
+  --filters "Name=tag:Name,Values=groundcontrol-ec2" \
+  --query 'Reservations[].Instances[].[InstanceId,State.Name,PrivateIpAddress]' \
+  --output table
+
+# The most recent S3 pg_dumps.
+aws s3 ls s3://groundcontrol-backups-catalyst-dev/pg-dumps/ \
+  --profile catalyst-dev --recursive | sort | tail -10
+
+# The most recent EBS snapshots of the data volume.
+aws ec2 describe-snapshots \
+  --profile catalyst-dev --region us-east-2 \
+  --filters "Name=tag:Service,Values=ground-control" \
+  --query 'Snapshots[].[SnapshotId,StartTime,VolumeSize,State]' \
+  --output table
+
+# SSM parameters the instance uses (names only; values are SecureString).
+aws ssm describe-parameters \
+  --profile catalyst-dev --region us-east-2 \
+  --parameter-filters "Key=Name,Option=BeginsWith,Values=/gc/dev/" \
+  --query 'Parameters[].Name' --output table
+```
+
+Tailscale hostname: `gc-dev`. SSH once to prove access:
+
+```bash
+ssh gc-dev 'echo ok && docker compose -f /opt/gc/docker-compose.yml ps'
+```
+
+---
+
+## 3. Recovery scenarios
+
+Pick the scenario that matches what failed.
+
+### 3a. Data corruption or accidental delete (instance still running)
+
+Use this when the database is up but the data is wrong (bad migration,
+user error, malicious delete).
+
+```bash
+ssh gc-dev /opt/gc/restore.sh --list
+```
+
+Choose a dump whose timestamp is **before** the corruption. Then:
+
+```bash
+ssh gc-dev /opt/gc/restore.sh --from-s3 pg-dumps/gc-<TIMESTAMP>.dump
+```
+
+The script takes a safety backup first and prompts for confirmation (use
+`--yes` to skip the prompt from an automation). After it completes,
+continue with [§ 5 Rematerialize the AGE graph](#5-rematerialize-the-age-graph)
+and [§ 6 Post-restore verification](#6-post-restore-verification).
+
+### 3b. Instance failed, data volume intact
+
+Use this if the EC2 instance is stopped/terminated but the EBS data
+volume still exists (the `/data` volume is `skip_destroy = true` in
+Terraform and survives instance replacement).
+
+1. Note the existing data volume ID:
+
+    ```bash
+    aws ec2 describe-volumes \
+      --profile catalyst-dev --region us-east-2 \
+      --filters "Name=tag:Name,Values=groundcontrol-data" \
+      --query 'Volumes[].[VolumeId,State,AvailabilityZone]' --output table
+    ```
+
+2. Launch a replacement instance via Terraform:
+
+    ```bash
+    cd deploy/terraform/environments/dev
+    terraform apply
+    ```
+
+    The `user-data.sh.tftpl` reinstalls Docker, pulls the container
+    image, and mounts `/data`. Because the volume still contains
+    `/data/postgres/`, Postgres comes back with all prior state.
+
+3. Verify as in [§ 6](#6-post-restore-verification). No AGE
+   rematerialize is required because the `ag_catalog` tables are on the
+   preserved volume.
+
+### 3c. Full loss — rebuild from backups
+
+Use this if both the instance and the data volume are lost, or if you
+are rebuilding into a new account.
+
+1. Choose a source of truth. Pick **one**:
+    - The latest valid EBS snapshot (preferred; includes everything on
+      `/data`):
+
+       ```bash
+       aws ec2 describe-snapshots \
+         --profile catalyst-dev --region us-east-2 \
+         --filters "Name=tag:Service,Values=ground-control" \
+         --query 'Snapshots|sort_by(@,&StartTime)[-3:].[SnapshotId,StartTime]' \
+         --output table
+       ```
+
+    - The latest valid S3 pg_dump (use this if EBS snapshots are gone):
+
+       ```bash
+       aws s3 ls s3://groundcontrol-backups-catalyst-dev/pg-dumps/ \
+         --profile catalyst-dev --recursive | sort | tail -3
+       ```
+
+2. **EBS-snapshot path**: create a new volume from the snapshot and let
+   Terraform attach it:
+
+    ```bash
+    aws ec2 create-volume \
+      --profile catalyst-dev --region us-east-2 \
+      --snapshot-id <snap-id> \
+      --availability-zone us-east-2a \
+      --volume-type gp3 \
+      --tag-specifications 'ResourceType=volume,Tags=[{Key=Name,Value=groundcontrol-data},{Key=Backup,Value=true},{Key=Service,Value=ground-control}]'
+
+    cd deploy/terraform/environments/dev
+    terraform import module.compute.aws_ebs_volume.data <new-vol-id>
+    terraform apply
+    ```
+
+   Terraform drives a fresh EC2 from
+   `deploy/terraform/modules/compute/user-data.sh.tftpl` and attaches the
+   restored volume. Skip to step 4.
+
+3. **S3 pg_dump path**: let Terraform create a new blank volume, then
+   restore the dump:
+
+    ```bash
+    cd deploy/terraform/environments/dev
+    terraform apply
+    # Wait for the instance to finish user-data. Tail /var/log/gc-init.log
+    # over Tailscale SSH to watch progress.
+    ssh gc-dev 'tail -f /var/log/gc-init.log'
+
+    # Once docker compose is up, pull a dump and restore.
+    ssh gc-dev /opt/gc/restore.sh --from-s3 pg-dumps/gc-<TIMESTAMP>.dump --yes
+    ```
+
+4. Rematerialize the AGE graph (see [§ 5](#5-rematerialize-the-age-graph)).
+
+5. Verify (see [§ 6](#6-post-restore-verification)).
+
+---
+
+## 4. Manually running backup or restore-test
+
+Useful when preparing for an intentionally-risky change, or when asked
+to prove the pipeline works.
+
+```bash
+# Take a pg_dump now.
+ssh gc-dev /opt/gc/backup.sh
+
+# Run the verification loop against the newest dump.
+ssh gc-dev /opt/gc/test-restore.sh
+
+# Tail the recurring-verification log.
+ssh gc-dev cat /var/log/gc-restore-test.log
+```
+
+Locally (no AWS access required), the equivalent loop is:
+
+```bash
+# Requires only Docker.
+scripts/test-backup-restore-locally.sh
+```
+
+This spins up a fresh `apache/age` Postgres, replays every Flyway
+migration, dumps, and runs `deploy/scripts/test-restore.sh` against the
+dump.
+
+---
+
+## 5. Rematerialize the AGE graph
+
+After **any** restore from an S3 pg_dump (§ 3a, § 3c path B), trigger the
+graph rematerialize. This ensures the AGE graph reflects the restored
+relational data even if the dump's `ag_catalog` OIDs drifted from what
+the fresh `create_graph('requirements')` allocated during the V010
+Flyway migration.
+
+```bash
+# From the gc-dev host (reaches localhost:8000):
+ssh gc-dev 'curl -sf -X POST http://localhost:8000/api/v1/admin/graph/materialize'
+
+# From a workstation with Tailscale + MagicDNS:
+curl -sf -X POST http://gc-dev:8000/api/v1/admin/graph/materialize
+```
+
+The endpoint returns HTTP 200 with no body. Confirm the graph is
+populated:
+
+```bash
+curl -s 'http://gc-dev:8000/api/v1/analysis/dashboard-stats?project=ground-control' \
+  | jq '.'
+```
+
+If `dashboard-stats` returns non-zero counts for requirements / links,
+the restored state is operational.
+
+---
+
+## 6. Post-restore verification
+
+Run **all** of the following from a workstation in the tailnet:
+
+```bash
+# 6a. Database is responding.
+ssh gc-dev 'docker compose -f /opt/gc/docker-compose.yml exec -T db \
+    pg_isready -U gc -d ground_control'
+
+# 6b. Spring Boot health.
+curl -sf http://gc-dev:8000/actuator/health | jq '.status'
+# Expect: "UP"
+
+# 6c. Data reachable via the API.
+curl -s 'http://gc-dev:8000/api/v1/analysis/dashboard-stats?project=ground-control' | jq '.'
+# Expect non-zero requirement / link counts that match your expectations
+# for the restored point in time.
+
+# 6d. Next scheduled backup succeeds.
+ssh gc-dev /opt/gc/backup.sh && ssh gc-dev 'ls -lht /data/backups/ | head'
+```
+
+If any check fails, loop back to § 3 and pick a different source of
+truth (an earlier dump or snapshot).
+
+---
+
+## 7. Rotating credentials
+
+The instance reads the database password and any other SecureString
+values from SSM at boot via `/opt/gc/refresh-env.sh`. Rotating is a
+three-step process:
+
+1. Write the new value to SSM:
+
+    ```bash
+    aws ssm put-parameter \
+      --profile catalyst-dev --region us-east-2 \
+      --name /gc/dev/db_password \
+      --type SecureString --overwrite \
+      --value "$(openssl rand -base64 24)"
+    ```
+
+2. Refresh the running instance's environment and restart the affected
+   service:
+
+    ```bash
+    ssh gc-dev /opt/gc/refresh-env.sh
+    ssh gc-dev 'cd /opt/gc && docker compose up -d'
+    ```
+
+3. Wait for the next scheduled backup (or force one with
+   `ssh gc-dev /opt/gc/backup.sh`) and confirm the dump completes and
+   lands in S3:
+
+    ```bash
+    aws s3 ls s3://groundcontrol-backups-catalyst-dev/pg-dumps/ \
+      --profile catalyst-dev | sort | tail -3
+    ssh gc-dev tail -30 /var/log/gc-backup.log
+    ```
+
+For IAM / ECR / Tailscale rotation see
+`deploy/terraform/modules/secrets/` and
+`deploy/terraform/modules/compute/main.tf`.
+
+---
+
+## 8. Escalation
+
+- Repository: https://github.com/KeplerOps/Ground-Control
+- Primary maintainer: owner of the `catalyst-dev` AWS account.
+- File issues against this repository with the `ops` label if this
+  runbook was wrong or incomplete.
+
+---
+
+## Appendix A. Where the tooling lives
+
+| Path | Purpose |
+|------|---------|
+| `/opt/gc/backup.sh` | Nightly + midday + evening pg_dump, uploads to S3, local rotation |
+| `/opt/gc/restore.sh` | `--list | --from-file | --from-s3` restore-in-place with safety-backup + confirm prompt |
+| `/opt/gc/test-restore.sh` | Verification loop run daily by cron (05:00 UTC); also runs from `scripts/test-backup-restore-locally.sh` |
+| `/var/log/gc-backup.log` | Output of scheduled backups |
+| `/var/log/gc-restore-test.log` | Output of the daily verification cron |
+| `/etc/cron.d/gc-backup` | Cron declaration for scheduled backups |
+| `/etc/cron.d/gc-restore-test` | Cron declaration for daily verification |
+| `/etc/cron.d/gc-watchdog` | 5-minute health-check watchdog (restarts backend on failure) |
+| `deploy/terraform/modules/compute/user-data.sh.tftpl` | Source of truth for every `/opt/gc/*` script (written at first boot) |
+| `deploy/scripts/*.sh` | Repo-side copies used for local testing and review |
+| `scripts/test-backup-restore-locally.sh` | Self-contained local end-to-end test of the restore loop |
+| `scripts/assert-backup-policy.sh` | Pre-commit / `make policy` guardrail preventing drift away from GC-P021 defaults |

--- a/scripts/assert-backup-policy.sh
+++ b/scripts/assert-backup-policy.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Assert that the Ground Control backup/restore infrastructure meets GC-P021:
+#   - backup cadence >= 3/day
+#   - local_retention_count guarantees >= 24h of backups (>= 4 files at 3x/day)
+#   - restore-test cron runs at least daily
+#   - test-restore.sh contains the AGE/core-table/graph/V010 sentinel checks
+#   - deploy/scripts/*.sh and deploy/terraform/modules/compute/user-data.sh.tftpl
+#     remain in sync on cadence + verification details
+#
+# This script is intentionally structural (grep-based) rather than a full
+# Terraform parse — the goal is a fast, dependency-free gate that runs in
+# pre-commit, `make policy`, and CI. It fails loudly the moment the repo
+# drifts away from GC-P021 defaults.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BACKUP_MODULE_VARS="${REPO_ROOT}/deploy/terraform/modules/backup/variables.tf"
+USER_DATA_TFTPL="${REPO_ROOT}/deploy/terraform/modules/compute/user-data.sh.tftpl"
+TFVARS_EXAMPLE="${REPO_ROOT}/deploy/terraform/environments/dev/terraform.tfvars.example"
+TEST_RESTORE_SCRIPT="${REPO_ROOT}/deploy/scripts/test-restore.sh"
+BACKUP_SCRIPT="${REPO_ROOT}/deploy/scripts/backup.sh"
+
+errors=0
+fail() {
+  echo "FAIL: $*" >&2
+  errors=$((errors + 1))
+}
+
+# 1. Backup module defaults.
+if ! grep -q 'default     = "0 3,11,19 \* \* \*"' "${BACKUP_MODULE_VARS}"; then
+  fail "backup_cron default in ${BACKUP_MODULE_VARS#${REPO_ROOT}/} must be \"0 3,11,19 * * *\" (3x/day per GC-P021)"
+fi
+# Accept any default >= 4 for local_retention_count.
+retention_default="$(awk '
+  /^variable "local_retention_count"/ { inblock = 1 }
+  inblock && /default *= *[0-9]+/ {
+    match($0, /default *= *[0-9]+/); value = substr($0, RSTART, RLENGTH);
+    gsub(/[^0-9]/, "", value); print value; exit
+  }
+' "${BACKUP_MODULE_VARS}")"
+if [[ -z "${retention_default}" ]]; then
+  fail "could not parse local_retention_count default from ${BACKUP_MODULE_VARS#${REPO_ROOT}/}"
+elif [[ "${retention_default}" -lt 4 ]]; then
+  fail "local_retention_count default is ${retention_default}; GC-P021 requires >= 4 (>= 24h at 3x/day cadence)"
+fi
+
+# 2. user-data cron lines: backup schedule + daily restore test.
+if ! grep -q '/etc/cron.d/gc-backup' "${USER_DATA_TFTPL}"; then
+  fail "${USER_DATA_TFTPL#${REPO_ROOT}/} no longer writes /etc/cron.d/gc-backup"
+fi
+if ! grep -q '0 5 \* \* \* root /opt/gc/test-restore.sh' "${USER_DATA_TFTPL}"; then
+  fail "restore-test cron in ${USER_DATA_TFTPL#${REPO_ROOT}/} must run daily (0 5 * * *) per GC-P021"
+fi
+if grep -q '0 5 \* \* 0 root /opt/gc/test-restore.sh' "${USER_DATA_TFTPL}"; then
+  fail "weekly restore-test cron (0 5 * * 0) still present in ${USER_DATA_TFTPL#${REPO_ROOT}/}; GC-P021 requires >= daily verification"
+fi
+
+# 3. tfvars.example must document the new defaults so operators aren't misled.
+if ! grep -q 'backup_cron *= *"0 3,11,19 \* \* \*"' "${TFVARS_EXAMPLE}"; then
+  fail "${TFVARS_EXAMPLE#${REPO_ROOT}/} must show backup_cron = \"0 3,11,19 * * *\" as the example value"
+fi
+if ! grep -q 'local_retention_count *= *4' "${TFVARS_EXAMPLE}"; then
+  fail "${TFVARS_EXAMPLE#${REPO_ROOT}/} must show local_retention_count = 4 as the example value"
+fi
+
+# 4. test-restore.sh and the inlined user-data copy must carry the new checks.
+#    Sentinel strings are stable across both files so drift between the two
+#    is caught here.
+for file in "${TEST_RESTORE_SCRIPT}" "${USER_DATA_TFTPL}"; do
+  label="${file#${REPO_ROOT}/}"
+  grep -q 'extname *= *.age.' "${file}"           || fail "${label} missing AGE extension load check (pg_extension query)"
+  grep -q 'AGE extension present' "${file}"       || fail "${label} missing AGE-extension sentinel log line"
+  grep -q 'CORE TABLES PRESENT' "${file}"         || fail "${label} missing core-tables sentinel log line"
+  grep -q 'GRAPH MATERIALIZABLE' "${file}"        || fail "${label} missing graph-materialize sentinel log line"
+  grep -q 'V010 PRESENT' "${file}"                || fail "${label} missing V010 Flyway-checksum sentinel log line"
+  grep -q "create_graph('requirements_verify')"   "${file}" \
+    || fail "${label} must invoke create_graph('requirements_verify') to prove AGE is operational"
+done
+
+# 5. Keep the repo-copy scripts in sync with the user-data template on cadence
+#    comments so reviewers can see them together in diffs.
+if ! grep -q 'GC-P021' "${BACKUP_SCRIPT}"; then
+  fail "${BACKUP_SCRIPT#${REPO_ROOT}/} header must reference GC-P021 so the policy anchor is visible in the script itself"
+fi
+if ! grep -q 'GC-P021' "${TEST_RESTORE_SCRIPT}"; then
+  fail "${TEST_RESTORE_SCRIPT#${REPO_ROOT}/} header must reference GC-P021 so the policy anchor is visible in the script itself"
+fi
+
+if [[ "${errors}" -gt 0 ]]; then
+  echo "assert-backup-policy.sh: ${errors} failure(s)" >&2
+  exit 1
+fi
+
+echo "assert-backup-policy.sh: OK"

--- a/scripts/assert-backup-policy.sh
+++ b/scripts/assert-backup-policy.sh
@@ -16,10 +16,13 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 BACKUP_MODULE_VARS="${REPO_ROOT}/deploy/terraform/modules/backup/variables.tf"
+DEV_ENV_VARS="${REPO_ROOT}/deploy/terraform/environments/dev/variables.tf"
 USER_DATA_TFTPL="${REPO_ROOT}/deploy/terraform/modules/compute/user-data.sh.tftpl"
 TFVARS_EXAMPLE="${REPO_ROOT}/deploy/terraform/environments/dev/terraform.tfvars.example"
 TEST_RESTORE_SCRIPT="${REPO_ROOT}/deploy/scripts/test-restore.sh"
 BACKUP_SCRIPT="${REPO_ROOT}/deploy/scripts/backup.sh"
+INSTALL_OPS_SCRIPT="${REPO_ROOT}/deploy/scripts/install-ops-scripts.sh"
+CI_WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
 
 errors=0
 fail() {
@@ -27,23 +30,26 @@ fail() {
   errors=$((errors + 1))
 }
 
-# 1. Backup module defaults.
-if ! grep -q 'default     = "0 3,11,19 \* \* \*"' "${BACKUP_MODULE_VARS}"; then
-  fail "backup_cron default in ${BACKUP_MODULE_VARS#${REPO_ROOT}/} must be \"0 3,11,19 * * *\" (3x/day per GC-P021)"
-fi
-# Accept any default >= 4 for local_retention_count.
-retention_default="$(awk '
-  /^variable "local_retention_count"/ { inblock = 1 }
-  inblock && /default *= *[0-9]+/ {
-    match($0, /default *= *[0-9]+/); value = substr($0, RSTART, RLENGTH);
-    gsub(/[^0-9]/, "", value); print value; exit
-  }
-' "${BACKUP_MODULE_VARS}")"
-if [[ -z "${retention_default}" ]]; then
-  fail "could not parse local_retention_count default from ${BACKUP_MODULE_VARS#${REPO_ROOT}/}"
-elif [[ "${retention_default}" -lt 4 ]]; then
-  fail "local_retention_count default is ${retention_default}; GC-P021 requires >= 4 (>= 24h at 3x/day cadence)"
-fi
+# 1. Backup module + dev env root defaults. The live deployment only sees
+#    the dev env's forwarded default, so both layers must carry GC-P021 values.
+for file in "${BACKUP_MODULE_VARS}" "${DEV_ENV_VARS}"; do
+  label="${file#${REPO_ROOT}/}"
+  if ! grep -q 'default *= *"0 3,11,19 \* \* \*"' "${file}"; then
+    fail "backup_cron default in ${label} must be \"0 3,11,19 * * *\" (3x/day per GC-P021)"
+  fi
+  retention_default="$(awk '
+    /^variable "local_retention_count"/ { inblock = 1 }
+    inblock && /default *= *[0-9]+/ {
+      match($0, /default *= *[0-9]+/); value = substr($0, RSTART, RLENGTH);
+      gsub(/[^0-9]/, "", value); print value; exit
+    }
+  ' "${file}")"
+  if [[ -z "${retention_default}" ]]; then
+    fail "could not parse local_retention_count default from ${label}"
+  elif [[ "${retention_default}" -lt 4 ]]; then
+    fail "local_retention_count default in ${label} is ${retention_default}; GC-P021 requires >= 4 (>= 24h at 3x/day cadence)"
+  fi
+done
 
 # 2. user-data cron lines: backup schedule + daily restore test.
 if ! grep -q '/etc/cron.d/gc-backup' "${USER_DATA_TFTPL}"; then
@@ -64,10 +70,10 @@ if ! grep -q 'local_retention_count *= *4' "${TFVARS_EXAMPLE}"; then
   fail "${TFVARS_EXAMPLE#${REPO_ROOT}/} must show local_retention_count = 4 as the example value"
 fi
 
-# 4. test-restore.sh and the inlined user-data copy must carry the new checks.
-#    Sentinel strings are stable across both files so drift between the two
-#    is caught here.
-for file in "${TEST_RESTORE_SCRIPT}" "${USER_DATA_TFTPL}"; do
+# 4. test-restore.sh, the inlined user-data copy, AND the canonical installer
+#    must all carry the new checks. Sentinel strings are stable across all
+#    three files so drift between them is caught here.
+for file in "${TEST_RESTORE_SCRIPT}" "${USER_DATA_TFTPL}" "${INSTALL_OPS_SCRIPT}"; do
   label="${file#${REPO_ROOT}/}"
   grep -q 'extname *= *.age.' "${file}"           || fail "${label} missing AGE extension load check (pg_extension query)"
   grep -q 'AGE extension present' "${file}"       || fail "${label} missing AGE-extension sentinel log line"
@@ -85,6 +91,66 @@ if ! grep -q 'GC-P021' "${BACKUP_SCRIPT}"; then
 fi
 if ! grep -q 'GC-P021' "${TEST_RESTORE_SCRIPT}"; then
   fail "${TEST_RESTORE_SCRIPT#${REPO_ROOT}/} header must reference GC-P021 so the policy anchor is visible in the script itself"
+fi
+if ! grep -q 'GC-P021' "${INSTALL_OPS_SCRIPT}"; then
+  fail "${INSTALL_OPS_SCRIPT#${REPO_ROOT}/} must reference GC-P021 so the policy anchor is visible in the installer"
+fi
+
+# 6. The CI deploy job must run install-ops-scripts.sh on every deploy so
+#    the live EC2 instance picks up /opt/gc script updates. This is the
+#    fix for codex P1: ignore_changes=[user_data] blocks Terraform from
+#    propagating script edits.
+if [ -f "${CI_WORKFLOW}" ]; then
+  if ! grep -q 'deploy/scripts/install-ops-scripts.sh' "${CI_WORKFLOW}"; then
+    fail "${CI_WORKFLOW#${REPO_ROOT}/} must run deploy/scripts/install-ops-scripts.sh during the deploy job (GC-P021 script rollout)"
+  fi
+  if ! grep -q 'ssm-install-ops' "${CI_WORKFLOW}"; then
+    fail "${CI_WORKFLOW#${REPO_ROOT}/} must wire the install-ops step (id=ssm-install-ops) in the deploy job"
+  fi
+fi
+
+# 7. Run the installer against an ephemeral prefix and prove it (a) refuses
+#    non-compliant inputs and (b) writes the expected artifacts. This catches
+#    bit-rot the grep-based sentinel checks cannot see.
+tmp_prefix="$(mktemp -d -t gc-install-ops-XXXXXXXX)"
+trap 'rm -rf "${tmp_prefix}"' EXIT
+
+if GC_INSTALL_PREFIX="${tmp_prefix}" \
+   GC_BACKUP_BUCKET=test-bucket \
+   GC_BACKUP_CRON='0 3 * * *' \
+   GC_LOCAL_RETENTION_COUNT=4 \
+   bash "${INSTALL_OPS_SCRIPT}" >/dev/null 2>&1; then
+  fail "install-ops-scripts.sh accepted 1x/day cron (GC-P021 requires >= 3x/day)"
+fi
+if GC_INSTALL_PREFIX="${tmp_prefix}" \
+   GC_BACKUP_BUCKET=test-bucket \
+   GC_BACKUP_CRON='0 3,11,19 * * *' \
+   GC_LOCAL_RETENTION_COUNT=3 \
+   bash "${INSTALL_OPS_SCRIPT}" >/dev/null 2>&1; then
+  fail "install-ops-scripts.sh accepted retention=3 (GC-P021 requires >= 4)"
+fi
+rm -rf "${tmp_prefix}"
+mkdir -p "${tmp_prefix}"
+
+if ! GC_INSTALL_PREFIX="${tmp_prefix}" \
+     GC_BACKUP_BUCKET=test-bucket \
+     GC_BACKUP_CRON='0 3,11,19 * * *' \
+     GC_LOCAL_RETENTION_COUNT=4 \
+     bash "${INSTALL_OPS_SCRIPT}" >/dev/null 2>&1; then
+  fail "install-ops-scripts.sh rejected compliant inputs — smoke test failed"
+else
+  for f in backup.sh restore.sh test-restore.sh watchdog.sh; do
+    [ -x "${tmp_prefix}/opt/gc/${f}" ] \
+      || fail "install-ops-scripts.sh did not install executable ${f}"
+  done
+  grep -q 's3://test-bucket/pg-dumps/' "${tmp_prefix}/opt/gc/backup.sh" \
+    || fail "installed backup.sh missing substituted GC_BACKUP_BUCKET"
+  grep -q 'tail -n +$((4 + 1))' "${tmp_prefix}/opt/gc/backup.sh" \
+    || fail "installed backup.sh missing substituted GC_LOCAL_RETENTION_COUNT"
+  grep -q '^0 3,11,19 \* \* \* root /opt/gc/backup.sh' "${tmp_prefix}/etc/cron.d/gc-backup" \
+    || fail "installed gc-backup cron entry does not reflect GC_BACKUP_CRON"
+  grep -q '^0 5 \* \* \* root /opt/gc/test-restore.sh' "${tmp_prefix}/etc/cron.d/gc-restore-test" \
+    || fail "installed gc-restore-test cron must run daily at 05:00 UTC"
 fi
 
 if [[ "${errors}" -gt 0 ]]; then

--- a/scripts/test-backup-restore-locally.sh
+++ b/scripts/test-backup-restore-locally.sh
@@ -46,12 +46,26 @@ docker run -d --name "${SEED_CONTAINER}" \
   -p "${SEED_PORT}:5432" \
   "${DB_IMAGE}" >/dev/null
 
-for _ in $(seq 1 60); do
-  if docker exec "${SEED_CONTAINER}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
-    break
+# Two-phase wait: the apache/age image briefly restarts after first boot.
+# Require three consecutive successful SELECT 1 calls so migrations don't
+# race against the restart.
+ready=0
+for _ in $(seq 1 120); do
+  if docker exec "${SEED_CONTAINER}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1 \
+     && docker exec "${SEED_CONTAINER}" \
+          psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -q -t -A \
+          -c "SELECT 1" >/dev/null 2>&1; then
+    ready=$((ready + 1))
+    [ "${ready}" -ge 3 ] && break
+  else
+    ready=0
   fi
   sleep 1
 done
+if [ "${ready}" -lt 3 ]; then
+  echo "ERROR: seed database did not stabilize within 120s" >&2
+  exit 1
+fi
 
 echo "Creating flyway_schema_history and applying migrations..."
 docker exec -i "${SEED_CONTAINER}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 <<'SQL'

--- a/scripts/test-backup-restore-locally.sh
+++ b/scripts/test-backup-restore-locally.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Local end-to-end exerciser for the GC-P021 backup/restore loop.
+#
+# Workflow:
+#   1. Start a fresh apache/age PostgreSQL container on a non-standard port.
+#   2. Apply the repo's Flyway migrations (V001..V058) in version order.
+#   3. pg_dump that container to produce a realistic dump.
+#   4. Run deploy/scripts/test-restore.sh against the dump via env overrides.
+#   5. Assert every GC-P021 sentinel check appears in the output.
+#
+# Self-contained — does not require the local docker-compose stack or a
+# built backend image. Always tears down the two ephemeral containers.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+SEED_CONTAINER="gc-backup-seed-local"
+TEST_CONTAINER="gc-restore-test-local"
+SEED_PORT="${SEED_PORT:-25432}"
+TEST_PORT="${TEST_PORT:-25433}"
+DB_IMAGE="apache/age:release_PG16_1.6.0"
+POSTGRES_USER="gc"
+POSTGRES_PASSWORD="gc"
+POSTGRES_DB="ground_control"
+MIGRATIONS_DIR="${REPO_ROOT}/backend/src/main/resources/db/migration"
+
+WORKDIR="$(mktemp -d -t gc-backup-local-XXXXXXXX)"
+DUMP_FILE="${WORKDIR}/gc-local.dump"
+LOG_FILE="${WORKDIR}/test-restore.log"
+
+cleanup() {
+  docker rm -f "${SEED_CONTAINER}" >/dev/null 2>&1 || true
+  docker rm -f "${TEST_CONTAINER}" >/dev/null 2>&1 || true
+  rm -rf "${WORKDIR}"
+}
+trap cleanup EXIT
+
+docker rm -f "${SEED_CONTAINER}" >/dev/null 2>&1 || true
+
+echo "Starting seed ${DB_IMAGE} on port ${SEED_PORT}..."
+docker run -d --name "${SEED_CONTAINER}" \
+  -e POSTGRES_DB="${POSTGRES_DB}" \
+  -e POSTGRES_USER="${POSTGRES_USER}" \
+  -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+  -p "${SEED_PORT}:5432" \
+  "${DB_IMAGE}" >/dev/null
+
+for _ in $(seq 1 60); do
+  if docker exec "${SEED_CONTAINER}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+echo "Creating flyway_schema_history and applying migrations..."
+docker exec -i "${SEED_CONTAINER}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 <<'SQL'
+CREATE TABLE IF NOT EXISTS flyway_schema_history (
+  installed_rank integer NOT NULL PRIMARY KEY,
+  version varchar(50),
+  description varchar(200) NOT NULL,
+  type varchar(20) NOT NULL,
+  script varchar(1000) NOT NULL,
+  checksum integer,
+  installed_by varchar(100) NOT NULL,
+  installed_on timestamp NOT NULL DEFAULT now(),
+  execution_time integer NOT NULL,
+  success boolean NOT NULL
+);
+SQL
+
+rank=0
+while IFS= read -r -d '' file; do
+  rank=$((rank + 1))
+  base="$(basename "${file}")"
+  version="${base%%__*}"      # e.g. V010
+  version="${version#V}"       # e.g. 010
+  desc="${base#V*__}"
+  desc="${desc%.sql}"
+  desc="${desc//_/ }"
+  echo "  apply V${version} — ${desc}"
+  docker exec -i "${SEED_CONTAINER}" \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 < "${file}"
+  docker exec "${SEED_CONTAINER}" \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -c \
+    "INSERT INTO flyway_schema_history(installed_rank, version, description, type, script, checksum, installed_by, execution_time, success) VALUES (${rank}, '${version}', '${desc}', 'SQL', '${base}', 0, '${POSTGRES_USER}', 0, true);" \
+    >/dev/null
+done < <(find "${MIGRATIONS_DIR}" -maxdepth 1 -name 'V*.sql' -print0 | sort -z)
+
+echo "Creating pg_dump at ${DUMP_FILE}..."
+docker exec "${SEED_CONTAINER}" \
+  pg_dump -Fc -U "${POSTGRES_USER}" "${POSTGRES_DB}" > "${DUMP_FILE}"
+
+echo "Running test-restore.sh against the dump..."
+BACKUP_DIR="${WORKDIR}" \
+  TEST_CONTAINER="${TEST_CONTAINER}" \
+  TEST_PORT="${TEST_PORT}" \
+  DB_IMAGE="${DB_IMAGE}" \
+  POSTGRES_DB="${POSTGRES_DB}" \
+  POSTGRES_USER="${POSTGRES_USER}" \
+  POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
+  SKIP_ENV_FILE=1 \
+  bash "${REPO_ROOT}/deploy/scripts/test-restore.sh" "${DUMP_FILE}" \
+  | tee "${LOG_FILE}"
+
+errors=0
+assert_log() {
+  local needle="$1"
+  if ! grep -qF "${needle}" "${LOG_FILE}"; then
+    echo "FAIL: expected '${needle}' in test-restore output" >&2
+    errors=$((errors + 1))
+  fi
+}
+assert_log 'PASS: AGE extension present'
+assert_log 'PASS: CORE TABLES PRESENT'
+assert_log 'PASS: GRAPH MATERIALIZABLE'
+assert_log 'PASS: V010 PRESENT'
+assert_log 'Restore test PASSED'
+
+if [[ "${errors}" -gt 0 ]]; then
+  echo "test-backup-restore-locally.sh: ${errors} sentinel check(s) missing — GC-P021 verification incomplete" >&2
+  exit 1
+fi
+
+echo "test-backup-restore-locally.sh: OK"


### PR DESCRIPTION
## Summary

- Raise pg_dump cadence to 3×/day and local retention to 4 dumps so every Ground Control production deployment meets GC-P021's ≥3/day + ≥24h clauses, enforced in `deploy/terraform/modules/backup/variables.tf` and guarded by `scripts/assert-backup-policy.sh`.
- Switch the `/opt/gc/test-restore.sh` cron from weekly to daily and extend verification to assert that the Apache AGE extension loaded, core Ground Control tables are present, V010 sits in `flyway_schema_history`, and `create_graph('requirements_verify')` succeeds on the restored catalog — proving AGE is operationally usable against restored data, not just installed.
- Ship ADR-025 (pg_dump over pgBackRest, with the AGE-derivative-from-relational invariant) and `docs/operations/backup-restore.md` — a standalone runbook for an operator with AWS + Tailscale credentials but no prior exposure.

## Requirement UIDs

- GC-P021 — Ground Control Deployment Backup Policy

## ADR Impact

ADR-025 (Backup Policy) — new ADR recording the decision to retain pg_dump + EBS rather than switching to pgBackRest, and the AGE-derivative-from-relational invariant that makes this safe. ADR-018 (AWS EC2 Deployment) is referenced but not modified.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason — deferred: this change ships infrastructure and documentation only; no requirements, ADRs, or relations were authored that would create new analysis findings beyond ADR-025 itself.

## Traceability

After CI and reviews are green this PR will reconcile the Ground Control traceability graph. Expected new links once GC-P021 transitions DRAFT → ACTIVE (per `/implement` Step 15/16):

- IMPLEMENTS: GC-P021 → `architecture/adrs/025-backup-policy.md` (ADR), `deploy/terraform/modules/backup/variables.tf` (CONFIG), `deploy/terraform/modules/compute/user-data.sh.tftpl` (CONFIG), `deploy/scripts/test-restore.sh` (CODE_FILE), `deploy/scripts/backup.sh` (CODE_FILE), `docs/operations/backup-restore.md` (DOCUMENTATION), `scripts/assert-backup-policy.sh` (POLICY)
- TESTS: GC-P021 → `scripts/test-backup-restore-locally.sh` (TEST)
- GITHUB_ISSUE: GC-P021 ↔ #533

## Policy clause → change

| GC-P021 clause | Satisfied by |
|---|---|
| ≥ 3 backups/day | `backup_cron` default `0 3,11,19 * * *` |
| ≥ 24 h retention | `local_retention_count = 4` (+ 30-day S3 lifecycle) |
| Covers all persistent state | `test-restore.sh` now asserts AGE present, core tables present, V010 present, and `create_graph()` succeeds |
| Recurring verification | daily cron `0 5 * * *` |
| Recovery documented without prior knowledge | `docs/operations/backup-restore.md` |

## Test plan

- [x] `bash -n` across `deploy/scripts/*.sh` and new `scripts/*.sh` (pre-commit hook `bash-syntax`)
- [x] `scripts/assert-backup-policy.sh` is green (wired into pre-commit + `make policy`)
- [x] `scripts/test-backup-restore-locally.sh` — self-contained local run: spins up apache/age, replays all 58 Flyway migrations, takes a pg_dump, runs `test-restore.sh` against it, asserts every new sentinel (`PASS: AGE extension present`, `PASS: CORE TABLES PRESENT`, `PASS: V010 PRESENT`, `PASS: GRAPH MATERIALIZABLE`, `Restore test PASSED`). Confirmed green on this branch.
- [x] `make policy` passes (`policy-tests` + `assert-backup-policy` + `python3 bin/policy --skip-pr-body`)
- [x] `terraform -chdir=deploy/terraform/environments/dev validate` + `terraform fmt -check -recursive deploy/terraform` green
- [x] `make check` passes (gradle `check` clean)
- [x] `pre-commit run --all-files` green (Spotless, Terraform fmt/validate, Checkov, gitleaks, repo-policy, gradle-check, openjml)

## Post-deploy validation (operator-owned)

Observation-shaped acceptance criteria from issue #533 land after the next terraform apply on `gc-dev` and cannot be signed off in this PR:

- [ ] Observe 3 daily backups for 7 consecutive days in `s3://groundcontrol-backups-catalyst-dev/pg-dumps/`.
- [ ] Confirm `/var/log/gc-restore-test.log` shows green for 7 consecutive runs.
- [ ] Execute § 3c of `docs/operations/backup-restore.md` once on a scratch environment and attach the log as a comment on #533 before closing the requirement.

Closes #533
