### PR TITLE
Cap pre-push gc_codex_review cycles at 2 (closes #796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gc_codex_review` enforces the GC-O007 hard-cap-2 contract on
   pre-push (`uncommitted=true`) reviews as well, closing the
   follow-up gap that #794 MVP-1 left open (closes #796). The cycle
-  counter is anchored to the resolved GitHub issue thread plus the
-  current branch name, in line with the ADR-029 issue-thread durable
-  record. After each successful pre-push run the tool posts a
+  counter is anchored to the resolved GitHub issue thread; the
+  current branch name is recorded in the marker for audit context
+  but is NOT part of the cap key (per #800 cycle-2 review — keying by
+  `(issue, branch)` would let a noncompliant agent rename the branch
+  and start fresh). After each successful pre-push run the tool posts a
   machine-readable marker (`<!-- gc:codex-prepush-cycle issue="..."
   branch="..." cycle="..." -->`); the next invocation reads existing
   markers and refuses cycle 3 with `error:
@@ -38,20 +40,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   --paginate --slurp` so issues with more than 100 comments don't
   hide markers on later pages and silently bypass enforcement
   (this also tightens the post-push and verify cap counts on
-  long-lived issues). Five new pure-function exports back the
+  long-lived issues). Clean cycles (no findings) return
+  `next_action: "proceed_clean"` so the cap-evaluator's pre-run
+  `fix_all_findings_...` hint doesn't mislead the caller after a
+  0-finding review. Five new pure-function exports back the
   enforcement: `parseCodexReviewPrePushCycleMarkers`,
   `evaluateCodexReviewPrePushCycleCap`,
   `buildCodexReviewPrePushCycleMarker`,
   `deriveIssueNumberFromBranch`, and constants
   `CODEX_REVIEW_PREPUSH_HARD_CAP` /
-  `CODEX_REVIEW_PREPUSH_MARKER_PREFIX`. 33 new unit + integration
+  `CODEX_REVIEW_PREPUSH_MARKER_PREFIX`. 35+ new unit + integration
   tests cover the parser, evaluator, marker round-trip (including
-  JSON-encoded branches with slashes and override-with-embedded-
-  quote reasons), branch derivation, the disjoint-family invariant,
-  and the `runCodexReview` `uncommitted=true` decision tree
-  (detached-HEAD refusal, missing-issue refusal, accepted positive
-  paths). Override paths on all three review/verify cap evaluators
-  now return a concrete `next_action` instead of `null`.
+  override-with-embedded-quote reasons and slashes-in-branch),
+  branch derivation, the disjoint-family invariant, the
+  `runCodexReview` `uncommitted=true` decision tree (detached-HEAD
+  refusal, missing-issue refusal, accepted positive paths), per-issue
+  keying (branch rename does NOT bypass cap), and the post-codex
+  marker-write path (success metadata + `prepush_cycle_record_failed`
+  on POST failure) via hermetic gh + codex shims. Override paths on
+  all three review/verify cap evaluators now return a concrete
+  `next_action` instead of `null`.
 - ADR-030 "On-prem Hetzner Deployment" — documents the new production deployment architecture (red-dragon, Hetzner dedicated, Tailscale-only), the runner→red-dragon tailnet path, the SSH authorization model (`gc-deploy` user with `command="/opt/gc/deploy.sh",restrict <ed25519-pubkey>`), what ADR-018 retains and sheds, and the migration timeline.
 - Canonical `skills/implement/SKILL.md` at the repo root (closes #791,
   GC-O007, GC-O009). One source of truth for the agentic implement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `gc_codex_review` enforces the GC-O007 hard-cap-2 contract on
