### PR TITLE
Sync gc_codex_review tool descriptions with live cap constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `gc_codex_review` MCP tool, `override_cap`, and `override_reason` field
+  descriptions no longer drift from the live cap constants (issue #794).
+  The previous strings said "Hard-cap-2 enforcement... two cycles per PR...
+  two cycles per (issue, branch) pair" — stale relative to issue #804
+  (which bumped both caps from 2 to 3) and ADR-029 (which keys the pre-push
+  cap by issue alone, with the branch recorded only as audit context). The
+  descriptions are now built by three pure functions in
+  `mcp/ground-control/lib.js`
+  (`buildCodexReviewToolDescription`, `buildCodexReviewOverrideCapDescription`,
+  `buildCodexReviewOverrideReasonDescription`) that interpolate
+  `CODEX_REVIEW_HARD_CAP` and `CODEX_REVIEW_PREPUSH_HARD_CAP` through a
+  shared `capPhrase()` helper. The tool description is mode-specific
+  ("post-push reviews auto-detect the PR via `gh pr view` when pr_number
+  is omitted; pre-push reviews target the issue thread and only post inline
+  PR review comments when pr_number is supplied explicitly") and uses a
+  mode-neutral "Cycle-cap enforcement" heading so caller catalogs that ever
+  see post-push and pre-push caps diverge surface both values rather than
+  collapsing to a single misleading "Hard-cap-N" leader. The override
+  description and example are per-cycle (every over-cap cycle requires its
+  own `override_reason`; a previous user authorization does not extend
+  forward). 17 new tests in `mcp/ground-control/lib.test.js` lock the
+  contract: live caps are interpolated, the stale "hard-cap-2" wording is
+  forbidden, the (issue, branch) pair shape is forbidden, both #794 and
+  #796 are referenced, the override-cap escape hatch is documented and
+  per-cycle, divergent post-push/pre-push caps surface both values
+  separately, and the override_reason example is cap-relative for
+  divergent caps and concrete for equal caps. Stale internal section-header
+  comments in `lib.js` are realigned to the live cap; the per-finding
+  verify cap remains 2 and is left unchanged. ADR-029 is amended to
+  preserve the user-authorized `override_cap=true` escape hatch and to
+  clarify that authorization is per-cycle and that the cap is hard against
+  agent self-authorization. ADR-028 carries a small clarification that
+  the Temporal bridge must continue using the MCP issue-thread marker
+  family rather than reintroducing a synchronous plan-approval gate.
 - `gc_codex_review` no longer relies on Codex calling `gh` from inside its
   sandbox to post inline PR review comments. Codex's sandbox does not carry
   GitHub credentials, so the prior architecture silently lost findings — they

--- a/architecture/adrs/028-temporal-workflow-orchestration-boundary.md
+++ b/architecture/adrs/028-temporal-workflow-orchestration-boundary.md
@@ -144,6 +144,20 @@ Temporal workflow may read them for observability but does not block on
 synchronous human input for plan approval — that gate was removed by ADR-029
 before Temporal lands.
 
+If GC-O009's draft requirement text, issue prose, or older workflow notes refer
+to "plan approval" as a Temporal signal, that wording is stale with respect to
+ADR-029 and must not drive implementation. GC-O009 may introduce signal
+endpoints only for gates that still exist in the accepted workflow contract
+or for explicit operator controls whose authorization, audit record, and
+failure semantics are defined in Ground Control. Do not reintroduce a
+synchronous plan-approval gate as a side effect of adopting Temporal.
+
+The transition bridge from the existing `/implement` skill must keep using the
+MCP-side issue-thread marker family for preflight, plan, review-cycle, and
+verify-cycle enforcement until Temporal owns those phases end to end. Bridge
+code may start workflows and send supported signals, but it must not become a
+second workflow engine with independent counters, phase state, or gate rules.
+
 ### Observability And Security
 
 Temporal Web and gRPC endpoints are infrastructure surfaces. They must not be

--- a/architecture/adrs/029-issue-thread-gate-model.md
+++ b/architecture/adrs/029-issue-thread-gate-model.md
@@ -110,11 +110,54 @@ available via the user-authorized `override_cap=true` + `override_reason`
 path; the override marker stays distinguishable from regular cycle markers in
 the audit trail.
 
+The three-cycle cap is hard against agent self-authorization: the agent
+cannot run cycle 4 to "verify the fix" of cycle 3 findings. Cycle 3 findings
+must be fixed in place; if concern remains after fixing them, the agent posts
+an issue-thread comment summarizing the remaining concern and fix history and
+escalates to the user. The user may then authorize cycle 4 explicitly via
+`override_cap=true` + an `override_reason` quoting that authorization, or
+decide a different workflow move (stop, re-scope, open a fresh issue). The
+marker preserves the distinction so the audit trail records whether each
+cycle ran in-cap or under user-authorized override.
+
 The marker belongs to the same issue-thread marker family as plan, phase,
 review-cycle, and verify-cycle markers. Implementations must reuse the
 existing issue-comment read/post helpers, marker parser/evaluator pattern, and
 structured refusal result style; they must not add a local state file, git
 notes, database row, Temporal state, or driver-local counter for this cap.
+
+### Tool-layer enforcement boundary
+
+The MCP server is the enforcement boundary for workflow ordering, cycle caps,
+GitHub posting, and durable markers. Implementation work for issue #794 must
+extend the existing MCP review/phase machinery rather than introducing a
+parallel workflow state model.
+
+Reuse these existing cross-cutting patterns:
+
+- the `ensureGitRepo` and `getOwnerRepo` repository resolution path before any
+  GitHub or git side effect;
+- the issue-comment marker family and paginated issue-comment reader for
+  durable state, including marker-shaped-text escaping so reviewer output
+  cannot poison counters;
+- pure parser/evaluator helpers for marker counting and prerequisite decisions,
+  with tests covering malformed markers, wrong issue/PR ids, and cap
+  boundaries;
+- structured refusal envelopes with stable `error`, `message`, `prior_cycles`
+  or `missing`, `cap`, and `next_action` fields instead of thrown control-flow
+  exceptions for expected gate failures;
+- the host-side GitHub posting boundary, sensitive-content guardrail, and
+  partial-failure envelopes already used by `gc_codex_review`;
+- `.ground-control.yaml` resolution through `gc_get_repo_ground_control_context`
+  when workflow behavior needs repo configuration.
+
+Do not duplicate the workflow contract in skill-only prose, local files, git
+notes, in-memory counters, ad hoc JSON blobs, Temporal state, or a new database
+table for this bridge implementation. Do not create separate schemas for
+pre-push and post-push review cycles unless their persisted marker identity
+actually differs. Do not make branch name, PR number, or commit lineage part of
+the pre-push cap key; those are audit context or post-push direct-caller
+defense-in-depth context, not reset levers for the canonical Step 6.5 cap.
 
 ### Codex findings issue-thread record
 

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -73,6 +73,11 @@ import {
   runCodexReview,
   runCodexVerifyFinding,
   runPostImplementationPlan,
+  buildCodexReviewToolDescription,
+  buildCodexReviewOverrideCapDescription,
+  buildCodexReviewOverrideReasonDescription,
+  CODEX_REVIEW_HARD_CAP,
+  CODEX_REVIEW_PREPUSH_HARD_CAP,
   embedRequirement,
   getEmbeddingStatus,
   embedProject,
@@ -749,15 +754,28 @@ server.tool(
 
 server.tool(
   "gc_codex_review",
-  "Run Codex against the current branch with a production-readiness review prompt. Codex enumerates all material findings (no triage) and, when a pull request is available, posts each finding as an inline PR review comment. Returns the list of posted comment ids, enriched with GraphQL review-thread ids and a short file/line/title preview so the coding agent can drive a fix/verify loop via gc_codex_verify_finding. Auto-detects the PR number for the current branch via `gh pr view` when pr_number is omitted. Hard-cap-2 enforcement: post-push reviews are capped at two cycles per PR (issue #794); pre-push reviews (uncommitted=true) are capped at two cycles per (issue, branch) pair anchored to the resolved GitHub issue thread (issue #796). The tool refuses cycle 3+ unless override_cap=true with a non-empty override_reason quoting the user's authorization.",
+  buildCodexReviewToolDescription({
+    postPushCap: CODEX_REVIEW_HARD_CAP,
+    prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+  }),
   {
     repo_path: z.string().describe("Absolute path to the target Git repository"),
     base_branch: z.string().optional().describe("Base branch to review against (defaults to 'dev')"),
     uncommitted: z.boolean().optional().describe("Review staged/unstaged/untracked changes instead of committed branch history"),
     pr_number: z.number().int().positive().optional().describe("Pull request number to post findings to. When omitted and uncommitted is false, the tool auto-detects via `gh pr view --json number`. When no PR can be found, codex emits findings inline without posting."),
     issue_number: z.number().int().positive().optional().describe("GitHub issue number used to anchor the pre-push cycle counter (uncommitted=true). When omitted, the tool derives it from the current branch's leading numeric prefix (e.g. '796-cap-pre-push' → 796). If neither resolves, the tool refuses with a structured error. Ignored for post-push reviews."),
-    override_cap: z.boolean().optional().describe("Override the hard-cap-2 cycle limit (post-push and pre-push). Only legitimate when the user has explicitly authorized cycle 3+ in the conversation. Requires override_reason."),
-    override_reason: z.string().optional().describe("Required when override_cap=true. Quote the user's authorization (e.g. 'user said: yes run cycle 3 to verify'). Stored in the marker for audit."),
+    override_cap: z.boolean().optional().describe(
+      buildCodexReviewOverrideCapDescription({
+        postPushCap: CODEX_REVIEW_HARD_CAP,
+        prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+      }),
+    ),
+    override_reason: z.string().optional().describe(
+      buildCodexReviewOverrideReasonDescription({
+        postPushCap: CODEX_REVIEW_HARD_CAP,
+        prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+      }),
+    ),
     override_phase_gate: z.boolean().optional().describe("Override the plan-before-review ordering gate. Only legitimate when the user explicitly authorized skipping planning (e.g., trivial bug fix). Requires override_phase_reason."),
     override_phase_reason: z.string().optional().describe("Required when override_phase_gate=true. Quote the user's authorization. Logged for audit."),
   },

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -2274,15 +2274,17 @@ function buildFindingsEmissionInstructions({ reviewerLabel }) {
 }
 
 // ---------------------------------------------------------------------------
-// gc_codex_review hard-cap-2 cycle enforcement (issue #794 MVP-1)
+// gc_codex_review post-push cycle cap enforcement (issue #794 MVP-1)
 //
-// GC-O007 / ADR-029 specify a hard cap of two `gc_codex_review` cycles per PR
-// (cycle 3+ hits diminishing returns and starts repeating out-of-scope
+// GC-O007 / ADR-029 specify a hard cap on `gc_codex_review` cycles per PR
+// (cycle N+1 hits diminishing returns and starts repeating out-of-scope
 // findings). The cap was previously prose-only in skills/implement/SKILL.md,
 // and agents routinely rationalized past it. This MVP moves enforcement onto
 // the MCP server's trusted side: each successful post-push review posts a
 // machine-readable marker comment to the PR, and the next invocation refuses
-// if two markers already exist for the same PR.
+// once `CODEX_REVIEW_HARD_CAP` markers already exist for the same PR. Issue
+// #804 bumped the cap from 2 to 3 when SKILL Step 12 (post-push) was removed
+// and the loop collapsed to a single pre-push pass.
 //
 // Persistence model: PR issue-comments authored by whoever the MCP server's
 // `gh` CLI authenticates as (typically the repo owner / a service account).
@@ -3677,6 +3679,75 @@ export function dedupFindings(comments) {
   return Array.from(seen.values());
 }
 
+// ---------------------------------------------------------------------------
+// gc_codex_review tool & override description builders (issue #794)
+//
+// MCP tool descriptions are part of the public protocol surface — every LLM
+// client that lists the tool sees them. Inline strings in index.js drifted
+// past the cap bumps in #804 (post-push and pre-push caps moved 2 → 3) and
+// the pre-push key change (was (issue, branch), now issue alone per ADR-029).
+// These builders are pure functions that interpolate the live cap constants
+// so the description cannot drift again, and they're tested in lib.test.js
+// against `CODEX_REVIEW_HARD_CAP` / `CODEX_REVIEW_PREPUSH_HARD_CAP`.
+// ---------------------------------------------------------------------------
+
+function capPhrase(postPushCap, prepushCap) {
+  // Equal-cap phrasing collapses to "hard-cap-N"; divergent caps surface
+  // both values so the protocol description stays accurate if they ever
+  // diverge. The same shape is reused by the override / override-reason
+  // builders so a divergence shows up consistently across tool metadata.
+  return postPushCap === prepushCap
+    ? `hard-cap-${postPushCap}`
+    : `hard-cap (post-push ${postPushCap}, pre-push ${prepushCap})`;
+}
+
+export function buildCodexReviewToolDescription({ postPushCap, prepushCap }) {
+  return (
+    "Run Codex against the current branch with a production-readiness review prompt. " +
+    "Codex enumerates all material findings (no triage) and, when a pull request is " +
+    "available, posts each finding as an inline PR review comment. Returns the list of " +
+    "posted comment ids, enriched with GraphQL review-thread ids and a short file/line/" +
+    "title preview so the coding agent can drive a fix/verify loop via " +
+    "gc_codex_verify_finding. For post-push reviews (uncommitted=false) the tool " +
+    "auto-detects the PR number for the current branch via `gh pr view` when " +
+    "pr_number is omitted; pre-push reviews (uncommitted=true) target the issue " +
+    "thread and only post inline PR review comments when pr_number is supplied " +
+    `explicitly. Cycle-cap enforcement (${capPhrase(postPushCap, prepushCap)}): ` +
+    `post-push reviews are capped at ${postPushCap} cycles per PR (issue #794); ` +
+    `pre-push reviews are capped at ${prepushCap} cycles per issue, anchored to ` +
+    "the resolved GitHub issue thread (issue #796 — the branch is recorded in the " +
+    "marker for audit context but is not part of the cap key, so a branch rename " +
+    "on the same issue cannot reset the counter). The tool refuses any over-cap " +
+    "cycle (cycle cap+1 or later) unless override_cap=true with a non-empty " +
+    "override_reason quoting the user's authorization; an already-authorized " +
+    "override cycle does NOT carry forward — every subsequent over-cap cycle " +
+    "requires its own user authorization."
+  );
+}
+
+export function buildCodexReviewOverrideCapDescription({ postPushCap, prepushCap }) {
+  return (
+    `Override the ${capPhrase(postPushCap, prepushCap)} cycle limit (post-push and ` +
+    "pre-push). Only legitimate when the user has explicitly authorized the requested " +
+    "over-cap cycle in the conversation. Authorization is per-cycle: a previous " +
+    "override does not extend to the next cycle. Requires override_reason."
+  );
+}
+
+export function buildCodexReviewOverrideReasonDescription({ postPushCap, prepushCap }) {
+  // Cap-neutral example so the description does not re-drift when either cap
+  // changes. The example references the next over-cap cycle relative to the
+  // current state — not "the first cycle past cap N", since the override is
+  // required for *every* over-cap cycle, not just cycle cap+1.
+  const example =
+    postPushCap === prepushCap
+      ? `'user said: yes run cycle ${postPushCap + 1} to verify'`
+      : "'user said: yes run the next over-cap cycle to verify'";
+  return (
+    `Required when override_cap=true. Quote the user's authorization (e.g. ${example}). ` +
+    "Stored in the marker for audit."
+  );
+}
 
 export async function runCodexReview({
   repoPath,
@@ -3696,10 +3767,12 @@ export async function runCodexReview({
     effectivePr = await autoDetectPrNumber(repoRoot);
   }
 
-  // Hard-cap-2 enforcement: post-push reviews use the (PR) marker family
-  // (issue #794 MVP-1); pre-push uncommitted reviews use the (issue, branch)
-  // marker family (issue #796). Plan-before-review ordering applies to
-  // post-push only.
+  // Hard-cap enforcement: post-push reviews use the (PR) marker family
+  // (issue #794 MVP-1, cap = CODEX_REVIEW_HARD_CAP); pre-push uncommitted
+  // reviews use the per-issue marker family (issue #796 / ADR-029, cap =
+  // CODEX_REVIEW_PREPUSH_HARD_CAP). The pre-push key is the issue alone — the
+  // branch is recorded in the marker for audit context only, never as part of
+  // the cap key. Plan-before-review ordering applies to post-push only.
   let cycleOwnership = null;
   let prePushOwnership = null;
 
@@ -3860,8 +3933,9 @@ export async function runCodexReview({
       }
     }
 
-    // (2) Hard-cap-2 cycle enforcement (MVP-1). overrideCap=true requires a
-    //     non-empty overrideReason — the agent cannot self-authorize.
+    // (2) Hard-cap cycle enforcement (MVP-1, cap = CODEX_REVIEW_HARD_CAP).
+    //     overrideCap=true requires a non-empty overrideReason — the agent
+    //     cannot self-authorize.
     const priorCount = await readPriorCodexReviewCycleCount(repoRoot, owner, name, effectivePr);
     const decision = evaluateCodexReviewCycleCap({
       priorCount,
@@ -4010,7 +4084,7 @@ export async function runCodexReview({
   // response carries ok=false so the agent doesn't treat it as durable.
   const partialFailure = parseErrors.length > 0 || postFailures.length > 0;
   // The cycle marker is a different question: it gates retries against the
-  // hard-cap-2 budget. Suppress it ONLY when no comments landed on the PR
+  // hard-cap budget. Suppress it ONLY when no comments landed on the PR
   // (so a retry doesn't double-spend a cycle that produced nothing). When
   // any post succeeded, the comments are durable and a retry would
   // duplicate them on the PR thread — treat the cycle as consumed (closes

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -28,6 +28,9 @@ import {
   parseCodexReviewCycleMarkers,
   evaluateCodexReviewCycleCap,
   buildCodexReviewCycleMarker,
+  buildCodexReviewToolDescription,
+  buildCodexReviewOverrideCapDescription,
+  buildCodexReviewOverrideReasonDescription,
   CODEX_REVIEW_HARD_CAP,
   CODEX_REVIEW_CYCLE_MARKER_PREFIX,
   parsePhaseMarkers,
@@ -5012,5 +5015,214 @@ describe("constants", () => {
 
   it("LINK_TYPES matches Java LinkType enum", () => {
     assert.deepEqual(LINK_TYPES, ["IMPLEMENTS", "TESTS", "DOCUMENTS", "CONSTRAINS", "VERIFIES"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gc_codex_review tool description / override description builders (#794)
+//
+// The MCP tool descriptions for `gc_codex_review` are part of the public
+// protocol surface — every LLM client that lists the tool sees them. Inline
+// strings in index.js drifted past the cap bumps in #804 (post-push and
+// pre-push caps moved 2 → 3) and the pre-push key change in #800 review
+// (was (issue, branch), now issue alone per ADR-029). These builders are
+// pure functions that interpolate the live constants so the description
+// cannot drift again.
+// ---------------------------------------------------------------------------
+
+describe("buildCodexReviewToolDescription", () => {
+  it("surfaces both live cap values (collapsed when equal)", () => {
+    const desc = buildCodexReviewToolDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.ok(
+      desc.includes(`${CODEX_REVIEW_HARD_CAP} cycles per PR`),
+      `description must mention "${CODEX_REVIEW_HARD_CAP} cycles per PR"; got: ${desc}`,
+    );
+    assert.ok(
+      desc.includes(`${CODEX_REVIEW_PREPUSH_HARD_CAP} cycles per issue`),
+      `description must mention "${CODEX_REVIEW_PREPUSH_HARD_CAP} cycles per issue"; got: ${desc}`,
+    );
+  });
+
+  it("uses a mode-neutral cap heading (not 'Hard-cap-N enforcement') so divergent caps don't mislead", () => {
+    const desc = buildCodexReviewToolDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.match(desc, /Cycle-cap enforcement/i);
+    assert.ok(
+      !/\bHard-cap-\d+\s+enforcement\b/i.test(desc),
+      `must not contain a hard-cap-N enforcement phrase anywhere (start of line or inline); got: ${desc}`,
+    );
+  });
+
+  it("does not contain the stale hard-cap-2 wording", () => {
+    const desc = buildCodexReviewToolDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.ok(
+      !/hard-cap-2\b/i.test(desc),
+      `description must not contain "hard-cap-2"; got: ${desc}`,
+    );
+    assert.ok(
+      !/two cycles per PR/.test(desc),
+      `description must not say "two cycles per PR"; got: ${desc}`,
+    );
+  });
+
+  it("does not advertise the (issue, branch) pair shape (ADR-029: keyed by issue alone)", () => {
+    const desc = buildCodexReviewToolDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.ok(
+      !/\(issue,\s*branch\)\s+pair/i.test(desc),
+      `description must not advertise (issue, branch) pair keying; got: ${desc}`,
+    );
+  });
+
+  it("references both #794 and #796 so audit history points at the right MVPs", () => {
+    const desc = buildCodexReviewToolDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.ok(desc.includes("#794"), `description must reference issue #794; got: ${desc}`);
+    assert.ok(desc.includes("#796"), `description must reference issue #796; got: ${desc}`);
+  });
+
+  it("documents the override_cap=true / override_reason escape hatch", () => {
+    const desc = buildCodexReviewToolDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.ok(desc.includes("override_cap=true"), `must mention override_cap=true; got: ${desc}`);
+    assert.ok(
+      desc.includes("override_reason"),
+      `must mention override_reason; got: ${desc}`,
+    );
+  });
+
+  it("makes PR auto-detect mode-specific (post-push only, pre-push needs explicit pr_number)", () => {
+    const desc = buildCodexReviewToolDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.match(
+      desc,
+      /post-push.*auto-detects/is,
+      `must scope auto-detect to post-push reviews; got: ${desc}`,
+    );
+    assert.match(
+      desc,
+      /pre-push.*pr_number.*explicit/is,
+      `must clarify pre-push needs an explicit pr_number; got: ${desc}`,
+    );
+  });
+
+  it("interpolates whatever caps the caller passes (equal case)", () => {
+    const desc = buildCodexReviewToolDescription({ postPushCap: 7, prepushCap: 7 });
+    assert.match(desc, /hard-cap-7\b/i);
+    assert.ok(desc.includes("7 cycles per PR"), `expected "7 cycles per PR"; got: ${desc}`);
+    assert.ok(desc.includes("7 cycles per issue"), `expected "7 cycles per issue"; got: ${desc}`);
+    assert.ok(!/\b3\s+cycles\s+per\s+PR\b/.test(desc), `must not leak default 3; got: ${desc}`);
+  });
+
+  it("surfaces both cap values when post-push and pre-push diverge", () => {
+    const desc = buildCodexReviewToolDescription({ postPushCap: 5, prepushCap: 11 });
+    assert.ok(desc.includes("5 cycles per PR"), `expected "5 cycles per PR"; got: ${desc}`);
+    assert.ok(desc.includes("11 cycles per issue"), `expected "11 cycles per issue"; got: ${desc}`);
+    assert.match(desc, /post-push 5.*pre-push 11|pre-push 11.*post-push 5/is);
+  });
+});
+
+describe("buildCodexReviewOverrideCapDescription", () => {
+  it("surfaces the live cap value", () => {
+    const desc = buildCodexReviewOverrideCapDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.ok(
+      desc.includes(String(CODEX_REVIEW_HARD_CAP)) ||
+        desc.includes(String(CODEX_REVIEW_PREPUSH_HARD_CAP)),
+      `must surface the live cap value(s); got: ${desc}`,
+    );
+  });
+
+  it("does not contain stale hard-cap-2 wording", () => {
+    const desc = buildCodexReviewOverrideCapDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.ok(!/hard-cap-2\b/i.test(desc), `must not contain hard-cap-2; got: ${desc}`);
+  });
+
+  it("nudges the agent toward fix-and-escalate, not silent retries", () => {
+    const desc = buildCodexReviewOverrideCapDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.ok(
+      desc.includes("override_reason"),
+      `must require override_reason; got: ${desc}`,
+    );
+    assert.ok(
+      /user\b/i.test(desc),
+      `must remind that only the user can authorize overrides; got: ${desc}`,
+    );
+  });
+
+  it("collapses to hard-cap-N when caps are equal", () => {
+    const desc = buildCodexReviewOverrideCapDescription({ postPushCap: 9, prepushCap: 9 });
+    assert.match(desc, /hard-cap-9\b/i);
+    assert.ok(!/hard-cap-3\b/i.test(desc), `must not leak default 3; got: ${desc}`);
+  });
+
+  it("surfaces both caps when post-push and pre-push diverge", () => {
+    const desc = buildCodexReviewOverrideCapDescription({ postPushCap: 4, prepushCap: 6 });
+    assert.match(desc, /post-push 4.*pre-push 6|pre-push 6.*post-push 4/is);
+    assert.ok(!/hard-cap-4\b/i.test(desc), `divergent caps must not collapse; got: ${desc}`);
+    assert.ok(!/hard-cap-6\b/i.test(desc), `divergent caps must not collapse; got: ${desc}`);
+  });
+});
+
+describe("buildCodexReviewOverrideReasonDescription", () => {
+  it("requires override_reason when override_cap=true", () => {
+    const desc = buildCodexReviewOverrideReasonDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.match(desc, /Required when override_cap=true/);
+    assert.match(desc, /Stored in the marker for audit/);
+  });
+
+  it("uses a concrete next-cycle example when caps are equal", () => {
+    const desc = buildCodexReviewOverrideReasonDescription({
+      postPushCap: CODEX_REVIEW_HARD_CAP,
+      prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
+    });
+    assert.match(
+      desc,
+      new RegExp(`run cycle ${CODEX_REVIEW_HARD_CAP + 1}`),
+      `equal-cap example should name the first cycle past the cap; got: ${desc}`,
+    );
+  });
+
+  it("uses cap-relative wording when caps diverge so it does not lock in a single number", () => {
+    const desc = buildCodexReviewOverrideReasonDescription({ postPushCap: 4, prepushCap: 6 });
+    assert.ok(
+      /next over-cap cycle/i.test(desc),
+      `divergent-cap example must avoid a hardcoded next-cycle integer; got: ${desc}`,
+    );
+    assert.ok(!/cycle 5\b/.test(desc), `must not pin to post-push next cycle; got: ${desc}`);
+    assert.ok(!/cycle 7\b/.test(desc), `must not pin to pre-push next cycle; got: ${desc}`);
+  });
+
+  it("does not hardcode the cap value (proves it follows the constants)", () => {
+    const desc = buildCodexReviewOverrideReasonDescription({ postPushCap: 9, prepushCap: 9 });
+    assert.match(desc, /run cycle 10\b/);
+    assert.ok(!/run cycle 4\b/.test(desc), `must not leak default cap+1; got: ${desc}`);
   });
 });

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -5139,16 +5139,28 @@ describe("buildCodexReviewToolDescription", () => {
 });
 
 describe("buildCodexReviewOverrideCapDescription", () => {
-  it("surfaces the live cap value", () => {
+  it("surfaces the live cap value as a structured cap phrase (not a bare digit)", () => {
     const desc = buildCodexReviewOverrideCapDescription({
       postPushCap: CODEX_REVIEW_HARD_CAP,
       prepushCap: CODEX_REVIEW_PREPUSH_HARD_CAP,
     });
-    assert.ok(
-      desc.includes(String(CODEX_REVIEW_HARD_CAP)) ||
-        desc.includes(String(CODEX_REVIEW_PREPUSH_HARD_CAP)),
-      `must surface the live cap value(s); got: ${desc}`,
-    );
+    if (CODEX_REVIEW_HARD_CAP === CODEX_REVIEW_PREPUSH_HARD_CAP) {
+      assert.match(
+        desc,
+        new RegExp(`hard-cap-${CODEX_REVIEW_HARD_CAP}\\b`, "i"),
+        `equal-cap form must surface "hard-cap-N"; got: ${desc}`,
+      );
+    } else {
+      assert.match(
+        desc,
+        new RegExp(
+          `post-push ${CODEX_REVIEW_HARD_CAP}\\b.*pre-push ${CODEX_REVIEW_PREPUSH_HARD_CAP}\\b|` +
+            `pre-push ${CODEX_REVIEW_PREPUSH_HARD_CAP}\\b.*post-push ${CODEX_REVIEW_HARD_CAP}\\b`,
+          "is",
+        ),
+        `divergent-cap form must surface both caps; got: ${desc}`,
+      );
+    }
   });
 
   it("does not contain stale hard-cap-2 wording", () => {


### PR DESCRIPTION
## Summary

- The MCP tool description for `gc_codex_review` and the `override_cap` / `override_reason` field descriptions were stale relative to the current cycle caps and the pre-push key shape — they still advertised "Hard-cap-2 enforcement... two cycles per PR... two cycles per (issue, branch) pair" even though #804 bumped the caps to 3 and ADR-029 (per #800 review) rekeyed pre-push to the issue alone. Wrong information reaching every LLM client that consumes the protocol.
- All three descriptions are now built by pure-function builders in `mcp/ground-control/lib.js` parameterized by `CODEX_REVIEW_HARD_CAP` / `CODEX_REVIEW_PREPUSH_HARD_CAP` through a shared `capPhrase()` helper, so the protocol surface cannot drift past the constants again.
- Override semantics clarified to be per-cycle (every over-cap cycle requires its own user authorization). ADR-029 amended; ADR-028 carries a small Temporal-bridge clarification.

## Requirement UIDs

- `GC-O007` (Gated Agentic Development Loop) — materially implemented (case pre-existing). Substantive enforcement landed via #800, #804, #793; this PR closes the description-drift gap.
- `GC-O009` (Workflow Orchestration via Temporal) — forward-looking. This issue is the bridge that GC-O009 supersedes; no Temporal code introduced here.

## ADR Impact

- ADR-029 (Issue-Thread Gate Model) — amended. New §"Tool-layer enforcement boundary" and clarified per-cycle override semantics on the cycle cap section. The user-authorized `override_cap=true` escape hatch is preserved (hard against agent self-authorization, not user authorization); cap is keyed by issue alone, branch is audit context only.
- ADR-028 (Temporal Workflow Orchestration Boundary) — small clarification that the Temporal bridge must continue using the MCP issue-thread marker family rather than reintroducing a synchronous plan-approval gate against ADR-029.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason
- [x] Plan posted on issue thread via `gc_post_implementation_plan` (preflight gate satisfied): https://github.com/KeplerOps/Ground-Control/issues/794#issuecomment-4411493052
- [x] Pre-push codex review ran, capped at 3 cycles. Findings posted to issue thread; decisions posted alongside each cycle. Cycles 1–3 totalled 8 findings, all `decision: fix`. Cap-3 reached on cycle 3; no cycle 4 (per ADR-029 / GC-O007).
- [x] CHANGELOG.md updated under `### Fixed`.
- [x] `make check` green locally with Java 21 (Spotless, gradle check, OpenJML ESC).
- [x] All 276 `mcp/ground-control/lib.test.js` tests green.

## Traceability

- Resolves #794.
- IMPLEMENTS:
  - `mcp/ground-control/lib.js` — adds `buildCodexReviewToolDescription`, `buildCodexReviewOverrideCapDescription`, `buildCodexReviewOverrideReasonDescription`, and the shared `capPhrase` helper (GC-O007).
  - `mcp/ground-control/index.js` — wires the builders into the `gc_codex_review` tool registration (GC-O007).
  - `architecture/adrs/029-issue-thread-gate-model.md` — amended with §"Tool-layer enforcement boundary" and per-cycle override clarification (GC-O007).
  - `architecture/adrs/028-temporal-workflow-orchestration-boundary.md` — DOCUMENTS GC-O009; small clarification that the Temporal bridge keeps using the MCP issue-thread marker family.
  - `CHANGELOG.md` — Fixed entry covering the description sync.
- TESTS:
  - `mcp/ground-control/lib.test.js` — 17 new tests across `buildCodexReviewToolDescription`, `buildCodexReviewOverrideCapDescription`, `buildCodexReviewOverrideReasonDescription` (GC-O007).
- `GC-O009` receives only a `DOCUMENTS` link (forward-looking; no Temporal code shipped here). Status remains `DRAFT`.

## Test plan

- [ ] CI green on this PR (build / test / integration / verify).
- [ ] SonarCloud quality gate `OK` on this PR; zero open issues attributable to this PR.
- [ ] All 276 `mcp/ground-control/lib.test.js` suites pass under `node --test`.
- [ ] 17 new test cases exercise: live-cap interpolation, stale-wording rejection (`hard-cap-2`, `(issue, branch)` pair, inline `Hard-cap-N enforcement`), mode-specific PR auto-detect wording, divergent-cap behavior for all three builders, and per-cycle override semantics.
- [ ] `make check` green locally with Java 21.
- [ ] Pre-commit `repo policy guardrails`, `spotless`, `gradle check`, `openjml ESC` all green.
- [ ] Codex pre-push review reached cycle 3 with cycle-by-cycle decisions posted to the issue thread per ADR-029.

Closes #794.