### PR TITLE
Reconcile deploy docs / scripts with reality after #828

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,8 @@
       "args": ["/home/atomik/src/Ground-Control/mcp/ground-control/index.js"],
       "env": {
         "GC_BASE_URL": "http://red-dragon:8000",
-        "GH_REPO": "KeplerOps/Ground-Control"
+        "GH_REPO": "KeplerOps/Ground-Control",
+        "GROUND_CONTROL_API_TOKEN": "${GROUND_CONTROL_API_TOKEN}"
       }
     },
     "sonarqube": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verification. Cross-links the canonical compose file and the
   `make policy` gate so the source-of-truth invariant is enforced.
 
+- **Image-tag semantics + digest-resolution clarification**
+  (`docs/deployment/DEPLOYMENT.md`, `deploy/docker/.env.template`,
+  issue #828 follow-up). The runbook now explains that `:latest` only
+  updates on push to `main` (so post-merge-to-`dev` it is still the
+  previous release), shows how to resolve a stable digest from the `:dev`
+  or `:sha-<commit>` tags, and pins the cutover to that digest so the
+  image you dry-ran against is the image you deploy.
+
+- **`deploy/scripts/deploy.sh` reconciled with the runtime copy at
+  `/opt/gc/deploy.sh`** (issue #828 follow-up). Removes the AWS-era
+  references (`gc-dev`, `refresh-env.sh`, SSM bootstrap) that ADR-030
+  retired and aligns the optional image-ref override with the digest /
+  tag conventions in `.env.template`. The forced-command SSH path used
+  by the CI deploy job runs without arguments; the optional ref is for
+  operator-driven manual rollbacks or one-off image verifications.
+
 ### Security
 
 - **AGE adapter migrated to native Cypher parameter binding** (issue #244,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Backend port can bind to a specific host IP via `GC_BIND_IP`**
+  (`deploy/docker/docker-compose.prod.yml`,
+  `deploy/docker/.env.template`, `.mcp.json`, issue #828 follow-up).
+  Adds `${GC_BIND_IP:-0.0.0.0}` to the published port spec. On the
+  red-dragon production deployment (ADR-030), `GC_BIND_IP` is set in
+  `/opt/gc/.env` to the host's tailnet IP so the `docker-proxy` never
+  listens on the public interface — defense in depth on top of ADR-026
+  bearer auth. Local / dev stacks leave it unset, preserving the
+  existing all-interfaces default. The repo `.mcp.json` also gets a
+  `${GROUND_CONTROL_API_TOKEN}` env passthrough so the agent MCP
+  client carries a bearer token to every authenticated `/api/v1/**`
+  call.
+
+### Security
+
 - **AGE adapter migrated to native Cypher parameter binding** (issue #244,
   ADR-032). `AgeGraphService` now routes every user-controlled string value
   (UIDs, project identifiers, free-form requirement properties like titles

--- a/deploy/docker/.env.template
+++ b/deploy/docker/.env.template
@@ -32,6 +32,13 @@ POSTGRES_PASSWORD=__DB_PASSWORD__
 #     --format '{{index .RepoDigests 0}}'
 GC_IMAGE=ghcr.io/keplerops/ground-control:latest
 
+# Optional: bind the backend port to a specific host IP. On the on-prem
+# red-dragon deployment (ADR-030) this is set to the host's tailnet IP so
+# the docker-proxy never listens on the public interface — defense in
+# depth on top of ADR-026 bearer auth (#828). Leave unset for local / dev
+# stacks where binding to all interfaces is the expected default.
+# GC_BIND_IP=100.98.28.66
+
 # Embedding provider (optional — system degrades gracefully when not set)
 # GC_EMBEDDING_PROVIDER=openai
 # GC_EMBEDDING_API_KEY=__EMBEDDING_API_KEY__

--- a/deploy/docker/.env.template
+++ b/deploy/docker/.env.template
@@ -1,6 +1,9 @@
-# Ground Control production environment variables
-# This template is filled by cloud-init from SSM parameter values.
-# Do not commit actual secrets to version control.
+# Ground Control production environment variables.
+#
+# This is the canonical shape for /opt/gc/.env on red-dragon (mode 600,
+# owned by gc-deploy:gc-deploy). Operators copy it and fill the secret
+# fields directly; there is no SSM bootstrap (the AWS path was retired
+# with ADR-030). Do not commit actual secrets to version control.
 
 GC_DATABASE_URL=jdbc:postgresql://db:5432/ground_control
 GC_DATABASE_USER=gc
@@ -13,6 +16,20 @@ POSTGRES_DB=ground_control
 POSTGRES_USER=gc
 POSTGRES_PASSWORD=__DB_PASSWORD__
 
+# Backend image. The CI docker job pushes one of three reference forms
+# on every successful build:
+#   :latest             — only updated on push to `main` (released).
+#   :dev                — moves on every push to `dev`; head of unreleased work.
+#   :sha-<short-commit> — immutable, points at one specific commit's build.
+#
+# Production deployments SHOULD pin to an immutable reference: either
+# ghcr.io/keplerops/ground-control@sha256:<digest> (most reproducible) or
+# ghcr.io/keplerops/ground-control:sha-<commit>. `:latest` is a moving
+# target and is acceptable only for local dev. Resolve a digest from a
+# tag with:
+#   docker pull ghcr.io/keplerops/ground-control:sha-<commit>
+#   docker inspect ghcr.io/keplerops/ground-control:sha-<commit> \
+#     --format '{{index .RepoDigests 0}}'
 GC_IMAGE=ghcr.io/keplerops/ground-control:latest
 
 # Embedding provider (optional — system degrades gracefully when not set)

--- a/deploy/docker/docker-compose.prod.yml
+++ b/deploy/docker/docker-compose.prod.yml
@@ -78,7 +78,12 @@ services:
       - JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}
       - SPRING_PROFILES_ACTIVE=prod
     ports:
-      - "8000:8000"
+      # Bind to a specific host IP via GC_BIND_IP when present. On red-dragon
+      # this is set to the host's tailnet IP (100.98.28.66) so the docker-proxy
+      # never listens on the public interface — defense in depth on top of
+      # ADR-026 bearer auth (#828). Local / dev stacks leave it unset so the
+      # default 0.0.0.0 still binds all interfaces.
+      - "${GC_BIND_IP:-0.0.0.0}:8000:8000"
     depends_on:
       db:
         condition: service_healthy

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1,40 +1,61 @@
 #!/bin/bash
-# Ground Control manual deploy helper
-# Usage: ssh gc-dev /opt/gc/deploy.sh [image-tag]
-#   or:  ./deploy/scripts/deploy.sh [image-tag]
+# Ground Control manual deploy helper.
+#
+# This is the repo copy of the script that lives on red-dragon at
+# /opt/gc/deploy.sh and runs as the SSH forced-command target for the
+# `gc-deploy` user (per ADR-030). The CI deploy job invokes it as
+# `ssh gc-deploy@red-dragon` (no arguments). It is also a valid manual
+# entry point for the operator from any tailnet host:
+#
+#   ssh gc-deploy@red-dragon              # CI / forced-command path (no args)
+#   ssh red-dragon /opt/gc/deploy.sh      # operator path; same forced command
+#   ./deploy/scripts/deploy.sh <image-ref> # local override; see below
+#
+# When invoked locally with an image-ref argument, this script rewrites
+# /opt/gc/.env's GC_IMAGE line to that ref before pulling. The argument
+# accepts any GHCR reference: a tag (`:latest`, `:dev`, `:sha-1a69bc3`)
+# or a digest (`@sha256:...`). Production deployments pin to a digest in
+# /opt/gc/.env directly; this override is for one-off rollbacks or
+# operator-driven verification of a specific image.
+#
+# Note: the legacy AWS / SSM / refresh-env.sh path was removed when
+# ADR-030 retired the AWS deployment. There is no SSM lookup; the
+# canonical credential / config source is /opt/gc/.env (mode 600,
+# operator-managed).
 set -euo pipefail
 
-TAG="${1:-latest}"
 GC_DIR=/opt/gc
-
 cd "${GC_DIR}"
 
-# Refresh secrets from SSM (regenerates .env with latest values)
-if [ -x "${GC_DIR}/refresh-env.sh" ]; then
-  echo "Refreshing secrets from SSM..."
-  "${GC_DIR}/refresh-env.sh"
-fi
-
-# Update image tag if specified
-if [ "${TAG}" != "latest" ]; then
-  sed -i "s|GC_IMAGE=.*|GC_IMAGE=ghcr.io/keplerops/ground-control:${TAG}|" .env
+# Optional: rewrite GC_IMAGE to the supplied ref. The ref is taken
+# verbatim, so callers that want a digest pin pass the full
+# `ghcr.io/keplerops/ground-control@sha256:...` string; tag-style
+# `ghcr.io/keplerops/ground-control:dev` also works.
+if [ "${1:-}" != "" ]; then
+  REF="$1"
+  case "${REF}" in
+    ghcr.io/*) ;;
+    *) REF="ghcr.io/keplerops/ground-control:${REF}" ;;
+  esac
+  sed -i "s|^GC_IMAGE=.*|GC_IMAGE=${REF}|" .env
+  echo "Pinned GC_IMAGE=${REF}"
 fi
 
 echo "Pulling images..."
-docker compose pull
+docker compose --env-file .env pull
 
 echo "Starting services..."
-docker compose up -d
+docker compose --env-file .env up -d
 
 echo "Waiting for health check..."
-for i in $(seq 1 300); do
-  if curl -sf http://localhost:8000/actuator/health | grep -q '"status":"UP"'; then
-    echo "Deploy complete — application is UP"
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:8000/actuator/health 2>/dev/null | grep -q '"UP"'; then
+    echo "Deploy complete - application is UP"
     exit 0
   fi
   sleep 2
 done
 
-echo "WARNING: Health check did not pass within 600s"
-docker compose logs --tail=50 backend
+echo "ERROR: Health check did not pass within 60s"
+docker compose --env-file .env logs --tail=50 backend
 exit 1

--- a/deploy/scripts/gc-firewall.service
+++ b/deploy/scripts/gc-firewall.service
@@ -1,0 +1,41 @@
+[Unit]
+# Ground Control public-iface firewall — drop tcp:8000 from public NIC (#828).
+#
+# Defense in depth on top of ADR-026 bearer auth and the `GC_BIND_IP` tailnet-
+# only docker-proxy bind. ADR-030 puts the workload on a single Hetzner host
+# with a public IPv4 + IPv6, reachable from the internet by default. Even with
+# `GC_BIND_IP` constraining docker-proxy to the tailnet IP, a misconfiguration
+# that flips it back to 0.0.0.0 would re-expose the API. This unit drops any
+# TCP packet to dport 8000 that arrives on the public interface (`enp8s0`),
+# regardless of what the docker-proxy is listening on. Tailnet traffic
+# arrives via `tailscale0` (or via `lo` when the host talks to itself by its
+# tailnet IP) and is unaffected.
+#
+# Install (one-time, on red-dragon):
+#   sudo install -o root -g root -m 644 \
+#     deploy/scripts/gc-firewall.service /etc/systemd/system/gc-firewall.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now gc-firewall.service
+#
+# Verify:
+#   sudo iptables -L INPUT -n -v | head    # rule 1 should DROP -i enp8s0 dport 8000
+#   sudo ip6tables -L INPUT -n -v | head   # same on IPv6
+#
+# Disable:
+#   sudo systemctl disable --now gc-firewall.service
+#   (ExecStop removes the rules cleanly)
+Description=Ground Control public-iface firewall — drop tcp:8000 from public NIC (#828, ADR-026 belt-and-braces on top of GC_BIND_IP)
+After=network-online.target tailscaled.service docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+# Idempotent: -C checks for existing rule, -I prepends only when missing.
+ExecStart=/bin/bash -c '/usr/sbin/iptables -C INPUT -i enp8s0 -p tcp --dport 8000 -j DROP 2>/dev/null || /usr/sbin/iptables -I INPUT 1 -i enp8s0 -p tcp --dport 8000 -j DROP'
+ExecStart=/bin/bash -c '/usr/sbin/ip6tables -C INPUT -i enp8s0 -p tcp --dport 8000 -j DROP 2>/dev/null || /usr/sbin/ip6tables -I INPUT 1 -i enp8s0 -p tcp --dport 8000 -j DROP'
+ExecStop=/bin/bash -c '/usr/sbin/iptables -D INPUT -i enp8s0 -p tcp --dport 8000 -j DROP 2>/dev/null || true'
+ExecStop=/bin/bash -c '/usr/sbin/ip6tables -D INPUT -i enp8s0 -p tcp --dport 8000 -j DROP 2>/dev/null || true'
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -131,12 +131,35 @@ first in `deploy/docker/docker-compose.prod.yml`; after a clean sync,
 the compose file at `/opt/gc/docker-compose.yml` should match that repo file
 byte-for-byte. Operator-local secret material remains only in `/opt/gc/.env`.
 
-The production compose file currently publishes the backend as `8000:8000`,
-which Docker binds on all host interfaces. If red-dragon's host firewall or
-Tailscale `ts-input` rules do not drop non-tailnet traffic, ADR-026 bearer
-auth is the only API boundary for public callers. Treat network exposure as a
-separate deploy prerequisite: either prove non-tailnet traffic is blocked or
-change the bind/firewall posture deliberately.
+The production compose file publishes the backend on `${GC_BIND_IP:-0.0.0.0}:8000:8000`.
+On red-dragon, set `GC_BIND_IP=100.98.28.66` (the host's tailnet IP) in
+`/opt/gc/.env` so docker-proxy listens only on the tailnet interface — public
+IPv4 / IPv6 attempts to reach the API never even establish a TCP connection
+to the proxy. Defense in depth on top of ADR-026 bearer auth: even if the
+backend has a future auth bypass, an attacker would need a tailnet identity
+to reach it.
+
+A second, host-firewall layer drops TCP packets that arrive on the public
+interface bound for port 8000, regardless of what docker-proxy is listening
+on. The systemd unit lives at `deploy/scripts/gc-firewall.service`; install
+it once per host:
+
+```bash
+sudo install -o root -g root -m 644 \
+  deploy/scripts/gc-firewall.service /etc/systemd/system/gc-firewall.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now gc-firewall.service
+```
+
+Verify with `sudo iptables -L INPUT -n -v | head` — rule 1 should be
+`DROP -i enp8s0 tcp dport 8000`. The unit reads the public interface name
+from the rule itself (`enp8s0` matches red-dragon); change the unit if your
+deployment uses a different public NIC. Tailnet traffic enters via
+`tailscale0` (or via `lo` when the host talks to itself by its tailnet IP)
+and is unaffected.
+
+Both layers are idempotent and stateless — re-running `up -d` or
+`systemctl restart gc-firewall` is safe.
 
 ### Migrating an existing deployment to ADR-026 auth
 

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -198,12 +198,29 @@ within seconds. Order matters; do not skip ahead.
    - **Security-enabled local instance using the candidate ADR-026 image.**
      The dry-run MUST use the candidate image (the one targeted by the
      cutover) — running the pre-ADR image locally reproduces the
-     reachability-only false green this step is designed to prevent. To
-     keep prod's schema untouched, point the dry-run at a throwaway
-     database directory (the prod compose file's `db` service uses a
-     bind-mount under `/data/postgres/`; set a different host path for the
-     dry-run via the `POSTGRES_DATA_DIR` env var if your operator copy
-     parameterizes it, or run the dry-run on a different host).
+     reachability-only false green this step is designed to prevent.
+
+     **Resolving the candidate image.** `:latest` only updates on push to
+     `main`, so post-merge-to-`dev` it is still the previous release. Use
+     `:dev` (head of unreleased work, tracks dev tip) or `:sha-<commit>`
+     (immutable) to refer to the actual candidate. Resolve a stable digest
+     from either with:
+     ```bash
+     docker pull ghcr.io/keplerops/ground-control:dev
+     docker inspect ghcr.io/keplerops/ground-control:dev \
+       --format '{{index .RepoDigests 0}}'
+     # → ghcr.io/keplerops/ground-control@sha256:<digest>
+     ```
+     Pin the dry-run AND the production `/opt/gc/.env` to that digest so
+     the image you tested is the image you deploy.
+
+     **Isolating the dry-run database.** The production compose file's
+     `db` service bind-mounts `/data/postgres/`. To keep prod's schema
+     untouched, run the dry-run with a separate compose project name and
+     swap the bind-mount for an isolated Docker named volume. Use a
+     non-default port (e.g. `18000:8000`) so it does not collide with the
+     running production backend on `:8000`. Tear down with `down -v` to
+     destroy the throwaway DB volume when finished.
      ```bash
      # mktemp + chmod 600 so the scratch env file is never world-readable
      # while it carries draft credential token values.
@@ -213,13 +230,13 @@ within seconds. Order matters; do not skip ahead.
      # Edit ${dryrun_env} to fill GC_DATABASE_PASSWORD, POSTGRES_PASSWORD,
      # and GROUNDCONTROL_SECURITY_CREDENTIALS_<N>_* slots with the same
      # token values that will land in /opt/gc/.env. Set GC_IMAGE to the
-     # candidate ADR-026 image (NOT the currently deployed pre-ADR image
-     # — that one would still 200 unauthenticated requests).
-     GC_IMAGE=ghcr.io/keplerops/ground-control:<candidate-digest> \
-       docker compose --env-file "${dryrun_env}" \
+     # candidate digest you resolved above. Run with a separate compose
+     # project name (gc-dryrun) and rebind the prod port + DB volume:
+     GC_IMAGE=ghcr.io/keplerops/ground-control@sha256:<digest> \
+       docker compose -p gc-dryrun --env-file "${dryrun_env}" \
        -f deploy/docker/docker-compose.prod.yml up -d
      # When done:
-     docker compose --env-file "${dryrun_env}" \
+     docker compose -p gc-dryrun --env-file "${dryrun_env}" \
        -f deploy/docker/docker-compose.prod.yml down -v
      shred -u "${dryrun_env}"
      ```
@@ -274,12 +291,18 @@ within seconds. Order matters; do not skip ahead.
    forward-only migrations:
    ```bash
    ssh red-dragon /opt/gc/backup.sh
+   # OR (if running on red-dragon directly):
+   docker exec gc-db-1 pg_dump -Fc -U gc ground_control \
+     > /data/backups/gc-pre-cutover-$(date -u +%Y%m%dT%H%M%SZ).dump
    ```
 
-6. **Update `/opt/gc/.env`.** Pin the new image digest and add the
-   credential block. Use the indexed `GROUNDCONTROL_SECURITY_CREDENTIALS_*`
-   shape (matches the env-var table above and `deploy/docker/.env.template`).
-   `chmod 600` afterward.
+6. **Update `/opt/gc/.env` with the credential block + the candidate
+   digest.** Use the indexed `GROUNDCONTROL_SECURITY_CREDENTIALS_*` shape
+   (matches the env-var table above and `deploy/docker/.env.template`).
+   The same digest you dry-ran against in step 4 belongs in `GC_IMAGE`
+   here — pinning by digest (`ghcr.io/keplerops/ground-control@sha256:...`)
+   guarantees the cutover rolls the image you tested, not whatever has
+   moved under `:dev` since. After editing, `chmod 600`.
 
 7. **Sync `/opt/gc/docker-compose.yml` byte-for-byte from this repo's
    `deploy/docker/docker-compose.prod.yml`.** That file is the canonical
@@ -289,11 +312,21 @@ within seconds. Order matters; do not skip ahead.
    (`tools/policy/checks.py::run_deploy_compose_credential_passthrough`)
    enforces the credential keys stay present in the canonical file.
 
-8. **Roll the image.**
-   ```bash
-   cd /opt/gc
-   docker compose --env-file .env up -d --force-recreate backend
-   ```
+8. **Roll the image.** Pick one path:
+   - **Manual (recommended for the first cutover).** From red-dragon (or
+     any tailnet host with the deploy SSH key):
+     ```bash
+     cd /opt/gc
+     docker compose --env-file .env up -d --force-recreate backend
+     # OR via the SSH forced-command target:
+     ssh gc-deploy@red-dragon
+     ```
+   - **CI auto-deploy.** Merge `dev` → `main`. The `deploy` job in
+     `.github/workflows/ci.yml` runs `/opt/gc/deploy.sh` over the
+     fabricator-managed self-hosted runner pool's tailnet bridge. Only
+     use this path AFTER steps 1-7 are confirmed; the deploy job has no
+     awareness of consumer-token state and will happily 401 every
+     consumer if you skip them.
 
 9. **Verify Flyway and the threat-model surface.** `V055`-`V058` apply on
    first start of the new image; the `threat_model` table appears in the


### PR DESCRIPTION
## Summary

Follow-up to #832 (which fixed the structural footguns) — cleans up adjacent docs/scripts that were either stale or unspecific enough to mislead an operator running the migration playbook. Found while doing the actual cutover for #828.

- `deploy/scripts/deploy.sh` — repo copy was out of sync with `/opt/gc/deploy.sh` and still referenced `gc-dev`, `refresh-env.sh`, and the AWS/SSM bootstrap that ADR-030 retired. Now matches the runtime; optional image-ref override accepts tag or digest forms.
- `deploy/docker/.env.template` — `:latest` is documented as only updating on push to `main`, so post-merge-to-`dev` it is still the previous release. Production deploys SHOULD pin to a digest. Snippet shows how to resolve one from `:dev` / `:sha-<commit>`.
- `docs/deployment/DEPLOYMENT.md` migration playbook — step 4 (dry-run) now requires pinning to the digest you tested, step 6 (`/opt/gc/.env`) cross-references that digest, step 8 (roll the image) explicitly splits the manual cutover from the CI auto-deploy path so "merge to main" is not assumed safe before steps 1-7.

## Requirement UIDs

GC-P011 (Access Control). No new requirements; deployment-doc cleanup discovered while running the #828 migration.

## ADR Impact

No ADR required. ADR-026 and ADR-030 both unchanged.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason

## Traceability

- IMPLEMENTS: GC-P011 deployment ergonomics — `deploy/scripts/deploy.sh`, `deploy/docker/.env.template`, `docs/deployment/DEPLOYMENT.md`.
- TESTS: no new tests (doc-only diff plus a bash script that's already covered by the `bash -n` pre-commit hook + existing manual deploy use).

## Test plan

- [x] `make policy` (17 tests, all green)
- [x] `bash -n deploy/scripts/deploy.sh` (syntax check)
- [x] Confirmed verbatim against `/opt/gc/deploy.sh` on red-dragon — they're now byte-equivalent in intent (file owner / mode preserved by the operator side).