+  pre-push (`uncommitted=true`) reviews as well, closing the
+  follow-up gap that #794 MVP-1 left open (closes #796). The cycle
+  counter is anchored to the resolved GitHub issue thread plus the
+  current branch name, in line with the ADR-029 issue-thread durable
+  record. After each successful pre-push run the tool posts a
+  machine-readable marker (`<!-- gc:codex-prepush-cycle issue="..."
+  branch="..." cycle="..." -->`); the next invocation reads existing
+  markers and refuses cycle 3 with `error:
+  "codex_review_prepush_cap_reached"` and `next_action:
+  "post_summary_and_escalate_to_user"`. The new family is disjoint
+  from the post-push `gc:codex-review-cycle` family so the two
+  parsers never cross-count. `override_cap` + `override_reason`
+  apply identically (user-only authorization; the agent cannot
+  self-authorize). Successful returns surface `cycle`, `cap`,
+  `next_action`, `override`, `override_reason`, plus the resolved
+  `issue_number` and `branch`. New optional `issue_number` parameter
+  on `gc_codex_review`; when omitted, the tool derives the issue
+  number from the current branch's leading numeric prefix (e.g.
+  `796-cap-pre-push` → 796) and refuses with a structured error if
+  neither resolves. Detached-HEAD pre-push runs are also refused.
+  Marker-post failures fail the entire pre-push run with
+  `error: "prepush_cycle_record_failed"` (findings are preserved in
+  the response so they aren't lost) — the cap is only durable if
+  the marker lands, so a silent failure cannot count as a completed
+  cycle. The shared issue-comment reader now uses `gh api
+  --paginate --slurp` so issues with more than 100 comments don't
+  hide markers on later pages and silently bypass enforcement
+  (this also tightens the post-push and verify cap counts on
+  long-lived issues). Five new pure-function exports back the
+  enforcement: `parseCodexReviewPrePushCycleMarkers`,
+  `evaluateCodexReviewPrePushCycleCap`,
+  `buildCodexReviewPrePushCycleMarker`,
+  `deriveIssueNumberFromBranch`, and constants
+  `CODEX_REVIEW_PREPUSH_HARD_CAP` /
+  `CODEX_REVIEW_PREPUSH_MARKER_PREFIX`. 33 new unit + integration
+  tests cover the parser, evaluator, marker round-trip (including
+  JSON-encoded branches with slashes and override-with-embedded-
+  quote reasons), branch derivation, the disjoint-family invariant,
+  and the `runCodexReview` `uncommitted=true` decision tree
+  (detached-HEAD refusal, missing-issue refusal, accepted positive
+  paths). Override paths on all three review/verify cap evaluators
+  now return a concrete `next_action` instead of `null`.
 - ADR-030 "On-prem Hetzner Deployment" — documents the new production deployment architecture (red-dragon, Hetzner dedicated, Tailscale-only), the runner→red-dragon tailnet path, the SSH authorization model (`gc-deploy` user with `command="/opt/gc/deploy.sh",restrict <ed25519-pubkey>`), what ADR-018 retains and sheds, and the migration timeline.
 - Canonical `skills/implement/SKILL.md` at the repo root (closes #791,
   GC-O007, GC-O009). One source of truth for the agentic implement

--- a/architecture/adrs/027-agent-neutral-implement-workflow-packaging.md
+++ b/architecture/adrs/027-agent-neutral-implement-workflow-packaging.md
@@ -153,8 +153,9 @@ engine.
   invariant.
 - After ADR-029 removes the synchronous plan-approval gate, agent silence on
   review-finding decisions becomes the new accountability risk. ADR-029
-  mitigates by mandating that every finding decision (fix / wontfix / defer /
-  not-applicable) is recorded as a comment on the issue thread.
+  mitigates by mandating that every finding decision (fix / wontfix /
+  not-applicable) is recorded as a comment on the issue thread. `defer` is not
+  a valid decision under GC-O007.
 
 ## Non-Goals
 

--- a/architecture/adrs/029-issue-thread-gate-model.md
+++ b/architecture/adrs/029-issue-thread-gate-model.md
@@ -80,6 +80,22 @@ effect. Reviews route through `gc_codex_review`, `gc_codex_verify_finding`,
 and `gc_codex_architecture_preflight` regardless of which agent runtime
 drives the workflow.
 
+### Pre-push review cycle state
+
+Pre-push `gc_codex_review` runs with `uncommitted=true` are the same Codex
+review loop as the post-push PR review, just before a PR number exists. They
+therefore inherit GC-O007's hard two-cycle cap and no cycle-3 verification pass.
+Any older workflow text or issue prose that refers to a five-cycle Codex cap is
+stale and must not drive implementation without a new ADR amending GC-O007.
+
+Because the pre-push review has no PR issue number, its durable cycle state is
+anchored to the GitHub issue resolved at workflow Step 1 plus the current branch
+name. The marker belongs to the same issue-thread marker family as plan,
+phase, review-cycle, and verify-cycle markers. Implementations must reuse the
+existing issue-comment read/post helpers, marker parser/evaluator pattern, and
+structured refusal result style; they must not add a local state file, git
+notes, database row, Temporal state, or driver-local counter for this cap.
+
 ## Consequences
 
 ### Positive

--- a/architecture/adrs/029-issue-thread-gate-model.md
+++ b/architecture/adrs/029-issue-thread-gate-model.md
@@ -89,12 +89,28 @@ Any older workflow text or issue prose that refers to a five-cycle Codex cap is
 stale and must not drive implementation without a new ADR amending GC-O007.
 
 Because the pre-push review has no PR issue number, its durable cycle state is
-anchored to the GitHub issue resolved at workflow Step 1 plus the current branch
-name. The marker belongs to the same issue-thread marker family as plan,
-phase, review-cycle, and verify-cycle markers. Implementations must reuse the
+anchored to the GitHub issue resolved at workflow Step 1. The marker records
+the current branch name as audit-only context — the cap counter itself is
+keyed by issue alone, so a branch rename on the same issue cannot reset the
+counter. Earlier drafts of this ADR had the cap keyed by `(issue, branch)`,
+but PR #800 review (cycle 2) flagged that as a bypass: a noncompliant agent
+could rename `<issue>-x` to `<issue>-x-2` and start fresh. Per-issue keying
+closes that path. Legitimate "abandon and restart on a new branch" remains
+available via the user-authorized `override_cap=true` + `override_reason`
+path; the override marker stays distinguishable from regular cycle markers in
+the audit trail.
+
+The marker belongs to the same issue-thread marker family as plan, phase,
+review-cycle, and verify-cycle markers. Implementations must reuse the
 existing issue-comment read/post helpers, marker parser/evaluator pattern, and
 structured refusal result style; they must not add a local state file, git
 notes, database row, Temporal state, or driver-local counter for this cap.
+
+The cap mechanism is an audit / discipline gate, not a security boundary. A
+fully noncompliant or compromised agent with shell access has many paths to
+bypass — the cap narrows the most likely accidental-bypass path (branch
+rename) but does not protect against all attacks. The user's PR merge
+remains the only synchronous human gate.
 
 ## Consequences
 

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -749,18 +749,19 @@ server.tool(
 
 server.tool(
   "gc_codex_review",
-  "Run Codex against the current branch with a production-readiness review prompt. Codex enumerates all material findings (no triage) and, when a pull request is available, posts each finding as an inline PR review comment. Returns the list of posted comment ids, enriched with GraphQL review-thread ids and a short file/line/title preview so the coding agent can drive a fix/verify loop via gc_codex_verify_finding. Auto-detects the PR number for the current branch via `gh pr view` when pr_number is omitted. Hard-cap-2 enforcement (issue #794): post-push reviews are capped at two cycles per PR; the tool refuses cycle 3+ unless override_cap=true with a non-empty override_reason quoting the user's authorization.",
+  "Run Codex against the current branch with a production-readiness review prompt. Codex enumerates all material findings (no triage) and, when a pull request is available, posts each finding as an inline PR review comment. Returns the list of posted comment ids, enriched with GraphQL review-thread ids and a short file/line/title preview so the coding agent can drive a fix/verify loop via gc_codex_verify_finding. Auto-detects the PR number for the current branch via `gh pr view` when pr_number is omitted. Hard-cap-2 enforcement: post-push reviews are capped at two cycles per PR (issue #794); pre-push reviews (uncommitted=true) are capped at two cycles per (issue, branch) pair anchored to the resolved GitHub issue thread (issue #796). The tool refuses cycle 3+ unless override_cap=true with a non-empty override_reason quoting the user's authorization.",
   {
     repo_path: z.string().describe("Absolute path to the target Git repository"),
     base_branch: z.string().optional().describe("Base branch to review against (defaults to 'dev')"),
     uncommitted: z.boolean().optional().describe("Review staged/unstaged/untracked changes instead of committed branch history"),
     pr_number: z.number().int().positive().optional().describe("Pull request number to post findings to. When omitted and uncommitted is false, the tool auto-detects via `gh pr view --json number`. When no PR can be found, codex emits findings inline without posting."),
-    override_cap: z.boolean().optional().describe("Override the hard-cap-2 cycle limit. Only legitimate when the user has explicitly authorized cycle 3+ in the conversation. Requires override_reason."),
+    issue_number: z.number().int().positive().optional().describe("GitHub issue number used to anchor the pre-push cycle counter (uncommitted=true). When omitted, the tool derives it from the current branch's leading numeric prefix (e.g. '796-cap-pre-push' → 796). If neither resolves, the tool refuses with a structured error. Ignored for post-push reviews."),
+    override_cap: z.boolean().optional().describe("Override the hard-cap-2 cycle limit (post-push and pre-push). Only legitimate when the user has explicitly authorized cycle 3+ in the conversation. Requires override_reason."),
     override_reason: z.string().optional().describe("Required when override_cap=true. Quote the user's authorization (e.g. 'user said: yes run cycle 3 to verify'). Stored in the marker for audit."),
     override_phase_gate: z.boolean().optional().describe("Override the plan-before-review ordering gate. Only legitimate when the user explicitly authorized skipping planning (e.g., trivial bug fix). Requires override_phase_reason."),
     override_phase_reason: z.string().optional().describe("Required when override_phase_gate=true. Quote the user's authorization. Logged for audit."),
   },
-  async ({ repo_path, base_branch, uncommitted, pr_number, override_cap, override_reason, override_phase_gate, override_phase_reason }) => {
+  async ({ repo_path, base_branch, uncommitted, pr_number, issue_number, override_cap, override_reason, override_phase_gate, override_phase_reason }) => {
     try {
       return ok(JSON.stringify(
         await runCodexReview({
@@ -768,6 +769,7 @@ server.tool(
           baseBranch: base_branch || "dev",
           uncommitted: Boolean(uncommitted),
           prNumber: pr_number != null ? pr_number : null,
+          issueNumber: issue_number != null ? issue_number : null,
           overrideCap: Boolean(override_cap),
           overrideReason: override_reason ?? null,
           overridePhaseGate: Boolean(override_phase_gate),

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -2556,26 +2556,30 @@ export function deriveIssueNumberFromBranch(branchName) {
   return n;
 }
 
-// Pure: count pre-push cycle markers for the given (issueNumber, branchName).
-// Branch names are compared after JSON-decoding the attribute value, so that
-// markers built with `branch="feat/200-x"` round-trip exactly. Defensive:
-// non-array input, non-string entries, empty/non-string branchName all return 0.
-export function parseCodexReviewPrePushCycleMarkers(commentBodies, issueNumber, branchName) {
+// Pure: count pre-push cycle markers for the given issueNumber. The marker
+// records the branch for audit context but the cap is anchored by issue
+// alone — a branch rename on the same issue cannot reset the counter. This
+// closes the bypass codex flagged in #800 review cycle 2: an agent
+// renaming `796-x` → `796-x-2` would previously start fresh under
+// (issue, branch) keying. Defensive: non-array input and non-string entries
+// return 0.
+export function parseCodexReviewPrePushCycleMarkers(commentBodies, issueNumber) {
   if (!Array.isArray(commentBodies)) return 0;
-  if (typeof branchName !== "string" || branchName === "") return 0;
   let count = 0;
   for (const body of commentBodies) {
     if (typeof body !== "string") continue;
     for (const m of body.matchAll(CODEX_REVIEW_PREPUSH_MARKER_RE)) {
       const markerIssue = Number.parseInt(m[1], 10);
       if (markerIssue !== issueNumber) continue;
-      let markerBranch;
+      // Validate branch attr is JSON-decodable so malformed markers don't
+      // pollute counts. We don't compare it against any specific branch; the
+      // attribute is audit-only context.
       try {
-        markerBranch = JSON.parse(`"${m[2]}"`);
+        JSON.parse(`"${m[2]}"`);
       } catch {
         continue;
       }
-      if (markerBranch === branchName) count += 1;
+      count += 1;
     }
   }
   return count;
@@ -3091,11 +3095,11 @@ async function postCodexReviewCycleMarker(repoRoot, owner, name, prNumber, cycle
 }
 
 // Read the issue's comments and count prior pre-push cycle markers for the
-// given (issueNumber, branchName). Reuses readIssueCommentBodies because the
-// pre-push markers live on the same issue thread as the phase markers.
-async function readPriorCodexReviewPrePushCycleCount(repoRoot, owner, name, issueNumber, branchName) {
+// given issueNumber. Cap is anchored by issue alone (branch rename does not
+// reset the counter — see parseCodexReviewPrePushCycleMarkers).
+async function readPriorCodexReviewPrePushCycleCount(repoRoot, owner, name, issueNumber) {
   const bodies = await readIssueCommentBodies(repoRoot, owner, name, issueNumber);
-  return parseCodexReviewPrePushCycleMarkers(bodies, issueNumber, branchName);
+  return parseCodexReviewPrePushCycleMarkers(bodies, issueNumber);
 }
 
 // Post the pre-push cycle marker on the resolved issue thread.
@@ -3460,7 +3464,6 @@ export async function runCodexReview({
       owner,
       name,
       effectiveIssue,
-      branchName,
     );
     const decision = evaluateCodexReviewPrePushCycleCap({
       priorCount,
@@ -3742,6 +3745,17 @@ export async function runCodexReview({
   }
 
   const cycleSource = cycleOwnership ?? prePushOwnership ?? null;
+  // When the cycle returned 0 findings, the cap-evaluator's pre-run
+  // next_action ("fix_all_findings_..." / "fix_all_findings_then_summarize_...")
+  // is misleading — there is nothing to fix. Override to a clean signal so the
+  // caller proceeds (and so cycle 2 doesn't carry the cycle-2 escalation cue
+  // when there are no findings to summarize). Refusal envelopes (returned
+  // earlier with their own next_action) and override-cycle metadata are
+  // unaffected.
+  let effectiveNextAction = cycleSource ? cycleSource.nextAction : null;
+  if (cycleSource != null && comments.length === 0) {
+    effectiveNextAction = "proceed_clean";
+  }
   return {
     repo_path: repoRoot,
     base_branch: baseBranch,
@@ -3759,7 +3773,7 @@ export async function runCodexReview({
     ],
     cycle: cycleSource ? cycleSource.cycleNumber : null,
     cap: cycleSource ? cycleSource.cap : null,
-    next_action: cycleSource ? cycleSource.nextAction : null,
+    next_action: effectiveNextAction,
     override: cycleSource && cycleSource.override === true ? true : false,
     override_reason: cycleSource ? cycleSource.overrideReason : null,
   };

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -2272,9 +2272,10 @@ function buildPostingInstructions({ prNumber, reviewerLabel }) {
 // No new database, no local state file — the durable record lives on the
 // issue thread per ADR-029. Restart-safe by construction.
 //
-// Scope: enforces on `runCodexReview({ uncommitted: false, prNumber: <N> })`
-// only. Pre-push uncommitted reviews (Step 6.5) have a separate cap (5)
-// and no PR yet; left for a follow-up MVP.
+// Scope: this section enforces on `runCodexReview({ uncommitted: false,
+// prNumber: <N> })`. Pre-push (`uncommitted=true`) reviews have their own
+// cap and marker family — see "gc_codex_review pre-push cycle enforcement
+// (issue #796)" below.
 // ---------------------------------------------------------------------------
 
 export const CODEX_REVIEW_HARD_CAP = 2;
@@ -2341,6 +2342,7 @@ export function evaluateCodexReviewCycleCap({
       cap: hardCap,
       override: true,
       override_reason: overrideReason.trim(),
+      next_action: "fix_findings_then_summarize_and_escalate",
     };
   }
 
@@ -2461,6 +2463,7 @@ export function evaluateCodexVerifyCycleCap({
       cap: hardCap,
       override: true,
       override_reason: overrideReason.trim(),
+      next_action: "fix_finding_then_escalate_if_still_unresolved",
     };
   }
 
@@ -2508,6 +2511,174 @@ export function buildCodexVerifyCycleMarker({ prNumber, commentId, cycleNumber, 
     headline +
       " Posted by the MCP server to enforce the per-finding hard-cap-2 contract (issue #794). " +
       "Do not edit or delete — used by the next `gc_codex_verify_finding` invocation to count cycles." +
+      reasonLine,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// gc_codex_review pre-push cycle enforcement (issue #796)
+//
+// Pre-push reviews run with `uncommitted=true` against the local working tree
+// before any PR exists. They hit the same diminishing-returns wall as
+// post-push reviews, so they inherit GC-O007 / ADR-029's hard-cap-2 contract.
+// Cycle 3 is forbidden unless the user explicitly authorizes an override —
+// the agent cannot self-authorize.
+//
+// Persistence: marker comment on the resolved GitHub issue thread (Step 1 of
+// the implement skill resolves an issue before reviews start). Anchored to
+// (issue_number, branch_name) so a re-checked-out branch resets cleanly and
+// distinct branches on the same issue do not collide. Same template family
+// as the existing post-push cycle markers and verify markers, but a disjoint
+// regex so the two parsers never accidentally cross-count.
+// ---------------------------------------------------------------------------
+
+export const CODEX_REVIEW_PREPUSH_HARD_CAP = 2;
+export const CODEX_REVIEW_PREPUSH_MARKER_PREFIX = "<!-- gc:codex-prepush-cycle";
+// Matches `<!-- gc:codex-prepush-cycle issue="N" branch="..." cycle="M" ... -->`.
+// `branch` is JSON-encoded so it can carry slashes and escaped quotes; the
+// regex captures the *raw* attribute body up to the first unescaped quote and
+// the caller JSON-parses it before comparing. Optional override/reason attrs
+// after `cycle` are tolerated, mirroring the post-push marker shape.
+const CODEX_REVIEW_PREPUSH_MARKER_RE =
+  /<!--\s*gc:codex-prepush-cycle\s+issue="(\d+)"\s+branch="((?:[^"\\]|\\.)*)"\s+cycle="(\d+)"[^]*?-->/g;
+
+// Pure: extract the leading positive integer from a branch name like
+// `796-cap-pre-push`. Returns null when the branch does not start with one or
+// more digits, or when the leading value would be zero / negative. Used as a
+// safe fallback for callers (the implement skill) that don't pass an explicit
+// `issue_number`.
+export function deriveIssueNumberFromBranch(branchName) {
+  if (typeof branchName !== "string" || branchName === "") return null;
+  const match = branchName.match(/^(\d+)(?:-|$)/);
+  if (!match) return null;
+  const n = Number.parseInt(match[1], 10);
+  if (!Number.isInteger(n) || n <= 0) return null;
+  return n;
+}
+
+// Pure: count pre-push cycle markers for the given (issueNumber, branchName).
+// Branch names are compared after JSON-decoding the attribute value, so that
+// markers built with `branch="feat/200-x"` round-trip exactly. Defensive:
+// non-array input, non-string entries, empty/non-string branchName all return 0.
+export function parseCodexReviewPrePushCycleMarkers(commentBodies, issueNumber, branchName) {
+  if (!Array.isArray(commentBodies)) return 0;
+  if (typeof branchName !== "string" || branchName === "") return 0;
+  let count = 0;
+  for (const body of commentBodies) {
+    if (typeof body !== "string") continue;
+    for (const m of body.matchAll(CODEX_REVIEW_PREPUSH_MARKER_RE)) {
+      const markerIssue = Number.parseInt(m[1], 10);
+      if (markerIssue !== issueNumber) continue;
+      let markerBranch;
+      try {
+        markerBranch = JSON.parse(`"${m[2]}"`);
+      } catch {
+        continue;
+      }
+      if (markerBranch === branchName) count += 1;
+    }
+  }
+  return count;
+}
+
+// Pure: decide whether the next pre-push cycle is allowed. Same shape and
+// override semantics as evaluateCodexReviewCycleCap, with (issue, branch)
+// identity instead of (PR).
+export function evaluateCodexReviewPrePushCycleCap({
+  priorCount,
+  issueNumber,
+  branchName,
+  hardCap = CODEX_REVIEW_PREPUSH_HARD_CAP,
+  overrideCap = false,
+  overrideReason = null,
+}) {
+  if (typeof priorCount !== "number" || !Number.isFinite(priorCount) || priorCount < 0) {
+    throw new Error(
+      `evaluateCodexReviewPrePushCycleCap: priorCount must be a non-negative number, got ${priorCount}`,
+    );
+  }
+
+  if (overrideCap === true) {
+    if (typeof overrideReason !== "string" || overrideReason.trim() === "") {
+      return {
+        ok: false,
+        error: "codex_review_prepush_override_missing_reason",
+        message:
+          "override_cap=true requires a non-empty override_reason quoting the user's authorization. " +
+          "Audits cannot distinguish legitimate overrides from accidental ones without a reason.",
+        issue_number: issueNumber,
+        branch: branchName,
+        prior_cycles: priorCount,
+        cap: hardCap,
+      };
+    }
+    return {
+      ok: true,
+      nextCycle: priorCount + 1,
+      cap: hardCap,
+      override: true,
+      override_reason: overrideReason.trim(),
+      next_action: "fix_findings_then_summarize_and_escalate",
+    };
+  }
+
+  if (priorCount >= hardCap) {
+    return {
+      ok: false,
+      error: "codex_review_prepush_cap_reached",
+      message:
+        `gc_codex_review pre-push hard cap reached (${hardCap} cycles) for issue #${issueNumber} ` +
+        `on branch '${branchName}'. Per GC-O007 / ADR-029, after cycle ${hardCap} you must (a) post a ` +
+        `summary of findings + fixes to the issue thread, then (b) escalate to the user and ask whether ` +
+        `to run cycle ${hardCap + 1} or push as-is. Do not address findings by silently re-invoking ` +
+        `codex. If the user authorizes another cycle, retry with override_cap=true and ` +
+        `override_reason="<their authorization>".`,
+      issue_number: issueNumber,
+      branch: branchName,
+      prior_cycles: priorCount,
+      cap: hardCap,
+      next_action: "post_summary_and_escalate_to_user",
+    };
+  }
+
+  const nextCycle = priorCount + 1;
+  return {
+    ok: true,
+    nextCycle,
+    cap: hardCap,
+    next_action:
+      nextCycle === hardCap
+        ? "fix_all_findings_then_summarize_and_escalate"
+        : "fix_all_findings_and_restage",
+  };
+}
+
+export function buildCodexReviewPrePushCycleMarker({
+  issueNumber,
+  branchName,
+  cycleNumber,
+  override = false,
+  overrideReason = null,
+}) {
+  const branchAttr = JSON.stringify(String(branchName)).slice(1, -1); // raw inner JSON-encoded form
+  const overrideAttr = override === true ? ' override="true"' : "";
+  const reasonAttr =
+    override === true && typeof overrideReason === "string" && overrideReason.trim() !== ""
+      ? ` reason=${JSON.stringify(overrideReason.trim())}`
+      : "";
+  const headline = override
+    ? `_gc_codex_review pre-push cycle ${cycleNumber} (USER-AUTHORIZED OVERRIDE past cap ${CODEX_REVIEW_PREPUSH_HARD_CAP}) complete for issue #${issueNumber} on branch '${branchName}'._`
+    : `_gc_codex_review pre-push cycle ${cycleNumber} of ${CODEX_REVIEW_PREPUSH_HARD_CAP} complete for issue #${issueNumber} on branch '${branchName}'._`;
+  const reasonLine =
+    override && typeof overrideReason === "string" && overrideReason.trim() !== ""
+      ? `\nOverride reason: ${overrideReason.trim()}`
+      : "";
+  return [
+    `${CODEX_REVIEW_PREPUSH_MARKER_PREFIX} issue="${issueNumber}" branch="${branchAttr}" cycle="${cycleNumber}"${overrideAttr}${reasonAttr} -->`,
+    "",
+    headline +
+      " Posted by the MCP server to enforce the pre-push hard-cap-2 contract (issue #796). " +
+      "Do not edit or delete — used by the next `gc_codex_review` (uncommitted) invocation to count cycles." +
       reasonLine,
   ].join("\n");
 }
@@ -2789,6 +2960,13 @@ async function getPullRequestClosingIssues(repoRoot, prNumber) {
 // PR is the same endpoint — issues/{N}/comments). Used by both cycle-marker
 // counting and phase-marker counting. Returns an array of comment body
 // strings; entries that don't have a string body are silently skipped.
+//
+// Paginates through every page (100 comments at a time) via `gh api
+// --paginate --slurp`. `--paginate` alone emits one JSON array per page
+// concatenated as adjacent arrays (invalid JSON); `--slurp` wraps them in an
+// outer array of arrays which we flatten. Without pagination, an active
+// issue with more than 100 comments would hide marker comments on later pages
+// and silently bypass the hard-cap enforcement.
 async function readIssueCommentBodies(repoRoot, owner, name, issueNumber) {
   const { stdout } = await execFile(
     "gh",
@@ -2796,14 +2974,20 @@ async function readIssueCommentBodies(repoRoot, owner, name, issueNumber) {
       "api",
       "--method",
       "GET",
+      "--paginate",
+      "--slurp",
       `/repos/${owner}/${name}/issues/${issueNumber}/comments`,
       "-F",
       "per_page=100",
     ],
     { cwd: repoRoot },
   );
-  const comments = JSON.parse(stdout);
-  if (!Array.isArray(comments)) return [];
+  const pages = JSON.parse(stdout);
+  if (!Array.isArray(pages)) return [];
+  // `--slurp` produces array-of-arrays (one inner array per page). Flatten
+  // before extracting body strings. Tolerate the legacy single-array shape
+  // as well, in case future gh versions change this behavior.
+  const comments = pages.length > 0 && Array.isArray(pages[0]) ? pages.flat() : pages;
   return comments
     .map((c) => (c && typeof c.body === "string" ? c.body : null))
     .filter((b) => b != null);
@@ -2904,6 +3088,61 @@ async function postCodexReviewCycleMarker(repoRoot, owner, name, prNumber, cycle
     ],
     { cwd: repoRoot },
   );
+}
+
+// Read the issue's comments and count prior pre-push cycle markers for the
+// given (issueNumber, branchName). Reuses readIssueCommentBodies because the
+// pre-push markers live on the same issue thread as the phase markers.
+async function readPriorCodexReviewPrePushCycleCount(repoRoot, owner, name, issueNumber, branchName) {
+  const bodies = await readIssueCommentBodies(repoRoot, owner, name, issueNumber);
+  return parseCodexReviewPrePushCycleMarkers(bodies, issueNumber, branchName);
+}
+
+// Post the pre-push cycle marker on the resolved issue thread.
+async function postCodexReviewPrePushCycleMarker(
+  repoRoot,
+  owner,
+  name,
+  issueNumber,
+  branchName,
+  cycleNumber,
+  extras = {},
+) {
+  const body = buildCodexReviewPrePushCycleMarker({
+    issueNumber,
+    branchName,
+    cycleNumber,
+    override: extras.override === true,
+    overrideReason: extras.overrideReason ?? null,
+  });
+  await execFile(
+    "gh",
+    [
+      "api",
+      "--method",
+      "POST",
+      `/repos/${owner}/${name}/issues/${issueNumber}/comments`,
+      "-f",
+      `body=${body}`,
+    ],
+    { cwd: repoRoot },
+  );
+}
+
+// Resolve the current branch via `git rev-parse --abbrev-ref HEAD`. Returns
+// null when HEAD is detached or when the call fails — the caller decides how
+// to surface that to the agent.
+async function getCurrentBranchName(repoRoot) {
+  try {
+    const { stdout } = await execFile("git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd: repoRoot,
+    });
+    const branch = String(stdout).trim();
+    if (!branch || branch === "HEAD") return null;
+    return branch;
+  } catch {
+    return null;
+  }
 }
 
 async function autoDetectPrNumber(repoRoot) {
@@ -3145,6 +3384,7 @@ export async function runCodexReview({
   baseBranch = "dev",
   uncommitted = false,
   prNumber = null,
+  issueNumber = null,
   overrideCap = false,
   overrideReason = null,
   overridePhaseGate = false,
@@ -3157,10 +3397,110 @@ export async function runCodexReview({
     effectivePr = await autoDetectPrNumber(repoRoot);
   }
 
-  // Hard-cap-2 enforcement (issue #794 MVP-1) + plan-before-review ordering
-  // gate (issue #794 MVP-2 extension). Both apply only to post-push reviews
-  // tied to a PR; pre-push uncommitted reviews use a separate mechanic.
+  // Hard-cap-2 enforcement: post-push reviews use the (PR) marker family
+  // (issue #794 MVP-1); pre-push uncommitted reviews use the (issue, branch)
+  // marker family (issue #796). Plan-before-review ordering applies to
+  // post-push only.
   let cycleOwnership = null;
+  let prePushOwnership = null;
+
+  if (uncommitted) {
+    // Pre-push enforcement (#796). Resolve (issueNumber, branchName) — the
+    // explicit param wins; otherwise derive from the current branch name. If
+    // neither resolves to a positive integer, refuse with a structured error
+    // so the agent fixes the input rather than silently bypassing the cap.
+    const branchName = await getCurrentBranchName(repoRoot);
+    if (!branchName) {
+      return {
+        repo_path: repoRoot,
+        base_branch: baseBranch,
+        uncommitted,
+        pr_number: null,
+        ok: false,
+        error: "prepush_branch_unresolved",
+        message:
+          "gc_codex_review (uncommitted=true) requires a named branch to anchor the cycle counter, " +
+          "but HEAD is detached or the branch could not be resolved. Switch to a named feature branch " +
+          "(typically the one created by `gh issue develop <issue>`) and retry.",
+        next_action: "checkout_named_feature_branch",
+        finding_count: 0,
+        comments: [],
+        reviewers: [],
+      };
+    }
+
+    let effectiveIssue = Number.isInteger(issueNumber) && issueNumber > 0 ? issueNumber : null;
+    if (effectiveIssue == null) {
+      effectiveIssue = deriveIssueNumberFromBranch(branchName);
+    }
+    if (effectiveIssue == null) {
+      return {
+        repo_path: repoRoot,
+        base_branch: baseBranch,
+        uncommitted,
+        pr_number: null,
+        ok: false,
+        error: "prepush_issue_unresolved",
+        message:
+          `gc_codex_review (uncommitted=true) requires an issue number to anchor the cycle counter ` +
+          `to the issue thread (per ADR-029). Branch '${branchName}' does not start with a numeric ` +
+          `issue prefix (e.g. '796-...'), and no issue_number was passed. Either pass issue_number ` +
+          `explicitly or switch to a branch created via 'gh issue develop <issue>'.`,
+        branch: branchName,
+        next_action: "pass_issue_number_or_use_numeric_branch_prefix",
+        finding_count: 0,
+        comments: [],
+        reviewers: [],
+      };
+    }
+
+    const { owner, name } = await getOwnerRepo(repoRoot);
+    const priorCount = await readPriorCodexReviewPrePushCycleCount(
+      repoRoot,
+      owner,
+      name,
+      effectiveIssue,
+      branchName,
+    );
+    const decision = evaluateCodexReviewPrePushCycleCap({
+      priorCount,
+      issueNumber: effectiveIssue,
+      branchName,
+      overrideCap,
+      overrideReason,
+    });
+    if (!decision.ok) {
+      return {
+        repo_path: repoRoot,
+        base_branch: baseBranch,
+        uncommitted,
+        pr_number: null,
+        ok: false,
+        error: decision.error,
+        message: decision.message,
+        issue_number: decision.issue_number,
+        branch: decision.branch,
+        prior_cycles: decision.prior_cycles,
+        cap: decision.cap,
+        next_action: decision.next_action ?? null,
+        finding_count: 0,
+        comments: [],
+        reviewers: [],
+      };
+    }
+    prePushOwnership = {
+      owner,
+      name,
+      issueNumber: effectiveIssue,
+      branchName,
+      cycleNumber: decision.nextCycle,
+      cap: decision.cap,
+      nextAction: decision.next_action ?? null,
+      override: decision.override === true,
+      overrideReason: decision.override_reason ?? null,
+    };
+  }
+
   if (!uncommitted && effectivePr != null) {
     const { owner, name } = await getOwnerRepo(repoRoot);
 
@@ -3324,12 +3664,12 @@ export async function runCodexReview({
 
   const comments = dedupFindings([...coreComments, ...securityComments]);
 
-  // Successfully ran codex — record the cycle marker on the PR so subsequent
-  // invocations honor the hard cap. Posting after the codex run (not before)
-  // means failed/aborted runs don't consume a cycle. Marker-post failures are
-  // not fatal: the review itself succeeded and surfaced findings; the worst
-  // case is the next cycle's count is off-by-one, which the cap-evaluator
-  // handles gracefully (it reads whatever count is on the PR at the time).
+  // Successfully ran codex — record the cycle marker so subsequent invocations
+  // honor the hard cap. Posting after the codex run (not before) means
+  // failed/aborted runs don't consume a cycle. Marker-post failures are not
+  // fatal: the review itself succeeded and surfaced findings; the worst case
+  // is the next cycle's count is off-by-one, which the cap-evaluator handles
+  // gracefully (it reads whatever count is on the issue thread at the time).
   if (cycleOwnership != null) {
     try {
       await postCodexReviewCycleMarker(
@@ -3349,11 +3689,66 @@ export async function runCodexReview({
     }
   }
 
+  if (prePushOwnership != null) {
+    // The cap is durable iff the marker lands on the issue thread. Pre-push
+    // has no PR / CI / other secondary check — the marker IS the enforcement
+    // surface, so a marker-post failure has to fail the run. Findings are
+    // preserved in the returned payload (the agent can still act on them);
+    // failing here pushes the agent to retry once the underlying issue
+    // (network, gh auth, repo perms) is resolved, which is idempotent
+    // because the cap evaluator reads whatever count is on the thread.
+    try {
+      await postCodexReviewPrePushCycleMarker(
+        repoRoot,
+        prePushOwnership.owner,
+        prePushOwnership.name,
+        prePushOwnership.issueNumber,
+        prePushOwnership.branchName,
+        prePushOwnership.cycleNumber,
+        { override: prePushOwnership.override, overrideReason: prePushOwnership.overrideReason },
+      );
+    } catch (markerError) {
+      return {
+        repo_path: repoRoot,
+        base_branch: baseBranch,
+        uncommitted,
+        pr_number: null,
+        issue_number: prePushOwnership.issueNumber,
+        branch: prePushOwnership.branchName,
+        ok: false,
+        error: "prepush_cycle_record_failed",
+        message:
+          `gc_codex_review (uncommitted=true) ran successfully but failed to record the pre-push ` +
+          `cycle marker on issue #${prePushOwnership.issueNumber} (branch ` +
+          `'${prePushOwnership.branchName}'): ${markerError.message}. The cap is not durable for ` +
+          `this run; do not treat as a completed cycle. Findings (if any) are returned below for ` +
+          `review, but the workflow must not proceed past Step 6.5 until a successful run records ` +
+          `the marker. Retry once the underlying issue (network, gh auth, repo permissions) is ` +
+          `resolved.`,
+        next_action: "fix_underlying_marker_post_failure_and_retry",
+        cycle_record_error: markerError.message,
+        attempted_cycle: prePushOwnership.cycleNumber,
+        cap: prePushOwnership.cap,
+        finding_count: comments.length,
+        comments,
+        core_review_text: core.body,
+        security_review_text: security.body,
+        reviewers: [
+          { name: "core", finding_count: core.commentIds.length },
+          { name: "security", finding_count: security.commentIds.length },
+        ],
+      };
+    }
+  }
+
+  const cycleSource = cycleOwnership ?? prePushOwnership ?? null;
   return {
     repo_path: repoRoot,
     base_branch: baseBranch,
     uncommitted,
     pr_number: effectivePr,
+    issue_number: prePushOwnership ? prePushOwnership.issueNumber : null,
+    branch: prePushOwnership ? prePushOwnership.branchName : null,
     finding_count: comments.length,
     comments,
     core_review_text: core.body,
@@ -3362,11 +3757,11 @@ export async function runCodexReview({
       { name: "core", finding_count: core.commentIds.length },
       { name: "security", finding_count: security.commentIds.length },
     ],
-    cycle: cycleOwnership ? cycleOwnership.cycleNumber : null,
-    cap: cycleOwnership ? cycleOwnership.cap : null,
-    next_action: cycleOwnership ? cycleOwnership.nextAction : null,
-    override: cycleOwnership && cycleOwnership.override === true ? true : false,
-    override_reason: cycleOwnership ? cycleOwnership.overrideReason : null,
+    cycle: cycleSource ? cycleSource.cycleNumber : null,
+    cap: cycleSource ? cycleSource.cap : null,
+    next_action: cycleSource ? cycleSource.nextAction : null,
+    override: cycleSource && cycleSource.override === true ? true : false,
+    override_reason: cycleSource ? cycleSource.overrideReason : null,
   };
 }
 

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -2668,6 +2668,236 @@ describe("runCodexReview uncommitted=true input gating", () => {
   });
 });
 
+describe("runCodexReview uncommitted=true cap enforcement (hermetic gh shim)", () => {
+  // These tests exercise the actual cap-enforcement wiring: read prior markers
+  // from the issue thread, evaluate the cap, refuse cycle 3+ with the right
+  // structured error. We cannot mock node:child_process execFile directly
+  // (ESM imports), so we shadow `gh` via a fake binary at the front of PATH.
+  // The cap-refusal short-circuit happens BEFORE codex is spawned, so we only
+  // need to fake `gh` (not `codex`) for these paths.
+
+  function makeShimRepo({ branch, ghHandler }) {
+    const repoDir = mkdtempSync(join(tmpdir(), "gc-shim-repo-"));
+    execFileSync("git", ["-C", repoDir, "init", "-q", "--initial-branch", branch]);
+    execFileSync("git", ["-C", repoDir, "config", "user.email", "t@example.com"]);
+    execFileSync("git", ["-C", repoDir, "config", "user.name", "t"]);
+    writeFileSync(join(repoDir, "README"), "x\n");
+    execFileSync("git", ["-C", repoDir, "add", "README"]);
+    execFileSync("git", ["-C", repoDir, "commit", "-q", "-m", "init"]);
+
+    const binDir = mkdtempSync(join(tmpdir(), "gc-shim-bin-"));
+    // Persist routing data in a JSON file so the shim — a separate process —
+    // can read it. Each test owns its own shim dir / config.
+    const configPath = join(binDir, "config.json");
+    writeFileSync(configPath, JSON.stringify(ghHandler));
+    // Fake `gh`: dispatch on argv to canned responses keyed by argv-prefix.
+    const ghShim = `#!/usr/bin/env node
+const fs = require("node:fs");
+const cfg = JSON.parse(fs.readFileSync(${JSON.stringify(configPath)}, "utf8"));
+const argv = process.argv.slice(2);
+function match(prefix) { return prefix.every((p, i) => argv[i] === p); }
+for (const route of cfg.routes) {
+  if (match(route.argv_prefix)) {
+    if (route.exit_code != null && route.exit_code !== 0) {
+      process.stderr.write(route.stderr || "");
+      process.exit(route.exit_code);
+    }
+    process.stdout.write(route.stdout || "");
+    process.exit(0);
+  }
+}
+process.stderr.write("gh shim: unhandled argv: " + JSON.stringify(argv) + "\\n");
+process.exit(2);
+`;
+    const ghPath = join(binDir, "gh");
+    writeFileSync(ghPath, ghShim, { mode: 0o755 });
+    return {
+      repoDir,
+      binDir,
+      cleanup() {
+        rmSync(repoDir, { recursive: true, force: true });
+        rmSync(binDir, { recursive: true, force: true });
+      },
+    };
+  }
+
+  async function withShimPath(binDir, fn) {
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${oldPath}`;
+    try {
+      return await fn();
+    } finally {
+      process.env.PATH = oldPath;
+    }
+  }
+
+  function commentBody(marker) {
+    return JSON.stringify([{ id: 1, body: marker, user: { login: "tester" } }]);
+  }
+
+  it("refuses cycle 3 with codex_review_prepush_cap_reached when 2 prior markers exist", async () => {
+    const m1 = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 796,
+      branchName: "796-x",
+      cycleNumber: 1,
+    });
+    const m2 = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 796,
+      branchName: "796-x",
+      cycleNumber: 2,
+    });
+    // gh api --paginate --slurp wraps pages in an outer array. One page with
+    // both markers as comments suffices; --slurp produces [[c1, c2]].
+    const slurpedComments = JSON.stringify([
+      [
+        { id: 1, body: m1, user: { login: "tester" } },
+        { id: 2, body: m2, user: { login: "tester" } },
+      ],
+    ]);
+
+    const shim = makeShimRepo({
+      branch: "796-x",
+      ghHandler: {
+        routes: [
+          {
+            argv_prefix: ["repo", "view", "--json", "nameWithOwner"],
+            stdout: JSON.stringify({ nameWithOwner: "fake/repo" }),
+          },
+          {
+            argv_prefix: ["api", "--method", "GET", "--paginate", "--slurp"],
+            stdout: slurpedComments,
+          },
+        ],
+      },
+    });
+
+    try {
+      await withShimPath(shim.binDir, async () => {
+        const result = await runCodexReview({
+          repoPath: shim.repoDir,
+          uncommitted: true,
+        });
+        assert.equal(result.ok, false);
+        assert.equal(result.error, "codex_review_prepush_cap_reached");
+        assert.equal(result.prior_cycles, 2);
+        assert.equal(result.cap, CODEX_REVIEW_PREPUSH_HARD_CAP);
+        assert.equal(result.issue_number, 796);
+        assert.equal(result.branch, "796-x");
+        assert.equal(result.next_action, "post_summary_and_escalate_to_user");
+        assert.equal(result.finding_count, 0);
+        assert.deepEqual(result.comments, []);
+      });
+    } finally {
+      shim.cleanup();
+    }
+  });
+
+  it("does NOT refuse on cycle 1 when no prior markers exist (positive path through cap evaluation)", async () => {
+    // Empty issue thread: 0 prior markers → cap evaluator returns ok with
+    // cycle 1. The function then progresses to computing diff and spawning
+    // codex, which we don't have. We accept either a thrown shell-exec
+    // failure or a returned non-cap-error envelope as proof we got past the
+    // cap-refusal short-circuit.
+    const shim = makeShimRepo({
+      branch: "796-x",
+      ghHandler: {
+        routes: [
+          {
+            argv_prefix: ["repo", "view", "--json", "nameWithOwner"],
+            stdout: JSON.stringify({ nameWithOwner: "fake/repo" }),
+          },
+          {
+            argv_prefix: ["api", "--method", "GET", "--paginate", "--slurp"],
+            stdout: JSON.stringify([[]]), // one empty page
+          },
+        ],
+      },
+    });
+
+    try {
+      await withShimPath(shim.binDir, async () => {
+        let result;
+        let threw = false;
+        try {
+          result = await runCodexReview({
+            repoPath: shim.repoDir,
+            uncommitted: true,
+          });
+        } catch {
+          threw = true;
+        }
+        if (!threw) {
+          assert.notEqual(result.error, "codex_review_prepush_cap_reached");
+        }
+      });
+    } finally {
+      shim.cleanup();
+    }
+  });
+
+  it("counts only matching (issue, branch) markers — other branches don't bump the count", async () => {
+    // Two prior markers exist on the issue, but for a DIFFERENT branch. The
+    // cap should still allow cycle 1 on the current branch.
+    const otherBranchM1 = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 796,
+      branchName: "796-different-branch",
+      cycleNumber: 1,
+    });
+    const otherBranchM2 = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 796,
+      branchName: "796-different-branch",
+      cycleNumber: 2,
+    });
+    const slurpedComments = JSON.stringify([
+      [
+        { id: 1, body: otherBranchM1, user: { login: "tester" } },
+        { id: 2, body: otherBranchM2, user: { login: "tester" } },
+      ],
+    ]);
+
+    const shim = makeShimRepo({
+      branch: "796-x", // current branch is different from marker branches
+      ghHandler: {
+        routes: [
+          {
+            argv_prefix: ["repo", "view", "--json", "nameWithOwner"],
+            stdout: JSON.stringify({ nameWithOwner: "fake/repo" }),
+          },
+          {
+            argv_prefix: ["api", "--method", "GET", "--paginate", "--slurp"],
+            stdout: slurpedComments,
+          },
+        ],
+      },
+    });
+
+    try {
+      await withShimPath(shim.binDir, async () => {
+        let result;
+        let threw = false;
+        try {
+          result = await runCodexReview({
+            repoPath: shim.repoDir,
+            uncommitted: true,
+          });
+        } catch {
+          threw = true;
+        }
+        if (!threw) {
+          // Current branch has 0 priors → no cap refusal.
+          assert.notEqual(result.error, "codex_review_prepush_cap_reached");
+        }
+      });
+    } finally {
+      shim.cleanup();
+    }
+  });
+
+  // Single-token reference so eslint-no-unused-vars is happy when the helper
+  // is otherwise indirectly used.
+  void commentBody;
+});
+
 // ---------------------------------------------------------------------------
 // Workflow phase markers (#794 MVP-2)
 // ---------------------------------------------------------------------------

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -2263,16 +2263,16 @@ describe("deriveIssueNumberFromBranch", () => {
 describe("parseCodexReviewPrePushCycleMarkers", () => {
   it("returns 0 when no comments contain markers", () => {
     const bodies = ["random comment", "another", "## summary"];
-    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 0);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796), 0);
   });
 
-  it("counts markers for the matching (issue, branch) pair", () => {
+  it("counts markers for the matching issue regardless of branch", () => {
     const bodies = [
       'cycle 1: <!-- gc:codex-prepush-cycle issue="796" branch="796-foo" cycle="1" -->',
       "unrelated",
       'cycle 2: <!-- gc:codex-prepush-cycle issue="796" branch="796-foo" cycle="2" -->',
     ];
-    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 2);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796), 2);
   });
 
   it("ignores markers for other issues", () => {
@@ -2280,16 +2280,19 @@ describe("parseCodexReviewPrePushCycleMarkers", () => {
       '<!-- gc:codex-prepush-cycle issue="100" branch="796-foo" cycle="1" -->',
       '<!-- gc:codex-prepush-cycle issue="796" branch="796-foo" cycle="1" -->',
     ];
-    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 1);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796), 1);
   });
 
-  it("ignores markers for other branches on the same issue", () => {
+  it("counts markers from any branch on the same issue (closes branch-rename bypass)", () => {
+    // Per #800 review cycle 2: a noncompliant agent could rename
+    // `796-x` → `796-x-2` to evade per-(issue, branch) keying. The cap is now
+    // anchored by issue alone — markers on either branch count toward the same
+    // budget. Branch is recorded in the marker for audit context only.
     const bodies = [
       '<!-- gc:codex-prepush-cycle issue="796" branch="796-foo" cycle="1" -->',
-      '<!-- gc:codex-prepush-cycle issue="796" branch="796-bar" cycle="1" -->',
+      '<!-- gc:codex-prepush-cycle issue="796" branch="796-bar" cycle="2" -->',
     ];
-    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 1);
-    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-bar"), 1);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796), 2);
   });
 
   it("does not cross-count post-push cycle markers (different family)", () => {
@@ -2297,7 +2300,7 @@ describe("parseCodexReviewPrePushCycleMarkers", () => {
       '<!-- gc:codex-review-cycle cycle="1" pr="500" -->',
       '<!-- gc:codex-review-cycle cycle="2" pr="500" -->',
     ];
-    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 500, "500-anything"), 0);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 500), 0);
   });
 
   it("ignores malformed markers (missing attrs, unquoted, garbled)", () => {
@@ -2308,19 +2311,13 @@ describe("parseCodexReviewPrePushCycleMarkers", () => {
       '<!-- gc:codex-prepush-cycle branch="796-foo" cycle="1" -->', // no issue
       "<!-- gc:codex-prepush-cycle issue=796 branch=796-foo cycle=1 -->", // unquoted
     ];
-    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 0);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796), 0);
   });
 
   it("tolerates non-string entries and non-array input", () => {
-    assert.equal(parseCodexReviewPrePushCycleMarkers(["a", 42, null], 1, "x"), 0);
-    assert.equal(parseCodexReviewPrePushCycleMarkers(null, 1, "x"), 0);
-    assert.equal(parseCodexReviewPrePushCycleMarkers("not an array", 1, "x"), 0);
-  });
-
-  it("rejects empty / non-string branch input as 0 (defensive)", () => {
-    const bodies = ['<!-- gc:codex-prepush-cycle issue="1" branch="x" cycle="1" -->'];
-    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 1, ""), 0);
-    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 1, null), 0);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(["a", 42, null], 1), 0);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(null, 1), 0);
+    assert.equal(parseCodexReviewPrePushCycleMarkers("not an array", 1), 0);
   });
 });
 
@@ -2478,7 +2475,7 @@ describe("buildCodexReviewPrePushCycleMarker", () => {
       cycleNumber: 1,
     });
     assert.ok(marker.startsWith(CODEX_REVIEW_PREPUSH_MARKER_PREFIX));
-    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 796, "796-foo"), 1);
+    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 796), 1);
   });
 
   it("includes the cycle, cap, issue, and branch in the human-readable body", () => {
@@ -2493,7 +2490,7 @@ describe("buildCodexReviewPrePushCycleMarker", () => {
     assert.match(marker, /issue #796\b/); // attribution stays scoped
   });
 
-  it("two markers from the same (issue, branch) are both counted", () => {
+  it("two markers for the same issue are both counted regardless of branch", () => {
     const m1 = buildCodexReviewPrePushCycleMarker({
       issueNumber: 50,
       branchName: "50-x",
@@ -2501,16 +2498,17 @@ describe("buildCodexReviewPrePushCycleMarker", () => {
     });
     const m2 = buildCodexReviewPrePushCycleMarker({
       issueNumber: 50,
-      branchName: "50-x",
+      branchName: "50-x-renamed",
       cycleNumber: 2,
     });
-    assert.equal(parseCodexReviewPrePushCycleMarkers([m1, m2], 50, "50-x"), 2);
+    // Same issue, different branches → both count under per-issue keying.
+    assert.equal(parseCodexReviewPrePushCycleMarkers([m1, m2], 50), 2);
     const other = buildCodexReviewPrePushCycleMarker({
       issueNumber: 999,
       branchName: "999-x",
       cycleNumber: 1,
     });
-    assert.equal(parseCodexReviewPrePushCycleMarkers([m1, m2, other], 50, "50-x"), 2);
+    assert.equal(parseCodexReviewPrePushCycleMarkers([m1, m2, other], 50), 2);
   });
 
   it("renders an override marker distinguishable from regular cycle markers", () => {
@@ -2526,7 +2524,7 @@ describe("buildCodexReviewPrePushCycleMarker", () => {
     assert.match(marker, /reason="[^"]+"/);
     assert.match(marker, /USER-AUTHORIZED OVERRIDE/);
     assert.match(marker, new RegExp(reason));
-    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 796, "796-foo"), 1);
+    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 796), 1);
   });
 
   it("escapes quotes in override reasons so the comment HTML stays parseable", () => {
@@ -2539,26 +2537,19 @@ describe("buildCodexReviewPrePushCycleMarker", () => {
       overrideReason: tricky,
     });
     assert.match(marker, /reason="user said \\"yes do it\\" then ran off"/);
-    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 1, "1-x"), 1);
+    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 1), 1);
   });
 
-  it("supports branches with slashes via JSON-encoded branch attribute", () => {
+  it("supports branches with slashes in the audit-context attribute", () => {
     const marker = buildCodexReviewPrePushCycleMarker({
       issueNumber: 200,
       branchName: "feat/200-cool",
       cycleNumber: 1,
     });
-    // The JSON-encoded form keeps slashes as-is (no escaping needed) and the
-    // marker still round-trips for the exact same branch string.
-    assert.equal(
-      parseCodexReviewPrePushCycleMarkers([marker], 200, "feat/200-cool"),
-      1,
-    );
-    // And does NOT match a different branch.
-    assert.equal(
-      parseCodexReviewPrePushCycleMarkers([marker], 200, "feat/200-other"),
-      0,
-    );
+    // JSON-encoding preserves slashes; the marker round-trips.
+    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 200), 1);
+    // Different issue still doesn't match.
+    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 999), 0);
   });
 
   it("attribution mentions the enforcement issue (#796) so reviewers can audit", () => {
@@ -2835,9 +2826,11 @@ process.exit(2);
     }
   });
 
-  it("counts only matching (issue, branch) markers — other branches don't bump the count", async () => {
-    // Two prior markers exist on the issue, but for a DIFFERENT branch. The
-    // cap should still allow cycle 1 on the current branch.
+  it("branch rename does NOT bypass cap — markers from any branch on the issue count", async () => {
+    // Per #800 review cycle 2: under per-(issue, branch) keying a noncompliant
+    // agent could rename the branch to evade the cap. Per-issue keying closes
+    // that bypass: 2 markers exist for issue #796 on branch '796-different',
+    // current branch is '796-x' (rename), cycle 3 must still be refused.
     const otherBranchM1 = buildCodexReviewPrePushCycleMarker({
       issueNumber: 796,
       branchName: "796-different-branch",
@@ -2856,7 +2849,7 @@ process.exit(2);
     ]);
 
     const shim = makeShimRepo({
-      branch: "796-x", // current branch is different from marker branches
+      branch: "796-x", // renamed branch
       ghHandler: {
         routes: [
           {
@@ -2873,20 +2866,14 @@ process.exit(2);
 
     try {
       await withShimPath(shim.binDir, async () => {
-        let result;
-        let threw = false;
-        try {
-          result = await runCodexReview({
-            repoPath: shim.repoDir,
-            uncommitted: true,
-          });
-        } catch {
-          threw = true;
-        }
-        if (!threw) {
-          // Current branch has 0 priors → no cap refusal.
-          assert.notEqual(result.error, "codex_review_prepush_cap_reached");
-        }
+        const result = await runCodexReview({
+          repoPath: shim.repoDir,
+          uncommitted: true,
+        });
+        assert.equal(result.ok, false);
+        assert.equal(result.error, "codex_review_prepush_cap_reached");
+        assert.equal(result.prior_cycles, 2);
+        assert.equal(result.branch, "796-x"); // current branch reflected
       });
     } finally {
       shim.cleanup();
@@ -2896,6 +2883,183 @@ process.exit(2);
   // Single-token reference so eslint-no-unused-vars is happy when the helper
   // is otherwise indirectly used.
   void commentBody;
+});
+
+describe("runCodexReview uncommitted=true marker-post path (hermetic codex+gh shims)", () => {
+  // These tests exercise the post-codex marker-write path. Codex is shimmed to
+  // emit an empty COMMENT_IDS=[] tail (clean review). gh is shimmed for the
+  // entire flow: repo view, paginated slurped comments read, and the issue-
+  // comment POST (the marker write). Test 1 succeeds the POST; Test 2 fails
+  // the POST and asserts the prepush_cycle_record_failed envelope shape.
+
+  function makeFullShimRepo({ branch, ghHandler, codexHandler }) {
+    const repoDir = mkdtempSync(join(tmpdir(), "gc-fullshim-repo-"));
+    execFileSync("git", ["-C", repoDir, "init", "-q", "--initial-branch", branch]);
+    execFileSync("git", ["-C", repoDir, "config", "user.email", "t@example.com"]);
+    execFileSync("git", ["-C", repoDir, "config", "user.name", "t"]);
+    writeFileSync(join(repoDir, "README"), "x\n");
+    execFileSync("git", ["-C", repoDir, "add", "README"]);
+    execFileSync("git", ["-C", repoDir, "commit", "-q", "-m", "init"]);
+
+    const binDir = mkdtempSync(join(tmpdir(), "gc-fullshim-bin-"));
+    const ghCfgPath = join(binDir, "gh-config.json");
+    writeFileSync(ghCfgPath, JSON.stringify(ghHandler));
+    const ghShim = `#!/usr/bin/env node
+const fs = require("node:fs");
+const cfg = JSON.parse(fs.readFileSync(${JSON.stringify(ghCfgPath)}, "utf8"));
+const argv = process.argv.slice(2);
+function match(prefix) { return prefix.every((p, i) => argv[i] === p); }
+for (const route of cfg.routes) {
+  if (match(route.argv_prefix)) {
+    if (route.exit_code != null && route.exit_code !== 0) {
+      process.stderr.write(route.stderr || "");
+      process.exit(route.exit_code);
+    }
+    process.stdout.write(route.stdout || "");
+    process.exit(0);
+  }
+}
+process.stderr.write("gh shim: unhandled argv: " + JSON.stringify(argv) + "\\n");
+process.exit(2);
+`;
+    writeFileSync(join(binDir, "gh"), ghShim, { mode: 0o755 });
+
+    // codex shim: parses --output-last-message <path>, writes the canned tail
+    // to that path AND to stdout, drains stdin so the prompt pipe doesn't
+    // SIGPIPE, then exits 0.
+    const codexCfgPath = join(binDir, "codex-config.json");
+    writeFileSync(codexCfgPath, JSON.stringify(codexHandler));
+    const codexShim = `#!/usr/bin/env node
+const fs = require("node:fs");
+const cfg = JSON.parse(fs.readFileSync(${JSON.stringify(codexCfgPath)}, "utf8"));
+const args = process.argv.slice(2);
+let outputPath = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--output-last-message") outputPath = args[i + 1];
+}
+let stdinBuf = "";
+process.stdin.on("data", (chunk) => { stdinBuf += chunk.toString(); });
+process.stdin.on("end", () => {
+  const tail = cfg.tail || "**Findings**\\n\\nNo issues found.\\n\\nCOMMENT_IDS=[]\\n";
+  if (outputPath) fs.writeFileSync(outputPath, tail);
+  process.stdout.write(tail);
+  process.exit(cfg.exit_code || 0);
+});
+`;
+    writeFileSync(join(binDir, "codex"), codexShim, { mode: 0o755 });
+
+    return {
+      repoDir,
+      binDir,
+      cleanup() {
+        rmSync(repoDir, { recursive: true, force: true });
+        rmSync(binDir, { recursive: true, force: true });
+      },
+    };
+  }
+
+  async function withShimPathFull(binDir, fn) {
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${oldPath}`;
+    try {
+      return await fn();
+    } finally {
+      process.env.PATH = oldPath;
+    }
+  }
+
+  it("returns ok=true with cycle metadata when codex is clean and the marker POST succeeds", async () => {
+    const shim = makeFullShimRepo({
+      branch: "796-x",
+      ghHandler: {
+        routes: [
+          {
+            argv_prefix: ["repo", "view", "--json", "nameWithOwner"],
+            stdout: JSON.stringify({ nameWithOwner: "fake/repo" }),
+          },
+          {
+            argv_prefix: ["api", "--method", "GET", "--paginate", "--slurp"],
+            stdout: JSON.stringify([[]]),
+          },
+          {
+            // Marker POST → success
+            argv_prefix: ["api", "--method", "POST"],
+            stdout: JSON.stringify({ id: 999, html_url: "https://example.test/c/999" }),
+          },
+        ],
+      },
+      codexHandler: { tail: "Clean review.\n\nCOMMENT_IDS=[]\n" },
+    });
+
+    try {
+      await withShimPathFull(shim.binDir, async () => {
+        const result = await runCodexReview({
+          repoPath: shim.repoDir,
+          uncommitted: true,
+        });
+        assert.equal(result.uncommitted, true);
+        assert.equal(result.issue_number, 796);
+        assert.equal(result.branch, "796-x");
+        assert.equal(result.cycle, 1);
+        assert.equal(result.cap, CODEX_REVIEW_PREPUSH_HARD_CAP);
+        assert.equal(result.finding_count, 0);
+        // Clean cycle should signal "proceed_clean" — the cap-evaluator's
+        // pre-run "fix..." hint is overridden when there are no findings.
+        assert.equal(result.next_action, "proceed_clean");
+        assert.equal(result.override, false);
+      });
+    } finally {
+      shim.cleanup();
+    }
+  });
+
+  it("returns prepush_cycle_record_failed when the marker POST fails", async () => {
+    const shim = makeFullShimRepo({
+      branch: "796-x",
+      ghHandler: {
+        routes: [
+          {
+            argv_prefix: ["repo", "view", "--json", "nameWithOwner"],
+            stdout: JSON.stringify({ nameWithOwner: "fake/repo" }),
+          },
+          {
+            argv_prefix: ["api", "--method", "GET", "--paginate", "--slurp"],
+            stdout: JSON.stringify([[]]),
+          },
+          {
+            // Marker POST → fail with non-zero exit and stderr
+            argv_prefix: ["api", "--method", "POST"],
+            exit_code: 1,
+            stderr: "HTTP 500: simulated server error\n",
+          },
+        ],
+      },
+      codexHandler: { tail: "Clean review.\n\nCOMMENT_IDS=[]\n" },
+    });
+
+    try {
+      await withShimPathFull(shim.binDir, async () => {
+        const result = await runCodexReview({
+          repoPath: shim.repoDir,
+          uncommitted: true,
+        });
+        assert.equal(result.ok, false);
+        assert.equal(result.error, "prepush_cycle_record_failed");
+        assert.equal(result.next_action, "fix_underlying_marker_post_failure_and_retry");
+        assert.equal(result.issue_number, 796);
+        assert.equal(result.branch, "796-x");
+        assert.equal(result.attempted_cycle, 1);
+        assert.equal(result.cap, CODEX_REVIEW_PREPUSH_HARD_CAP);
+        // Findings preserved (codex output was clean, so 0 here, but the
+        // shape includes the comments array).
+        assert.equal(result.finding_count, 0);
+        assert.deepEqual(result.comments, []);
+        assert.match(result.cycle_record_error, /HTTP 500|simulated/);
+      });
+    } finally {
+      shim.cleanup();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -35,6 +35,13 @@ import {
   buildCodexVerifyCycleMarker,
   CODEX_VERIFY_HARD_CAP,
   CODEX_VERIFY_CYCLE_MARKER_PREFIX,
+  parseCodexReviewPrePushCycleMarkers,
+  evaluateCodexReviewPrePushCycleCap,
+  buildCodexReviewPrePushCycleMarker,
+  deriveIssueNumberFromBranch,
+  CODEX_REVIEW_PREPUSH_HARD_CAP,
+  CODEX_REVIEW_PREPUSH_MARKER_PREFIX,
+  runCodexReview,
   dedupFindings,
   buildCodexVerifyPrompt,
   parseCodexVerifyTail,
@@ -2009,6 +2016,7 @@ describe("evaluateCodexReviewCycleCap", () => {
     assert.equal(result.override, true);
     assert.equal(result.nextCycle, 3);
     assert.match(result.override_reason, /yes run cycle 3 to verify/);
+    assert.equal(result.next_action, "fix_findings_then_summarize_and_escalate");
   });
 
   it("rejects overrideCap=true without an overrideReason (audit requirement)", () => {
@@ -2179,6 +2187,10 @@ describe("evaluateCodexVerifyCycleCap", () => {
     assert.equal(goodOverride.ok, true);
     assert.equal(goodOverride.override, true);
     assert.equal(goodOverride.nextCycle, 3);
+    assert.equal(
+      goodOverride.next_action,
+      "fix_finding_then_escalate_if_still_unresolved",
+    );
   });
 
   it("throws on garbage priorCount (defensive)", () => {
@@ -2206,6 +2218,453 @@ describe("buildCodexVerifyCycleMarker", () => {
     assert.match(m, /USER-AUTHORIZED OVERRIDE/);
     assert.match(m, new RegExp(reason));
     assert.equal(parseCodexVerifyCycleMarkers([m], 1, 7), 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gc_codex_review pre-push cycle enforcement (#796)
+//
+// Pre-push reviews (`uncommitted=true`) hit the same diminishing-returns wall
+// as post-push reviews, so they inherit GC-O007's hard-cap-2. The marker is a
+// new, disjoint family from the post-push one — anchored to (issue, branch)
+// instead of (PR) — so the two parsers never accidentally cross-count.
+// ---------------------------------------------------------------------------
+
+describe("deriveIssueNumberFromBranch", () => {
+  it("extracts the leading integer from a gh-issue-develop-style branch", () => {
+    assert.equal(deriveIssueNumberFromBranch("796-cap-pre-push"), 796);
+    assert.equal(deriveIssueNumberFromBranch("1-x"), 1);
+  });
+
+  it("returns the integer when the branch is just digits", () => {
+    assert.equal(deriveIssueNumberFromBranch("796"), 796);
+  });
+
+  it("returns null when the branch does not start with digits", () => {
+    assert.equal(deriveIssueNumberFromBranch("feature/796-x"), null);
+    assert.equal(deriveIssueNumberFromBranch("dev"), null);
+    assert.equal(deriveIssueNumberFromBranch("main"), null);
+    assert.equal(deriveIssueNumberFromBranch("release-2.0"), null);
+  });
+
+  it("returns null on empty / non-string / nullish input", () => {
+    assert.equal(deriveIssueNumberFromBranch(""), null);
+    assert.equal(deriveIssueNumberFromBranch(null), null);
+    assert.equal(deriveIssueNumberFromBranch(undefined), null);
+    assert.equal(deriveIssueNumberFromBranch(42), null);
+  });
+
+  it("rejects zero or negative leading values (issue numbers are positive)", () => {
+    assert.equal(deriveIssueNumberFromBranch("0-foo"), null);
+    assert.equal(deriveIssueNumberFromBranch("-1-foo"), null);
+  });
+});
+
+describe("parseCodexReviewPrePushCycleMarkers", () => {
+  it("returns 0 when no comments contain markers", () => {
+    const bodies = ["random comment", "another", "## summary"];
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 0);
+  });
+
+  it("counts markers for the matching (issue, branch) pair", () => {
+    const bodies = [
+      'cycle 1: <!-- gc:codex-prepush-cycle issue="796" branch="796-foo" cycle="1" -->',
+      "unrelated",
+      'cycle 2: <!-- gc:codex-prepush-cycle issue="796" branch="796-foo" cycle="2" -->',
+    ];
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 2);
+  });
+
+  it("ignores markers for other issues", () => {
+    const bodies = [
+      '<!-- gc:codex-prepush-cycle issue="100" branch="796-foo" cycle="1" -->',
+      '<!-- gc:codex-prepush-cycle issue="796" branch="796-foo" cycle="1" -->',
+    ];
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 1);
+  });
+
+  it("ignores markers for other branches on the same issue", () => {
+    const bodies = [
+      '<!-- gc:codex-prepush-cycle issue="796" branch="796-foo" cycle="1" -->',
+      '<!-- gc:codex-prepush-cycle issue="796" branch="796-bar" cycle="1" -->',
+    ];
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 1);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-bar"), 1);
+  });
+
+  it("does not cross-count post-push cycle markers (different family)", () => {
+    const bodies = [
+      '<!-- gc:codex-review-cycle cycle="1" pr="500" -->',
+      '<!-- gc:codex-review-cycle cycle="2" pr="500" -->',
+    ];
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 500, "500-anything"), 0);
+  });
+
+  it("ignores malformed markers (missing attrs, unquoted, garbled)", () => {
+    const bodies = [
+      "<!-- gc:codex-prepush-cycle -->",
+      '<!-- gc:codex-prepush-cycle issue="796" branch="796-foo" -->', // no cycle
+      '<!-- gc:codex-prepush-cycle issue="796" cycle="1" -->', // no branch
+      '<!-- gc:codex-prepush-cycle branch="796-foo" cycle="1" -->', // no issue
+      "<!-- gc:codex-prepush-cycle issue=796 branch=796-foo cycle=1 -->", // unquoted
+    ];
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 796, "796-foo"), 0);
+  });
+
+  it("tolerates non-string entries and non-array input", () => {
+    assert.equal(parseCodexReviewPrePushCycleMarkers(["a", 42, null], 1, "x"), 0);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(null, 1, "x"), 0);
+    assert.equal(parseCodexReviewPrePushCycleMarkers("not an array", 1, "x"), 0);
+  });
+
+  it("rejects empty / non-string branch input as 0 (defensive)", () => {
+    const bodies = ['<!-- gc:codex-prepush-cycle issue="1" branch="x" cycle="1" -->'];
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 1, ""), 0);
+    assert.equal(parseCodexReviewPrePushCycleMarkers(bodies, 1, null), 0);
+  });
+});
+
+describe("evaluateCodexReviewPrePushCycleCap", () => {
+  it("allows cycle 1 with a fix-and-push next_action", () => {
+    const r = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 0,
+      issueNumber: 796,
+      branchName: "796-foo",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.nextCycle, 1);
+    assert.equal(r.cap, CODEX_REVIEW_PREPUSH_HARD_CAP);
+    assert.equal(r.next_action, "fix_all_findings_and_restage");
+    assert.notEqual(r.override, true);
+  });
+
+  it("allows cycle 2 with the summarize-and-escalate discipline", () => {
+    const r = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 1,
+      issueNumber: 796,
+      branchName: "796-foo",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.nextCycle, 2);
+    assert.equal(r.next_action, "fix_all_findings_then_summarize_and_escalate");
+  });
+
+  it("refuses cycle 3 with codex_review_prepush_cap_reached", () => {
+    const r = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 2,
+      issueNumber: 796,
+      branchName: "796-foo",
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.error, "codex_review_prepush_cap_reached");
+    assert.equal(r.prior_cycles, 2);
+    assert.equal(r.cap, 2);
+    assert.equal(r.issue_number, 796);
+    assert.equal(r.branch, "796-foo");
+    assert.equal(r.next_action, "post_summary_and_escalate_to_user");
+    assert.match(r.message, /hard cap reached/);
+    assert.match(r.message, /escalate to the user/);
+    assert.match(r.message, /override_cap=true/);
+  });
+
+  it("refuses higher counts the same way (cap is a floor)", () => {
+    const r = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 9,
+      issueNumber: 1,
+      branchName: "1-x",
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.prior_cycles, 9);
+  });
+
+  it("respects an override hardCap (used by tests / future per-tool caps)", () => {
+    const allowed = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 2,
+      issueNumber: 1,
+      branchName: "1-x",
+      hardCap: 5,
+    });
+    assert.equal(allowed.ok, true);
+    assert.equal(allowed.nextCycle, 3);
+    const refused = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 5,
+      issueNumber: 1,
+      branchName: "1-x",
+      hardCap: 5,
+    });
+    assert.equal(refused.ok, false);
+    assert.equal(refused.cap, 5);
+  });
+
+  it("allows cycle 3 when overrideCap=true with a non-empty overrideReason", () => {
+    const r = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 2,
+      issueNumber: 796,
+      branchName: "796-foo",
+      overrideCap: true,
+      overrideReason: "user said 'yes run cycle 3 to verify' on 2026-05-04",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.override, true);
+    assert.equal(r.nextCycle, 3);
+    assert.match(r.override_reason, /yes run cycle 3 to verify/);
+    assert.equal(r.next_action, "fix_findings_then_summarize_and_escalate");
+  });
+
+  it("rejects overrideCap=true without an overrideReason (audit requirement)", () => {
+    const r1 = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 2,
+      issueNumber: 1,
+      branchName: "1-x",
+      overrideCap: true,
+    });
+    assert.equal(r1.ok, false);
+    assert.equal(r1.error, "codex_review_prepush_override_missing_reason");
+
+    const r2 = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 2,
+      issueNumber: 1,
+      branchName: "1-x",
+      overrideCap: true,
+      overrideReason: "   ",
+    });
+    assert.equal(r2.ok, false);
+    assert.equal(r2.error, "codex_review_prepush_override_missing_reason");
+  });
+
+  it("override applies even within the cap (allows arbitrary mid-flight overrides)", () => {
+    const r = evaluateCodexReviewPrePushCycleCap({
+      priorCount: 0,
+      issueNumber: 796,
+      branchName: "796-foo",
+      overrideCap: true,
+      overrideReason: "user wants cycle 1 marked as override for some reason",
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.override, true);
+    assert.equal(r.nextCycle, 1);
+  });
+
+  it("throws on garbage priorCount (defensive)", () => {
+    assert.throws(() =>
+      evaluateCodexReviewPrePushCycleCap({
+        priorCount: -1,
+        issueNumber: 1,
+        branchName: "x",
+      }),
+    );
+    assert.throws(() =>
+      evaluateCodexReviewPrePushCycleCap({
+        priorCount: NaN,
+        issueNumber: 1,
+        branchName: "x",
+      }),
+    );
+    assert.throws(() =>
+      evaluateCodexReviewPrePushCycleCap({
+        priorCount: "1",
+        issueNumber: 1,
+        branchName: "x",
+      }),
+    );
+  });
+});
+
+describe("buildCodexReviewPrePushCycleMarker", () => {
+  it("produces a marker that round-trips through parseCodexReviewPrePushCycleMarkers", () => {
+    const marker = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 796,
+      branchName: "796-foo",
+      cycleNumber: 1,
+    });
+    assert.ok(marker.startsWith(CODEX_REVIEW_PREPUSH_MARKER_PREFIX));
+    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 796, "796-foo"), 1);
+  });
+
+  it("includes the cycle, cap, issue, and branch in the human-readable body", () => {
+    const marker = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 796,
+      branchName: "796-foo",
+      cycleNumber: 2,
+    });
+    assert.match(marker, /cycle 2 of 2/);
+    assert.match(marker, /issue #796/);
+    assert.match(marker, /796-foo/);
+    assert.match(marker, /issue #796\b/); // attribution stays scoped
+  });
+
+  it("two markers from the same (issue, branch) are both counted", () => {
+    const m1 = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 50,
+      branchName: "50-x",
+      cycleNumber: 1,
+    });
+    const m2 = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 50,
+      branchName: "50-x",
+      cycleNumber: 2,
+    });
+    assert.equal(parseCodexReviewPrePushCycleMarkers([m1, m2], 50, "50-x"), 2);
+    const other = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 999,
+      branchName: "999-x",
+      cycleNumber: 1,
+    });
+    assert.equal(parseCodexReviewPrePushCycleMarkers([m1, m2, other], 50, "50-x"), 2);
+  });
+
+  it("renders an override marker distinguishable from regular cycle markers", () => {
+    const reason = "user authorized cycle 3 to verify cycle-2 fixes";
+    const marker = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 796,
+      branchName: "796-foo",
+      cycleNumber: 3,
+      override: true,
+      overrideReason: reason,
+    });
+    assert.match(marker, /override="true"/);
+    assert.match(marker, /reason="[^"]+"/);
+    assert.match(marker, /USER-AUTHORIZED OVERRIDE/);
+    assert.match(marker, new RegExp(reason));
+    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 796, "796-foo"), 1);
+  });
+
+  it("escapes quotes in override reasons so the comment HTML stays parseable", () => {
+    const tricky = 'user said "yes do it" then ran off';
+    const marker = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 1,
+      branchName: "1-x",
+      cycleNumber: 3,
+      override: true,
+      overrideReason: tricky,
+    });
+    assert.match(marker, /reason="user said \\"yes do it\\" then ran off"/);
+    assert.equal(parseCodexReviewPrePushCycleMarkers([marker], 1, "1-x"), 1);
+  });
+
+  it("supports branches with slashes via JSON-encoded branch attribute", () => {
+    const marker = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 200,
+      branchName: "feat/200-cool",
+      cycleNumber: 1,
+    });
+    // The JSON-encoded form keeps slashes as-is (no escaping needed) and the
+    // marker still round-trips for the exact same branch string.
+    assert.equal(
+      parseCodexReviewPrePushCycleMarkers([marker], 200, "feat/200-cool"),
+      1,
+    );
+    // And does NOT match a different branch.
+    assert.equal(
+      parseCodexReviewPrePushCycleMarkers([marker], 200, "feat/200-other"),
+      0,
+    );
+  });
+
+  it("attribution mentions the enforcement issue (#796) so reviewers can audit", () => {
+    const marker = buildCodexReviewPrePushCycleMarker({
+      issueNumber: 1,
+      branchName: "1-x",
+      cycleNumber: 1,
+    });
+    assert.match(marker, /issue #796/);
+  });
+});
+
+describe("runCodexReview uncommitted=true input gating", () => {
+  // These tests exercise the uncommitted=true decision tree before any gh /
+  // codex shells out. The refusal paths (detached HEAD, missing issue) are the
+  // most important pre-flight checks because they are the only thing standing
+  // between an unresolvable input and a half-completed run that no marker can
+  // anchor.
+  function makeTempRepo({ branch = "main", detached = false } = {}) {
+    const dir = mkdtempSync(join(tmpdir(), "gc-prepush-test-"));
+    execFileSync("git", ["-C", dir, "init", "-q", "--initial-branch", branch]);
+    execFileSync("git", ["-C", dir, "config", "user.email", "test@example.com"]);
+    execFileSync("git", ["-C", dir, "config", "user.name", "test"]);
+    // Need at least one commit so HEAD points somewhere we can detach onto.
+    writeFileSync(join(dir, "README"), "x\n");
+    execFileSync("git", ["-C", dir, "add", "README"]);
+    execFileSync("git", ["-C", dir, "commit", "-q", "-m", "init"]);
+    if (detached) {
+      const sha = execFileSync("git", ["-C", dir, "rev-parse", "HEAD"]).toString().trim();
+      execFileSync("git", ["-C", dir, "-c", "advice.detachedHead=false", "checkout", "-q", sha]);
+    }
+    return dir;
+  }
+
+  it("refuses with prepush_branch_unresolved on detached HEAD before invoking gh/codex", async () => {
+    const dir = makeTempRepo({ detached: true });
+    try {
+      const result = await runCodexReview({ repoPath: dir, uncommitted: true });
+      assert.equal(result.ok, false);
+      assert.equal(result.error, "prepush_branch_unresolved");
+      assert.equal(result.next_action, "checkout_named_feature_branch");
+      assert.equal(result.finding_count, 0);
+      assert.deepEqual(result.comments, []);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses with prepush_issue_unresolved when the branch has no numeric prefix and no issue_number is passed", async () => {
+    const dir = makeTempRepo({ branch: "feature-x" });
+    try {
+      const result = await runCodexReview({ repoPath: dir, uncommitted: true });
+      assert.equal(result.ok, false);
+      assert.equal(result.error, "prepush_issue_unresolved");
+      assert.equal(result.branch, "feature-x");
+      assert.equal(result.next_action, "pass_issue_number_or_use_numeric_branch_prefix");
+      assert.equal(result.finding_count, 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("derives the issue number from a numeric-prefix branch and proceeds past the input gates", async () => {
+    // We cannot test the full happy path in unit-test scope (it shells out to
+    // gh and codex), but we can confirm that with a numeric-prefix branch the
+    // gate accepts the input and the failure surface is no longer one of the
+    // input-resolution errors. The next failure on this code path will come
+    // from `gh repo view` (no remote configured), which proves we got past
+    // the input gates.
+    const dir = makeTempRepo({ branch: "796-x" });
+    try {
+      let result;
+      let threw = false;
+      try {
+        result = await runCodexReview({ repoPath: dir, uncommitted: true });
+      } catch {
+        // gh/codex shelling out throws on a no-remote repo; that's fine — we
+        // explicitly want to confirm we got *past* the input gates.
+        threw = true;
+      }
+      if (!threw) {
+        assert.notEqual(result.error, "prepush_issue_unresolved");
+        assert.notEqual(result.error, "prepush_branch_unresolved");
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts an explicit issue_number even when the branch has no numeric prefix", async () => {
+    const dir = makeTempRepo({ branch: "feature-x" });
+    try {
+      let result;
+      let threw = false;
+      try {
+        result = await runCodexReview({ repoPath: dir, uncommitted: true, issueNumber: 796 });
+      } catch {
+        threw = true;
+      }
+      if (!threw) {
+        assert.notEqual(result.error, "prepush_issue_unresolved");
+        assert.notEqual(result.error, "prepush_branch_unresolved");
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -2612,51 +2612,12 @@ describe("runCodexReview uncommitted=true input gating", () => {
     }
   });
 
-  it("derives the issue number from a numeric-prefix branch and proceeds past the input gates", async () => {
-    // We cannot test the full happy path in unit-test scope (it shells out to
-    // gh and codex), but we can confirm that with a numeric-prefix branch the
-    // gate accepts the input and the failure surface is no longer one of the
-    // input-resolution errors. The next failure on this code path will come
-    // from `gh repo view` (no remote configured), which proves we got past
-    // the input gates.
-    const dir = makeTempRepo({ branch: "796-x" });
-    try {
-      let result;
-      let threw = false;
-      try {
-        result = await runCodexReview({ repoPath: dir, uncommitted: true });
-      } catch {
-        // gh/codex shelling out throws on a no-remote repo; that's fine — we
-        // explicitly want to confirm we got *past* the input gates.
-        threw = true;
-      }
-      if (!threw) {
-        assert.notEqual(result.error, "prepush_issue_unresolved");
-        assert.notEqual(result.error, "prepush_branch_unresolved");
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("accepts an explicit issue_number even when the branch has no numeric prefix", async () => {
-    const dir = makeTempRepo({ branch: "feature-x" });
-    try {
-      let result;
-      let threw = false;
-      try {
-        result = await runCodexReview({ repoPath: dir, uncommitted: true, issueNumber: 796 });
-      } catch {
-        threw = true;
-      }
-      if (!threw) {
-        assert.notEqual(result.error, "prepush_issue_unresolved");
-        assert.notEqual(result.error, "prepush_branch_unresolved");
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
+  // Note: the "numeric-prefix branch derives issueNumber" path is exercised by
+  // every test in the cap-enforcement and marker-post suites below (all of
+  // which use a numeric-prefix branch and rely on derivation). A standalone
+  // weak-assertion test for it is subsumed and intentionally not duplicated.
+  // The "explicit issue_number on a non-numeric branch" path is covered by
+  // the strong assertion test at the bottom of the marker-post suite.
 });
 
 describe("runCodexReview uncommitted=true cap enforcement (hermetic gh shim)", () => {
@@ -3007,6 +2968,52 @@ process.stdin.on("end", () => {
         // pre-run "fix..." hint is overridden when there are no findings.
         assert.equal(result.next_action, "proceed_clean");
         assert.equal(result.override, false);
+      });
+    } finally {
+      shim.cleanup();
+    }
+  });
+
+  it("honors an explicit issue_number even when the branch has no numeric prefix", async () => {
+    // Strong-assertion replacement for the deleted weak input-gating test:
+    // proves that an explicit issue_number is honored when the branch has no
+    // numeric prefix that derivation could pick up. End-to-end through to the
+    // marker POST so we observe the resolved issue_number in the response.
+    const shim = makeFullShimRepo({
+      branch: "feature-x", // no leading digits → derivation returns null
+      ghHandler: {
+        routes: [
+          {
+            argv_prefix: ["repo", "view", "--json", "nameWithOwner"],
+            stdout: JSON.stringify({ nameWithOwner: "fake/repo" }),
+          },
+          {
+            argv_prefix: ["api", "--method", "GET", "--paginate", "--slurp"],
+            stdout: JSON.stringify([[]]),
+          },
+          {
+            argv_prefix: ["api", "--method", "POST"],
+            stdout: JSON.stringify({ id: 1, html_url: "https://example.test/c/1" }),
+          },
+        ],
+      },
+      codexHandler: { tail: "Clean review.\n\nCOMMENT_IDS=[]\n" },
+    });
+
+    try {
+      await withShimPathFull(shim.binDir, async () => {
+        const result = await runCodexReview({
+          repoPath: shim.repoDir,
+          uncommitted: true,
+          issueNumber: 4242,
+        });
+        // Explicit issue_number is the resolved issue, not derived from
+        // "feature-x" (which derivation returns null for).
+        assert.equal(result.issue_number, 4242);
+        assert.equal(result.branch, "feature-x");
+        assert.equal(result.cycle, 1);
+        assert.equal(result.finding_count, 0);
+        assert.equal(result.next_action, "proceed_clean");
       });
     } finally {
       shim.cleanup();

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -222,8 +222,9 @@ Run `gc_codex_review` with `uncommitted=true` against the staged + unstaged chan
    - `repo_path`: absolute path from Step 1
    - `base_branch`: `{cfg.workflow.base_branch|default dev}`
    - `uncommitted`: `true`
+   - `issue_number`: the issue number resolved at Step 1, so the MCP server anchors the cycle counter to the issue thread (per ADR-029). When omitted, the server derives it from the current branch's leading numeric prefix (e.g. `796-cap-pre-push` → 796); pass it explicitly when the branch was named manually.
 3. Apply the **Review loop rules** (defined above Step 12) to the returned findings, fix locally, re-stage, and re-invoke `gc_codex_review` until clean.
-4. **Hard cap: 2 iterations.** No escape clause. After 2 invocations, if findings remain, STOP and post the remaining findings + your fix history as an issue comment, escalate to the user.
+4. **Hard cap: 2 iterations** (enforced by the MCP server, issue #796). The next invocation reads existing markers on the issue thread, counts pre-push cycles for the current (issue, branch) pair, and refuses cycle 3 with `error: "codex_review_prepush_cap_reached"` and `next_action: "post_summary_and_escalate_to_user"`. After cycle 2, if findings remain, STOP, post the remaining findings + your fix history as an issue comment, and escalate to the user. If the user authorizes cycle 3, retry with `override_cap=true` and `override_reason="<one-line quote of the user's authorization>"`.
 5. Once clean, proceed to Phase C with the staged diff. Step 12 then becomes a verification pass against the merge commit (typically a no-op).
 
 Skip this step only if the diff is so trivial (one-liner typo fix) that codex would have nothing to find. When in doubt, run it.


### PR DESCRIPTION
## Summary

- Pre-push (`uncommitted=true`) `gc_codex_review` runs now inherit the GC-O007 / ADR-029 hard-cap-2 contract; cycle 3 refused with `error: "codex_review_prepush_cap_reached"` and `next_action: "post_summary_and_escalate_to_user"` unless the user authorizes via `override_cap=true` + `override_reason`.
- Cycle counter anchored to (resolved issue, current branch) on the issue thread per ADR-029. New `<!-- gc:codex-prepush-cycle ... -->` marker family is disjoint from the post-push family.
- Marker-post failures fail the entire pre-push run (`error: "prepush_cycle_record_failed"`, findings preserved). The shared issue-comment reader switches to `gh api --paginate --slurp` + flatten so issues with >100 comments don't silently bypass enforcement (also tightens post-push and verify caps on long-lived issues).
- Override paths on all three review/verify cap evaluators now return a concrete `next_action`. New optional `issue_number` parameter on `gc_codex_review`; otherwise derived from the branch's leading numeric prefix.
- 33 new unit + integration tests across the parser, evaluator, marker round-trip, branch derivation, disjoint-family invariant, and the `runCodexReview` `uncommitted=true` decision tree (detached HEAD refusal, missing issue refusal, accepted positive paths).

Cap value follows ADR-029 (cap=2), not the issue body's "cap=5" — the latter was a stale mismatch with the SKILL prose and the GC-O007 contract.

Closes #796

## Requirement UIDs

- **GC-O007** — Gated Agentic Development Loop. The hard-cap-2 contract for `gc_codex_review` cycles is part of the loop's enforcement surface. #794 MVP-1 covered post-push; this PR closes the pre-push gap so the cap applies to all `gc_codex_review` invocations regardless of whether a PR exists yet.

## ADR Impact

- **ADR-027** (Agent-Neutral Implement Workflow Packaging) — clarified during preflight: removed stale `defer` language from the agent-silence mitigation paragraph (`defer` is not a valid decision under GC-O007).
- **ADR-029** (Issue-Thread Gate Model) — clarified during preflight: new "Pre-push review cycle state" section spells out the inheritance of GC-O007's hard two-cycle cap, the (issue, branch) anchor, and the prohibition on adding a new persistence surface.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason — repo-only change to MCP tooling and SKILL prose; no requirement state changes the sweep would catch.
- [x] `make check` (full Java completion gate) passes on Java 21 toolchain
- [x] `gc_codex_architecture_preflight` ran for #796 / GC-O007 before planning; preflight phase marker recorded
- [x] `gc_post_implementation_plan` posted the plan as an issue-thread comment; plan phase marker recorded
- [x] Pre-push `gc_codex_review` (Step 6.5) cycles 1+2 — 6 findings, 6 fixed, decisions posted to issue thread (zero deferred)
- [ ] Post-push `gc_codex_review` (Step 12) — runs after CI green
- [ ] `review-tests` skill (Step 13) — runs after Step 12

## Traceability

- IMPLEMENTS: GC-O007 via
  - `mcp/ground-control/lib.js` (pre-push cycle parser, evaluator, marker builder, async helpers; pagination fix on `readIssueCommentBodies`; override `next_action` fixes on all three cap evaluators; fail-fast on pre-push marker post failure)
  - `mcp/ground-control/index.js` (new optional `issue_number` parameter on `gc_codex_review`; description updated)
  - `skills/implement/SKILL.md` Step 6.5 (pass `issue_number`, document override semantics)
- TESTS: GC-O007 via
  - `mcp/ground-control/lib.test.js` (33 new unit + integration tests)
- DOCUMENTS: GC-O007 via
  - `architecture/adrs/027-agent-neutral-implement-workflow-packaging.md` (preflight cleanup)
  - `architecture/adrs/029-issue-thread-gate-model.md` (pre-push review cycle state section)

## Test plan

- [x] `node --test mcp/ground-control/lib.test.js` — 200 tests, 0 failing
- [x] `make check` (full Java completion gate) — passing on Java 21 toolchain
- [x] `pre-commit run --all-files` — passing
- [x] Pre-push `gc_codex_review` (Step 6.5) cycles 1+2 — 6 findings, 6 fixed, decisions posted to the issue thread
- [ ] CI green on `dev`-base PR
- [ ] SonarCloud quality gate green
- [ ] Post-push `gc_codex_review` (Step 12) — 0 findings or all fixed
- [ ] `review-tests` skill (Step 13) — clean
