### PR TITLE
ci: docker depends on sonar (hard gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,11 +152,13 @@ jobs:
         run: cd backend && ./gradlew openjmlEsc --no-daemon
 
   # ---------------------------------------------------------------------------
-  # Docker — builds after integration tests and verification both complete
+  # Docker — builds after integration, verify, and sonar all pass.
+  # `sonar` is part of the gate (not just informational): a quality-gate
+  # failure must block deploy, so docker can't proceed without it.
   # ---------------------------------------------------------------------------
   docker:
     runs-on: [self-hosted, linux, x64]
-    needs: [integration, verify]
+    needs: [integration, verify, sonar]
     if: |
       github.event_name == 'push'
       && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/v'))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `.github/workflows/ci.yml` — `docker` now `needs: [integration, verify, sonar]` instead of `[integration, verify]`. The `sonar` job is part of the gate, not informational: a quality-gate failure must block the deploy chain (`docker → smoke → deploy`). Without this, the post-merge dev push for #536 produced `sonar:failure` while `docker:success` proceeded toward `smoke`/`deploy`.
+
 ### Fixed
 
 - `gc_codex_review` no longer hangs indefinitely. Three independent


### PR DESCRIPTION
## Summary

CI graph bug surfaced by the post-merge dev run for #536: `sonar:failure` co-existed with `docker:success`, with `smoke`/`deploy` queued behind. Sonar is supposed to gate the deploy chain. Add `sonar` to `docker`'s `needs` list so the chain blocks correctly.

## Requirement UIDs

- GC-O007 — Gated Agentic Development Loop. The CI graph implements part of the loop's quality gate; this PR fixes a structural gap in that gate. Not an implementation of the requirement, just a corrective infrastructure change in support of it.

## ADR Impact

No ADR required.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason — deferred: workflow change only, no Ground Control artifacts authored.

## Traceability

- IMPLEMENTS: — (CI graph correction)
- TESTS: — (validated by this PR's own CI run; sonar failure on the prior dev run is the regression case being closed)

## Files

- `.github/workflows/ci.yml` — `docker.needs` `[integration, verify]` → `[integration, verify, sonar]`.
- `CHANGELOG.md` — Unreleased entry.

## Test plan

- [ ] CI on this PR runs sonar to completion. If sonar fails, docker / smoke / deploy never start. If sonar passes, the chain proceeds.
- [ ] After merge, the post-merge dev run also exhibits the new ordering.

## Notes for follow-up

The dev push run for #536 had `sonar:failure` *before* reaching SonarCloud (no failed analysis recorded server-side). Whatever caused that — gradle step, network, token — needs a separate diagnosis once we have logs from a fresh run. This PR only closes the CI-graph hole; it doesn't address whatever made sonar fail.