### PR TITLE
Add REST API access control via Spring Security (closes #243)

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -178,6 +178,20 @@ Implementation is NOT ready for commit until ALL of the following are verified:
 
 If any check fails, fix it before proceeding. Do NOT move to Phase C until every check passes.
 
+### Step 6.5: Pre-push Codex Review (uncommitted)
+
+Run `gc_codex_review` with `uncommitted=true` against the staged + unstaged changes BEFORE the first push. Each codex review cycle takes ~5 min locally; each CI cycle to discover the same findings takes 10–15 min plus self-hosted runner overhead. Iterating locally collapses N CI runs into N local runs and one push.
+
+1. Stage everything you intend to push (`git add -A` for the full diff).
+2. Call the `gc_codex_review` MCP tool with:
+   - `repo_path`: absolute path from Step 1
+   - `base_branch`: `dev`
+   - `uncommitted`: `true`
+3. Apply the **Review loop rules** (defined above Step 12) to the returned findings, fix locally, re-stage, and re-invoke `gc_codex_review` until clean. **Cap: 5 iterations** — same as the post-push review loop.
+4. Once clean, proceed to Phase C with the staged diff. Step 12 then becomes a verification pass against the merge commit (typically a no-op) instead of the loop driver.
+
+Skip this step only if the diff is so trivial (one-liner typo fix) that codex would have nothing to find. When in doubt, run it.
+
 ---
 
 ## Phase C: Stage, Commit, Push
@@ -274,6 +288,8 @@ Every review step below (Codex cross-model, refactor & cross-cutting concerns, t
 For every cycle, after applying fixes, commit and push BEFORE re-running the review so the reviewer sees the updated tree. Format every fix commit as `Fix review findings (<reviewer>, cycle <N>)` so the loop history is visible in git log.
 
 ### Step 12: Cross-Model Review (Codex)
+
+This step normally lands as a **verification pass** rather than a fix/verify loop, because Step 6.5 should already have driven the diff through codex locally before the first push. Treat Step 12 as the post-merge-commit re-check: codex sometimes catches issues that only surface on the merged tree (interactions with target-branch changes since the local review ran). Most of the time it returns 0 findings.
 
 `gc_codex_review` runs two focused codex reviewers — a core production-readiness reviewer and a dedicated application-security reviewer — against a single pre-computed diff. By default the reviewers run sequentially (set `GC_CODEX_REVIEW_PARALLEL=2` to opt back into parallel execution). Both post their findings as inline PR review comments with a reviewer-tagged title (`[core]` or `[security]`). The tool returns a single deduplicated list; you then drive a per-finding fix/verify loop via `gc_codex_verify_finding`, which handles the GitHub API bookkeeping for you.
 

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,25 @@ GC_DATABASE_PASSWORD=gc
 GC_REDIS_URL=redis://localhost:6379
 GC_SERVER_PORT=8000
 
+# API access control (see ADR-026, GC-P011)
+# Production deployments MUST configure at least one credential.
+# Set to false only on the dev/test profile.
+GC_SECURITY_ENABLED=true
+# Whether the OpenAPI schema is reachable anonymously.
+GC_SECURITY_OPENAPI_PUBLIC=false
+# Credentials are bound as an indexed list. Each entry needs a principal
+# name (used for audit), a token (Bearer), and a role (USER or ADMIN).
+# GROUNDCONTROL_SECURITY_CREDENTIALS_0_PRINCIPAL_NAME=admin
+# GROUNDCONTROL_SECURITY_CREDENTIALS_0_TOKEN=replace-with-strong-random-secret
+# GROUNDCONTROL_SECURITY_CREDENTIALS_0_ROLE=ADMIN
+# GROUNDCONTROL_SECURITY_CREDENTIALS_1_PRINCIPAL_NAME=alice
+# GROUNDCONTROL_SECURITY_CREDENTIALS_1_TOKEN=another-strong-random-secret
+# GROUNDCONTROL_SECURITY_CREDENTIALS_1_ROLE=USER
+# Optional CIDR allowlist applied before token auth. Empty = allow all
+# source IPs (token auth only). X-Forwarded-For is NOT trusted.
+# GROUNDCONTROL_SECURITY_IP_ALLOWLIST_0=10.0.0.0/8
+# GROUNDCONTROL_SECURITY_IP_ALLOWLIST_1=192.168.0.0/16
+
 # Embedding provider (optional — system degrades gracefully when not set)
 # GC_EMBEDDING_PROVIDER=openai
 # GC_EMBEDDING_API_KEY=sk-...

--- a/.github/workflows/pack-registry-sync.yml
+++ b/.github/workflows/pack-registry-sync.yml
@@ -43,10 +43,15 @@ jobs:
             exit 1
           fi
 
+          # Stores the bearer token as an ADMIN credential under the unified
+          # groundcontrol.security tree (ADR-026 / GC-P011). Pre-#243 this
+          # parameter held ground-control.pack-registry.security.admin-credentials;
+          # it is now consumed by both the application Spring Security layer and
+          # the deploy/scripts/sync_pack_catalog.sh helper.
           SPRING_JSON="$(jq -nc \
             --arg principal "${PACK_REGISTRY_ADMIN_PRINCIPAL}" \
             --arg token "${GC_PACK_REGISTRY_ADMIN_TOKEN}" \
-            '{"ground-control":{"pack-registry":{"security":{"admin-credentials":[{"principal-name":$principal,"token":$token}]}}}}')"
+            '{"groundcontrol":{"security":{"credentials":[{"principal-name":$principal,"token":$token,"role":"ADMIN"}]}}}')"
 
           aws ssm put-parameter \
             --name "${PACK_REGISTRY_SECURITY_PARAM}" \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,14 @@ repos:
         files: ^(AGENTS\.md|\.claude/|\.github/|architecture/|backend/|docs/|mcp/|specs/|tools/)
         pass_filenames: false
 
+      - id: pr-body-policy
+        name: pr body template (only on push, when a PR exists)
+        entry: scripts/check-pr-body.sh
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true
+
       - id: gradle-check
         name: gradle check (build + test + static analysis + coverage)
         entry: bash -c 'cd backend && ./gradlew check -q'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `bin/policy --pr-body-file <path>` and `--pr-number <n>` modes so the
+  PR-body template check can run from a local draft or a fetched
+  GitHub PR body. Backed by a new `scripts/check-pr-body.sh` pre-push
+  hook (registered via `pre-commit install --hook-type pre-push`)
+  that catches missing template sections before the push triggers a
+  CI run that would fail at the policy job.
+- New `Step 6.5: Pre-push Codex Review (uncommitted)` in the
+  `/implement` skill. Runs `gc_codex_review` with `uncommitted=true`
+  against the staged diff before the first push so each fix iterates
+  through codex locally (~5 min) instead of through CI (~10–15 min).
+  Step 12 becomes a verification pass against the merge commit
+  rather than the loop driver.
 - REST API access control via Spring Security (closes #243, GC-P011). All
   `/api/v1/**` endpoints now require `Authorization: Bearer <token>` against
   the configured `groundcontrol.security.credentials` list; admin paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   over the `X-Actor` request header. The header remains a fallback when
   `groundcontrol.security.enabled=false` (dev/test) but can no longer
   spoof identity in production.
-
 - `.github/workflows/ci.yml` — `docker` now `needs: [integration, verify, sonar]` instead of `[integration, verify]`. The `sonar` job is part of the gate, not informational: a quality-gate failure must block the deploy chain (`docker → smoke → deploy`). Without this, the post-merge dev push for #536 produced `sonar:failure` while `docker:success` proceeded toward `smoke`/`deploy`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spoof identity in production.
 - `.github/workflows/ci.yml` — `docker` now `needs: [integration, verify, sonar]` instead of `[integration, verify]`. The `sonar` job is part of the gate, not informational: a quality-gate failure must block the deploy chain (`docker → smoke → deploy`). Without this, the post-merge dev push for #536 produced `sonar:failure` while `docker:success` proceeded toward `smoke`/`deploy`.
 
+### Removed
+
+- `ground-control.pack-registry.security.admin-credentials`,
+  `ground-control.pack-registry.security.authentication-header`, and
+  `ground-control.pack-registry.security.token-scheme` — superseded by
+  the unified `groundcontrol.security` model (see ADR-026). Operators
+  using the old keys MUST migrate their admin token entries into
+  `groundcontrol.security.credentials` with `role: ADMIN` before
+  upgrading. The pack-signing block
+  (`ground-control.pack-registry.security.trusted-signers`) is unchanged.
+
 ### Fixed
 
 - `gc_codex_review` no longer hangs indefinitely. Three independent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- REST API access control via Spring Security (closes #243, GC-P011). All
+  `/api/v1/**` endpoints now require `Authorization: Bearer <token>` against
+  the configured `groundcontrol.security.credentials` list; admin paths
+  (`/api/v1/admin/**`, `/api/v1/embeddings/**`, `/api/v1/analysis/sweep/**`,
+  `/api/v1/pack-registry/**`) require `ROLE_ADMIN`. Optional CIDR allowlist
+  via `groundcontrol.security.ip-allowlist`. Only `/actuator/health` and
+  `/actuator/info` are anonymous; OpenAPI schema is gated by
+  `groundcontrol.security.openapi-public` (default `false`). Filter chain,
+  configuration model, and rationale documented in
+  `architecture/adrs/026-rest-api-access-control.md`. The `dev` and `test`
+  profiles ship with `groundcontrol.security.enabled=false` so local dev
+  and the existing test suite are unaffected.
+
 ### Changed
+
+- Pack registry admin authentication is now part of the unified
+  `groundcontrol.security` model. `ground-control.pack-registry.security.admin-credentials`,
+  `authentication-header`, and `token-scheme` are removed; deployments
+  must move admin entries into `groundcontrol.security.credentials` with
+  `role: ADMIN`. Pack-signing settings (`trusted-signers`) are unchanged.
+  `PackRegistryAccessGuard` no longer parses tokens — it reads the
+  authenticated principal from `SecurityContextHolder` for audit fields.
+- `ActorFilter` prefers the authenticated `SecurityContext` principal name
+  over the `X-Actor` request header. The header remains a fallback when
+  `groundcontrol.security.enabled=false` (dev/test) but can no longer
+  spoof identity in production.
 
 - `.github/workflows/ci.yml` — `docker` now `needs: [integration, verify, sonar]` instead of `[integration, verify]`. The `sonar` job is part of the gate, not informational: a quality-gate failure must block the deploy chain (`docker → smoke → deploy`). Without this, the post-merge dev push for #536 produced `sonar:failure` while `docker:success` proceeded toward `smoke`/`deploy`.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ make frontend-install   # Install Node dependencies (first time only)
 make frontend-dev       # Vite dev server on http://localhost:5173 (proxies /api to :8000)
 ```
 
+### Production Deployments
+
+The `dev` and `test` profiles disable the API access control layer for
+zero-friction local work. **Production deployments MUST configure**
+`groundcontrol.security.credentials` (and optionally
+`groundcontrol.security.ip-allowlist`) before exposing the backend
+beyond loopback. With `GC_SECURITY_ENABLED=true` and an empty credential
+list, every authenticated route returns 401. See
+[ADR-026](architecture/adrs/026-rest-api-access-control.md) and
+[`docs/deployment/DEPLOYMENT.md`](docs/deployment/DEPLOYMENT.md) for the
+full configuration reference.
+
 ### MCP Server (Claude Code)
 
 Configured in `.mcp.json`, works automatically with Claude Code. Start the

--- a/architecture/adrs/026-rest-api-access-control.md
+++ b/architecture/adrs/026-rest-api-access-control.md
@@ -1,0 +1,175 @@
+# ADR-026: REST API Access Control (GC-P011)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-03
+
+## Context
+
+Issue [#243](https://github.com/KeplerOps/Ground-Control/issues/243) (P0,
+security) documented that the Ground Control backend exposed every REST
+endpoint without authentication or authorization. Any caller who could
+reach `:8000` could create, modify, archive, import, sync, and materialize
+arbitrary data — including triggering GitHub syncs and rebuilding graph
+state. Before #243 the only access control was an in-controller bearer
+token on `/api/v1/pack-registry/**` (`PackRegistryAccessGuard`). All other
+controllers, including `RequirementController`, `ImportController`,
+`SyncController`, `GraphController`, `AnalysisController`, were reachable
+unauthenticated.
+
+GC-P011 ("Access Control", NON_FUNCTIONAL, MUST, wave 1) states:
+
+> The system shall support configurable access restrictions such that only
+> authorized users or network locations can reach the application. Access
+> policy shall be configurable without code changes.
+
+The non-localhost deployment posture (ADR-018, AWS EC2) requires the
+restriction to be enforced at the application layer; relying purely on
+network isolation, a reverse proxy, or deployment documentation is not
+sufficient.
+
+## Decision
+
+Add an application-layer access control stack centred on Spring Security.
+Configuration is driven from `groundcontrol.security.*` (a new
+`@ConfigurationProperties` bean) so policy is editable in `application.yml`
+or via `GC_SECURITY_*` environment variables — zero code change is needed
+to rotate credentials, adjust roles, or change the IP allowlist.
+
+The chain is wired by `ApiSecurityConfig` in this order:
+
+1. **`IpAllowlistFilter`** — rejects requests whose source `remoteAddr` is
+   outside any configured CIDR. Empty allowlist is opt-out (token auth
+   alone). Spring's `IpAddressMatcher` evaluates the CIDRs. The filter
+   intentionally does NOT honour `X-Forwarded-For`; in deployments behind
+   a reverse proxy, the proxy must terminate the IP gate or set the source
+   IP via `RemoteIpFilter` configured separately and explicitly.
+2. **`BearerTokenAuthFilter`** — parses `Authorization: Bearer <token>`,
+   compares against the configured credential list with `MessageDigest.isEqual`
+   for constant-time compare (mirrors the pre-existing pack-registry
+   pattern), and on match sets a `UsernamePasswordAuthenticationToken` with
+   `ROLE_USER` or `ROLE_ADMIN` in the `SecurityContext`. Tokens are never
+   logged. Wrong scheme, missing header, or bad token leaves the context
+   empty (anonymous).
+3. **Spring Security authorization** — path matrix:
+
+   | Path | Authority |
+   |------|-----------|
+   | `/actuator/health`, `/actuator/info`, `/actuator/health/**`, `/error` | anonymous |
+   | `/api/openapi.json`, `/api/docs/**`, `/v3/api-docs/**`, `/swagger-ui/**` | gated by `groundcontrol.security.openapi-public` (default `false` → authenticated) |
+   | `/api/v1/admin/**` | `ROLE_ADMIN` |
+   | `/api/v1/embeddings/**` | `ROLE_ADMIN` |
+   | `/api/v1/analysis/sweep/**` | `ROLE_ADMIN` |
+   | `/api/v1/pack-registry/**` | `ROLE_ADMIN` |
+   | Other `/api/v1/**` | authenticated (USER or ADMIN) |
+   | Anything else | denyAll |
+
+4. **`ApiAuthenticationEntryPoint` / `ApiAccessDeniedHandler`** — emit 401
+   and 403 respectively using the existing `ErrorResponse` JSON envelope so
+   wire format stays consistent with `GlobalExceptionHandler`. Underlying
+   exception messages are NOT echoed in response bodies. The 401 response
+   carries `WWW-Authenticate: Bearer`.
+
+5. **`ActorFilter`** then runs AFTER the security chain and prefers the
+   authenticated principal name over the legacy `X-Actor` header. The
+   header remains a fallback only when security is disabled (dev / test
+   profiles) so audit identity stays useful in those environments.
+
+CSRF is disabled (stateless REST API; bearer auth, no cookies). Sessions
+are stateless. Anonymous, form-login, http-basic, and logout filters are
+explicitly disabled.
+
+The pre-existing pack-registry `PackRegistryAccessGuard` is consolidated
+into this model: its only remaining responsibility is reading the
+authenticated principal name from the `SecurityContext` for audit fields.
+The legacy per-feature `groundcontrol.pack-registry.security.adminCredentials`
+list and its `authenticationHeader` / `tokenScheme` knobs are removed in
+favour of the unified `groundcontrol.security.credentials` store with
+`ROLE_ADMIN`. Pack signing remains separate
+(`groundcontrol.pack-registry.security.trustedSigners`).
+
+### Profile defaults
+
+| Profile | `groundcontrol.security.enabled` | Why |
+|---------|---------------------------------|-----|
+| default (production) | `true` | denyAll without configured credentials/allowlist |
+| `dev` | `false` | zero-friction local development |
+| `test` | `false` | existing 200+ controller tests do not need to mint tokens |
+
+Even when `enabled=false` the framework filter chain still owns request
+mapping; it just degrades to `permitAll()`. The chain is never absent —
+disabling Spring Security entirely would silently regress to the
+pre-#243 posture if the flag flipped.
+
+### Why bearer + CIDR (and not OAuth2/OIDC, mTLS, or basic auth)
+
+- The repo already uses `Authorization: Bearer <token>` in the pack-registry
+  pre-existing guard; consistent UX and one fewer auth scheme to operate.
+- "Users **or** network locations" in GC-P011 explicitly authorizes IP-based
+  gating. CIDR allowlisting fits single-tenant perimeter deployments.
+- OAuth2/OIDC would require an identity provider that does not exist for
+  the current single-operator deployment posture. It remains a valid
+  upgrade path; a future ADR can flip the auth backend without changing
+  the path matrix or the configuration namespace.
+- mTLS would push the auth boundary to the load balancer / reverse proxy
+  and create deployment friction disproportionate to the threat model.
+- HTTP Basic stores plaintext credentials in client config and provides no
+  meaningful improvement over bearer tokens.
+
+## Consequences
+
+### Positive
+
+- Every `/api/v1/**` endpoint is now authenticated by default.
+- Admin endpoints require an explicit `ROLE_ADMIN` principal.
+- Operators can rotate credentials and adjust the IP allowlist via env
+  vars or yaml — no code change, no rebuild, just a restart.
+- Pack registry admin auth is now part of the same surface as the rest of
+  the API; no second credential store to manage.
+- `ActorFilter` audit identity tracks the authenticated principal, so
+  audit logs are no longer trivially spoofable via the `X-Actor` header
+  in production.
+
+### Negative / require operator attention
+
+- **Breaking change for any caller of `/api/v1/**`**: production
+  deployments MUST configure `groundcontrol.security.credentials` (and/or
+  `ip-allowlist`) before upgrading. With `enabled=true` and an empty
+  credential list, every authenticated route returns 401.
+- **Pack registry admin credentials migrate**: deployments that were using
+  `ground-control.pack-registry.security.admin-credentials` must move
+  those entries into `groundcontrol.security.credentials` with
+  `role: ADMIN`. The old keys are removed; misconfiguration surfaces at
+  startup.
+- The `X-Actor` header is no longer a self-service identity claim; it is
+  ignored when an authenticated principal is in scope.
+
+## Alternatives considered
+
+- **OAuth2/OIDC via Spring Authorization Server or an external IdP** —
+  superior identity model but requires deploying an IdP. Deferred until
+  the deployment topology grows beyond a single operator.
+- **mTLS with client certs at the load balancer** — strong but creates
+  certificate-management overhead disproportionate to the current threat
+  model.
+- **Per-controller `@PreAuthorize` annotations only** — rejected; spreads
+  authorization logic across 35+ controllers (codex preflight flagged
+  this as the primary anti-pattern to avoid). The path-matrix approach
+  keeps the policy in one place.
+- **Network isolation only (no application-layer auth)** — explicitly
+  rejected by GC-P011 ("only authorized **users** or network locations")
+  and by codex preflight ("do not rely on deployment documentation,
+  reverse-proxy examples, or agent/user hooks as the only enforcement
+  layer for non-localhost deployments").
+
+## References
+
+- Issue [#243](https://github.com/KeplerOps/Ground-Control/issues/243)
+- GC-P011 (Access Control)
+- ADR-018 (AWS EC2 Deployment)
+- `backend/src/main/java/com/keplerops/groundcontrol/shared/security/`
+- `backend/src/test/java/com/keplerops/groundcontrol/integration/ApiSecurityIntegrationTest.java`

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-security")
 
     // Audit trail
     implementation("org.springframework.data:spring-data-envers")
@@ -68,6 +69,7 @@ dependencies {
 
     // Testing
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // jqwik property-based testing

--- a/backend/config/spotbugs/exclusions.xml
+++ b/backend/config/spotbugs/exclusions.xml
@@ -61,6 +61,14 @@
         <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
     </Match>
 
+    <!-- ActorFilter constructor resolves SecurityProperties via ObjectProvider.getIfAvailable;
+         that call propagates BeansException on a misconfigured context, which is the desired
+         fail-fast behavior. CT_CONSTRUCTOR_THROW would otherwise flag the indirect throw. -->
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.web.ActorFilter" />
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
+
     <!-- Spring Security filters and HTTP handlers store the injected SecurityProperties /
          ObjectMapper bean by reference — that is the standard Spring DI pattern. -->
     <Match>

--- a/backend/config/spotbugs/exclusions.xml
+++ b/backend/config/spotbugs/exclusions.xml
@@ -37,6 +37,13 @@
         <Bug pattern="EI_EXPOSE_REP2" />
     </Match>
 
+    <!-- Spring-managed shared components (security filters, properties, web) store
+         injected dependencies and expose @ConfigurationProperties lists by design. -->
+    <Match>
+        <Package name="~com\.keplerops\.groundcontrol\.shared\..*" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
     <!-- Constructors that validate inputs and throw are by-design -->
     <Match>
         <Package name="~com\.keplerops\.groundcontrol\.domain\.exception" />

--- a/backend/config/spotbugs/exclusions.xml
+++ b/backend/config/spotbugs/exclusions.xml
@@ -37,11 +37,47 @@
         <Bug pattern="EI_EXPOSE_REP2" />
     </Match>
 
-    <!-- Spring-managed shared components (security filters, properties, web) store
-         injected dependencies and expose @ConfigurationProperties lists by design. -->
+    <!-- ErrorResponse is a JSON envelope record that carries a Map<String, Object> detail
+         block. The Map ref is exposed via the record accessor by design — same as the
+         api/* records that were already excluded. -->
     <Match>
-        <Package name="~com\.keplerops\.groundcontrol\.shared\..*" />
+        <Class name="com.keplerops.groundcontrol.shared.web.ErrorResponse" />
         <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.web.ErrorResponse$ErrorBody" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- @ConfigurationProperties POJO returns/accepts a mutable list by design — Spring's
+         relaxed binding requires the live list during binding. EI_EXPOSE_REP applies to the
+         outer class and the nested ApiCredential record-style class. -->
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.security.SecurityProperties" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.security.SecurityProperties$ApiCredential" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
+    <!-- Spring Security filters and HTTP handlers store the injected SecurityProperties /
+         ObjectMapper bean by reference — that is the standard Spring DI pattern. -->
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.security.BearerTokenAuthFilter" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.security.IpAllowlistFilter" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.security.ApiAuthenticationEntryPoint" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.security.ApiAccessDeniedHandler" />
+        <Bug pattern="EI_EXPOSE_REP2" />
     </Match>
 
     <!-- Constructors that validate inputs and throw are by-design -->

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.GroundControlException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.shared.web.ErrorResponse;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackInstallRecordController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackInstallRecordController.java
@@ -4,7 +4,6 @@ import com.keplerops.groundcontrol.domain.packregistry.service.InstallPackComman
 import com.keplerops.groundcontrol.domain.packregistry.service.PackInstallOrchestrator;
 import com.keplerops.groundcontrol.domain.packregistry.state.InstallOutcome;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -35,10 +34,8 @@ public class PackInstallRecordController {
 
     @PostMapping("/install")
     public ResponseEntity<PackInstallRecordResponse> install(
-            @Valid @RequestBody InstallPackRequest request,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        var performedBy = accessGuard.requireAdminActor(httpRequest);
+            @Valid @RequestBody InstallPackRequest request, @RequestParam(required = false) String project) {
+        var performedBy = accessGuard.requireAdminActor();
         var projectId = projectService.resolveProjectId(project);
         var result = orchestrator.installPack(
                 new InstallPackCommand(projectId, request.packId(), request.versionConstraint(), performedBy));
@@ -49,10 +46,8 @@ public class PackInstallRecordController {
 
     @PostMapping("/upgrade")
     public ResponseEntity<PackInstallRecordResponse> upgrade(
-            @Valid @RequestBody InstallPackRequest request,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        var performedBy = accessGuard.requireAdminActor(httpRequest);
+            @Valid @RequestBody InstallPackRequest request, @RequestParam(required = false) String project) {
+        var performedBy = accessGuard.requireAdminActor();
         var projectId = projectService.resolveProjectId(project);
         var result = orchestrator.upgradePack(
                 new InstallPackCommand(projectId, request.packId(), request.versionConstraint(), performedBy));
@@ -63,10 +58,8 @@ public class PackInstallRecordController {
 
     @GetMapping
     public List<PackInstallRecordResponse> list(
-            @RequestParam(required = false) String project,
-            @RequestParam(required = false) String packId,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @RequestParam(required = false) String project, @RequestParam(required = false) String packId) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.resolveProjectId(project);
         var records = packId != null
                 ? orchestrator.listInstallRecords(projectId, packId)
@@ -75,8 +68,8 @@ public class PackInstallRecordController {
     }
 
     @GetMapping("/{id}")
-    public PackInstallRecordResponse get(@PathVariable UUID id, HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+    public PackInstallRecordResponse get(@PathVariable UUID id) {
+        accessGuard.requireAdminActor();
         return PackInstallRecordResponse.from(orchestrator.getInstallRecord(id));
     }
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackRegistryAccessGuard.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackRegistryAccessGuard.java
@@ -1,60 +1,49 @@
 package com.keplerops.groundcontrol.api.packregistry;
 
 import com.keplerops.groundcontrol.domain.exception.AuthenticationException;
-import com.keplerops.groundcontrol.domain.packregistry.service.PackRegistrySecurityProperties;
-import jakarta.servlet.http.HttpServletRequest;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+/**
+ * Returns the authenticated admin principal name for pack-registry audit fields.
+ *
+ * <p>The actual authentication and {@code ROLE_ADMIN} authorization are performed by
+ * {@link com.keplerops.groundcontrol.shared.security.ApiSecurityConfig} earlier in the filter
+ * chain. This guard exists only to bridge from Spring Security's {@link SecurityContextHolder} to
+ * the controller's audit identity, and to fail closed if security has been bypassed (for example
+ * in dev profile) without a valid admin principal in scope.
+ */
 @Component
 public class PackRegistryAccessGuard {
 
-    private final PackRegistrySecurityProperties securityProperties;
+    private static final String ADMIN_AUTHORITY = "ROLE_ADMIN";
 
-    public PackRegistryAccessGuard(PackRegistrySecurityProperties securityProperties) {
-        this.securityProperties = securityProperties;
+    /*@ ensures \result != null && !\result.isBlank(); @*/
+    public String requireAdminActor() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new AuthenticationException("Pack registry admin authentication is required");
+        }
+        String name = auth.getName();
+        if (name == null || name.isBlank()) {
+            throw new AuthenticationException("Pack registry admin authentication is required");
+        }
+        if (!hasAdminAuthority(auth)) {
+            throw new AuthenticationException("Pack registry endpoints require the admin role");
+        }
+        return name;
     }
 
-    /*@ requires request != null;
-    @ ensures \result != null; @*/
-    public String requireAdminActor(HttpServletRequest request) {
-        if (securityProperties.getAdminCredentials().isEmpty()) {
-            throw new AuthenticationException("Pack registry admin authentication is not configured");
-        }
-
-        var headerValue = request.getHeader(securityProperties.getAuthenticationHeader());
-        if (headerValue == null || headerValue.isBlank()) {
-            throw new AuthenticationException("Pack registry admin credentials are required");
-        }
-
-        var expectedScheme = securityProperties.getTokenScheme();
-        var prefix = expectedScheme + " ";
-        if (!headerValue.regionMatches(true, 0, prefix, 0, prefix.length())) {
-            throw new AuthenticationException(
-                    "Pack registry admin credentials must use the " + expectedScheme + " scheme");
-        }
-
-        var token = headerValue.substring(prefix.length()).trim();
-        if (token.isEmpty()) {
-            throw new AuthenticationException("Pack registry admin token is missing");
-        }
-
-        for (var credential : securityProperties.getAdminCredentials()) {
-            if (!hasText(credential.getPrincipalName()) || !hasText(credential.getToken())) {
-                continue;
-            }
-            if (MessageDigest.isEqual(
-                    token.getBytes(StandardCharsets.UTF_8),
-                    credential.getToken().getBytes(StandardCharsets.UTF_8))) {
-                return credential.getPrincipalName().trim();
+    /*@ requires auth != null;
+    @ pure @*/
+    private static boolean hasAdminAuthority(Authentication auth) {
+        for (GrantedAuthority granted : auth.getAuthorities()) {
+            if (ADMIN_AUTHORITY.equals(granted.getAuthority())) {
+                return true;
             }
         }
-
-        throw new AuthenticationException("Invalid pack registry admin token");
-    }
-
-    private boolean hasText(String value) {
-        return value != null && !value.isBlank();
+        return false;
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackRegistryAccessGuard.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackRegistryAccessGuard.java
@@ -1,6 +1,8 @@
 package com.keplerops.groundcontrol.api.packregistry;
 
+import com.keplerops.groundcontrol.domain.audit.ActorHolder;
 import com.keplerops.groundcontrol.domain.exception.AuthenticationException;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,6 +16,12 @@ import org.springframework.stereotype.Component;
  * chain. This guard exists only to bridge from Spring Security's {@link SecurityContextHolder} to
  * the controller's audit identity, and to fail closed if security has been bypassed (for example
  * in dev profile) without a valid admin principal in scope.
+ *
+ * <p>When {@code groundcontrol.security.enabled=false} (dev/test profile), the security chain
+ * does not populate the SecurityContext. The guard then falls back to {@link ActorHolder}, which
+ * {@code ActorFilter} populates from the {@code X-Actor} request header (or {@code "anonymous"}
+ * if absent). This keeps the local pack registry usable without forcing operators to mint admin
+ * tokens just to develop, while production (security enabled) still enforces ROLE_ADMIN.
  */
 @Component
 @SuppressWarnings("java:S125") // JML block comments (/*@ ... @*/) are contracts, not commented-out code
@@ -21,8 +29,18 @@ public class PackRegistryAccessGuard {
 
     private static final String ADMIN_AUTHORITY = "ROLE_ADMIN";
 
+    private final SecurityProperties securityProperties;
+
+    public PackRegistryAccessGuard(SecurityProperties securityProperties) {
+        this.securityProperties = securityProperties;
+    }
+
     /*@ ensures \result != null && !\result.isBlank(); @*/
     public String requireAdminActor() {
+        if (!securityProperties.isEnabled()) {
+            String actor = ActorHolder.get();
+            return actor != null && !actor.isBlank() ? actor : "anonymous";
+        }
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !auth.isAuthenticated()) {
             throw new AuthenticationException("Pack registry admin authentication is required");

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackRegistryAccessGuard.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackRegistryAccessGuard.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
  * in dev profile) without a valid admin principal in scope.
  */
 @Component
+@SuppressWarnings("java:S125") // JML block comments (/*@ ... @*/) are contracts, not commented-out code
 public class PackRegistryAccessGuard {
 
     private static final String ADMIN_AUTHORITY = "ROLE_ADMIN";

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackRegistryController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/PackRegistryController.java
@@ -13,7 +13,6 @@ import com.keplerops.groundcontrol.domain.packregistry.service.RegisterPackComma
 import com.keplerops.groundcontrol.domain.packregistry.service.UpdatePackRegistryEntryCommand;
 import com.keplerops.groundcontrol.domain.packregistry.state.PackType;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import java.util.List;
@@ -58,10 +57,8 @@ public class PackRegistryController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public PackRegistryEntryResponse register(
-            @Valid @RequestBody RegisterPackRequest request,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @Valid @RequestBody RegisterPackRequest request, @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.resolveProjectId(project);
         var result = registryService.registerEntry(new RegisterPackCommand(
                 projectId,
@@ -86,9 +83,8 @@ public class PackRegistryController {
     public PackRegistryEntryResponse importEntry(
             @RequestPart("file") MultipartFile file,
             @Valid @RequestPart(value = "options", required = false) PackRegistryImportRequest request,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.resolveProjectId(project);
         var bytes = readFileBytes(file);
         var filename = file.getOriginalFilename() != null ? file.getOriginalFilename() : "import.json";
@@ -105,10 +101,8 @@ public class PackRegistryController {
 
     @GetMapping
     public List<PackRegistryEntryResponse> list(
-            @RequestParam(required = false) String project,
-            @RequestParam(required = false) PackType packType,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @RequestParam(required = false) String project, @RequestParam(required = false) PackType packType) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.resolveProjectId(project);
         var entries = packType != null
                 ? registryService.listEntries(projectId, packType)
@@ -118,10 +112,8 @@ public class PackRegistryController {
 
     @GetMapping("/{packId}")
     public List<PackRegistryEntryResponse> listVersions(
-            @PathVariable String packId,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @PathVariable String packId, @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.requireProjectId(project);
         return registryService.listVersions(projectId, packId).stream()
                 .map(PackRegistryEntryResponse::from)
@@ -130,11 +122,8 @@ public class PackRegistryController {
 
     @GetMapping("/{packId}/{version}")
     public PackRegistryEntryResponse getEntry(
-            @PathVariable String packId,
-            @PathVariable String version,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @PathVariable String packId, @PathVariable String version, @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.requireProjectId(project);
         return PackRegistryEntryResponse.from(registryService.findEntry(projectId, packId, version));
     }
@@ -144,9 +133,8 @@ public class PackRegistryController {
             @PathVariable String packId,
             @PathVariable String version,
             @Valid @RequestBody UpdatePackRegistryEntryRequest request,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.requireProjectId(project);
         var result = registryService.updateEntry(
                 projectId,
@@ -170,11 +158,8 @@ public class PackRegistryController {
 
     @PutMapping("/{packId}/{version}/withdraw")
     public PackRegistryEntryResponse withdraw(
-            @PathVariable String packId,
-            @PathVariable String version,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @PathVariable String packId, @PathVariable String version, @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.requireProjectId(project);
         return PackRegistryEntryResponse.from(registryService.withdrawEntry(projectId, packId, version));
     }
@@ -182,21 +167,16 @@ public class PackRegistryController {
     @DeleteMapping("/{packId}/{version}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteEntry(
-            @PathVariable String packId,
-            @PathVariable String version,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @PathVariable String packId, @PathVariable String version, @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.requireProjectId(project);
         registryService.deleteEntry(projectId, packId, version);
     }
 
     @PostMapping("/resolve")
     public ResolvedPackResponse resolve(
-            @Valid @RequestBody ResolvePackRequest request,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @Valid @RequestBody ResolvePackRequest request, @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.requireProjectId(project);
         var resolved = packResolver.resolve(projectId, request.packId(), request.versionConstraint());
         var compatible = packResolver.checkCompatibility(resolved);
@@ -205,10 +185,8 @@ public class PackRegistryController {
 
     @PostMapping("/check-compatibility")
     public CompatibilityCheckResponse checkCompatibility(
-            @Valid @RequestBody ResolvePackRequest request,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @Valid @RequestBody ResolvePackRequest request, @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.requireProjectId(project);
         var resolved = packResolver.resolve(projectId, request.packId(), request.versionConstraint());
         var compatible = packResolver.checkCompatibility(resolved);

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/TrustPolicyController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/packregistry/TrustPolicyController.java
@@ -4,7 +4,6 @@ import com.keplerops.groundcontrol.domain.packregistry.service.CreateTrustPolicy
 import com.keplerops.groundcontrol.domain.packregistry.service.TrustPolicyService;
 import com.keplerops.groundcontrol.domain.packregistry.service.UpdateTrustPolicyCommand;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -38,10 +37,8 @@ public class TrustPolicyController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public TrustPolicyResponse create(
-            @Valid @RequestBody CreateTrustPolicyRequest request,
-            @RequestParam(required = false) String project,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+            @Valid @RequestBody CreateTrustPolicyRequest request, @RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.resolveProjectId(project);
         var result = trustPolicyService.create(new CreateTrustPolicyCommand(
                 projectId,
@@ -55,9 +52,8 @@ public class TrustPolicyController {
     }
 
     @GetMapping
-    public List<TrustPolicyResponse> list(
-            @RequestParam(required = false) String project, HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+    public List<TrustPolicyResponse> list(@RequestParam(required = false) String project) {
+        accessGuard.requireAdminActor();
         var projectId = projectService.resolveProjectId(project);
         return trustPolicyService.list(projectId).stream()
                 .map(TrustPolicyResponse::from)
@@ -65,17 +61,14 @@ public class TrustPolicyController {
     }
 
     @GetMapping("/{id}")
-    public TrustPolicyResponse get(@PathVariable UUID id, HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+    public TrustPolicyResponse get(@PathVariable UUID id) {
+        accessGuard.requireAdminActor();
         return TrustPolicyResponse.from(trustPolicyService.get(id));
     }
 
     @PutMapping("/{id}")
-    public TrustPolicyResponse update(
-            @PathVariable UUID id,
-            @Valid @RequestBody UpdateTrustPolicyRequest request,
-            HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+    public TrustPolicyResponse update(@PathVariable UUID id, @Valid @RequestBody UpdateTrustPolicyRequest request) {
+        accessGuard.requireAdminActor();
         var result = trustPolicyService.update(
                 id,
                 new UpdateTrustPolicyCommand(
@@ -90,8 +83,8 @@ public class TrustPolicyController {
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable UUID id, HttpServletRequest httpRequest) {
-        accessGuard.requireAdminActor(httpRequest);
+    public void delete(@PathVariable UUID id) {
+        accessGuard.requireAdminActor();
         trustPolicyService.delete(id);
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/packregistry/service/PackRegistrySecurityProperties.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/packregistry/service/PackRegistrySecurityProperties.java
@@ -10,7 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * tokens); this properties class only carries the list of trusted signers used by
  * {@link PackIntegrityVerifier} to validate signed pack imports.
  */
-@ConfigurationProperties(prefix = "ground-control.pack-registry.security")
+@ConfigurationProperties(prefix = "ground-control.pack-registry.security", ignoreUnknownFields = false)
 public class PackRegistrySecurityProperties {
 
     private List<TrustedSigner> trustedSigners = new ArrayList<>();

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/packregistry/service/PackRegistrySecurityProperties.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/packregistry/service/PackRegistrySecurityProperties.java
@@ -4,37 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * Pack registry signing configuration. Admin authentication for pack registry endpoints is now
+ * handled by the unified {@code groundcontrol.security} layer (Spring Security with bearer
+ * tokens); this properties class only carries the list of trusted signers used by
+ * {@link PackIntegrityVerifier} to validate signed pack imports.
+ */
 @ConfigurationProperties(prefix = "ground-control.pack-registry.security")
 public class PackRegistrySecurityProperties {
 
-    private String authenticationHeader = "Authorization";
-    private String tokenScheme = "Bearer";
-    private List<AdminCredential> adminCredentials = new ArrayList<>();
     private List<TrustedSigner> trustedSigners = new ArrayList<>();
-
-    public String getAuthenticationHeader() {
-        return authenticationHeader;
-    }
-
-    public void setAuthenticationHeader(String authenticationHeader) {
-        this.authenticationHeader = authenticationHeader;
-    }
-
-    public String getTokenScheme() {
-        return tokenScheme;
-    }
-
-    public void setTokenScheme(String tokenScheme) {
-        this.tokenScheme = tokenScheme;
-    }
-
-    public List<AdminCredential> getAdminCredentials() {
-        return adminCredentials;
-    }
-
-    public void setAdminCredentials(List<AdminCredential> adminCredentials) {
-        this.adminCredentials = adminCredentials != null ? adminCredentials : new ArrayList<>();
-    }
 
     public List<TrustedSigner> getTrustedSigners() {
         return trustedSigners;
@@ -42,28 +21,6 @@ public class PackRegistrySecurityProperties {
 
     public void setTrustedSigners(List<TrustedSigner> trustedSigners) {
         this.trustedSigners = trustedSigners != null ? trustedSigners : new ArrayList<>();
-    }
-
-    public static class AdminCredential {
-
-        private String principalName;
-        private String token;
-
-        public String getPrincipalName() {
-            return principalName;
-        }
-
-        public void setPrincipalName(String principalName) {
-            this.principalName = principalName;
-        }
-
-        public String getToken() {
-            return token;
-        }
-
-        public void setToken(String token) {
-            this.token = token;
-        }
     }
 
     public static class TrustedSigner {

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiAccessDeniedHandler.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keplerops.groundcontrol.api.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+/**
+ * Emits a 403 with the standard {@link ErrorResponse} envelope when an authenticated caller is
+ * missing the required role. Never echoes the underlying exception message.
+ */
+public class ApiAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final String STABLE_MESSAGE = "You do not have permission to access this resource";
+
+    private final ObjectMapper objectMapper;
+
+    public ApiAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException ex)
+            throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        var body = ErrorResponse.of("access_denied", STABLE_MESSAGE);
+        objectMapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiAccessDeniedHandler.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiAccessDeniedHandler.java
@@ -1,7 +1,7 @@
 package com.keplerops.groundcontrol.shared.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.keplerops.groundcontrol.api.ErrorResponse;
+import com.keplerops.groundcontrol.shared.web.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keplerops.groundcontrol.api.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+/**
+ * Emits a 401 with the standard {@link ErrorResponse} envelope when an unauthenticated request
+ * hits a protected route. Sends {@code WWW-Authenticate: Bearer} so spec-compliant clients know
+ * which scheme to use. Never echoes the underlying exception message — that can leak internals.
+ */
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final String STABLE_MESSAGE = "Authentication is required to access this resource";
+
+    private final ObjectMapper objectMapper;
+
+    public ApiAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authEx)
+            throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer");
+        var body = ErrorResponse.of("authentication_required", STABLE_MESSAGE);
+        objectMapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiAuthenticationEntryPoint.java
@@ -1,7 +1,7 @@
 package com.keplerops.groundcontrol.shared.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.keplerops.groundcontrol.api.ErrorResponse;
+import com.keplerops.groundcontrol.shared.web.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
@@ -26,6 +26,8 @@ import org.springframework.security.web.access.intercept.AuthorizationFilter;
 @EnableConfigurationProperties(SecurityProperties.class)
 public class ApiSecurityConfig {
 
+    private static final String ROLE_ADMIN = "ADMIN";
+
     @Bean
     public BearerTokenAuthFilter bearerTokenAuthFilter(SecurityProperties properties) {
         return new BearerTokenAuthFilter(properties);
@@ -55,6 +57,13 @@ public class ApiSecurityConfig {
             ApiAuthenticationEntryPoint authenticationEntryPoint,
             ApiAccessDeniedHandler accessDeniedHandler)
             throws Exception {
+        // CSRF is disabled by design: this is a stateless REST API authenticated by
+        // Authorization: Bearer <token>. There are no session cookies, no form-login
+        // flow, and no logout endpoint — the three things a CSRF attack relies on to
+        // ride a user's authenticated session. Bearer tokens are explicit per request,
+        // so a malicious cross-origin page cannot trigger an authenticated call from a
+        // signed-in browser. ADR-026 documents this; do not re-enable CSRF without
+        // simultaneously moving to cookie-based sessions and re-evaluating the model.
         http.csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.disable())
                 .formLogin(form -> form.disable())
@@ -95,13 +104,13 @@ public class ApiSecurityConfig {
                         .authenticated();
             }
             auth.requestMatchers("/api/v1/admin/**")
-                    .hasRole("ADMIN")
+                    .hasRole(ROLE_ADMIN)
                     .requestMatchers("/api/v1/embeddings/**")
-                    .hasRole("ADMIN")
+                    .hasRole(ROLE_ADMIN)
                     .requestMatchers("/api/v1/analysis/sweep/**")
-                    .hasRole("ADMIN")
+                    .hasRole(ROLE_ADMIN)
                     .requestMatchers("/api/v1/pack-registry/**")
-                    .hasRole("ADMIN")
+                    .hasRole(ROLE_ADMIN)
                     .requestMatchers("/api/v1/**")
                     .authenticated()
                     .anyRequest()

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
@@ -1,0 +1,113 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+
+/**
+ * Wires the API access control filter chain.
+ *
+ * <p>When {@code groundcontrol.security.enabled=true}, the chain runs IP allowlist → bearer token
+ * authn → Spring Security authorization, with the path matrix set up so {@code /api/v1/admin/**}
+ * and the privileged subpaths require {@code ROLE_ADMIN}, the rest of {@code /api/v1/**} requires
+ * authentication, and only health/info actuator probes are anonymous.
+ *
+ * <p>When disabled, the chain still owns request mapping but every path is permitAll — the same
+ * Spring Security framework object stays in charge so behavior never silently degrades.
+ */
+@Configuration
+@EnableWebSecurity
+@EnableConfigurationProperties(SecurityProperties.class)
+public class ApiSecurityConfig {
+
+    @Bean
+    public BearerTokenAuthFilter bearerTokenAuthFilter(SecurityProperties properties) {
+        return new BearerTokenAuthFilter(properties);
+    }
+
+    @Bean
+    public IpAllowlistFilter ipAllowlistFilter(SecurityProperties properties, ObjectMapper objectMapper) {
+        return new IpAllowlistFilter(properties, objectMapper);
+    }
+
+    @Bean
+    public ApiAuthenticationEntryPoint apiAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        return new ApiAuthenticationEntryPoint(objectMapper);
+    }
+
+    @Bean
+    public ApiAccessDeniedHandler apiAccessDeniedHandler(ObjectMapper objectMapper) {
+        return new ApiAccessDeniedHandler(objectMapper);
+    }
+
+    @Bean
+    public SecurityFilterChain apiSecurityFilterChain(
+            HttpSecurity http,
+            SecurityProperties properties,
+            BearerTokenAuthFilter bearerTokenAuthFilter,
+            IpAllowlistFilter ipAllowlistFilter,
+            ApiAuthenticationEntryPoint authenticationEntryPoint,
+            ApiAccessDeniedHandler accessDeniedHandler)
+            throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .logout(logout -> logout.disable())
+                .anonymous(anon -> anon.disable())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(ipAllowlistFilter, AuthorizationFilter.class)
+                .addFilterBefore(bearerTokenAuthFilter, AuthorizationFilter.class)
+                .exceptionHandling(ex ->
+                        ex.authenticationEntryPoint(authenticationEntryPoint).accessDeniedHandler(accessDeniedHandler));
+
+        if (!properties.isEnabled()) {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+            return http.build();
+        }
+
+        http.authorizeHttpRequests(auth -> {
+            auth.requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info")
+                    .permitAll()
+                    .requestMatchers("/error")
+                    .permitAll();
+            if (properties.isOpenapiPublic()) {
+                auth.requestMatchers(
+                                "/api/openapi.json",
+                                "/api/docs/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html")
+                        .permitAll();
+            } else {
+                auth.requestMatchers(
+                                "/api/openapi.json",
+                                "/api/docs/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html")
+                        .authenticated();
+            }
+            auth.requestMatchers("/api/v1/admin/**")
+                    .hasRole("ADMIN")
+                    .requestMatchers("/api/v1/embeddings/**")
+                    .hasRole("ADMIN")
+                    .requestMatchers("/api/v1/analysis/sweep/**")
+                    .hasRole("ADMIN")
+                    .requestMatchers("/api/v1/pack-registry/**")
+                    .hasRole("ADMIN")
+                    .requestMatchers("/api/v1/**")
+                    .authenticated()
+                    .anyRequest()
+                    .denyAll();
+        });
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -65,7 +66,10 @@ public class ApiSecurityConfig {
         // signed-in browser. ADR-026 documents this; do not re-enable CSRF without
         // simultaneously moving to cookie-based sessions and re-evaluating the model.
         http.csrf(csrf -> csrf.disable())
-                .cors(cors -> cors.disable())
+                // Use Spring Security's CORS support so the registered MVC CorsConfigurationSource
+                // is honored on preflight requests. With cors.disable() preflight OPTIONS calls hit
+                // the security chain before MVC and would be rejected for protected routes.
+                .cors(Customizer.withDefaults())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
                 .logout(logout -> logout.disable())
@@ -111,10 +115,21 @@ public class ApiSecurityConfig {
                     .hasRole(ROLE_ADMIN)
                     .requestMatchers("/api/v1/pack-registry/**")
                     .hasRole(ROLE_ADMIN)
+                    .requestMatchers("/api/v1/trust-policies/**")
+                    .hasRole(ROLE_ADMIN)
+                    .requestMatchers("/api/v1/pack-install-records/**")
+                    .hasRole(ROLE_ADMIN)
                     .requestMatchers("/api/v1/**")
                     .authenticated()
+                    .requestMatchers("/actuator/**")
+                    .denyAll()
+                    // SPA static assets and client-side routes (anything not under /api or
+                    // /actuator) are served anonymously — without an auth token the API calls
+                    // they make will return 401, but the shell HTML/CSS/JS must load so a
+                    // login UI can render. The SpaController forwards non-API routes to
+                    // index.html; static resources are served from the classpath.
                     .anyRequest()
-                    .denyAll();
+                    .permitAll();
         });
 
         return http.build();

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
@@ -2,6 +2,7 @@ package com.keplerops.groundcontrol.shared.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -39,6 +40,30 @@ public class ApiSecurityConfig {
     @Bean
     public IpAllowlistFilter ipAllowlistFilter(SecurityProperties properties, ObjectMapper objectMapper) {
         return new IpAllowlistFilter(properties, objectMapper);
+    }
+
+    /**
+     * Spring Boot auto-registers any {@link jakarta.servlet.Filter} bean with the servlet
+     * container. Both filters above are also wired into the {@link SecurityFilterChain} below;
+     * leaving servlet auto-registration on would run them twice (once outside the security
+     * chain). Disabling auto-registration keeps the filters scoped to the chain only.
+     */
+    @Bean
+    public FilterRegistrationBean<BearerTokenAuthFilter> bearerTokenAuthFilterRegistration(
+            BearerTokenAuthFilter filter) {
+        return disableServletAutoRegistration(filter);
+    }
+
+    @Bean
+    public FilterRegistrationBean<IpAllowlistFilter> ipAllowlistFilterRegistration(IpAllowlistFilter filter) {
+        return disableServletAutoRegistration(filter);
+    }
+
+    private static <F extends jakarta.servlet.Filter> FilterRegistrationBean<F> disableServletAutoRegistration(
+            F filter) {
+        var registration = new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
     }
 
     @Bean

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 
 /**
  * Wires the API access control filter chain.
@@ -123,13 +125,29 @@ public class ApiSecurityConfig {
                     .authenticated()
                     .requestMatchers("/actuator/**")
                     .denyAll()
-                    // SPA static assets and client-side routes (anything not under /api or
-                    // /actuator) are served anonymously — without an auth token the API calls
-                    // they make will return 401, but the shell HTML/CSS/JS must load so a
-                    // login UI can render. The SpaController forwards non-API routes to
-                    // index.html; static resources are served from the classpath.
+                    // SPA static assets and client-side routes are anonymous so the React
+                    // shell loads (the API calls it then makes still require a token, returning
+                    // 401 to drive the login UI). Permit only known static asset paths and a
+                    // strict GET regex that mirrors SpaController's pattern (no dot in any
+                    // segment, first segment not /api or /actuator). Anything outside that
+                    // narrow allowlist is denyAll, so a future controller mounted outside the
+                    // documented matrix is fail-closed.
+                    .requestMatchers(
+                            HttpMethod.GET,
+                            "/",
+                            "/index.html",
+                            "/favicon.ico",
+                            "/favicon.svg",
+                            "/manifest.json",
+                            "/robots.txt",
+                            "/assets/**",
+                            "/static/**")
+                    .permitAll()
+                    .requestMatchers(RegexRequestMatcher.regexMatcher(
+                            HttpMethod.GET, "^/(?!api/|api$|actuator/|actuator$)[^.]+$"))
+                    .permitAll()
                     .anyRequest()
-                    .permitAll();
+                    .denyAll();
         });
 
         return http.build();

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BearerTokenAuthFilter.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BearerTokenAuthFilter.java
@@ -1,0 +1,85 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.ApiCredential;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Authenticates callers with {@code Authorization: Bearer <token>} against the configured
+ * credential list. On match, sets a {@link UsernamePasswordAuthenticationToken} in the
+ * SecurityContext with {@code ROLE_USER} or {@code ROLE_ADMIN}.
+ *
+ * <p>Constant-time token compare via {@link MessageDigest#isEqual} mirrors the existing pack
+ * registry guard convention. Tokens are never logged.
+ */
+public class BearerTokenAuthFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final SecurityProperties properties;
+
+    public BearerTokenAuthFilter(SecurityProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        if (!properties.isEnabled()) {
+            chain.doFilter(request, response);
+            return;
+        }
+        String header = request.getHeader(AUTHORIZATION_HEADER);
+        String token = extractToken(header);
+        if (token != null) {
+            ApiCredential matched = findMatch(properties.getCredentials(), token);
+            if (matched != null) {
+                var authority =
+                        new SimpleGrantedAuthority("ROLE_" + matched.getRole().name());
+                var auth = UsernamePasswordAuthenticationToken.authenticated(
+                        matched.getPrincipalName(), null, List.of(authority));
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    /*@ pure @*/
+    private static String extractToken(String headerValue) {
+        if (headerValue == null) {
+            return null;
+        }
+        if (!headerValue.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+            return null;
+        }
+        String token = headerValue.substring(BEARER_PREFIX.length()).trim();
+        return token.isEmpty() ? null : token;
+    }
+
+    /*@ requires credentials != null && presented != null;
+    @ pure @*/
+    private static ApiCredential findMatch(List<ApiCredential> credentials, String presented) {
+        byte[] presentedBytes = presented.getBytes(StandardCharsets.UTF_8);
+        ApiCredential match = null;
+        for (var cred : credentials) {
+            byte[] storedBytes = cred.getToken().getBytes(StandardCharsets.UTF_8);
+            if (MessageDigest.isEqual(presentedBytes, storedBytes)) {
+                match = cred;
+            }
+        }
+        return match;
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BearerTokenAuthFilter.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BearerTokenAuthFilter.java
@@ -23,6 +23,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * <p>Constant-time token compare via {@link MessageDigest#isEqual} mirrors the existing pack
  * registry guard convention. Tokens are never logged.
  */
+@SuppressWarnings("java:S125") // JML block comments (/*@ ... @*/) are contracts, not commented-out code
 public class BearerTokenAuthFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/IpAllowlistFilter.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/IpAllowlistFilter.java
@@ -1,0 +1,88 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keplerops.groundcontrol.api.ErrorResponse;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.util.matcher.IpAddressMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Rejects requests whose source address is outside the configured CIDR allowlist.
+ *
+ * <p>An empty allowlist is a pass-through — IP filtering is opt-in. Only the connection's
+ * {@code remoteAddr} is consulted; X-Forwarded-For is intentionally NOT trusted, since trusting
+ * client-supplied headers without a configured proxy would let attackers bypass the gate.
+ */
+public class IpAllowlistFilter extends OncePerRequestFilter {
+
+    private final SecurityProperties properties;
+    private final ObjectMapper objectMapper;
+    private List<IpAddressMatcher> matchers = List.of();
+
+    public IpAllowlistFilter(SecurityProperties properties, ObjectMapper objectMapper) {
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    @PostConstruct
+    public void compile() {
+        var compiled =
+                new ArrayList<IpAddressMatcher>(properties.getIpAllowlist().size());
+        for (String cidr : properties.getIpAllowlist()) {
+            if (cidr == null || cidr.isBlank()) {
+                throw new IllegalStateException(
+                        "groundcontrol.security.ipAllowlist contains a blank entry; remove it or supply a CIDR");
+            }
+            try {
+                compiled.add(new IpAddressMatcher(cidr));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalStateException(
+                        "groundcontrol.security.ipAllowlist contains an invalid CIDR: " + cidr, ex);
+            }
+        }
+        this.matchers = List.copyOf(compiled);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        if (!properties.isEnabled() || matchers.isEmpty()) {
+            chain.doFilter(request, response);
+            return;
+        }
+        String remote = request.getRemoteAddr();
+        if (remote != null && matches(remote)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        writeAccessDenied(response);
+    }
+
+    /*@ pure @*/
+    private boolean matches(String remoteAddr) {
+        for (var matcher : matchers) {
+            if (matcher.matches(remoteAddr)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void writeAccessDenied(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        var body = ErrorResponse.of("access_denied", "Source IP is not in the allowlist");
+        objectMapper.writeValue(response.getOutputStream(), body);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/IpAllowlistFilter.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/IpAllowlistFilter.java
@@ -1,7 +1,7 @@
 package com.keplerops.groundcontrol.shared.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.keplerops.groundcontrol.api.ErrorResponse;
+import com.keplerops.groundcontrol.shared.web.ErrorResponse;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/SecurityProperties.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/SecurityProperties.java
@@ -13,7 +13,7 @@ import org.springframework.security.web.util.matcher.IpAddressMatcher;
  * <p>Driven from {@code groundcontrol.security.*} — operators rotate credentials, adjust the IP
  * allowlist, or toggle OpenAPI exposure without code changes.
  */
-@ConfigurationProperties(prefix = "groundcontrol.security")
+@ConfigurationProperties(prefix = "groundcontrol.security", ignoreUnknownFields = false)
 public class SecurityProperties {
 
     private boolean enabled = true;

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/SecurityProperties.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/SecurityProperties.java
@@ -1,0 +1,135 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.security.web.util.matcher.IpAddressMatcher;
+
+/**
+ * Configuration for the API access control layer.
+ *
+ * <p>Driven from {@code groundcontrol.security.*} — operators rotate credentials, adjust the IP
+ * allowlist, or toggle OpenAPI exposure without code changes.
+ */
+@ConfigurationProperties(prefix = "groundcontrol.security")
+public class SecurityProperties {
+
+    private boolean enabled = true;
+    private List<ApiCredential> credentials = new ArrayList<>();
+    private List<String> ipAllowlist = new ArrayList<>();
+    private boolean openapiPublic = false;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public List<ApiCredential> getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(List<ApiCredential> credentials) {
+        this.credentials = credentials != null ? credentials : new ArrayList<>();
+    }
+
+    public List<String> getIpAllowlist() {
+        return ipAllowlist;
+    }
+
+    public void setIpAllowlist(List<String> ipAllowlist) {
+        this.ipAllowlist = ipAllowlist != null ? ipAllowlist : new ArrayList<>();
+    }
+
+    public boolean isOpenapiPublic() {
+        return openapiPublic;
+    }
+
+    public void setOpenapiPublic(boolean openapiPublic) {
+        this.openapiPublic = openapiPublic;
+    }
+
+    /**
+     * Validate the configured properties. Called after Spring binds the bean so misconfiguration
+     * surfaces at startup rather than on the first request. Public so unit tests can drive it
+     * directly without bootstrapping a Spring context.
+     */
+    @PostConstruct
+    public void validate() {
+        var seenTokens = new HashSet<String>();
+        for (var cred : credentials) {
+            cred.validate();
+            if (!seenTokens.add(cred.getToken())) {
+                throw new IllegalStateException(
+                        "groundcontrol.security.credentials contains duplicate tokens; each token must be unique");
+            }
+        }
+        for (var cidr : ipAllowlist) {
+            if (cidr == null || cidr.isBlank()) {
+                throw new IllegalStateException(
+                        "groundcontrol.security.ipAllowlist contains a blank entry; remove it or supply a CIDR");
+            }
+            try {
+                new IpAddressMatcher(cidr);
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalStateException(
+                        "groundcontrol.security.ipAllowlist contains an invalid CIDR: " + cidr, ex);
+            }
+        }
+    }
+
+    public enum Role {
+        USER,
+        ADMIN
+    }
+
+    public static class ApiCredential {
+
+        private String principalName;
+        private String token;
+        private Role role;
+
+        public String getPrincipalName() {
+            return principalName;
+        }
+
+        public void setPrincipalName(String principalName) {
+            this.principalName = principalName;
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public void setToken(String token) {
+            this.token = token;
+        }
+
+        public Role getRole() {
+            return role;
+        }
+
+        public void setRole(Role role) {
+            this.role = role;
+        }
+
+        public void validate() {
+            if (principalName == null || principalName.isBlank()) {
+                throw new IllegalStateException(
+                        "groundcontrol.security.credentials[].principalName is required and must be non-blank");
+            }
+            if (token == null || token.isBlank()) {
+                throw new IllegalStateException(
+                        "groundcontrol.security.credentials[].token is required and must be non-blank");
+            }
+            if (role == null) {
+                throw new IllegalStateException(
+                        "groundcontrol.security.credentials[].role is required (USER or ADMIN)");
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ActorFilter.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ActorFilter.java
@@ -9,15 +9,28 @@ import java.io.IOException;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * Populates ActorHolder and MDC with the actor identity from X-Actor header.
- * Defaults to "anonymous" if the header is missing or blank.
+ * Populates {@link ActorHolder} and the SLF4J MDC with the calling actor's identity for the
+ * lifetime of the request.
+ *
+ * <p>Resolution order:
+ * <ol>
+ *   <li>Authenticated principal from {@link SecurityContextHolder} — set by the bearer token
+ *       filter when security is enabled.</li>
+ *   <li>{@code X-Actor} header — fallback when security is disabled (dev profile, test profile).</li>
+ *   <li>{@code "anonymous"} — default when neither is present.</li>
+ * </ol>
+ *
+ * <p>Runs after {@code AuthorizationFilter} so the security chain has had a chance to populate
+ * the context. Order is set high enough to still wrap controllers.
  */
 @Component
-@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
 public class ActorFilter extends OncePerRequestFilter {
 
     private static final String ACTOR_HEADER = "X-Actor";
@@ -27,10 +40,7 @@ public class ActorFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String actor = request.getHeader(ACTOR_HEADER);
-        if (actor == null || actor.isBlank()) {
-            actor = DEFAULT_ACTOR;
-        }
+        String actor = resolveActor(request);
         ActorHolder.set(actor);
         MDC.put(MDC_ACTOR, actor);
         try {
@@ -39,5 +49,23 @@ public class ActorFilter extends OncePerRequestFilter {
             ActorHolder.clear();
             MDC.remove(MDC_ACTOR);
         }
+    }
+
+    /*@ requires request != null;
+    @ ensures \result != null && !\result.isBlank();
+    @ pure @*/
+    private static String resolveActor(HttpServletRequest request) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null
+                && auth.isAuthenticated()
+                && auth.getName() != null
+                && !auth.getName().isBlank()) {
+            return auth.getName();
+        }
+        String header = request.getHeader(ACTOR_HEADER);
+        if (header != null && !header.isBlank()) {
+            return header;
+        }
+        return DEFAULT_ACTOR;
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ActorFilter.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ActorFilter.java
@@ -31,6 +31,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 @Component
 @Order(Ordered.LOWEST_PRECEDENCE - 100)
+@SuppressWarnings("java:S125") // JML block comments (/*@ ... @*/) are contracts, not commented-out code
 public class ActorFilter extends OncePerRequestFilter {
 
     private static final String ACTOR_HEADER = "X-Actor";

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ActorFilter.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ActorFilter.java
@@ -1,12 +1,14 @@
 package com.keplerops.groundcontrol.shared.web;
 
 import com.keplerops.groundcontrol.domain.audit.ActorHolder;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.core.Authentication;
@@ -20,10 +22,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
  *
  * <p>Resolution order:
  * <ol>
- *   <li>Authenticated principal from {@link SecurityContextHolder} — set by the bearer token
- *       filter when security is enabled.</li>
- *   <li>{@code X-Actor} header — fallback when security is disabled (dev profile, test profile).</li>
- *   <li>{@code "anonymous"} — default when neither is present.</li>
+ *   <li><b>Security enabled (production):</b> the authenticated principal from
+ *       {@link SecurityContextHolder} when present, else {@code "anonymous"}. The
+ *       {@code X-Actor} header is intentionally ignored — accepting it on permitted anonymous
+ *       routes (e.g. {@code /actuator/health}) would let any caller spoof an audit identity.</li>
+ *   <li><b>Security disabled (dev/test profile):</b> {@code X-Actor} header is honored as a
+ *       legacy convenience, falling back to {@code "anonymous"}.</li>
  * </ol>
  *
  * <p>Runs after {@code AuthorizationFilter} so the security chain has had a chance to populate
@@ -37,6 +41,18 @@ public class ActorFilter extends OncePerRequestFilter {
     private static final String ACTOR_HEADER = "X-Actor";
     private static final String MDC_ACTOR = "actor";
     private static final String DEFAULT_ACTOR = "anonymous";
+
+    private final SecurityProperties securityProperties;
+
+    /**
+     * Constructor takes an {@link ObjectProvider} so {@code @WebMvcTest} slices that don't
+     * import the configuration-properties bean still wire ActorFilter (with a security-disabled
+     * default that mirrors the {@code test} profile). Production runs always have the bean
+     * available and the provider hands it back.
+     */
+    public ActorFilter(ObjectProvider<SecurityProperties> securityPropertiesProvider) {
+        this.securityProperties = securityPropertiesProvider.getIfAvailable(SecurityProperties::new);
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -55,7 +71,7 @@ public class ActorFilter extends OncePerRequestFilter {
     /*@ requires request != null;
     @ ensures \result != null && !\result.isBlank();
     @ pure @*/
-    private static String resolveActor(HttpServletRequest request) {
+    private String resolveActor(HttpServletRequest request) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth != null
                 && auth.isAuthenticated()
@@ -63,9 +79,11 @@ public class ActorFilter extends OncePerRequestFilter {
                 && !auth.getName().isBlank()) {
             return auth.getName();
         }
-        String header = request.getHeader(ACTOR_HEADER);
-        if (header != null && !header.isBlank()) {
-            return header;
+        if (!securityProperties.isEnabled()) {
+            String header = request.getHeader(ACTOR_HEADER);
+            if (header != null && !header.isBlank()) {
+                return header;
+            }
         }
         return DEFAULT_ACTOR;
     }

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ErrorResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ErrorResponse.java
@@ -1,14 +1,19 @@
-package com.keplerops.groundcontrol.api;
+package com.keplerops.groundcontrol.shared.web;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
 
 /**
- * Structured error response envelope.
+ * Structured error response envelope used across HTTP responses.
  *
  * <pre>
  * {"error": {"code": "not_found", "message": "...", "detail": null}}
  * </pre>
+ *
+ * <p>Lives in {@code shared.web} because both the {@code api.GlobalExceptionHandler} and the
+ * {@code shared.security} filter chain handlers need to emit it. Keeping the envelope in the
+ * shared HTTP package avoids a {@code shared -> api} dependency for the security entry point and
+ * access-denied handler.
  */
 public record ErrorResponse(ErrorBody error) {
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -2,6 +2,11 @@ spring:
   jpa:
     show-sql: true
 
+groundcontrol:
+  security:
+    enabled: false
+    openapi-public: true
+
 logging:
   level:
     com.keplerops.groundcontrol: DEBUG

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -5,3 +5,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+groundcontrol:
+  security:
+    enabled: false
+    openapi-public: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,6 +41,11 @@ management:
         include: health,info,metrics
 
 groundcontrol:
+  security:
+    enabled: ${GC_SECURITY_ENABLED:true}
+    openapi-public: ${GC_SECURITY_OPENAPI_PUBLIC:false}
+    credentials: []
+    ip-allowlist: []
   github:
     gh-path: ${GC_GH_PATH:}
   age:

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/ApiSecurityIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/ApiSecurityIntegrationTest.java
@@ -1,0 +1,133 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * End-to-end coverage of the API access control layer wired by
+ * {@link com.keplerops.groundcontrol.shared.security.ApiSecurityConfig}.
+ *
+ * <p>Flips {@code groundcontrol.security.enabled=true} for this test only via
+ * {@link TestPropertySource}; the rest of the integration suite continues to run with security
+ * disabled (default for the {@code test} profile). Asserts the cardinal contracts of issue #243:
+ * anonymous requests rejected, USER cannot reach admin paths, ADMIN can, actuator probes are
+ * anonymous, OpenAPI is gated, and the IP allowlist denies out-of-range traffic.
+ */
+@AutoConfigureMockMvc
+@Transactional
+@TestPropertySource(
+        properties = {
+            "groundcontrol.security.enabled=true",
+            "groundcontrol.security.openapi-public=false",
+            "groundcontrol.security.credentials[0].principal-name=alice",
+            "groundcontrol.security.credentials[0].token=user-token-aaa",
+            "groundcontrol.security.credentials[0].role=USER",
+            "groundcontrol.security.credentials[1].principal-name=admin-bob",
+            "groundcontrol.security.credentials[1].token=admin-token-bbb",
+            "groundcontrol.security.credentials[1].role=ADMIN",
+            "groundcontrol.security.ip-allowlist[0]=127.0.0.0/8",
+            "groundcontrol.security.ip-allowlist[1]=::1/128"
+        })
+class ApiSecurityIntegrationTest extends BaseIntegrationTest {
+
+    private static final String USER_TOKEN = "Bearer user-token-aaa";
+    private static final String ADMIN_TOKEN = "Bearer admin-token-bbb";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void anonymousReadOfApiV1_returns401() throws Exception {
+        mockMvc.perform(get("/api/v1/requirements"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code", is("authentication_required")))
+                .andExpect(jsonPath("$.error.message", notNullValue()));
+    }
+
+    @Test
+    void userTokenReadingApiV1_returns200() throws Exception {
+        mockMvc.perform(get("/api/v1/requirements").header("Authorization", USER_TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void userTokenHittingAdminPath_returns403() throws Exception {
+        var file = new MockMultipartFile(
+                "file", "test.sdoc", "text/plain", "[[SECTION]]\n".getBytes(StandardCharsets.UTF_8));
+        mockMvc.perform(multipart("/api/v1/admin/import/strictdoc").file(file).header("Authorization", USER_TOKEN))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code", is("access_denied")));
+    }
+
+    @Test
+    void adminTokenHittingAdminPath_passesAuthLayer() throws Exception {
+        // The strictdoc import will succeed or fail with a downstream parse status. Either way,
+        // the request must clear the auth/authz layer — i.e., NOT 401 and NOT 403.
+        var file = new MockMultipartFile(
+                "file", "test.sdoc", "text/plain", "[[SECTION]]\n".getBytes(StandardCharsets.UTF_8));
+        mockMvc.perform(multipart("/api/v1/admin/import/strictdoc").file(file).header("Authorization", ADMIN_TOKEN))
+                .andExpect(result -> {
+                    int status = result.getResponse().getStatus();
+                    if (status == 401 || status == 403) {
+                        throw new AssertionError("Admin token rejected at auth layer; status=" + status + " body="
+                                + result.getResponse().getContentAsString());
+                    }
+                });
+    }
+
+    @Test
+    void actuatorHealth_isAnonymous() throws Exception {
+        mockMvc.perform(get("/actuator/health")).andExpect(status().isOk());
+    }
+
+    @Test
+    void openApiSchema_requiresAuth_whenOpenapiPublicFalse() throws Exception {
+        mockMvc.perform(get("/api/openapi.json"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code", is("authentication_required")));
+    }
+
+    @Test
+    void openApiSchema_userTokenAccepted() throws Exception {
+        mockMvc.perform(get("/api/openapi.json").header("Authorization", USER_TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void ipAllowlist_blocksOutOfRangeSourceWith403() throws Exception {
+        mockMvc.perform(get("/api/v1/requirements")
+                        .header("Authorization", USER_TOKEN)
+                        .with(request -> {
+                            request.setRemoteAddr("203.0.113.42");
+                            return request;
+                        }))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code", is("access_denied")));
+    }
+
+    @Test
+    void invalidBearerToken_returns401() throws Exception {
+        mockMvc.perform(get("/api/v1/requirements").header("Authorization", "Bearer not-a-real-token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code", is("authentication_required")));
+    }
+
+    @Test
+    void wrongScheme_returns401() throws Exception {
+        mockMvc.perform(get("/api/v1/requirements").header("Authorization", "Basic dXNlcjpwYXNz"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ActorFilterTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ActorFilterTest.java
@@ -4,18 +4,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.keplerops.groundcontrol.domain.audit.ActorHolder;
 import com.keplerops.groundcontrol.shared.web.ActorFilter;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 class ActorFilterTest {
 
     private final ActorFilter filter = new ActorFilter();
 
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
     @Test
-    void setsActorFromHeader() throws Exception {
+    void clearsActorAfterFilterChain() throws Exception {
         var request = new MockHttpServletRequest();
         request.addHeader("X-Actor", "test-user");
         var response = new MockHttpServletResponse();
@@ -23,7 +35,6 @@ class ActorFilterTest {
 
         filter.doFilter(request, response, chain);
 
-        // After filter completes, ActorHolder and MDC should be cleared
         assertThat(ActorHolder.get()).isNull();
         assertThat(MDC.get("actor")).isNull();
     }
@@ -32,15 +43,7 @@ class ActorFilterTest {
     void defaultsToAnonymousWhenHeaderMissing() throws Exception {
         var request = new MockHttpServletRequest();
         var response = new MockHttpServletResponse();
-        // Capture the actor value during filter execution
-        var chain = new MockFilterChain() {
-            String capturedActor;
-
-            @Override
-            public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res) {
-                capturedActor = ActorHolder.get();
-            }
-        };
+        var chain = capturingChain();
 
         filter.doFilter(request, response, chain);
 
@@ -52,14 +55,7 @@ class ActorFilterTest {
         var request = new MockHttpServletRequest();
         request.addHeader("X-Actor", "   ");
         var response = new MockHttpServletResponse();
-        var chain = new MockFilterChain() {
-            String capturedActor;
-
-            @Override
-            public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res) {
-                capturedActor = ActorHolder.get();
-            }
-        };
+        var chain = capturingChain();
 
         filter.doFilter(request, response, chain);
 
@@ -67,27 +63,79 @@ class ActorFilterTest {
     }
 
     @Test
-    void setsActorHolderAndMdcDuringRequest() throws Exception {
+    void setsActorHolderAndMdcFromHeader_whenNoAuthentication() throws Exception {
         var request = new MockHttpServletRequest();
         request.addHeader("X-Actor", "alice");
         var response = new MockHttpServletResponse();
-        var chain = new MockFilterChain() {
-            String capturedActor;
-            String capturedMdc;
-
-            @Override
-            public void doFilter(jakarta.servlet.ServletRequest req, jakarta.servlet.ServletResponse res) {
-                capturedActor = ActorHolder.get();
-                capturedMdc = MDC.get("actor");
-            }
-        };
+        var chain = capturingChain();
 
         filter.doFilter(request, response, chain);
 
         assertThat(chain.capturedActor).isEqualTo("alice");
         assertThat(chain.capturedMdc).isEqualTo("alice");
-        // Cleared after
         assertThat(ActorHolder.get()).isNull();
         assertThat(MDC.get("actor")).isNull();
+    }
+
+    @Test
+    void prefersAuthenticatedPrincipal_overXActorHeader() throws Exception {
+        var auth = UsernamePasswordAuthenticationToken.authenticated(
+                "bob", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Actor", "spoofed");
+        var response = new MockHttpServletResponse();
+        var chain = capturingChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.capturedActor).isEqualTo("bob");
+        assertThat(chain.capturedMdc).isEqualTo("bob");
+    }
+
+    @Test
+    void usesAuthenticatedPrincipal_whenHeaderMissing() throws Exception {
+        var auth = UsernamePasswordAuthenticationToken.authenticated(
+                "carol", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var chain = capturingChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chain.capturedActor).isEqualTo("carol");
+    }
+
+    @Test
+    void unauthenticatedToken_isIgnored() throws Exception {
+        var auth = new UsernamePasswordAuthenticationToken("dave", null);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        var request = new MockHttpServletRequest();
+        request.addHeader("X-Actor", "fallback-user");
+        var response = new MockHttpServletResponse();
+        var chain = capturingChain();
+
+        filter.doFilter(request, response, chain);
+
+        // Unauthenticated Authentication objects must NOT short-circuit the audit identity. The
+        // X-Actor header should win in that case so we never silently treat unauthenticated state
+        // as an authenticated principal.
+        assertThat(chain.capturedActor).isEqualTo("fallback-user");
+    }
+
+    private static CapturingChain capturingChain() {
+        return new CapturingChain();
+    }
+
+    private static final class CapturingChain extends MockFilterChain {
+        String capturedActor;
+        String capturedMdc;
+
+        @Override
+        public void doFilter(ServletRequest req, ServletResponse res) {
+            capturedActor = ActorHolder.get();
+            capturedMdc = MDC.get("actor");
+        }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ActorFilterTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ActorFilterTest.java
@@ -3,11 +3,13 @@ package com.keplerops.groundcontrol.unit.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.keplerops.groundcontrol.domain.audit.ActorHolder;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties;
 import com.keplerops.groundcontrol.shared.web.ActorFilter;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 import org.springframework.mock.web.MockFilterChain;
@@ -19,109 +21,172 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 class ActorFilterTest {
 
-    private final ActorFilter filter = new ActorFilter();
-
     @AfterEach
     void clearContext() {
         SecurityContextHolder.clearContext();
     }
 
-    @Test
-    void clearsActorAfterFilterChain() throws Exception {
-        var request = new MockHttpServletRequest();
-        request.addHeader("X-Actor", "test-user");
-        var response = new MockHttpServletResponse();
-        var chain = new MockFilterChain();
-
-        filter.doFilter(request, response, chain);
-
-        assertThat(ActorHolder.get()).isNull();
-        assertThat(MDC.get("actor")).isNull();
+    private static ActorFilter newFilter(boolean securityEnabled) {
+        var props = new SecurityProperties();
+        props.setEnabled(securityEnabled);
+        return new ActorFilter(new TestObjectProvider<>(props));
     }
 
-    @Test
-    void defaultsToAnonymousWhenHeaderMissing() throws Exception {
-        var request = new MockHttpServletRequest();
-        var response = new MockHttpServletResponse();
-        var chain = capturingChain();
+    private static final class TestObjectProvider<T> implements org.springframework.beans.factory.ObjectProvider<T> {
+        private final T value;
 
-        filter.doFilter(request, response, chain);
+        TestObjectProvider(T value) {
+            this.value = value;
+        }
 
-        assertThat(chain.capturedActor).isEqualTo("anonymous");
+        @Override
+        public T getObject(Object... args) {
+            return value;
+        }
+
+        @Override
+        public T getObject() {
+            return value;
+        }
+
+        @Override
+        public T getIfAvailable() {
+            return value;
+        }
+
+        @Override
+        public T getIfUnique() {
+            return value;
+        }
     }
 
-    @Test
-    void defaultsToAnonymousWhenHeaderBlank() throws Exception {
-        var request = new MockHttpServletRequest();
-        request.addHeader("X-Actor", "   ");
-        var response = new MockHttpServletResponse();
-        var chain = capturingChain();
+    @Nested
+    class WhenSecurityEnabled {
 
-        filter.doFilter(request, response, chain);
+        private final ActorFilter filter = newFilter(true);
 
-        assertThat(chain.capturedActor).isEqualTo("anonymous");
+        @Test
+        void anonymousRoute_doesNotHonorXActorHeader() throws Exception {
+            // Production: X-Actor on a permitted anonymous route must NOT spoof identity.
+            var request = new MockHttpServletRequest();
+            request.addHeader("X-Actor", "spoofed");
+            var response = new MockHttpServletResponse();
+            var chain = capturingChain();
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(chain.capturedActor).isEqualTo("anonymous");
+        }
+
+        @Test
+        void anonymousRoute_withNoHeader_isAnonymous() throws Exception {
+            var chain = capturingChain();
+
+            filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), chain);
+
+            assertThat(chain.capturedActor).isEqualTo("anonymous");
+        }
+
+        @Test
+        void authenticatedPrincipal_isUsed() throws Exception {
+            var auth = UsernamePasswordAuthenticationToken.authenticated(
+                    "bob", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            var chain = capturingChain();
+
+            filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), chain);
+
+            assertThat(chain.capturedActor).isEqualTo("bob");
+        }
+
+        @Test
+        void authenticatedPrincipal_winsOverXActorHeader() throws Exception {
+            var auth = UsernamePasswordAuthenticationToken.authenticated(
+                    "bob", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            var request = new MockHttpServletRequest();
+            request.addHeader("X-Actor", "spoofed");
+            var chain = capturingChain();
+
+            filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+            assertThat(chain.capturedActor).isEqualTo("bob");
+        }
+
+        @Test
+        void clearsActorAfterFilterChain() throws Exception {
+            var request = new MockHttpServletRequest();
+            request.addHeader("X-Actor", "test-user");
+
+            filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+            assertThat(ActorHolder.get()).isNull();
+            assertThat(MDC.get("actor")).isNull();
+        }
     }
 
-    @Test
-    void setsActorHolderAndMdcFromHeader_whenNoAuthentication() throws Exception {
-        var request = new MockHttpServletRequest();
-        request.addHeader("X-Actor", "alice");
-        var response = new MockHttpServletResponse();
-        var chain = capturingChain();
+    @Nested
+    class WhenSecurityDisabled {
 
-        filter.doFilter(request, response, chain);
+        private final ActorFilter filter = newFilter(false);
 
-        assertThat(chain.capturedActor).isEqualTo("alice");
-        assertThat(chain.capturedMdc).isEqualTo("alice");
-        assertThat(ActorHolder.get()).isNull();
-        assertThat(MDC.get("actor")).isNull();
-    }
+        @Test
+        void honorsXActorHeader_whenNoAuthentication() throws Exception {
+            var request = new MockHttpServletRequest();
+            request.addHeader("X-Actor", "alice");
+            var chain = capturingChain();
 
-    @Test
-    void prefersAuthenticatedPrincipal_overXActorHeader() throws Exception {
-        var auth = UsernamePasswordAuthenticationToken.authenticated(
-                "bob", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        var request = new MockHttpServletRequest();
-        request.addHeader("X-Actor", "spoofed");
-        var response = new MockHttpServletResponse();
-        var chain = capturingChain();
+            filter.doFilter(request, new MockHttpServletResponse(), chain);
 
-        filter.doFilter(request, response, chain);
+            assertThat(chain.capturedActor).isEqualTo("alice");
+            assertThat(chain.capturedMdc).isEqualTo("alice");
+        }
 
-        assertThat(chain.capturedActor).isEqualTo("bob");
-        assertThat(chain.capturedMdc).isEqualTo("bob");
-    }
+        @Test
+        void defaultsToAnonymousWhenHeaderMissing() throws Exception {
+            var chain = capturingChain();
 
-    @Test
-    void usesAuthenticatedPrincipal_whenHeaderMissing() throws Exception {
-        var auth = UsernamePasswordAuthenticationToken.authenticated(
-                "carol", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        var request = new MockHttpServletRequest();
-        var response = new MockHttpServletResponse();
-        var chain = capturingChain();
+            filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), chain);
 
-        filter.doFilter(request, response, chain);
+            assertThat(chain.capturedActor).isEqualTo("anonymous");
+        }
 
-        assertThat(chain.capturedActor).isEqualTo("carol");
-    }
+        @Test
+        void defaultsToAnonymousWhenHeaderBlank() throws Exception {
+            var request = new MockHttpServletRequest();
+            request.addHeader("X-Actor", "   ");
+            var chain = capturingChain();
 
-    @Test
-    void unauthenticatedToken_isIgnored() throws Exception {
-        var auth = new UsernamePasswordAuthenticationToken("dave", null);
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        var request = new MockHttpServletRequest();
-        request.addHeader("X-Actor", "fallback-user");
-        var response = new MockHttpServletResponse();
-        var chain = capturingChain();
+            filter.doFilter(request, new MockHttpServletResponse(), chain);
 
-        filter.doFilter(request, response, chain);
+            assertThat(chain.capturedActor).isEqualTo("anonymous");
+        }
 
-        // Unauthenticated Authentication objects must NOT short-circuit the audit identity. The
-        // X-Actor header should win in that case so we never silently treat unauthenticated state
-        // as an authenticated principal.
-        assertThat(chain.capturedActor).isEqualTo("fallback-user");
+        @Test
+        void unauthenticatedTokenIsIgnored_andHeaderWins() throws Exception {
+            var auth = new UsernamePasswordAuthenticationToken("dave", null);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            var request = new MockHttpServletRequest();
+            request.addHeader("X-Actor", "fallback-user");
+            var chain = capturingChain();
+
+            filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+            assertThat(chain.capturedActor).isEqualTo("fallback-user");
+        }
+
+        @Test
+        void authenticatedPrincipalIsUsed_evenWhenSecurityDisabled() throws Exception {
+            // If something (e.g. dev tooling) populated the SecurityContext, prefer it.
+            var auth = UsernamePasswordAuthenticationToken.authenticated(
+                    "carol", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            var chain = capturingChain();
+
+            filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), chain);
+
+            assertThat(chain.capturedActor).isEqualTo("carol");
+        }
     }
 
     private static CapturingChain capturingChain() {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ActorFilterTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ActorFilterTest.java
@@ -39,24 +39,30 @@ class ActorFilterTest {
             this.value = value;
         }
 
+        // All ObjectProvider lookup methods delegate to one helper so the test stub stays a
+        // simple "always return value" without four byte-identical method bodies.
+        private T value() {
+            return value;
+        }
+
         @Override
         public T getObject(Object... args) {
-            return value;
+            return value();
         }
 
         @Override
         public T getObject() {
-            return value;
+            return value();
         }
 
         @Override
         public T getIfAvailable() {
-            return value;
+            return value();
         }
 
         @Override
         public T getIfUnique() {
-            return value;
+            return value();
         }
     }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AdrControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AdrControllerTest.java
@@ -27,11 +27,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(AdrController.class)
 class AdrControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AnalysisControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AnalysisControllerTest.java
@@ -32,10 +32,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(AnalysisController.class)
 class AnalysisControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AssetControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AssetControllerTest.java
@@ -36,11 +36,13 @@ import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(AssetController.class)
 class AssetControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AuditControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/AuditControllerTest.java
@@ -24,10 +24,12 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(AuditController.class)
 class AuditControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/BaselineControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/BaselineControllerTest.java
@@ -33,11 +33,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(BaselineController.class)
 class BaselineControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ControlControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ControlControllerTest.java
@@ -26,11 +26,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ControlController.class)
 class ControlControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ControlLinkControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ControlLinkControllerTest.java
@@ -27,11 +27,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ControlLinkController.class)
 class ControlLinkControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ControlPackControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ControlPackControllerTest.java
@@ -30,11 +30,13 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ControlPackController.class)
 class ControlPackControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/DocumentControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/DocumentControllerTest.java
@@ -28,11 +28,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(DocumentController.class)
 class DocumentControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/EmbeddingControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/EmbeddingControllerTest.java
@@ -24,10 +24,12 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(EmbeddingController.class)
 class EmbeddingControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ExportControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ExportControllerTest.java
@@ -28,10 +28,12 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ExportController.class)
 class ExportControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GitHubIssueControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GitHubIssueControllerTest.java
@@ -17,11 +17,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(GitHubIssueController.class)
 class GitHubIssueControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GlobalExceptionHandlerTest.java
@@ -2,10 +2,10 @@ package com.keplerops.groundcontrol.unit.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.keplerops.groundcontrol.api.ErrorResponse;
 import com.keplerops.groundcontrol.api.GlobalExceptionHandler;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.shared.web.ErrorResponse;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GraphControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GraphControllerTest.java
@@ -30,10 +30,12 @@ import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(GraphController.class)
 class GraphControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ImportControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ImportControllerTest.java
@@ -24,12 +24,14 @@ import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.multipart.MultipartFile;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ImportController.class)
 class ImportControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/MethodologyProfileControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/MethodologyProfileControllerTest.java
@@ -27,11 +27,13 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(MethodologyProfileController.class)
 class MethodologyProfileControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ObservationControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ObservationControllerTest.java
@@ -26,11 +26,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ObservationController.class)
 class ObservationControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PackInstallRecordControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PackInstallRecordControllerTest.java
@@ -26,11 +26,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(PackInstallRecordController.class)
 class PackInstallRecordControllerTest {
 
@@ -70,7 +72,7 @@ class PackInstallRecordControllerTest {
 
     @BeforeEach
     void setUp() {
-        when(accessGuard.requireAdminActor(any())).thenReturn(ADMIN_ACTOR);
+        when(accessGuard.requireAdminActor()).thenReturn(ADMIN_ACTOR);
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PackRegistryAccessGuardTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PackRegistryAccessGuardTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.keplerops.groundcontrol.api.packregistry.PackRegistryAccessGuard;
+import com.keplerops.groundcontrol.domain.audit.ActorHolder;
 import com.keplerops.groundcontrol.domain.exception.AuthenticationException;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -14,56 +17,99 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 class PackRegistryAccessGuardTest {
 
-    private final PackRegistryAccessGuard guard = new PackRegistryAccessGuard();
-
     @AfterEach
     void clearContext() {
         SecurityContextHolder.clearContext();
+        ActorHolder.clear();
     }
 
-    @Test
-    void returnsAuthenticatedAdminPrincipalName() {
-        var auth = UsernamePasswordAuthenticationToken.authenticated(
-                "pack-admin", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        var actor = guard.requireAdminActor();
-
-        assertThat(actor).isEqualTo("pack-admin");
+    private static PackRegistryAccessGuard guardWithSecurityEnabled(boolean enabled) {
+        var props = new SecurityProperties();
+        props.setEnabled(enabled);
+        return new PackRegistryAccessGuard(props);
     }
 
-    @Test
-    void rejectsRequest_whenSecurityContextIsEmpty() {
-        assertThatThrownBy(guard::requireAdminActor)
-                .isInstanceOf(AuthenticationException.class)
-                .hasMessageContaining("authentication");
+    @Nested
+    class SecurityEnabled {
+
+        @Test
+        void returnsAuthenticatedAdminPrincipalName() {
+            var auth = UsernamePasswordAuthenticationToken.authenticated(
+                    "pack-admin", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            var guard = guardWithSecurityEnabled(true);
+
+            assertThat(guard.requireAdminActor()).isEqualTo("pack-admin");
+        }
+
+        @Test
+        void rejectsRequest_whenSecurityContextIsEmpty() {
+            var guard = guardWithSecurityEnabled(true);
+
+            assertThatThrownBy(guard::requireAdminActor)
+                    .isInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("authentication");
+        }
+
+        @Test
+        void rejectsRequest_whenAuthenticationIsNotAuthenticated() {
+            SecurityContextHolder.getContext()
+                    .setAuthentication(new UsernamePasswordAuthenticationToken("nobody", null));
+            var guard = guardWithSecurityEnabled(true);
+
+            assertThatThrownBy(guard::requireAdminActor).isInstanceOf(AuthenticationException.class);
+        }
+
+        @Test
+        void rejectsRequest_whenAuthenticatedButMissingAdminRole() {
+            var auth = UsernamePasswordAuthenticationToken.authenticated(
+                    "user", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            var guard = guardWithSecurityEnabled(true);
+
+            assertThatThrownBy(guard::requireAdminActor)
+                    .isInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("admin");
+        }
+
+        @Test
+        void rejectsRequest_whenPrincipalNameIsBlank() {
+            var auth = UsernamePasswordAuthenticationToken.authenticated(
+                    "  ", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            var guard = guardWithSecurityEnabled(true);
+
+            assertThatThrownBy(guard::requireAdminActor).isInstanceOf(AuthenticationException.class);
+        }
     }
 
-    @Test
-    void rejectsRequest_whenAuthenticationIsNotAuthenticated() {
-        var auth = new UsernamePasswordAuthenticationToken("nobody", null);
-        SecurityContextHolder.getContext().setAuthentication(auth);
+    @Nested
+    class SecurityDisabled {
 
-        assertThatThrownBy(guard::requireAdminActor).isInstanceOf(AuthenticationException.class);
-    }
+        @Test
+        void returnsActorHolderValue_whenPresent() {
+            ActorHolder.set("dev-user");
+            var guard = guardWithSecurityEnabled(false);
 
-    @Test
-    void rejectsRequest_whenAuthenticatedButMissingAdminRole() {
-        var auth = UsernamePasswordAuthenticationToken.authenticated(
-                "user", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
-        SecurityContextHolder.getContext().setAuthentication(auth);
+            assertThat(guard.requireAdminActor()).isEqualTo("dev-user");
+        }
 
-        assertThatThrownBy(guard::requireAdminActor)
-                .isInstanceOf(AuthenticationException.class)
-                .hasMessageContaining("admin");
-    }
+        @Test
+        void fallsBackToAnonymous_whenActorHolderIsEmpty() {
+            var guard = guardWithSecurityEnabled(false);
 
-    @Test
-    void rejectsRequest_whenPrincipalNameIsBlank() {
-        var auth = UsernamePasswordAuthenticationToken.authenticated(
-                "  ", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
-        SecurityContextHolder.getContext().setAuthentication(auth);
+            assertThat(guard.requireAdminActor()).isEqualTo("anonymous");
+        }
 
-        assertThatThrownBy(guard::requireAdminActor).isInstanceOf(AuthenticationException.class);
+        @Test
+        void doesNotConsultSecurityContext() {
+            // Even with an unauthorized SecurityContext, security-disabled mode must not throw.
+            SecurityContextHolder.getContext()
+                    .setAuthentication(new UsernamePasswordAuthenticationToken("nobody", null));
+            ActorHolder.set("dev-actor");
+            var guard = guardWithSecurityEnabled(false);
+
+            assertThat(guard.requireAdminActor()).isEqualTo("dev-actor");
+        }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PackRegistryAccessGuardTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PackRegistryAccessGuardTest.java
@@ -5,48 +5,65 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.keplerops.groundcontrol.api.packregistry.PackRegistryAccessGuard;
 import com.keplerops.groundcontrol.domain.exception.AuthenticationException;
-import com.keplerops.groundcontrol.domain.packregistry.service.PackRegistrySecurityProperties;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 class PackRegistryAccessGuardTest {
 
-    @Test
-    void returnsConfiguredAdminPrincipalForBearerToken() {
-        var properties = new PackRegistrySecurityProperties();
-        var credential = new PackRegistrySecurityProperties.AdminCredential();
-        credential.setPrincipalName("pack-admin");
-        credential.setToken("test-admin-token");
-        properties.setAdminCredentials(java.util.List.of(credential));
-        var guard = new PackRegistryAccessGuard(properties);
-        var request = new MockHttpServletRequest();
-        request.addHeader("Authorization", "Bearer test-admin-token");
+    private final PackRegistryAccessGuard guard = new PackRegistryAccessGuard();
 
-        var actor = guard.requireAdminActor(request);
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void returnsAuthenticatedAdminPrincipalName() {
+        var auth = UsernamePasswordAuthenticationToken.authenticated(
+                "pack-admin", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        var actor = guard.requireAdminActor();
 
         assertThat(actor).isEqualTo("pack-admin");
     }
 
     @Test
-    void rejectsRequestsWhenAdminCredentialsAreNotConfigured() {
-        var guard = new PackRegistryAccessGuard(new PackRegistrySecurityProperties());
-        var request = new MockHttpServletRequest();
-        request.addHeader("Authorization", "Bearer test-admin-token");
-
-        assertThatThrownBy(() -> guard.requireAdminActor(request)).isInstanceOf(AuthenticationException.class);
+    void rejectsRequest_whenSecurityContextIsEmpty() {
+        assertThatThrownBy(guard::requireAdminActor)
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessageContaining("authentication");
     }
 
     @Test
-    void rejectsInvalidToken() {
-        var properties = new PackRegistrySecurityProperties();
-        var credential = new PackRegistrySecurityProperties.AdminCredential();
-        credential.setPrincipalName("pack-admin");
-        credential.setToken("test-admin-token");
-        properties.setAdminCredentials(java.util.List.of(credential));
-        var guard = new PackRegistryAccessGuard(properties);
-        var request = new MockHttpServletRequest();
-        request.addHeader("Authorization", "Bearer wrong-token");
+    void rejectsRequest_whenAuthenticationIsNotAuthenticated() {
+        var auth = new UsernamePasswordAuthenticationToken("nobody", null);
+        SecurityContextHolder.getContext().setAuthentication(auth);
 
-        assertThatThrownBy(() -> guard.requireAdminActor(request)).isInstanceOf(AuthenticationException.class);
+        assertThatThrownBy(guard::requireAdminActor).isInstanceOf(AuthenticationException.class);
+    }
+
+    @Test
+    void rejectsRequest_whenAuthenticatedButMissingAdminRole() {
+        var auth = UsernamePasswordAuthenticationToken.authenticated(
+                "user", null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        assertThatThrownBy(guard::requireAdminActor)
+                .isInstanceOf(AuthenticationException.class)
+                .hasMessageContaining("admin");
+    }
+
+    @Test
+    void rejectsRequest_whenPrincipalNameIsBlank() {
+        var auth = UsernamePasswordAuthenticationToken.authenticated(
+                "  ", null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        assertThatThrownBy(guard::requireAdminActor).isInstanceOf(AuthenticationException.class);
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PackRegistryControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PackRegistryControllerTest.java
@@ -35,12 +35,14 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(PackRegistryController.class)
 class PackRegistryControllerTest {
 
@@ -67,7 +69,7 @@ class PackRegistryControllerTest {
 
     @org.junit.jupiter.api.BeforeEach
     void setUp() {
-        when(accessGuard.requireAdminActor(any())).thenReturn("pack-admin");
+        when(accessGuard.requireAdminActor()).thenReturn("pack-admin");
     }
 
     private Project makeProject() {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PluginControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/PluginControllerTest.java
@@ -23,11 +23,13 @@ import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(PluginController.class)
 class PluginControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ProjectControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ProjectControllerTest.java
@@ -24,11 +24,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ProjectController.class)
 class ProjectControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/QualityGateControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/QualityGateControllerTest.java
@@ -28,11 +28,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(QualityGateController.class)
 class QualityGateControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTest.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -65,6 +66,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(RequirementController.class)
 class RequirementControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementGraphControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementGraphControllerTest.java
@@ -18,10 +18,12 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(RequirementGraphController.class)
 class RequirementGraphControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskAssessmentResultControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskAssessmentResultControllerTest.java
@@ -29,11 +29,13 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(RiskAssessmentResultController.class)
 class RiskAssessmentResultControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskRegisterRecordControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskRegisterRecordControllerTest.java
@@ -27,11 +27,13 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(RiskRegisterRecordController.class)
 class RiskRegisterRecordControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskScenarioControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskScenarioControllerTest.java
@@ -25,11 +25,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(RiskScenarioController.class)
 class RiskScenarioControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskScenarioLinkControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskScenarioLinkControllerTest.java
@@ -26,11 +26,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(RiskScenarioLinkController.class)
 class RiskScenarioLinkControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SectionControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SectionControllerTest.java
@@ -29,11 +29,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(SectionController.class)
 class SectionControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SweepControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SweepControllerTest.java
@@ -20,10 +20,12 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(SweepController.class)
 class SweepControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SyncControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/SyncControllerTest.java
@@ -18,10 +18,12 @@ import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(SyncController.class)
 class SyncControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ThreatModelControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ThreatModelControllerTest.java
@@ -31,11 +31,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ThreatModelController.class)
 class ThreatModelControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ThreatModelLinkControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ThreatModelLinkControllerTest.java
@@ -28,11 +28,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ThreatModelLinkController.class)
 class ThreatModelLinkControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TreatmentPlanControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TreatmentPlanControllerTest.java
@@ -30,11 +30,13 @@ import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(TreatmentPlanController.class)
 class TreatmentPlanControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TrustPolicyControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TrustPolicyControllerTest.java
@@ -31,11 +31,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(TrustPolicyController.class)
 class TrustPolicyControllerTest {
 
@@ -56,7 +58,7 @@ class TrustPolicyControllerTest {
 
     @org.junit.jupiter.api.BeforeEach
     void setUp() {
-        when(accessGuard.requireAdminActor(any())).thenReturn("pack-admin");
+        when(accessGuard.requireAdminActor()).thenReturn("pack-admin");
     }
 
     private Project makeProject() {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/VerificationResultControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/VerificationResultControllerTest.java
@@ -28,11 +28,13 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(VerificationResultController.class)
 class VerificationResultControllerTest {
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiAccessDeniedHandlerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiAccessDeniedHandlerTest.java
@@ -1,0 +1,40 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keplerops.groundcontrol.shared.security.ApiAccessDeniedHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+class ApiAccessDeniedHandlerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final ApiAccessDeniedHandler handler = new ApiAccessDeniedHandler(mapper);
+
+    @Test
+    void emits403WithErrorEnvelope() throws Exception {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+
+        handler.handle(request, response, new AccessDeniedException("forbidden"));
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentType()).contains("application/json");
+        var body = mapper.readTree(response.getContentAsString());
+        assertThat(body.path("error").path("code").asText()).isEqualTo("access_denied");
+        assertThat(body.path("error").path("message").asText()).isNotBlank();
+    }
+
+    @Test
+    void doesNotLeakExceptionMessage_inResponseBody() throws Exception {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+
+        handler.handle(request, response, new AccessDeniedException("internal:user-table:secret"));
+
+        assertThat(response.getContentAsString()).doesNotContain("internal:user-table");
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiAuthenticationEntryPointTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiAuthenticationEntryPointTest.java
@@ -1,0 +1,55 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keplerops.groundcontrol.shared.security.ApiAuthenticationEntryPoint;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+
+class ApiAuthenticationEntryPointTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final ApiAuthenticationEntryPoint entryPoint = new ApiAuthenticationEntryPoint(mapper);
+
+    @Test
+    void emits401WithErrorEnvelope() throws Exception {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var ex = new BadCredentialsException("token rejected");
+
+        entryPoint.commence(request, response, ex);
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentType()).contains("application/json");
+        var body = mapper.readTree(response.getContentAsString());
+        assertThat(body.path("error").path("code").asText()).isEqualTo("authentication_required");
+        assertThat(body.path("error").path("message").asText()).isNotBlank();
+    }
+
+    @Test
+    void setsWwwAuthenticateBearerHeader() throws Exception {
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var ex = new BadCredentialsException("token rejected");
+
+        entryPoint.commence(request, response, ex);
+
+        assertThat(response.getHeader("WWW-Authenticate")).isEqualTo("Bearer");
+    }
+
+    @Test
+    void doesNotLeakExceptionMessage_inResponseBody() throws Exception {
+        // Don't echo the exception message — that can include internal details. The body should
+        // be a stable, non-revealing message.
+        var request = new MockHttpServletRequest();
+        var response = new MockHttpServletResponse();
+        var ex = new BadCredentialsException("internal:database:user-not-found:secret");
+
+        entryPoint.commence(request, response, ex);
+
+        assertThat(response.getContentAsString()).doesNotContain("internal:database");
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiSecurityConfigTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiSecurityConfigTest.java
@@ -1,0 +1,214 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keplerops.groundcontrol.shared.security.ApiSecurityConfig;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Slice unit tests for {@link ApiSecurityConfig}. Loads only the config under test plus a tiny
+ * stub controller, so the {@code SecurityFilterChain} is wired (and exercised by
+ * {@code MockMvc}) without bringing in the JPA / Testcontainers stack of
+ * {@code ApiSecurityIntegrationTest}. This lets the chain contribute to JaCoCo unit-test
+ * coverage (the SonarCloud {@code new_coverage} metric).
+ */
+class ApiSecurityConfigTest {
+
+    @RestController
+    static class StubController {
+        @GetMapping("/api/v1/echo")
+        String echo() {
+            return "echo-ok";
+        }
+
+        @GetMapping("/api/v1/admin/echo")
+        String adminEcho() {
+            return "admin-ok";
+        }
+
+        @GetMapping("/api/v1/embeddings/echo")
+        String embeddingsEcho() {
+            return "embeddings-ok";
+        }
+
+        @GetMapping("/api/v1/analysis/sweep/echo")
+        String sweepEcho() {
+            return "sweep-ok";
+        }
+
+        @GetMapping("/api/v1/pack-registry/echo")
+        String packRegistryEcho() {
+            return "pack-registry-ok";
+        }
+
+        @GetMapping("/api/v1/trust-policies/echo")
+        String trustEcho() {
+            return "trust-ok";
+        }
+
+        @GetMapping("/api/v1/pack-install-records/echo")
+        String installEcho() {
+            return "install-ok";
+        }
+
+        @GetMapping("/")
+        String spaShell() {
+            return "spa-shell";
+        }
+    }
+
+    @Nested
+    @WebMvcTest(controllers = StubController.class)
+    @Import({ApiSecurityConfig.class, StubController.class})
+    @TestPropertySource(
+            properties = {
+                "groundcontrol.security.enabled=true",
+                "groundcontrol.security.openapi-public=false",
+                "groundcontrol.security.credentials[0].principal-name=alice",
+                "groundcontrol.security.credentials[0].token=user-token-aaa",
+                "groundcontrol.security.credentials[0].role=USER",
+                "groundcontrol.security.credentials[1].principal-name=admin-bob",
+                "groundcontrol.security.credentials[1].token=admin-token-bbb",
+                "groundcontrol.security.credentials[1].role=ADMIN"
+            })
+    class WithSecurityEnabled {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        void anonymousApiV1_returns401() throws Exception {
+            mockMvc.perform(get("/api/v1/echo"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error.code").value("authentication_required"));
+        }
+
+        @Test
+        void userTokenOnApiV1_returns200() throws Exception {
+            mockMvc.perform(get("/api/v1/echo").header("Authorization", "Bearer user-token-aaa"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("echo-ok"));
+        }
+
+        @Test
+        void userTokenOnAdminPath_returns403() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/echo").header("Authorization", "Bearer user-token-aaa"))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.error.code").value("access_denied"));
+        }
+
+        @Test
+        void adminTokenOnAdminPath_returns200() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/echo").header("Authorization", "Bearer admin-token-bbb"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("admin-ok"));
+        }
+
+        @Test
+        void userTokenOnEmbeddings_returns403() throws Exception {
+            mockMvc.perform(get("/api/v1/embeddings/echo").header("Authorization", "Bearer user-token-aaa"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void userTokenOnAnalysisSweep_returns403() throws Exception {
+            mockMvc.perform(get("/api/v1/analysis/sweep/echo").header("Authorization", "Bearer user-token-aaa"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void userTokenOnPackRegistry_returns403() throws Exception {
+            mockMvc.perform(get("/api/v1/pack-registry/echo").header("Authorization", "Bearer user-token-aaa"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void userTokenOnTrustPolicies_returns403() throws Exception {
+            mockMvc.perform(get("/api/v1/trust-policies/echo").header("Authorization", "Bearer user-token-aaa"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void userTokenOnPackInstallRecords_returns403() throws Exception {
+            mockMvc.perform(get("/api/v1/pack-install-records/echo").header("Authorization", "Bearer user-token-aaa"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void anonymousSpaShell_returns200() throws Exception {
+            mockMvc.perform(get("/"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("spa-shell"));
+        }
+
+        @Test
+        void invalidBearerToken_returns401() throws Exception {
+            mockMvc.perform(get("/api/v1/echo").header("Authorization", "Bearer not-a-token"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.error.code").value("authentication_required"));
+        }
+
+        @Test
+        void wrongScheme_returns401() throws Exception {
+            mockMvc.perform(get("/api/v1/echo").header("Authorization", "Basic dXNlcjpwYXNz"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @WebMvcTest(controllers = StubController.class)
+    @Import({ApiSecurityConfig.class, StubController.class})
+    @TestPropertySource(properties = {"groundcontrol.security.enabled=false"})
+    class WithSecurityDisabled {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        void anonymousApiV1_returns200() throws Exception {
+            mockMvc.perform(get("/api/v1/echo"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("echo-ok"));
+        }
+
+        @Test
+        void anonymousAdminPath_returns200() throws Exception {
+            mockMvc.perform(get("/api/v1/admin/echo"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("admin-ok"));
+        }
+    }
+
+    @Nested
+    @WebMvcTest(controllers = StubController.class)
+    @Import({ApiSecurityConfig.class, StubController.class})
+    @TestPropertySource(
+            properties = {
+                "groundcontrol.security.enabled=true",
+                "groundcontrol.security.openapi-public=true",
+                "groundcontrol.security.credentials[0].principal-name=alice",
+                "groundcontrol.security.credentials[0].token=user-token-aaa",
+                "groundcontrol.security.credentials[0].role=USER"
+            })
+    class WithOpenApiPublic {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        void apiV1_stillRequiresAuth() throws Exception {
+            mockMvc.perform(get("/api/v1/echo")).andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiSecurityConfigTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiSecurityConfigTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.keplerops.groundcontrol.shared.security.ApiSecurityConfig;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -115,33 +117,17 @@ class ApiSecurityConfigTest {
                     .andExpect(content().string("admin-ok"));
         }
 
-        @Test
-        void userTokenOnEmbeddings_returns403() throws Exception {
-            mockMvc.perform(get("/api/v1/embeddings/echo").header("Authorization", "Bearer user-token-aaa"))
-                    .andExpect(status().isForbidden());
-        }
-
-        @Test
-        void userTokenOnAnalysisSweep_returns403() throws Exception {
-            mockMvc.perform(get("/api/v1/analysis/sweep/echo").header("Authorization", "Bearer user-token-aaa"))
-                    .andExpect(status().isForbidden());
-        }
-
-        @Test
-        void userTokenOnPackRegistry_returns403() throws Exception {
-            mockMvc.perform(get("/api/v1/pack-registry/echo").header("Authorization", "Bearer user-token-aaa"))
-                    .andExpect(status().isForbidden());
-        }
-
-        @Test
-        void userTokenOnTrustPolicies_returns403() throws Exception {
-            mockMvc.perform(get("/api/v1/trust-policies/echo").header("Authorization", "Bearer user-token-aaa"))
-                    .andExpect(status().isForbidden());
-        }
-
-        @Test
-        void userTokenOnPackInstallRecords_returns403() throws Exception {
-            mockMvc.perform(get("/api/v1/pack-install-records/echo").header("Authorization", "Bearer user-token-aaa"))
+        @ParameterizedTest(name = "[{index}] USER on {0} returns 403")
+        @ValueSource(
+                strings = {
+                    "/api/v1/embeddings/echo",
+                    "/api/v1/analysis/sweep/echo",
+                    "/api/v1/pack-registry/echo",
+                    "/api/v1/trust-policies/echo",
+                    "/api/v1/pack-install-records/echo"
+                })
+        void userTokenOnAdminPath_returns403(String adminPath) throws Exception {
+            mockMvc.perform(get(adminPath).header("Authorization", "Bearer user-token-aaa"))
                     .andExpect(status().isForbidden());
         }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/BearerTokenAuthFilterTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/BearerTokenAuthFilterTest.java
@@ -1,0 +1,172 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.keplerops.groundcontrol.shared.security.BearerTokenAuthFilter;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.ApiCredential;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class BearerTokenAuthFilterTest {
+
+    private SecurityProperties props;
+    private BearerTokenAuthFilter filter;
+    private MockHttpServletResponse response;
+    private FilterChain chain;
+
+    @BeforeEach
+    void setUp() {
+        props = new SecurityProperties();
+        var user = new ApiCredential();
+        user.setPrincipalName("alice");
+        user.setToken("user-token-aaa");
+        user.setRole(Role.USER);
+        var admin = new ApiCredential();
+        admin.setPrincipalName("bob");
+        admin.setToken("admin-token-bbb");
+        admin.setRole(Role.ADMIN);
+        props.setCredentials(List.of(user, admin));
+        filter = new BearerTokenAuthFilter(props);
+        response = new MockHttpServletResponse();
+        chain = mock(FilterChain.class);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void validUserToken_authenticatesWithRoleUser() throws Exception {
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer user-token-aaa");
+
+        filter.doFilter(request, response, chain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getName()).isEqualTo("alice");
+        assertThat(auth.isAuthenticated()).isTrue();
+        assertThat(auth.getAuthorities()).extracting(Object::toString).containsExactly("ROLE_USER");
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void validAdminToken_authenticatesWithRoleAdmin() throws Exception {
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer admin-token-bbb");
+
+        filter.doFilter(request, response, chain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getName()).isEqualTo("bob");
+        assertThat(auth.getAuthorities()).extracting(Object::toString).containsExactly("ROLE_ADMIN");
+    }
+
+    @Test
+    void noHeader_leavesContextEmpty_andContinuesChain() throws Exception {
+        var request = new MockHttpServletRequest();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void wrongScheme_leavesContextEmpty() throws Exception {
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void invalidToken_leavesContextEmpty() throws Exception {
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer wrong-token");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void emptyTokenAfterBearer_leavesContextEmpty() throws Exception {
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer ");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void caseInsensitiveScheme_isAccepted() throws Exception {
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "bearer user-token-aaa");
+
+        filter.doFilter(request, response, chain);
+
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getName()).isEqualTo("alice");
+    }
+
+    @Test
+    void sameLengthWrongToken_doesNotAuthenticate() throws Exception {
+        // user-token-aaa is 14 chars; provide a same-length wrong token to confirm the constant-time
+        // compare fails closed when lengths match.
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer user-token-XYZ");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void securityDisabled_skipsAuthentication() throws Exception {
+        props.setEnabled(false);
+        var request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer user-token-aaa");
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void chainIsCalledExactlyOnce_evenOnInvalidToken() throws Exception {
+        var request = mock(HttpServletRequest.class);
+        var resp = mock(HttpServletResponse.class);
+        org.mockito.Mockito.when(request.getHeader("Authorization")).thenReturn("Bearer nope");
+        var localChain = mock(FilterChain.class);
+
+        filter.doFilter(request, resp, localChain);
+
+        verify(localChain, times(1)).doFilter(request, resp);
+        verify(localChain, never()).doFilter(null, null);
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/BearerTokenAuthFilterTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/BearerTokenAuthFilterTest.java
@@ -14,9 +14,13 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -78,9 +82,14 @@ class BearerTokenAuthFilterTest {
         assertThat(auth.getAuthorities()).extracting(Object::toString).containsExactly("ROLE_ADMIN");
     }
 
-    @Test
-    void noHeader_leavesContextEmpty_andContinuesChain() throws Exception {
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("rejectedAuthorizationHeaders")
+    void unauthorizedHeader_leavesContextEmpty_andContinuesChain(String description, String headerValue)
+            throws Exception {
         var request = new MockHttpServletRequest();
+        if (headerValue != null) {
+            request.addHeader("Authorization", headerValue);
+        }
 
         filter.doFilter(request, response, chain);
 
@@ -88,37 +97,12 @@ class BearerTokenAuthFilterTest {
         verify(chain).doFilter(request, response);
     }
 
-    @Test
-    void wrongScheme_leavesContextEmpty() throws Exception {
-        var request = new MockHttpServletRequest();
-        request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
-
-        filter.doFilter(request, response, chain);
-
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-        verify(chain).doFilter(request, response);
-    }
-
-    @Test
-    void invalidToken_leavesContextEmpty() throws Exception {
-        var request = new MockHttpServletRequest();
-        request.addHeader("Authorization", "Bearer wrong-token");
-
-        filter.doFilter(request, response, chain);
-
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-        verify(chain).doFilter(request, response);
-    }
-
-    @Test
-    void emptyTokenAfterBearer_leavesContextEmpty() throws Exception {
-        var request = new MockHttpServletRequest();
-        request.addHeader("Authorization", "Bearer ");
-
-        filter.doFilter(request, response, chain);
-
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-        verify(chain).doFilter(request, response);
+    static Stream<Arguments> rejectedAuthorizationHeaders() {
+        return Stream.of(
+                Arguments.of("no header at all", null),
+                Arguments.of("wrong scheme (Basic)", "Basic dXNlcjpwYXNz"),
+                Arguments.of("Bearer with unknown token", "Bearer wrong-token"),
+                Arguments.of("Bearer with empty token", "Bearer "));
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/BearerTokenAuthFilterTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/BearerTokenAuthFilterTest.java
@@ -2,7 +2,6 @@ package com.keplerops.groundcontrol.unit.api.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -151,6 +150,5 @@ class BearerTokenAuthFilterTest {
         filter.doFilter(request, resp, localChain);
 
         verify(localChain, times(1)).doFilter(request, resp);
-        verify(localChain, never()).doFilter(null, null);
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/IpAllowlistFilterTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/IpAllowlistFilterTest.java
@@ -1,0 +1,140 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keplerops.groundcontrol.shared.security.IpAllowlistFilter;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties;
+import jakarta.servlet.FilterChain;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class IpAllowlistFilterTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private IpAllowlistFilter newFilter(SecurityProperties props) {
+        var filter = new IpAllowlistFilter(props, mapper);
+        filter.compile();
+        return filter;
+    }
+
+    @Test
+    void emptyAllowlist_passesThrough() throws Exception {
+        var props = new SecurityProperties();
+        var filter = newFilter(props);
+        var request = new MockHttpServletRequest();
+        request.setRemoteAddr("203.0.113.42");
+        var response = new MockHttpServletResponse();
+        var chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain, times(1)).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void inRangeIpv4_passes() throws Exception {
+        var props = new SecurityProperties();
+        props.setIpAllowlist(List.of("10.0.0.0/8", "127.0.0.0/8"));
+        var filter = newFilter(props);
+        var request = new MockHttpServletRequest();
+        request.setRemoteAddr("10.5.6.7");
+        var response = new MockHttpServletResponse();
+        var chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void outOfRange_returns403WithErrorEnvelope() throws Exception {
+        var props = new SecurityProperties();
+        props.setIpAllowlist(List.of("10.0.0.0/8"));
+        var filter = newFilter(props);
+        var request = new MockHttpServletRequest();
+        request.setRemoteAddr("203.0.113.42");
+        var response = new MockHttpServletResponse();
+        var chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain, never()).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentType()).contains("application/json");
+        var body = mapper.readTree(response.getContentAsString());
+        assertThat(body.path("error").path("code").asText()).isEqualTo("access_denied");
+        assertThat(body.path("error").path("message").asText()).isNotBlank();
+    }
+
+    @Test
+    void ipv6_inRange_passes() throws Exception {
+        var props = new SecurityProperties();
+        props.setIpAllowlist(List.of("::1/128"));
+        var filter = newFilter(props);
+        var request = new MockHttpServletRequest();
+        request.setRemoteAddr("::1");
+        var response = new MockHttpServletResponse();
+        var chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void securityDisabled_skipsAllowlist() throws Exception {
+        var props = new SecurityProperties();
+        props.setEnabled(false);
+        props.setIpAllowlist(List.of("10.0.0.0/8"));
+        var filter = newFilter(props);
+        var request = new MockHttpServletRequest();
+        request.setRemoteAddr("203.0.113.42");
+        var response = new MockHttpServletResponse();
+        var chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void doesNotTrustForwardedForHeader() throws Exception {
+        // X-Forwarded-For must NOT be honored by default; only the connection's remoteAddr counts.
+        var props = new SecurityProperties();
+        props.setIpAllowlist(List.of("10.0.0.0/8"));
+        var filter = newFilter(props);
+        var request = new MockHttpServletRequest();
+        request.setRemoteAddr("203.0.113.42");
+        request.addHeader("X-Forwarded-For", "10.0.0.5");
+        var response = new MockHttpServletResponse();
+        var chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void compile_failsFastOnInvalidCidr() {
+        var props = new SecurityProperties();
+        props.setIpAllowlist(List.of("not-a-cidr"));
+        var filter = new IpAllowlistFilter(props, mapper);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(filter::compile)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ipAllowlist");
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/SecurityPropertiesTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/SecurityPropertiesTest.java
@@ -7,8 +7,13 @@ import com.keplerops.groundcontrol.shared.security.SecurityProperties;
 import com.keplerops.groundcontrol.shared.security.SecurityProperties.ApiCredential;
 import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SecurityPropertiesTest {
 
@@ -40,39 +45,29 @@ class SecurityPropertiesTest {
     @Nested
     class CredentialValidation {
 
-        @Test
-        void blankPrincipalName_rejected() {
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("invalidCredentials")
+        void invalidCredential_rejectedWithDescriptiveMessage(
+                String description, Consumer<ApiCredential> fieldMutator, String expectedMessageFragment) {
             var cred = new ApiCredential();
-            cred.setPrincipalName(" ");
+            cred.setPrincipalName("alice");
             cred.setToken("t1");
             cred.setRole(Role.USER);
+            fieldMutator.accept(cred);
 
             assertThatThrownBy(cred::validate)
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("principalName");
+                    .hasMessageContaining(expectedMessageFragment);
         }
 
-        @Test
-        void blankToken_rejected() {
-            var cred = new ApiCredential();
-            cred.setPrincipalName("alice");
-            cred.setToken("");
-            cred.setRole(Role.ADMIN);
-
-            assertThatThrownBy(cred::validate)
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("token");
-        }
-
-        @Test
-        void nullRole_rejected() {
-            var cred = new ApiCredential();
-            cred.setPrincipalName("alice");
-            cred.setToken("t1");
-
-            assertThatThrownBy(cred::validate)
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("role");
+        static Stream<Arguments> invalidCredentials() {
+            Consumer<ApiCredential> blankPrincipal = c -> c.setPrincipalName(" ");
+            Consumer<ApiCredential> blankToken = c -> c.setToken("");
+            Consumer<ApiCredential> nullRole = c -> c.setRole(null);
+            return Stream.of(
+                    Arguments.of("blank principalName is rejected", blankPrincipal, "principalName"),
+                    Arguments.of("blank token is rejected", blankToken, "token"),
+                    Arguments.of("null role is rejected", nullRole, "role"));
         }
 
         @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/SecurityPropertiesTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/SecurityPropertiesTest.java
@@ -1,0 +1,135 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.keplerops.groundcontrol.shared.security.SecurityProperties;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.ApiCredential;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SecurityPropertiesTest {
+
+    @Nested
+    class Defaults {
+
+        @Test
+        void newInstance_isEnabledWithEmptyLists_andOpenapiNotPublic() {
+            var props = new SecurityProperties();
+
+            assertThat(props.isEnabled()).isTrue();
+            assertThat(props.getCredentials()).isEmpty();
+            assertThat(props.getIpAllowlist()).isEmpty();
+            assertThat(props.isOpenapiPublic()).isFalse();
+        }
+
+        @Test
+        void setNullLists_normalizesToEmpty() {
+            var props = new SecurityProperties();
+
+            props.setCredentials(null);
+            props.setIpAllowlist(null);
+
+            assertThat(props.getCredentials()).isEmpty();
+            assertThat(props.getIpAllowlist()).isEmpty();
+        }
+    }
+
+    @Nested
+    class CredentialValidation {
+
+        @Test
+        void blankPrincipalName_rejected() {
+            var cred = new ApiCredential();
+            cred.setPrincipalName(" ");
+            cred.setToken("t1");
+            cred.setRole(Role.USER);
+
+            assertThatThrownBy(cred::validate)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("principalName");
+        }
+
+        @Test
+        void blankToken_rejected() {
+            var cred = new ApiCredential();
+            cred.setPrincipalName("alice");
+            cred.setToken("");
+            cred.setRole(Role.ADMIN);
+
+            assertThatThrownBy(cred::validate)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("token");
+        }
+
+        @Test
+        void nullRole_rejected() {
+            var cred = new ApiCredential();
+            cred.setPrincipalName("alice");
+            cred.setToken("t1");
+
+            assertThatThrownBy(cred::validate)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("role");
+        }
+
+        @Test
+        void wellFormed_accepted() {
+            var cred = new ApiCredential();
+            cred.setPrincipalName("alice");
+            cred.setToken("strong-token-1234");
+            cred.setRole(Role.ADMIN);
+
+            cred.validate();
+
+            assertThat(cred.getPrincipalName()).isEqualTo("alice");
+            assertThat(cred.getToken()).isEqualTo("strong-token-1234");
+            assertThat(cred.getRole()).isEqualTo(Role.ADMIN);
+        }
+    }
+
+    @Nested
+    class IpAllowlistValidation {
+
+        @Test
+        void invalidCidr_rejectedDuringValidate() {
+            var props = new SecurityProperties();
+            props.setIpAllowlist(List.of("not-a-cidr"));
+
+            assertThatThrownBy(props::validate)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("ipAllowlist");
+        }
+
+        @Test
+        void wellFormedCidrs_accepted() {
+            var props = new SecurityProperties();
+            props.setIpAllowlist(List.of("10.0.0.0/8", "127.0.0.1/32", "::1/128"));
+
+            props.validate();
+
+            assertThat(props.getIpAllowlist()).hasSize(3);
+        }
+
+        @Test
+        void duplicateCredentialTokens_rejected() {
+            var c1 = new ApiCredential();
+            c1.setPrincipalName("a");
+            c1.setToken("same-token");
+            c1.setRole(Role.USER);
+            var c2 = new ApiCredential();
+            c2.setPrincipalName("b");
+            c2.setToken("same-token");
+            c2.setRole(Role.ADMIN);
+
+            var props = new SecurityProperties();
+            props.setCredentials(List.of(c1, c2));
+
+            assertThatThrownBy(props::validate)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("duplicate");
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/SpaControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/SpaControllerTest.java
@@ -7,9 +7,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.keplerops.groundcontrol.infrastructure.web.SpaController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(SpaController.class)
 class SpaControllerTest {
 

--- a/deploy/scripts/sync_pack_catalog.sh
+++ b/deploy/scripts/sync_pack_catalog.sh
@@ -15,9 +15,16 @@ catalog_path="${tmp_dir}/catalog.json"
 curl -fsSL "${RAW_BASE_URL}/packs/catalog.json" -o "${catalog_path}"
 
 spring_json="$(aws ssm get-parameter --region "${AWS_REGION}" --name "${PARAM_PATH}" --with-decryption --query 'Parameter.Value' --output text)"
-auth_token="$(printf '%s' "${spring_json}" | jq -r '.["ground-control"]["pack-registry"]["security"]["admin-credentials"][0].token // empty')"
+# Resolve an ADMIN-role bearer token from the unified groundcontrol.security
+# credentials list (ADR-026 / GC-P011).
+auth_token="$(printf '%s' "${spring_json}" | jq -r '
+  (.groundcontrol.security.credentials // [])
+    | map(select(.role == "ADMIN"))
+    | .[0].token // empty
+')"
 if [ -z "${auth_token}" ]; then
-  echo "Could not resolve pack-registry admin token from ${PARAM_PATH}."
+  echo "Could not resolve an ADMIN-role token from ${PARAM_PATH}."
+  echo "Expected SSM parameter shape: {\"groundcontrol\":{\"security\":{\"credentials\":[{\"principal-name\":\"...\",\"token\":\"...\",\"role\":\"ADMIN\"}]}}}"
   exit 1
 fi
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,30 @@
 # Ground Control REST API
 
-REST API for direct HTTP usage. Pre-alpha, localhost only, no authentication.
+REST API for direct HTTP usage. Pre-alpha. The `dev` profile disables
+authentication for local work; **production deployments require it**
+(see [ADR-026](../architecture/adrs/026-rest-api-access-control.md) and
+[`docs/deployment/DEPLOYMENT.md`](deployment/DEPLOYMENT.md)).
+
+## Authentication
+
+When `groundcontrol.security.enabled=true`:
+
+- Send `Authorization: Bearer <token>` on every `/api/v1/**` request.
+- `/api/v1/admin/**`, `/api/v1/embeddings/**`, `/api/v1/analysis/sweep/**`,
+  and `/api/v1/pack-registry/**` require a token whose configured `role`
+  is `ADMIN`. Other `/api/v1/**` paths accept any authenticated token.
+- `/actuator/health` and `/actuator/info` are anonymous; the OpenAPI
+  schema is gated by `groundcontrol.security.openapi-public`.
+- An optional CIDR allowlist (`groundcontrol.security.ip-allowlist`)
+  rejects out-of-range source addresses with 403 `access_denied` before
+  the token check runs.
+
+Errors use the standard envelope:
+
+```
+401 → {"error": {"code": "authentication_required", "message": "..."}}
+403 → {"error": {"code": "access_denied", "message": "..."}}
+```
 
 ## Base URL
 
@@ -787,11 +811,12 @@ Response wraps results in a Spring Page object with `content`, `totalElements`,
 
 ### Pack Registry
 
-All pack registry, trust policy, and pack install record routes require a pack
-registry admin token: `Authorization: Bearer <token>`. Tokens and their audit
-principal names are configured with
-`ground-control.pack-registry.security.admin-credentials`. The repo-local MCP
-helper forwards `GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN` when set.
+All pack registry, trust policy, and pack install record routes require an
+ADMIN-role bearer token: `Authorization: Bearer <token>`. Tokens and their
+audit principal names are configured under the unified
+`groundcontrol.security.credentials` list (`role: ADMIN`); see ADR-026 and
+the deployment env-var reference. The repo-local MCP helper forwards
+`GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN` when set.
 
 | Method | Path | Body | Status | Purpose |
 |--------|------|------|--------|---------|

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -78,7 +78,11 @@ backend/src/main/java/com/keplerops/groundcontrol/
 │   ├── sweep/                    # ScheduledSweepRunner, notifiers
 │   └── web/                      # CORS config, SPA routing
 ├── shared/
-│   └── logging/                  # RequestLoggingFilter (MDC request_id)
+│   ├── logging/                  # RequestLoggingFilter (MDC request_id)
+│   ├── security/                 # ApiSecurityConfig, BearerTokenAuthFilter,
+│   │                             # IpAllowlistFilter, ApiAuthenticationEntryPoint,
+│   │                             # ApiAccessDeniedHandler, SecurityProperties (ADR-026)
+│   └── web/                      # ActorFilter (audit identity from SecurityContext)
 └── GroundControlApplication.java
 ```
 
@@ -98,10 +102,28 @@ Enforced at compile time by ArchUnit tests in `ArchitectureTest.java`.
 
 Spring profiles drive environment-specific behavior:
 
-- `application.yml` — base config (datasource, JPA, Flyway, server port)
-- `application-test.yml` — test overrides (Testcontainers)
+- `application.yml` — base config (datasource, JPA, Flyway, server port, security defaults)
+- `application-dev.yml` — local dev (`groundcontrol.security.enabled=false`)
+- `application-test.yml` — test overrides (Testcontainers, security disabled)
 
 Environment variables use the `GC_` prefix (e.g., `GC_DATABASE_URL`, `GC_SERVER_PORT`). See `.env.example`.
+
+## Request filter chain
+
+Once Spring Security is enabled (production default; `dev`/`test` profiles
+opt out), every request passes through:
+
+```
+IpAllowlistFilter           # CIDR check (skipped if allowlist empty)
+  → BearerTokenAuthFilter   # Authorization: Bearer <token> → SecurityContext
+    → AuthorizationFilter   # path-matrix / ROLE_USER / ROLE_ADMIN
+      → ActorFilter         # populates ActorHolder + MDC actor=<principal>
+        → controllers
+```
+
+Authorization is centralized in `ApiSecurityConfig` (ADR-026); controllers
+do not perform per-method auth checks. `ActorFilter` runs after the
+security chain so audit identity tracks the authenticated principal.
 
 ## What Exists vs. What Doesn't
 

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -53,6 +53,45 @@ All settings use the `GC_` prefix. See `.env.example`.
 | `GC_EMBEDDING_DIMENSIONS` | `1536` | Embedding vector dimensions |
 | `GC_EMBEDDING_BATCH_SIZE` | `100` | Max texts per batch embedding request |
 | `GC_EMBEDDING_SIMILARITY_THRESHOLD` | `0.85` | Default cosine similarity threshold |
+| `GC_SECURITY_ENABLED` | `true` | Master switch for the API access control layer (ADR-026, GC-P011). The `dev` and `test` profiles override this to `false`. |
+| `GC_SECURITY_OPENAPI_PUBLIC` | `false` | When `true`, `/api/openapi.json` and `/api/docs/**` are reachable anonymously. Otherwise authenticated. |
+| `GROUNDCONTROL_SECURITY_CREDENTIALS_<N>_PRINCIPAL_NAME` | _(unset)_ | Principal name written to audit fields when this token authenticates. |
+| `GROUNDCONTROL_SECURITY_CREDENTIALS_<N>_TOKEN` | _(unset)_ | Bearer token presented as `Authorization: Bearer <token>`. |
+| `GROUNDCONTROL_SECURITY_CREDENTIALS_<N>_ROLE` | _(unset)_ | `USER` or `ADMIN`. Admin roles are required for `/api/v1/admin/**`, `/api/v1/embeddings/**`, `/api/v1/analysis/sweep/**`, `/api/v1/pack-registry/**`. |
+| `GROUNDCONTROL_SECURITY_IP_ALLOWLIST_<N>` | _(unset)_ | Optional CIDR. Empty list = no IP gating. `X-Forwarded-For` is NOT honored — proxies must terminate the IP gate or set the source IP via `RemoteIpFilter`. |
+
+### Authentication & Network Access (ADR-026)
+
+Production deployments MUST configure `groundcontrol.security.credentials`
+(or supply equivalent `GROUNDCONTROL_SECURITY_CREDENTIALS_*` env vars).
+With `GC_SECURITY_ENABLED=true` and an empty credential list, every
+authenticated route returns 401.
+
+Authority matrix:
+
+| Path | Required authority |
+|------|--------------------|
+| `/actuator/health`, `/actuator/info` | anonymous |
+| `/error` | anonymous |
+| `/api/openapi.json`, `/api/docs/**`, `/v3/api-docs/**`, `/swagger-ui/**` | gated by `GC_SECURITY_OPENAPI_PUBLIC` |
+| `/api/v1/admin/**` | `ROLE_ADMIN` |
+| `/api/v1/embeddings/**` | `ROLE_ADMIN` |
+| `/api/v1/analysis/sweep/**` | `ROLE_ADMIN` |
+| `/api/v1/pack-registry/**` | `ROLE_ADMIN` |
+| Other `/api/v1/**` | authenticated (USER or ADMIN) |
+| Anything else | denyAll |
+
+Clients send `Authorization: Bearer <token>` on every request. Tokens are
+compared with `MessageDigest.isEqual` for constant-time compare; rotation
+is a config edit + restart.
+
+Migrating from pre-#243 deployments:
+
+- `ground-control.pack-registry.security.admin-credentials` is removed.
+  Move admin entries into `groundcontrol.security.credentials` with
+  `role: ADMIN`. The pack-signing block (`trusted-signers`) is unchanged.
+- The `X-Actor` header is no longer a self-service identity claim when
+  security is enabled; the authenticated principal name is used for audit.
 
 ### Makefile Targets
 

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -78,7 +78,10 @@ Authority matrix:
 | `/api/v1/embeddings/**` | `ROLE_ADMIN` |
 | `/api/v1/analysis/sweep/**` | `ROLE_ADMIN` |
 | `/api/v1/pack-registry/**` | `ROLE_ADMIN` |
+| `/api/v1/trust-policies/**` | `ROLE_ADMIN` |
+| `/api/v1/pack-install-records/**` | `ROLE_ADMIN` |
 | Other `/api/v1/**` | authenticated (USER or ADMIN) |
+| SPA shell, static assets, SPA client routes (GET only, non-API non-actuator) | anonymous |
 | Anything else | denyAll |
 
 Clients send `Authorization: Bearer <token>` on every request. Tokens are

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -1,5 +1,17 @@
 #!/usr/bin/env node
 // Ground Control MCP Server
+//
+// Environment variables consumed by this server (see mcp/ground-control/lib.js):
+//   GC_BASE_URL                              Base URL of the Ground Control backend
+//                                             (default: http://localhost:8000).
+//   GROUND_CONTROL_API_TOKEN                 Bearer token forwarded on every
+//                                             /api/v1/** request when the backend
+//                                             has groundcontrol.security.enabled=true
+//                                             (ADR-026 / GC-P011).
+//   GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN Legacy admin-only token; forwarded only
+//                                             on paths requiring ROLE_ADMIN. Used as
+//                                             a fallback when GROUND_CONTROL_API_TOKEN
+//                                             is unset.
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -582,23 +582,30 @@ function requiresAdminRole(path) {
 
 // Forwards a bearer token on `/api/v1/**` requests so the MCP server can talk
 // to a Ground Control deployment with `groundcontrol.security.enabled=true`.
+//
 // Resolution order:
-//   1. GROUND_CONTROL_API_TOKEN — generic token (USER or ADMIN role).
-//   2. GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN — admin-role legacy var,
-//      forwarded only for paths that require ADMIN.
+//   - On admin-only paths: prefer GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN
+//     when set (it's, by definition, an ADMIN-role token), then fall back to
+//     GROUND_CONTROL_API_TOKEN. Picking the admin token first prevents a
+//     deployment that has both vars configured but a USER-only generic token
+//     from getting 403s on admin endpoints.
+//   - On non-admin paths: use GROUND_CONTROL_API_TOKEN.
 // When neither is set the header is omitted (dev profile / disabled security).
 function addAuthorizationHeader(path, headers) {
   if (!path.startsWith("/api/v1/")) {
     return;
   }
   const apiToken = process.env.GROUND_CONTROL_API_TOKEN;
-  if (apiToken) {
-    headers.Authorization = `Bearer ${apiToken}`;
+  const adminToken = process.env.GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN;
+  if (requiresAdminRole(path)) {
+    const token = adminToken || apiToken;
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
     return;
   }
-  const adminToken = process.env.GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN;
-  if (adminToken && requiresAdminRole(path)) {
-    headers.Authorization = `Bearer ${adminToken}`;
+  if (apiToken) {
+    headers.Authorization = `Bearer ${apiToken}`;
   }
 }
 

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -589,7 +589,11 @@ function requiresAdminRole(path) {
 //     GROUND_CONTROL_API_TOKEN. Picking the admin token first prevents a
 //     deployment that has both vars configured but a USER-only generic token
 //     from getting 403s on admin endpoints.
-//   - On non-admin paths: use GROUND_CONTROL_API_TOKEN.
+//   - On non-admin paths: use GROUND_CONTROL_API_TOKEN if set, otherwise fall
+//     back to GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN. An ADMIN credential is
+//     valid for all `/api/v1/**` paths under the unified security model
+//     (ADR-026), so deployments that migrated from the legacy admin-only var
+//     keep working for ordinary requirement / project / graph reads.
 // When neither is set the header is omitted (dev profile / disabled security).
 function addAuthorizationHeader(path, headers) {
   if (!path.startsWith("/api/v1/")) {
@@ -597,15 +601,14 @@ function addAuthorizationHeader(path, headers) {
   }
   const apiToken = process.env.GROUND_CONTROL_API_TOKEN;
   const adminToken = process.env.GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN;
+  let token;
   if (requiresAdminRole(path)) {
-    const token = adminToken || apiToken;
-    if (token) {
-      headers.Authorization = `Bearer ${token}`;
-    }
-    return;
+    token = adminToken || apiToken;
+  } else {
+    token = apiToken || adminToken;
   }
-  if (apiToken) {
-    headers.Authorization = `Bearer ${apiToken}`;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
   }
 }
 

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -571,16 +571,34 @@ export function parseErrorBody(text) {
   return { code: null, message: text, detail: null };
 }
 
-function requiresPackRegistryAdmin(path) {
+function requiresAdminRole(path) {
   return path.startsWith("/api/v1/pack-registry")
     || path.startsWith("/api/v1/trust-policies")
-    || path.startsWith("/api/v1/pack-install-records");
+    || path.startsWith("/api/v1/pack-install-records")
+    || path.startsWith("/api/v1/admin/")
+    || path.startsWith("/api/v1/embeddings")
+    || path.startsWith("/api/v1/analysis/sweep");
 }
 
-function addPackRegistryAdminHeader(path, headers) {
-  const token = process.env.GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN;
-  if (requiresPackRegistryAdmin(path) && token) {
-    headers.Authorization = `Bearer ${token}`;
+// Forwards a bearer token on `/api/v1/**` requests so the MCP server can talk
+// to a Ground Control deployment with `groundcontrol.security.enabled=true`.
+// Resolution order:
+//   1. GROUND_CONTROL_API_TOKEN — generic token (USER or ADMIN role).
+//   2. GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN — admin-role legacy var,
+//      forwarded only for paths that require ADMIN.
+// When neither is set the header is omitted (dev profile / disabled security).
+function addAuthorizationHeader(path, headers) {
+  if (!path.startsWith("/api/v1/")) {
+    return;
+  }
+  const apiToken = process.env.GROUND_CONTROL_API_TOKEN;
+  if (apiToken) {
+    headers.Authorization = `Bearer ${apiToken}`;
+    return;
+  }
+  const adminToken = process.env.GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN;
+  if (adminToken && requiresAdminRole(path)) {
+    headers.Authorization = `Bearer ${adminToken}`;
   }
 }
 
@@ -598,7 +616,7 @@ async function request(method, path, { body, params, formData } = {}) {
   } else {
     options.headers = { "X-Actor": "mcp-server" };
   }
-  addPackRegistryAdminHeader(path, options.headers);
+  addAuthorizationHeader(path, options.headers);
 
   const res = await fetch(url, options);
 

--- a/scripts/check-pr-body.sh
+++ b/scripts/check-pr-body.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Pre-push policy check: if the current branch has an open pull request,
+# fetch its body and validate it against the Ground Control template
+# requirements (`bin/policy --pr-body-file`). Catches missing sections
+# before the push triggers a CI run that would fail at the policy job.
+#
+# Skips silently when:
+#   - no branch is checked out (detached HEAD), or
+#   - no PR exists for the current branch yet (first push of a branch is
+#     fine — the body is validated again on PR creation), or
+#   - `gh` is not on PATH (developer hasn't installed the GitHub CLI).
+#
+# To bypass deliberately, run `git push --no-verify`.
+
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  exit 0
+fi
+
+branch="$(git symbolic-ref --short -q HEAD || true)"
+if [ -z "${branch}" ]; then
+  exit 0
+fi
+
+# `gh pr view --head <branch>` is broken in older versions, but `gh pr list`
+# is reliable. Look for an open PR with this branch as the head ref.
+pr_number="$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+if [ -z "${pr_number}" ]; then
+  exit 0
+fi
+
+tmp_body="$(mktemp -t gc-pr-body.XXXXXX)"
+trap 'rm -f "${tmp_body}"' EXIT
+gh pr view "${pr_number}" --json body --jq '.body' > "${tmp_body}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+exec python3 "${repo_root}/bin/policy" --pr-body-file "${tmp_body}"

--- a/tools/policy/checks.py
+++ b/tools/policy/checks.py
@@ -246,9 +246,21 @@ def run_migration_policy(changed_files: list[str], root: Path = REPO_ROOT) -> li
 
 
 def run_pr_body_check(event_path: Path) -> list[Violation]:
+    """Backwards-compatible wrapper that loads the PR body from a GitHub event payload."""
     event = json.loads(event_path.read_text(encoding="utf-8"))
     pull_request = event.get("pull_request") or {}
     body = pull_request.get("body") or ""
+    return check_pr_body(body)
+
+
+def check_pr_body(body: str) -> list[Violation]:
+    """Validate a PR body against the Ground Control template requirements.
+
+    Pure function over the body string so it can be driven from GitHub event
+    payloads (CI), a local draft file (pre-push hook), or `gh pr view --json
+    body`. The CI path is `run_pr_body_check`; local tooling should call this
+    directly.
+    """
     violations: list[Violation] = []
 
     required_headers = [
@@ -340,6 +352,23 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--event-path",
         help="Path to a GitHub event payload. Defaults to GITHUB_EVENT_PATH when present.",
     )
+    parser.add_argument(
+        "--pr-body-file",
+        help=(
+            "Path to a plain-text PR body draft. Use this in pre-push hooks to "
+            "validate the PR body before push. Mutually exclusive with --event-path / "
+            "--pr-number; --pr-body-file wins when supplied."
+        ),
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        help=(
+            "GitHub PR number. When set (and neither --pr-body-file nor "
+            "--event-path is supplied), the body is fetched via "
+            "`gh pr view <n> --json body`."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -371,11 +400,39 @@ def main(argv: list[str] | None = None) -> int:
     violations.extend(run_controller_contracts(changed_files))
     violations.extend(run_migration_policy(changed_files))
 
-    event_path = args.event_path or os.getenv("GITHUB_EVENT_PATH")
-    if not args.skip_pr_body and event_path:
-        violations.extend(run_pr_body_check(Path(event_path)))
+    if not args.skip_pr_body:
+        body = _resolve_pr_body(args)
+        if body is not None:
+            violations.extend(check_pr_body(body))
 
     return render_and_exit(violations)
+
+
+def _resolve_pr_body(args: argparse.Namespace) -> str | None:
+    """Resolve the PR body string from CLI args / environment, in priority order.
+
+    1. ``--pr-body-file`` — local pre-push hook driver.
+    2. ``--pr-number`` — fetched via ``gh pr view <n> --json body``.
+    3. ``--event-path`` or ``GITHUB_EVENT_PATH`` — CI driver.
+
+    Returns ``None`` when no source is configured (the check is skipped).
+    """
+    if args.pr_body_file:
+        return Path(args.pr_body_file).read_text(encoding="utf-8")
+    if args.pr_number is not None:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(args.pr_number), "--json", "body", "--jq", ".body"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout
+    event_path = args.event_path or os.getenv("GITHUB_EVENT_PATH")
+    if event_path:
+        event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        pull_request = event.get("pull_request") or {}
+        return pull_request.get("body") or ""
+    return None
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_policy.py
+++ b/tools/tests/test_policy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from tools.policy.checks import (
     REPO_ROOT,
+    check_pr_body,
     parse_args,
     run_adr_guard,
     run_controller_contracts,
@@ -49,10 +50,36 @@ class PolicyChecksTest(unittest.TestCase):
             violations = run_pr_body_check(event_path)
             self.assertTrue(any(item.code == "pr-template-sections" for item in violations))
 
+    def test_check_pr_body_accepts_string_directly(self):
+        violations = check_pr_body("## Summary\n\nMissing policy sections")
+        codes = {item.code for item in violations}
+        self.assertIn("pr-template-sections", codes)
+
+    def test_check_pr_body_passes_for_well_formed_body(self):
+        body = (
+            "## Summary\n\nFix.\n"
+            "## Requirement UIDs\n\n- GC-X001\n"
+            "## ADR Impact\n\nADR-026 added.\n"
+            "## Ground Control Checks\n\n"
+            "- [x] `make policy` passes\n"
+            "- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change\n"
+            "- [x] `gc_run_sweep` reviewed or intentionally deferred with reason\n"
+            "## Traceability\n\n- IMPLEMENTS: foo\n- TESTS: bar\n"
+        )
+        self.assertEqual(check_pr_body(body), [])
+
     def test_parse_args_accepts_pre_commit_positional_files(self):
         args = parse_args(["--skip-pr-body", "docs/WORKFLOW.md", "mcp/ground-control/lib.js"])
         self.assertEqual(args.paths, ["docs/WORKFLOW.md", "mcp/ground-control/lib.js"])
         self.assertIsNone(args.files)
+
+    def test_parse_args_accepts_pr_body_file(self):
+        args = parse_args(["--pr-body-file", "/tmp/pr-body.md"])
+        self.assertEqual(args.pr_body_file, "/tmp/pr-body.md")
+
+    def test_parse_args_accepts_pr_number(self):
+        args = parse_args(["--pr-number", "790"])
+        self.assertEqual(args.pr_number, 790)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Replaces the unauthenticated REST API surface (P0 #243) with a unified Spring Security layer: bearer-token auth + role-based path matrix + optional CIDR allowlist, all driven by `groundcontrol.security.*` configuration.
- Consolidates the legacy pack-registry admin token into the new model — one credential store, one set of env vars, no per-feature auth path.
- ADR-026 records the decision and the configuration migration; CHANGELOG, DEPLOYMENT, README, and `.env.example` updated accordingly.

## Requirement UIDs

- GC-P011 — Access Control (NON_FUNCTIONAL, MUST, wave 1)

## ADR Impact

- ADR-026 added — REST API Access Control (GC-P011). Documents the Spring Security choice (Bearer token + CIDR + ROLE_ADMIN path matrix), the consolidation of `PackRegistryAccessGuard` into the unified credential store, and the dev/test profile defaults. No prior ADR is superseded.

## What changed

- New `shared/security/` package: `SecurityProperties`, `BearerTokenAuthFilter`, `IpAllowlistFilter`, `ApiAuthenticationEntryPoint`, `ApiAccessDeniedHandler`, `ApiSecurityConfig` (filter chain wiring with CSRF off, stateless sessions, path matrix).
- `ActorFilter` now prefers `SecurityContextHolder` principal over `X-Actor` so audit identity tracks the authenticated caller.
- `PackRegistryAccessGuard` simplified to read `SecurityContextHolder`; `ground-control.pack-registry.security.admin-credentials` removed and pack-registry endpoints rely on `ROLE_ADMIN` from the unified credential store. Pack-signing settings (`trusted-signers`) preserved.
- `dev` and `test` profiles set `groundcontrol.security.enabled=false` for zero-friction local development; production defaults to enabled.
- MCP server forwards `GROUND_CONTROL_API_TOKEN` on every `/api/v1/**` call (with the legacy admin token as a fallback for ROLE_ADMIN paths only).
- Deploy script and pack-registry-sync workflow migrate the SSM parameter shape to the new structure.

## Path matrix (when security is enabled)

| Path | Authority |
|------|-----------|
| `/actuator/health`, `/actuator/info`, `/error` | anonymous |
| `/api/openapi.json`, `/api/docs/**` | gated by `openapi-public` |
| `/api/v1/admin/**`, `/api/v1/embeddings/**`, `/api/v1/analysis/sweep/**`, `/api/v1/pack-registry/**` | `ROLE_ADMIN` |
| Other `/api/v1/**` | authenticated |
| anything else | denyAll |

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason

`make check` (Spotless, Checkstyle, SpotBugs, ErrorProne, ArchUnit, ControllerPolicyTest, JaCoCo coverage ≥ 80%) is green locally; `cd backend && ./gradlew integrationTest` (including the new `ApiSecurityIntegrationTest`) is green; `pre-commit run --all-files` is green. Sweep is unaffected by an authentication-layer change — deferred with reason.

## Test plan

- [x] `make check` green (CI-equivalent).
- [x] `make policy` green.
- [x] `./gradlew integrationTest` green — `ApiSecurityIntegrationTest` covers anonymous→401, USER→200, USER on admin→403, ADMIN on admin→200, `/actuator/health` anonymous, OpenAPI gating, IP allowlist 403, invalid bearer→401, wrong scheme→401.
- [x] All existing `@WebMvcTest` controller tests pass with `@AutoConfigureMockMvc(addFilters = false)`.
- [x] Pre-commit passes.

## Traceability

- IMPLEMENTS: GC-P011 → `backend/src/main/java/com/keplerops/groundcontrol/shared/security/{SecurityProperties,ApiSecurityConfig,BearerTokenAuthFilter,IpAllowlistFilter,ApiAuthenticationEntryPoint,ApiAccessDeniedHandler}.java`, `architecture/adrs/026-rest-api-access-control.md`, `backend/src/main/resources/application.yml`.
- TESTS: GC-P011 → `backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/*.java`, `backend/src/test/java/com/keplerops/groundcontrol/integration/ApiSecurityIntegrationTest.java`.

Issue ↔ requirement linkage and `DRAFT → ACTIVE` transition will be reconciled via Ground Control MCP after CI / reviews are green (the implement workflow's Step 15 / Step 16).

## Operator migration

Deployments using `ground-control.pack-registry.security.admin-credentials` MUST move those entries into `groundcontrol.security.credentials` with `role: ADMIN`. Without `groundcontrol.security.credentials` (or with `GC_SECURITY_ENABLED=true` and an empty list), every authenticated route returns 401. See ADR-026 and `docs/deployment/DEPLOYMENT.md` for the full env-var reference.

Closes #243
