### PR TITLE
Make red-dragon ADR-026 cutover safe (#828)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,18 +46,33 @@ jobs:
     # intended target, not the empty-default behavior.
     runs-on: [self-hosted, linux, x64]
     needs: [policy]
-    if: vars.GC_BASE_URL != ''
+    # The live token may NEVER run against attacker-controlled refs. `main` is
+    # the only branch with merge protection, so restrict execution to it on
+    # both `push` and `workflow_dispatch`. PR runs, dev/tag pushes, and
+    # workflow_dispatch on a feature branch all otherwise expose
+    # `secrets.GROUND_CONTROL_API_TOKEN` to checked-out JS that the attacker
+    # could rewrite to exfiltrate the bearer token (#828 cycle 3 security
+    # finding). Cancel-in-progress is governed by the workflow-level concurrency
+    # block; this guard is purely about which refs may see the secret.
+    if: vars.GC_BASE_URL != '' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install MCP helper dependencies
         run: npm --prefix mcp/ground-control ci
       - name: Live Ground Control ADR drift check
         env:
+          # ADR-026 / GC-P011: the live instance enforces bearer auth, so the
+          # MCP client below needs GROUND_CONTROL_API_TOKEN exposed (it falls
+          # back to GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN for legacy
+          # pack-registry calls). Without this passthrough the job 401s every
+          # request — exactly the failure mode #828 was filed against.
           GC_BASE_URL: ${{ vars.GC_BASE_URL }}
+          GROUND_CONTROL_API_TOKEN: ${{ secrets.GROUND_CONTROL_API_TOKEN }}
         run: node tools/ground_control/check_adr_drift.mjs
       - name: Live Ground Control policy check
         env:
           GC_BASE_URL: ${{ vars.GC_BASE_URL }}
+          GROUND_CONTROL_API_TOKEN: ${{ secrets.GROUND_CONTROL_API_TOKEN }}
         run: node tools/ground_control/check_live_policy.mjs
 
   # ---------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`NoResourceFoundException` now returns `404 not_found` instead of
+  `500 internal_error`** (issue #828). Spring throws this exception for
+  unmapped paths in 3.2+; without an explicit `@ExceptionHandler` it fell
+  through to `handleGeneric` and surfaced as a generic server error, which
+  muddied the #821 diagnosis of the threat-model 500 (an image without the
+  threat-model controllers looked like a real server bug). The new handler
+  emits the standard `ErrorResponse` envelope with code `not_found`. The
+  exception's resource path is intentionally NOT echoed in the response body.
+
+### Changed
+
+- **Production compose file enumerates ADR-026 credential env vars
+  explicitly** (issue #828). `deploy/docker/docker-compose.prod.yml` now
+  passes `GC_SECURITY_ENABLED`, `GC_SECURITY_OPENAPI_PUBLIC`, five indexed
+  `GROUNDCONTROL_SECURITY_CREDENTIALS_<N>_*` slots, and five
+  `GROUNDCONTROL_SECURITY_IP_ALLOWLIST_<N>` slots through to the backend
+  container. Prior to this change, an operator who set the values in
+  `/opt/gc/.env` still got a 401-storm on cutover because compose never
+  forwarded the variables — the regression that triggered the 2026-05-09
+  rollback. Defaults are empty (`:-`) so back-compat is preserved.
+  `deploy/docker/.env.template` mirrors the new shape with commented
+  placeholders. `tools/policy/checks.py` adds
+  `run_deploy_compose_credential_passthrough` (wired into `make policy`)
+  as the structural gate that prevents future diffs from silently stripping
+  the keys.
+
+### Documentation
+
+- **Pre-existing-deployment ADR-026 auth migration runbook**
+  (`docs/deployment/DEPLOYMENT.md`, issue #828). Adds a 10-step playbook
+  ordered to prevent the 2026-05-09 rollback pattern: inventory consumers
+  first, provision and distribute tokens, verify each consumer hits `200`
+  *before* the new image rolls, then the cutover and post-deploy
+  verification. Cross-links the canonical compose file and the
+  `make policy` gate so the source-of-truth invariant is enforced.
+
 ### Security
 
 - **AGE adapter migrated to native Cypher parameter binding** (issue #244,

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/GlobalExceptionHandler.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -116,6 +117,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleConstraintViolation(jakarta.validation.ConstraintViolationException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of("validation_error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException ex) {
+        // Spring throws this for unmapped paths in 3.2+. Without an explicit handler
+        // it falls through to handleGeneric and returns 500 internal_error, which
+        // muddied #821 diagnosis (a missing-controller deployment was first read as
+        // a real server bug). The resource path is intentionally NOT echoed in the
+        // body — keep the message stable and avoid reflecting client-controlled
+        // bytes back through the error envelope.
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of("not_found", "Resource not found"));
     }
 
     @ExceptionHandler(GroundControlException.class)

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/GlobalExceptionHandlerTest.java
@@ -11,12 +11,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 class GlobalExceptionHandlerTest {
 
@@ -80,6 +82,27 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().error().code()).isEqualTo("bad_request");
         assertThat(response.getBody().error().message()).isEqualTo("Missing required part 'file'");
+    }
+
+    @Test
+    void handleNoResourceFound_returnsNotFound() {
+        // Spring throws NoResourceFoundException for unmapped paths in 3.2+. Without
+        // a dedicated handler it falls through to handleGeneric and surfaces
+        // 500 internal_error (#828: muddied #821 diagnosis of the threat-model 500
+        // by hiding "this image doesn't have the threat-model controllers" behind
+        // the same envelope a real server bug would emit).
+        var ex = new NoResourceFoundException(HttpMethod.GET, "/api/v1/nonexistent");
+
+        var response = handler.handleNoResourceFound(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().error().code()).isEqualTo("not_found");
+        assertThat(response.getBody().error().message()).isEqualTo("Resource not found");
+        // Resource path is not echoed in the response body — consistent with the
+        // other handlers' message style and avoids reflecting client-controlled
+        // bytes back through the error envelope.
+        assertThat(response.getBody().error().detail()).isNull();
     }
 
     @Test

--- a/deploy/docker/.env.template
+++ b/deploy/docker/.env.template
@@ -18,3 +18,29 @@ GC_IMAGE=ghcr.io/keplerops/ground-control:latest
 # Embedding provider (optional — system degrades gracefully when not set)
 # GC_EMBEDDING_PROVIDER=openai
 # GC_EMBEDDING_API_KEY=__EMBEDDING_API_KEY__
+
+# ADR-026 / GC-P011 access control (REQUIRED in production). With
+# GC_SECURITY_ENABLED=true and an empty credential list, every authenticated
+# route returns 401 (#828). Provision one indexed slot per principal class —
+# typical layout: 0 = ground-control-mcp (USER), 1 = operator-admin (ADMIN),
+# 2 = automation (CI / pack-sync, ADMIN). Slots 3 and 4 are reserved for
+# future consumers; leave them unset and the production compose file omits
+# them from the container (the inherited list-form `- KEY` only forwards
+# when the host variable is set).
+#
+# Tokens NEVER live in this template or in git; populate them only in
+# /opt/gc/.env (mode 600) on the host or from an operator-managed secret
+# store. Leaving any slot's PRINCIPAL_NAME, TOKEN, or ROLE blank fails
+# startup (SecurityProperties.validate rejects blank credential entries).
+# GC_SECURITY_ENABLED=true
+# GC_SECURITY_OPENAPI_PUBLIC=false
+# GROUNDCONTROL_SECURITY_CREDENTIALS_0_PRINCIPAL_NAME=ground-control-mcp
+# GROUNDCONTROL_SECURITY_CREDENTIALS_0_TOKEN=__MCP_TOKEN__
+# GROUNDCONTROL_SECURITY_CREDENTIALS_0_ROLE=USER
+# GROUNDCONTROL_SECURITY_CREDENTIALS_1_PRINCIPAL_NAME=operator-admin
+# GROUNDCONTROL_SECURITY_CREDENTIALS_1_TOKEN=__OPERATOR_TOKEN__
+# GROUNDCONTROL_SECURITY_CREDENTIALS_1_ROLE=ADMIN
+# GROUNDCONTROL_SECURITY_CREDENTIALS_2_PRINCIPAL_NAME=automation
+# GROUNDCONTROL_SECURITY_CREDENTIALS_2_TOKEN=__AUTOMATION_TOKEN__
+# GROUNDCONTROL_SECURITY_CREDENTIALS_2_ROLE=ADMIN
+# GROUNDCONTROL_SECURITY_IP_ALLOWLIST_0=100.0.0.0/8

--- a/deploy/docker/docker-compose.prod.yml
+++ b/deploy/docker/docker-compose.prod.yml
@@ -25,20 +25,58 @@ services:
 
   backend:
     image: ${GC_IMAGE}
+    # List form is required for the ADR-026 indexed credential / IP-allowlist
+    # slots: `- KEY` inherits from the host (or .env) only when set, so unset
+    # slots are NOT injected into the container. Map form with `${VAR:-}` would
+    # set the variable to an empty string, and Spring's
+    # SecurityProperties.validate() rejects blank principal/token/role/CIDR
+    # entries — turning the intended "5 reserved slots, populate as needed"
+    # ergonomic into a startup failure for any unfilled slot. The other
+    # backend env vars stay in `KEY=${VAR}` form so they keep the same
+    # explicit-default semantics as before.
     environment:
-      GC_DATABASE_URL: ${GC_DATABASE_URL}
-      GC_DATABASE_USER: ${GC_DATABASE_USER}
-      GC_DATABASE_PASSWORD: ${GC_DATABASE_PASSWORD}
-      GC_SERVER_PORT: "8000"
-      GC_CACHE_TYPE: "none"
-      GC_EMBEDDING_PROVIDER: ${GC_EMBEDDING_PROVIDER:-none}
-      GC_EMBEDDING_API_KEY: ${GC_EMBEDDING_API_KEY:-}
-      GC_EMBEDDING_MODEL: ${GC_EMBEDDING_MODEL:-text-embedding-3-small}
-      GC_EMBEDDING_DIMENSIONS: ${GC_EMBEDDING_DIMENSIONS:-1536}
-      GC_EMBEDDING_SIMILARITY_THRESHOLD: ${GC_EMBEDDING_SIMILARITY_THRESHOLD:-0.85}
-      SPRING_APPLICATION_JSON: ${SPRING_APPLICATION_JSON:-}
-      JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS}
-      SPRING_PROFILES_ACTIVE: prod
+      - GC_DATABASE_URL=${GC_DATABASE_URL}
+      - GC_DATABASE_USER=${GC_DATABASE_USER}
+      - GC_DATABASE_PASSWORD=${GC_DATABASE_PASSWORD}
+      - GC_SERVER_PORT=8000
+      - GC_CACHE_TYPE=none
+      - GC_EMBEDDING_PROVIDER=${GC_EMBEDDING_PROVIDER:-none}
+      - GC_EMBEDDING_API_KEY=${GC_EMBEDDING_API_KEY:-}
+      - GC_EMBEDDING_MODEL=${GC_EMBEDDING_MODEL:-text-embedding-3-small}
+      - GC_EMBEDDING_DIMENSIONS=${GC_EMBEDDING_DIMENSIONS:-1536}
+      - GC_EMBEDDING_SIMILARITY_THRESHOLD=${GC_EMBEDDING_SIMILARITY_THRESHOLD:-0.85}
+      # ADR-026 / GC-P011 access control. Compose only forwards explicitly
+      # listed variables, so omitting these here means a populated /opt/gc/.env
+      # still leaves the container with an empty credential list and 401s
+      # every caller (#828). Five indexed slots cover the standard MCP /
+      # operator / automation split with headroom; the runtime mirror at
+      # /opt/gc/docker-compose.yml may extend further temporarily before
+      # being upstreamed back here.
+      - GC_SECURITY_ENABLED=${GC_SECURITY_ENABLED:-true}
+      - GC_SECURITY_OPENAPI_PUBLIC=${GC_SECURITY_OPENAPI_PUBLIC:-false}
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_0_PRINCIPAL_NAME
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_0_TOKEN
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_0_ROLE
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_1_PRINCIPAL_NAME
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_1_TOKEN
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_1_ROLE
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_2_PRINCIPAL_NAME
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_2_TOKEN
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_2_ROLE
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_3_PRINCIPAL_NAME
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_3_TOKEN
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_3_ROLE
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_4_PRINCIPAL_NAME
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_4_TOKEN
+      - GROUNDCONTROL_SECURITY_CREDENTIALS_4_ROLE
+      - GROUNDCONTROL_SECURITY_IP_ALLOWLIST_0
+      - GROUNDCONTROL_SECURITY_IP_ALLOWLIST_1
+      - GROUNDCONTROL_SECURITY_IP_ALLOWLIST_2
+      - GROUNDCONTROL_SECURITY_IP_ALLOWLIST_3
+      - GROUNDCONTROL_SECURITY_IP_ALLOWLIST_4
+      - SPRING_APPLICATION_JSON=${SPRING_APPLICATION_JSON:-}
+      - JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
+      - SPRING_PROFILES_ACTIVE=prod
     ports:
       - "8000:8000"
     depends_on:

--- a/deploy/scripts/enable_pack_registry_auth.sh
+++ b/deploy/scripts/enable_pack_registry_auth.sh
@@ -4,7 +4,28 @@ set -euo pipefail
 GC_DIR=/opt/gc
 REFRESH_ENV="${GC_DIR}/refresh-env.sh"
 COMPOSE_FILE="${GC_DIR}/docker-compose.yml"
+ENV_FILE="${GC_DIR}/.env"
 PARAM_PATH="${1:-/gc/dev/pack_registry_security_json}"
+
+# Refuse to run when the host is already configured with ADR-026 indexed
+# credential slots. Spring's bound configuration treats SPRING_APPLICATION_JSON
+# as a higher-precedence list source — and List properties replace, not merge —
+# so injecting the SSM-supplied JSON credential block would silently retire any
+# MCP / operator / automation principals the operator added via indexed env
+# vars. The ADR-026 path is the supported way forward; route the pack-registry
+# admin credential to a free GROUNDCONTROL_SECURITY_CREDENTIALS_<N>_* slot
+# instead of running this script (#828 cycle 3).
+if [ -r "${ENV_FILE}" ] && grep -qE '^GROUNDCONTROL_SECURITY_CREDENTIALS_[0-9]+_' "${ENV_FILE}"; then
+  cat <<EOF >&2
+ERROR: ${ENV_FILE} already contains GROUNDCONTROL_SECURITY_CREDENTIALS_* entries.
+This script writes the pack-registry admin credential into SPRING_APPLICATION_JSON,
+which would replace the indexed ADR-026 credential list at startup and 401 every
+other consumer. Add the pack-registry admin token to a free
+GROUNDCONTROL_SECURITY_CREDENTIALS_<N>_{PRINCIPAL_NAME,TOKEN,ROLE} slot
+(role=ADMIN) directly in ${ENV_FILE} instead and skip this bootstrap.
+EOF
+  exit 2
+fi
 
 python3 - "$REFRESH_ENV" "$PARAM_PATH" <<'PY'
 from pathlib import Path
@@ -40,12 +61,39 @@ import sys
 
 compose_path = Path(sys.argv[1])
 content = compose_path.read_text(encoding="utf-8")
-line = "      SPRING_APPLICATION_JSON: $${SPRING_APPLICATION_JSON:-}\n"
-if line not in content:
-    marker = "      SPRING_PROFILES_ACTIVE: prod\n"
-    if marker not in content:
+
+# Accept either of the two compose shapes the canonical
+# deploy/docker/docker-compose.prod.yml has used: legacy map form
+# (SPRING_APPLICATION_JSON: ${...}) or post-#828 list form
+# (- SPRING_APPLICATION_JSON=${...} / bare - SPRING_APPLICATION_JSON). The
+# canonical file now ships the list-form line in both production and the
+# runtime mirror, so the patch is a no-op there. The map-form fallback
+# preserves compatibility with any pre-cutover host that still carries the
+# older shape. The single-dollar form below matches what compose actually
+# interpolates from .env / the host environment — a `$$` escape would
+# inject the literal string `${SPRING_APPLICATION_JSON:-}` into the
+# container, which is not what the operator wants.
+list_form_present = any(
+    fragment in content
+    for fragment in (
+        "- SPRING_APPLICATION_JSON=${SPRING_APPLICATION_JSON:-}\n",
+        "- SPRING_APPLICATION_JSON\n",
+    )
+)
+map_form_line = "      SPRING_APPLICATION_JSON: ${SPRING_APPLICATION_JSON:-}\n"
+if not list_form_present and map_form_line not in content:
+    map_marker = "      SPRING_PROFILES_ACTIVE: prod\n"
+    list_marker = "      - SPRING_PROFILES_ACTIVE=prod\n"
+    if map_marker in content:
+        content = content.replace(map_marker, map_form_line + map_marker, 1)
+    elif list_marker in content:
+        content = content.replace(
+            list_marker,
+            "      - SPRING_APPLICATION_JSON=${SPRING_APPLICATION_JSON:-}\n" + list_marker,
+            1,
+        )
+    else:
         raise SystemExit("Unable to patch docker-compose.yml: backend environment marker not found")
-    content = content.replace(marker, line + marker, 1)
 compose_path.write_text(content, encoding="utf-8")
 PY
 

--- a/deploy/scripts/sync_pack_catalog.sh
+++ b/deploy/scripts/sync_pack_catalog.sh
@@ -92,7 +92,15 @@ while IFS= read -r entry; do
   fi
 
   installed_body="${tmp_dir}/${pack_id}-installed.json"
+  # ADR-026 protects every /api/v1/** path with at least authenticated access.
+  # Without the bearer header this read 401s after the security-enabled image
+  # rolls out, breaking the install-state probe (#828 cycle 2). Pass the
+  # bearer header through curl's --config FD instead of -H "...${TOKEN}..."
+  # so the token never lands in this process's argv (which `ps`, `/proc/<pid>/
+  # cmdline`, or audit logs would expose to other local users on the host —
+  # #828 cycle 3 security finding).
   installed_status="$(curl -s -o "${installed_body}" -w '%{http_code}' \
+    --config <(printf 'header = "Authorization: Bearer %s"\n' "${auth_token}") \
     "${BASE_URL}/api/v1/control-packs/${pack_id}?project=${PROJECT}")"
 
   if [ "${installed_status}" = "404" ]; then

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -96,6 +96,226 @@ Migrating from pre-#243 deployments:
 - The `X-Actor` header is no longer a self-service identity claim when
   security is enabled; the authenticated principal name is used for audit.
 
+### Authenticated red-dragon redeploy guardrails
+
+Rolling a pre-ADR-026 deployment forward to an ADR-026 image is an
+authentication cutover, not just an image update. Before a security-enabled
+image is deployed to red-dragon, every existing consumer of
+`http://red-dragon:8000/api/v1/**` must be inventoried and configured with a
+Bearer token. This includes repo-local MCP servers, agent `.mcp.json` entries,
+GitHub Actions live-policy or pack-sync jobs, ad-hoc `curl` / `gh api` scripts,
+and any long-running agent process that inherited `GC_BASE_URL`.
+
+Use the existing ADR-026 credential model only:
+
+```env
+GC_SECURITY_ENABLED=true
+GROUNDCONTROL_SECURITY_CREDENTIALS_0_PRINCIPAL_NAME=ground-control-mcp
+GROUNDCONTROL_SECURITY_CREDENTIALS_0_TOKEN=...
+GROUNDCONTROL_SECURITY_CREDENTIALS_0_ROLE=USER
+GROUNDCONTROL_SECURITY_CREDENTIALS_1_PRINCIPAL_NAME=operator-admin
+GROUNDCONTROL_SECURITY_CREDENTIALS_1_TOKEN=...
+GROUNDCONTROL_SECURITY_CREDENTIALS_1_ROLE=ADMIN
+```
+
+The token values live only in operator-managed secrets or `/opt/gc/.env`
+(mode 600), never in git or transcripts. MCP consumers should receive the
+appropriate value as `GROUND_CONTROL_API_TOKEN`; admin-only pack-registry
+automation may continue to use `GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN`
+because the repo-local MCP client maps it onto the unified ADR-026 bearer
+scheme.
+
+`/opt/gc/docker-compose.yml` is a runtime mirror, not the source of truth.
+Any backend environment passthrough needed for ADR-026 credentials belongs
+first in `deploy/docker/docker-compose.prod.yml`; after a clean sync,
+the compose file at `/opt/gc/docker-compose.yml` should match that repo file
+byte-for-byte. Operator-local secret material remains only in `/opt/gc/.env`.
+
+The production compose file currently publishes the backend as `8000:8000`,
+which Docker binds on all host interfaces. If red-dragon's host firewall or
+Tailscale `ts-input` rules do not drop non-tailnet traffic, ADR-026 bearer
+auth is the only API boundary for public callers. Treat network exposure as a
+separate deploy prerequisite: either prove non-tailnet traffic is blocked or
+change the bind/firewall posture deliberately.
+
+### Migrating an existing deployment to ADR-026 auth
+
+Use this playbook when rolling forward from a pre-ADR-026 image (every
+deployed image before the V055-V058 / threat-model wave) to a security-enabled
+image. The 2026-05-09 attempt failed by skipping steps 1-4: the image was
+rolled in before consumers had tokens, and every in-flight agent caller 401'd
+within seconds. Order matters; do not skip ahead.
+
+1. **Inventory every consumer of `http://red-dragon:8000/api/v1/**`.** Sweep:
+   - This repo's MCP server (`mcp/ground-control/lib.js`) and any
+     agent-side `.mcp.json` entry that points at `red-dragon`.
+   - GitHub Actions live-policy / pack-sync jobs (`policy-live`,
+     `scripts/pack-sync.sh`, `tools/ground_control/check_live_policy.mjs`,
+     `tools/ground_control/check_adr_drift.mjs`,
+     `tools/ground_control/sync_policy.mjs`,
+     `tools/packs/sync_packs.mjs`).
+   - Long-running agent processes that inherited `GC_BASE_URL` from the
+     operator's shell (each one needs a token of its own logical class —
+     consumer-classes share a single token, individual processes do not
+     each need a unique one).
+   - Ad-hoc `curl`, `gh api`, or scripted callers.
+   Every entry on the list needs a token before step 6 happens.
+
+2. **Provision tokens — one principal per logical consumer-class.** Generate
+   long random tokens (e.g. `openssl rand -hex 32`). Typical layout:
+   - slot 0: `ground-control-mcp` / `USER` — every MCP / agent caller.
+   - slot 1: `operator-admin` / `ADMIN` — the human operator's CLI.
+   - slot 2: `automation` / `ADMIN` — CI live-policy + pack-sync jobs.
+   Reserve slots 3-4 for unforeseen consumers without re-editing the compose
+   file. Tokens NEVER land in git or transcripts.
+
+3. **Distribute tokens to each consumer.** Pick one mechanism and stay
+   consistent with the existing `${SONAR_TOKEN}` precedent:
+   - Env-var inheritance via `${GROUND_CONTROL_API_TOKEN}` substitution in
+     `.mcp.json`. Operator sets `GROUND_CONTROL_API_TOKEN` in their shell
+     and `claude`/agent processes inherit it.
+   - Operator secret store (1Password, `pass`, etc.) read by each agent's
+     start-up script.
+   For GitHub Actions, both:
+   (a) store the token as a repo secret (`GROUND_CONTROL_API_TOKEN`); and
+   (b) inject it into each step that talks to Ground Control via
+       `env: GROUND_CONTROL_API_TOKEN: ${{ secrets.GROUND_CONTROL_API_TOKEN }}`
+       on the workflow step (already wired into `policy-live` in
+       `.github/workflows/ci.yml`; any new live-API workflow step must do the
+       same).
+   The pre-existing `GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN` continues to
+   work for pack-sync since `mcp/ground-control/lib.js` maps it onto the
+   unified ADR-026 bearer scheme.
+
+4. **Verify each consumer is actually sending its bearer token — not just
+   that it can reach the API.** A `200` against the pre-ADR-026 production
+   image only proves reachability; a consumer with no `Authorization` header
+   at all also returns `200` there, then immediately `401` after cutover.
+   The root `docker-compose.yml` uses `SPRING_PROFILES_ACTIVE=dev`, which
+   sets `groundcontrol.security.enabled=false` — running consumers against
+   that local stack would also produce a false green for the same reason.
+   Use one of these dry-runs instead:
+   - **Security-enabled local instance using the candidate ADR-026 image.**
+     The dry-run MUST use the candidate image (the one targeted by the
+     cutover) — running the pre-ADR image locally reproduces the
+     reachability-only false green this step is designed to prevent. To
+     keep prod's schema untouched, point the dry-run at a throwaway
+     database directory (the prod compose file's `db` service uses a
+     bind-mount under `/data/postgres/`; set a different host path for the
+     dry-run via the `POSTGRES_DATA_DIR` env var if your operator copy
+     parameterizes it, or run the dry-run on a different host).
+     ```bash
+     # mktemp + chmod 600 so the scratch env file is never world-readable
+     # while it carries draft credential token values.
+     dryrun_env="$(mktemp -t gc-prod-dryrun.env.XXXXXX)"
+     chmod 600 "${dryrun_env}"
+     cp deploy/docker/.env.template "${dryrun_env}"
+     # Edit ${dryrun_env} to fill GC_DATABASE_PASSWORD, POSTGRES_PASSWORD,
+     # and GROUNDCONTROL_SECURITY_CREDENTIALS_<N>_* slots with the same
+     # token values that will land in /opt/gc/.env. Set GC_IMAGE to the
+     # candidate ADR-026 image (NOT the currently deployed pre-ADR image
+     # — that one would still 200 unauthenticated requests).
+     GC_IMAGE=ghcr.io/keplerops/ground-control:<candidate-digest> \
+       docker compose --env-file "${dryrun_env}" \
+       -f deploy/docker/docker-compose.prod.yml up -d
+     # When done:
+     docker compose --env-file "${dryrun_env}" \
+       -f deploy/docker/docker-compose.prod.yml down -v
+     shred -u "${dryrun_env}"
+     ```
+     Point each consumer at `http://localhost:8000` and confirm each
+     returns `200` against `/api/v1/projects`. The compose file declares
+     the indexed credential slots as list-form passthroughs, so unset
+     slots are NOT injected into the container and Spring sees only the
+     populated entries. A green dry-run here proves token delivery
+     end-to-end against the same auth layer production will run after
+     cutover.
+   - **Server-side audit-log inspection.** Make each consumer issue one
+     known authenticated call against the dry-run instance, then read the
+     backend's structured logs and confirm the request appears with the
+     expected principal name (`ground-control-mcp`, `operator-admin`,
+     `automation`). The principal name comes from `ActorFilter` /
+     `ActorHolder` and is logged via the per-request MDC, NOT the bearer
+     token itself. This proves token delivery without the token ever
+     leaving the server-side process boundary, so the captured output is
+     safe to keep around for review:
+     ```bash
+     docker compose -f deploy/docker/docker-compose.prod.yml \
+       --env-file "${dryrun_env}" logs --tail=200 backend | \
+       grep -E '"actor"|"principal"'
+     ```
+   Do NOT capture wire-level traces (e.g. `curl --trace-ascii`,
+   `tcpdump`, agent debug stdout) for this verification: those formats
+   embed the literal `Authorization: Bearer <token>` header, and any
+   resulting file or transcript becomes a credential leak — anyone who
+   can read the saved capture can replay the token. Status-code +
+   server-side principal-name verification covers the same property
+   without that exposure.
+
+   A consumer that gets `200` against the pre-ADR-026 production but fails
+   the candidate-image dry-run is exactly the regression this step
+   prevents — its bearer header is missing or wrong, and it will 401 the
+   moment the new image starts.
+
+   **Important precedence note:** `SPRING_APPLICATION_JSON` is also
+   forwarded to the container (legacy support for the pack-registry
+   bootstrap path in `deploy/scripts/enable_pack_registry_auth.sh`). When
+   it carries a `groundcontrol.security.credentials` block, Spring
+   *replaces* the indexed env-var list rather than merging — the new env
+   vars are silently ignored. Before the cutover, confirm
+   `SPRING_APPLICATION_JSON` either does NOT include
+   `groundcontrol.security.credentials` at all, or contains the same
+   principals you provisioned via the indexed env vars. The dry-run
+   above will surface this if it bites: a consumer that authenticates
+   under indexed env vars but fails inside the dry-run container is
+   most likely losing to a stale `SPRING_APPLICATION_JSON` block.
+
+5. **`pg_dump -Fc` snapshot.** Defensive — the new image carries V055-V058
+   forward-only migrations:
+   ```bash
+   ssh red-dragon /opt/gc/backup.sh
+   ```
+
+6. **Update `/opt/gc/.env`.** Pin the new image digest and add the
+   credential block. Use the indexed `GROUNDCONTROL_SECURITY_CREDENTIALS_*`
+   shape (matches the env-var table above and `deploy/docker/.env.template`).
+   `chmod 600` afterward.
+
+7. **Sync `/opt/gc/docker-compose.yml` byte-for-byte from this repo's
+   `deploy/docker/docker-compose.prod.yml`.** That file is the canonical
+   source of the env-passthrough block; the runtime copy must match it
+   after sync, otherwise the next sync clobbers operator-local edits.
+   The `make policy` gate
+   (`tools/policy/checks.py::run_deploy_compose_credential_passthrough`)
+   enforces the credential keys stay present in the canonical file.
+
+8. **Roll the image.**
+   ```bash
+   cd /opt/gc
+   docker compose --env-file .env up -d --force-recreate backend
+   ```
+
+9. **Verify Flyway and the threat-model surface.** `V055`-`V058` apply on
+   first start of the new image; the `threat_model` table appears in the
+   schema:
+   ```bash
+   docker compose exec db psql -U gc -d ground_control -c \
+     "SELECT version FROM flyway_schema_history WHERE version IN ('55','56','57','58');"
+   docker compose exec db psql -U gc -d ground_control -c "\\d threat_model"
+   ```
+
+10. **Re-verify every consumer from step 1 returns `200` (or its expected
+    status, e.g. `404` for a not-found lookup) — never `401`.** Hit the
+    threat-model MCP path explicitly (`gc_list_threat_models`,
+    `gc_create_threat_model`, `gc_get_threat_model`) since that is the
+    surface this whole migration was meant to enable. A `401` from any
+    consumer at this point means the token was not delivered (back to
+    step 3) — do NOT roll back the image; rollback is reserved for
+    actual schema/data damage.
+
+If any step fails, stop and surface the failure to the operator before
+continuing — every later step assumes the earlier one succeeded.
+
 ### Makefile Targets
 
 | Target | Description |

--- a/tools/packs/sync_packs.mjs
+++ b/tools/packs/sync_packs.mjs
@@ -172,8 +172,12 @@ async function getRegistryEntry(baseUrl, project, packId, version) {
 
 async function getInstalledPack(baseUrl, project, packId) {
   try {
+    // ADR-026 protects every /api/v1/** path with at least authenticated
+    // access. Without `auth: true` this read 401s after the security-enabled
+    // image rolls out, breaking the install-state probe (#828 cycle 2).
     return await apiRequest(baseUrl, "GET", `/api/v1/control-packs/${encodeURIComponent(packId)}`, {
       params: { project },
+      auth: true,
     });
   } catch (error) {
     if (error.status === 404) {

--- a/tools/policy/checks.py
+++ b/tools/policy/checks.py
@@ -20,6 +20,44 @@ CONTROLLER_PATH_RE = re.compile(
 MIGRATION_PATH_RE = re.compile(r"^backend/src/main/resources/db/migration/V\d+__.+\.sql$")
 PR_REQUIREMENT_RE = re.compile(r"\b[A-Z][A-Z0-9]+-[A-Z0-9]+(?:-\d+|\d+)\b")
 
+DEPLOY_COMPOSE_PROD_PATH = Path("deploy/docker/docker-compose.prod.yml")
+REQUIRED_ADR026_CREDENTIAL_SLOT_COUNT = 5
+REQUIRED_ADR026_ALLOWLIST_SLOT_COUNT = 5
+
+
+def _required_adr026_backend_env_keys() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return the (always-set, inherit-only) ADR-026 keys.
+
+    Always-set keys are typed config (security toggles); list or map form is
+    fine for them because their defaults are guaranteed non-empty. Inherit-only
+    keys are the optional indexed credential / allowlist slots — those MUST
+    use bare list form (``- KEY`` with no ``=``) so unset host variables
+    are NOT injected as empty strings (Spring's
+    ``SecurityProperties.validate()`` rejects blank principal/token/role/CIDR
+    entries and the container fails startup).
+    """
+    always_set: list[str] = ["GC_SECURITY_ENABLED", "GC_SECURITY_OPENAPI_PUBLIC"]
+    inherit_only: list[str] = []
+    for index in range(REQUIRED_ADR026_CREDENTIAL_SLOT_COUNT):
+        inherit_only.append(f"GROUNDCONTROL_SECURITY_CREDENTIALS_{index}_PRINCIPAL_NAME")
+        inherit_only.append(f"GROUNDCONTROL_SECURITY_CREDENTIALS_{index}_TOKEN")
+        inherit_only.append(f"GROUNDCONTROL_SECURITY_CREDENTIALS_{index}_ROLE")
+    for index in range(REQUIRED_ADR026_ALLOWLIST_SLOT_COUNT):
+        inherit_only.append(f"GROUNDCONTROL_SECURITY_IP_ALLOWLIST_{index}")
+    return tuple(always_set), tuple(inherit_only)
+
+
+(
+    REQUIRED_ADR026_ALWAYS_SET_KEYS,
+    REQUIRED_ADR026_INHERIT_ONLY_KEYS,
+) = _required_adr026_backend_env_keys()
+REQUIRED_ADR026_BACKEND_ENV_KEYS: tuple[str, ...] = (
+    *REQUIRED_ADR026_ALWAYS_SET_KEYS,
+    *REQUIRED_ADR026_INHERIT_ONLY_KEYS,
+)
+COMPOSE_ENV_KEY_RE = re.compile(r"^\s*-\s*([A-Z][A-Z0-9_]*)(?:=.*)?\s*$|^\s*([A-Z][A-Z0-9_]*)\s*:.*$")
+COMPOSE_ENV_INHERIT_FORM_RE = re.compile(r"^\s*-\s*([A-Z][A-Z0-9_]*)\s*$")
+
 
 @dataclass
 class Violation:
@@ -245,6 +283,132 @@ def run_migration_policy(changed_files: list[str], root: Path = REPO_ROOT) -> li
     return violations
 
 
+def _extract_compose_backend_env_entries(text: str) -> dict[str, str]:
+    """Extract environment entries declared on the `backend` service.
+
+    Returns a mapping of key → form, where form is one of:
+      ``"inherit"`` — list shorthand ``- KEY`` (no value, host-inheritance only).
+      ``"list-value"`` — list form with explicit value ``- KEY=...``.
+      ``"map"``    — map form ``KEY: ...``.
+
+    Compose allows both list-form (``- KEY=VALUE`` / ``- KEY``) and map-form
+    (``KEY: VALUE``) under ``environment:``; honor either. A handwritten
+    indentation walker is intentional here — adding a PyYAML dependency for
+    one check would make ``make policy`` fail with ``ModuleNotFoundError`` on
+    a clean Python installation, since the rest of ``tools/policy/`` is
+    stdlib-only.
+    """
+    found: dict[str, str] = {}
+    in_backend = False
+    backend_indent = -1
+    in_environment = False
+    env_indent = -1
+    for raw_line in text.splitlines():
+        stripped = raw_line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw_line) - len(stripped)
+
+        # Track sibling-out-of-block exits before recognizing new starts.
+        if in_environment and indent <= env_indent:
+            in_environment = False
+        if in_backend and indent <= backend_indent and not stripped.startswith("backend:"):
+            in_backend = False
+
+        if stripped.startswith("backend:"):
+            in_backend = True
+            backend_indent = indent
+            in_environment = False
+            continue
+        if in_backend and stripped.startswith("environment:") and not in_environment:
+            in_environment = True
+            env_indent = indent
+            continue
+        if in_environment:
+            inherit_match = COMPOSE_ENV_INHERIT_FORM_RE.match(raw_line)
+            if inherit_match:
+                found.setdefault(inherit_match.group(1), "inherit")
+                continue
+            match = COMPOSE_ENV_KEY_RE.match(raw_line)
+            if match:
+                key = match.group(1) or match.group(2)
+                form = "list-value" if match.group(1) is not None else "map"
+                found.setdefault(key, form)
+    return found
+
+
+def run_deploy_compose_credential_passthrough(root: Path = REPO_ROOT) -> list[Violation]:
+    """Assert the production compose file enumerates ADR-026 credential env vars.
+
+    #828 was triggered because the operator filled `GROUNDCONTROL_SECURITY_*`
+    values into `/opt/gc/.env` but `deploy/docker/docker-compose.prod.yml` did
+    not list them on the backend service's `environment:` block, so docker
+    compose never propagated them into the container. The first deploy of the
+    ADR-026 image therefore 401'd every consumer. The check below is a static
+    post-condition — independent of `changed_files` — so any future diff that
+    silently strips one of the required keys fails `make policy`. All five
+    documented credential slots and all five allowlist slots must remain
+    enumerated; partial removal is itself the regression.
+    """
+    compose_path = root / DEPLOY_COMPOSE_PROD_PATH
+    if not compose_path.exists():
+        return [
+            Violation(
+                code="deploy-compose-missing",
+                message=(
+                    "Canonical production compose file is missing — ADR-026 "
+                    "credential passthrough cannot be verified."
+                ),
+                details=[f"expected at {DEPLOY_COMPOSE_PROD_PATH.as_posix()}"],
+            )
+        ]
+
+    text = compose_path.read_text(encoding="utf-8")
+    entries = _extract_compose_backend_env_entries(text)
+
+    violations: list[Violation] = []
+
+    missing = [key for key in REQUIRED_ADR026_BACKEND_ENV_KEYS if key not in entries]
+    if missing:
+        violations.append(
+            Violation(
+                code="deploy-compose-adr026-passthrough",
+                message=(
+                    "deploy/docker/docker-compose.prod.yml backend service is "
+                    "missing ADR-026 credential env-var passthroughs (GC-P011)."
+                ),
+                details=[f"missing keys: {', '.join(missing)}"],
+            )
+        )
+
+    # Indexed credential / allowlist slots MUST use bare list form (- KEY).
+    # Map form with ${VAR:-} or list-with-value form ${VAR:-} both inject the
+    # variable into the container as an empty string when the host variable
+    # is unset, which Spring's SecurityProperties.validate() then rejects —
+    # exactly the brittle path #828 cycle 1 surfaced. Bare list form inherits
+    # only when the host has the variable set.
+    wrong_form = [
+        key
+        for key in REQUIRED_ADR026_INHERIT_ONLY_KEYS
+        if key in entries and entries[key] != "inherit"
+    ]
+    if wrong_form:
+        violations.append(
+            Violation(
+                code="deploy-compose-adr026-inherit-only",
+                message=(
+                    "Optional ADR-026 credential / allowlist slots in "
+                    "deploy/docker/docker-compose.prod.yml must use bare list form "
+                    "(- KEY) so unset host variables are not injected as blank "
+                    "(GC-P011 / SecurityProperties.validate)."
+                ),
+                details=[f"keys not in inherit-only form: {', '.join(wrong_form)}"],
+            )
+        )
+
+    return violations
+
+
 def run_pr_body_check(event_path: Path) -> list[Violation]:
     """Backwards-compatible wrapper that loads the PR body from a GitHub event payload."""
     event = json.loads(event_path.read_text(encoding="utf-8"))
@@ -399,6 +563,7 @@ def main(argv: list[str] | None = None) -> int:
     violations.extend(run_adr_guard(changed_files))
     violations.extend(run_controller_contracts(changed_files))
     violations.extend(run_migration_policy(changed_files))
+    violations.extend(run_deploy_compose_credential_passthrough())
 
     if not args.skip_pr_body:
         body = _resolve_pr_body(args)

--- a/tools/tests/test_policy.py
+++ b/tools/tests/test_policy.py
@@ -9,6 +9,7 @@ from tools.policy.checks import (
     parse_args,
     run_adr_guard,
     run_controller_contracts,
+    run_deploy_compose_credential_passthrough,
     run_migration_policy,
     run_pr_body_check,
 )
@@ -71,6 +72,136 @@ class PolicyChecksTest(unittest.TestCase):
             "## Traceability\n\n- IMPLEMENTS: foo\n- TESTS: bar\n"
         )
         self.assertEqual(check_pr_body(body), [])
+
+    def test_deploy_compose_credential_passthrough_passes_on_committed_file(self):
+        # The committed deploy/docker/docker-compose.prod.yml must enumerate the
+        # ADR-026 credential and IP-allowlist env vars on the backend service so
+        # an operator who fills .env still has them propagate into the container.
+        # #828 was triggered by exactly this gap. Run the check against the live
+        # repo file as the post-condition assertion.
+        violations = run_deploy_compose_credential_passthrough(root=REPO_ROOT)
+        self.assertEqual(violations, [], msg=f"unexpected violations: {[v.render() for v in violations]}")
+
+    def test_deploy_compose_credential_passthrough_fires_when_keys_missing(self):
+        # If the backend service's environment block stops enumerating the
+        # ADR-026 keys, the check must fail loudly so the regression is caught
+        # in `make policy` before it ships.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            compose_path = root / "deploy/docker/docker-compose.prod.yml"
+            compose_path.parent.mkdir(parents=True, exist_ok=True)
+            compose_path.write_text(
+                "services:\n"
+                "  backend:\n"
+                "    image: ghcr.io/keplerops/ground-control:latest\n"
+                "    environment:\n"
+                "      - GC_DATABASE_URL=${GC_DATABASE_URL}\n",
+                encoding="utf-8",
+            )
+            violations = run_deploy_compose_credential_passthrough(root=root)
+            codes = {item.code for item in violations}
+            self.assertIn("deploy-compose-adr026-passthrough", codes)
+            # The violation must enumerate the missing keys so the operator's
+            # fix is unambiguous.
+            details = " ".join(detail for v in violations for detail in v.details)
+            self.assertIn("GC_SECURITY_ENABLED", details)
+            self.assertIn("GROUNDCONTROL_SECURITY_CREDENTIALS_0_TOKEN", details)
+            self.assertIn("GROUNDCONTROL_SECURITY_IP_ALLOWLIST_0", details)
+
+    def test_deploy_compose_credential_passthrough_requires_all_five_slots(self):
+        # The runbook tells operators they have five reserved slots; the policy
+        # gate must enforce all five so a future diff stripping slot 4 fails
+        # `make policy` rather than silently regressing the documented headroom.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            compose_path = root / "deploy/docker/docker-compose.prod.yml"
+            compose_path.parent.mkdir(parents=True, exist_ok=True)
+            compose_path.write_text(
+                "services:\n"
+                "  backend:\n"
+                "    environment:\n"
+                "      - GC_SECURITY_ENABLED=${GC_SECURITY_ENABLED:-true}\n"
+                "      - GC_SECURITY_OPENAPI_PUBLIC=${GC_SECURITY_OPENAPI_PUBLIC:-false}\n"
+                # Only slots 0..3 declared — slot 4 missing.
+                + "".join(
+                    f"      - GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_PRINCIPAL_NAME\n"
+                    f"      - GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_TOKEN\n"
+                    f"      - GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_ROLE\n"
+                    for i in range(4)
+                )
+                + "".join(
+                    f"      - GROUNDCONTROL_SECURITY_IP_ALLOWLIST_{i}\n"
+                    for i in range(4)
+                ),
+                encoding="utf-8",
+            )
+            violations = run_deploy_compose_credential_passthrough(root=root)
+            codes = {item.code for item in violations}
+            self.assertIn("deploy-compose-adr026-passthrough", codes)
+            details = " ".join(detail for v in violations for detail in v.details)
+            self.assertIn("GROUNDCONTROL_SECURITY_CREDENTIALS_4_TOKEN", details)
+            self.assertIn("GROUNDCONTROL_SECURITY_IP_ALLOWLIST_4", details)
+
+    def test_deploy_compose_credential_passthrough_rejects_map_form_for_indexed_slots(self):
+        # Map form with `${VAR:-}` defaults injects the variable into the
+        # container as an empty string when the host variable is unset, which
+        # SecurityProperties.validate() rejects (the failure mode that
+        # codex flagged in #828 cycle 2). The policy gate must reject any
+        # indexed slot in map form, even if the typed config keys remain in
+        # map form (they have non-empty defaults so they are safe either way).
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            compose_path = root / "deploy/docker/docker-compose.prod.yml"
+            compose_path.parent.mkdir(parents=True, exist_ok=True)
+            body = "services:\n  backend:\n    environment:\n"
+            body += "      GC_SECURITY_ENABLED: ${GC_SECURITY_ENABLED:-true}\n"
+            body += "      GC_SECURITY_OPENAPI_PUBLIC: ${GC_SECURITY_OPENAPI_PUBLIC:-false}\n"
+            # Indexed slots in map form — NOT acceptable.
+            for i in range(5):
+                body += f"      GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_PRINCIPAL_NAME: ${{GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_PRINCIPAL_NAME:-}}\n"
+                body += f"      GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_TOKEN: ${{GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_TOKEN:-}}\n"
+                body += f"      GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_ROLE: ${{GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_ROLE:-}}\n"
+            for i in range(5):
+                body += f"      GROUNDCONTROL_SECURITY_IP_ALLOWLIST_{i}: ${{GROUNDCONTROL_SECURITY_IP_ALLOWLIST_{i}:-}}\n"
+            compose_path.write_text(body, encoding="utf-8")
+            violations = run_deploy_compose_credential_passthrough(root=root)
+            codes = {item.code for item in violations}
+            self.assertIn("deploy-compose-adr026-inherit-only", codes)
+            details = " ".join(detail for v in violations for detail in v.details)
+            self.assertIn("GROUNDCONTROL_SECURITY_CREDENTIALS_0_TOKEN", details)
+            self.assertIn("GROUNDCONTROL_SECURITY_IP_ALLOWLIST_4", details)
+
+    def test_deploy_compose_credential_passthrough_rejects_list_form_with_default(self):
+        # `- KEY=${VAR:-}` is also unsafe: it injects empty string when the
+        # host variable is unset. Only bare `- KEY` (inherit-only) form is
+        # acceptable for the indexed slots.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            compose_path = root / "deploy/docker/docker-compose.prod.yml"
+            compose_path.parent.mkdir(parents=True, exist_ok=True)
+            body = "services:\n  backend:\n    environment:\n"
+            body += "      - GC_SECURITY_ENABLED=${GC_SECURITY_ENABLED:-true}\n"
+            body += "      - GC_SECURITY_OPENAPI_PUBLIC=${GC_SECURITY_OPENAPI_PUBLIC:-false}\n"
+            for i in range(5):
+                body += f"      - GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_PRINCIPAL_NAME=${{GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_PRINCIPAL_NAME:-}}\n"
+                body += f"      - GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_TOKEN=${{GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_TOKEN:-}}\n"
+                body += f"      - GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_ROLE=${{GROUNDCONTROL_SECURITY_CREDENTIALS_{i}_ROLE:-}}\n"
+            for i in range(5):
+                body += f"      - GROUNDCONTROL_SECURITY_IP_ALLOWLIST_{i}=${{GROUNDCONTROL_SECURITY_IP_ALLOWLIST_{i}:-}}\n"
+            compose_path.write_text(body, encoding="utf-8")
+            violations = run_deploy_compose_credential_passthrough(root=root)
+            codes = {item.code for item in violations}
+            self.assertIn("deploy-compose-adr026-inherit-only", codes)
+
+    def test_deploy_compose_credential_passthrough_handles_missing_file(self):
+        # If the canonical compose file disappears entirely the check must fail
+        # rather than silently pass — the absence is itself a regression worth
+        # surfacing in `make policy`.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            violations = run_deploy_compose_credential_passthrough(root=root)
+            codes = {item.code for item in violations}
+            self.assertIn("deploy-compose-missing", codes)
 
     def test_parse_args_accepts_pre_commit_positional_files(self):
         args = parse_args(["--skip-pr-body", "docs/WORKFLOW.md", "mcp/ground-control/lib.js"])


### PR DESCRIPTION
## Summary

The 2026-05-09 cutover failed because three structural footguns lined up at once. This PR removes all three so the next attempt cannot reproduce the failure.

- `deploy/docker/docker-compose.prod.yml` — backend `environment:` block converted to list form so unset indexed credential / IP-allowlist slots are NOT injected. Spring's `SecurityProperties.validate()` would otherwise reject blank entries on reserved slots and fail startup. The typed config knobs (`GC_SECURITY_ENABLED`, `GC_SECURITY_OPENAPI_PUBLIC`) keep their explicit defaults.
- `docs/deployment/DEPLOYMENT.md` — 10-step pre-existing-deployment migration playbook. Inventory consumers, provision and distribute tokens, dry-run against the **candidate** ADR-026 image with `mktemp`-d / `chmod 600` scratch env, verify each consumer actually sends a bearer header (not just reachability) using server-side principal-name logging, then cut over and re-verify. Wire-trace capture is explicitly forbidden because those formats embed bearer tokens.
- `GlobalExceptionHandler` — `NoResourceFoundException` → `404 not_found`. Without it, an image missing the threat-model controllers surfaces `500 internal_error` and muddies #821-style diagnoses. Path is intentionally not echoed in the response body.
- `tools/policy/checks.py` — structural gate `run_deploy_compose_credential_passthrough` wired into `make policy`. Stdlib-only (no PyYAML dependency on the policy hot path). Required keys cover all five credential slots and all five allowlist slots; the indexed slots must use bare list form.
- Pack-sync auth — `tools/packs/sync_packs.mjs` and `deploy/scripts/sync_pack_catalog.sh` now send a bearer header on the `/api/v1/control-packs/{packId}` install-state probe so pack sync survives the cutover. The new curl invocation passes the token through `--config <(printf ...)` so it never lands in argv.
- `deploy/scripts/enable_pack_registry_auth.sh` — refuses to run when `/opt/gc/.env` already carries indexed credential slots (its `SPRING_APPLICATION_JSON` injection would replace them at startup); list-form compose detection now uses single-dollar interpolation that matches the canonical compose.
- `.github/workflows/ci.yml` — live API token wired into `policy-live`, but the job is restricted to `refs/heads/main` so PR-controlled or attacker-pushed JS cannot exfiltrate `secrets.GROUND_CONTROL_API_TOKEN`.

## Requirement UIDs

GC-P011 (Access Control). No new requirements; this PR closes operational gaps around an existing requirement that the 2026-05-09 cutover surfaced.

## ADR Impact

No ADR required. ADR-026 (REST API Access Control) and ADR-030 (On-prem Hetzner Deployment) are unchanged. The runbook extension references both.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason

## Traceability

- IMPLEMENTS: GC-P011 deployment ergonomics — `deploy/docker/docker-compose.prod.yml`, `docs/deployment/DEPLOYMENT.md`, `tools/policy/checks.py`, `backend/src/main/java/com/keplerops/groundcontrol/api/GlobalExceptionHandler.java`.
- TESTS: `backend/src/test/java/com/keplerops/groundcontrol/unit/api/GlobalExceptionHandlerTest.java::handleNoResourceFound_returnsNotFound`, `tools/tests/test_policy.py` (5 new tests covering presence, missing keys, all-five-slots, list-form-required, missing-file).

## Test plan

- [x] `make policy` (15 → 17 tests, all green)
- [x] `make check` (full build + tests + spotless + spotbugs + checkstyle + jacoco)
- [x] Pre-commit hooks (`bash -n`, secret scan, gradle-check, GC-P021 backup policy)
- [x] Empirically confirmed `docker compose` list-form `- KEY` does NOT inject unset host vars (alpine container test)
- [ ] Operator: run the new migration playbook end-to-end on red-dragon (this is the deploy step #828's acceptance criteria 1-3 require, and is intentionally outside the agent's reach)

Closes #828.