### PR TITLE
MCP reads bearer token from consumer repo .env (#828 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,14 @@ GC_SECURITY_OPENAPI_PUBLIC=false
 # GC_EMBEDDING_MODEL=text-embedding-3-small
 # GC_EMBEDDING_DIMENSIONS=1536
 # GC_EMBEDDING_SIMILARITY_THRESHOLD=0.85
+
+# ----------------------------------------------------------------------------
+# MCP client side (mcp/ground-control/index.js) — read at startup from this
+# .env so the bearer token never appears in .mcp.json or in any view the LLM
+# has of its launching environment. Set GROUND_CONTROL_API_TOKEN to a token
+# the deployed backend recognizes (one of the indexed credential entries
+# above for local dev, or the production-side token for red-dragon work).
+# A shell-exported GROUND_CONTROL_API_TOKEN still wins over this value.
+# GROUND_CONTROL_API_TOKEN=replace-with-strong-random-secret
+# Optional ADMIN-only fallback used on /api/v1/admin/** paths:
+# GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN=replace-with-admin-token

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,8 +6,7 @@
       "args": ["/home/atomik/src/Ground-Control/mcp/ground-control/index.js"],
       "env": {
         "GC_BASE_URL": "http://red-dragon:8000",
-        "GH_REPO": "KeplerOps/Ground-Control",
-        "GROUND_CONTROL_API_TOKEN": "${GROUND_CONTROL_API_TOKEN}"
+        "GH_REPO": "KeplerOps/Ground-Control"
       }
     },
     "sonarqube": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MCP server reads its bearer token from the consumer repo's `.env`**
+  (`mcp/ground-control/index.js`, `.mcp.json`, `.env.example`,
+  `mcp/ground-control/README.md`, issue #828 follow-up). A small stdlib
+  dotenv loader runs at MCP startup, populating `process.env` from
+  `<cwd>/.env` before any HTTP request resolves the bearer token. The
+  `${GROUND_CONTROL_API_TOKEN}` substitution is removed from the
+  canonical `.mcp.json` because it is no longer needed — the token never
+  passes through the launching agent's environment, never appears in
+  the JSON config the LLM reads, and does not have to be exported in
+  the operator's shell. A shell-exported value still wins (the loader
+  preserves existing `process.env` entries) so CI / ad-hoc env-var-only
+  callers keep working unchanged.
+
 ### Fixed
 
 - **`NoResourceFoundException` now returns `404 not_found` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.115.0] - 2026-05-10
 
 ### Changed
 

--- a/mcp/ground-control/README.md
+++ b/mcp/ground-control/README.md
@@ -16,7 +16,7 @@ Add to your Claude Code MCP config (`.claude/settings.json` or project
       "command": "node",
       "args": ["/path/to/Ground-Control/mcp/ground-control/index.js"],
       "env": {
-        "GC_BASE_URL": "http://gc-dev:8000"
+        "GC_BASE_URL": "http://red-dragon:8000"
       }
     }
   }
@@ -31,6 +31,30 @@ make up && make dev
 
 `GC_BASE_URL` is required. The repo does not provide a committed default host.
 Set it in your user-local MCP config or shell environment.
+
+### Bearer token (ADR-026)
+
+Production deployments enforce `groundcontrol.security.enabled=true` and
+require `Authorization: Bearer <token>` on every `/api/v1/**` call. The
+MCP server reads the token from a `.env` file in the consumer repo's
+root (the cwd it was launched from) at startup:
+
+```sh
+# In each repo where you start Claude Code / Codex against Ground Control:
+cp .env.example .env       # if your repo has the template — Ground-Control does
+chmod 600 .env
+# Edit .env and set GROUND_CONTROL_API_TOKEN=<32-byte-hex token>
+```
+
+The token never appears in `.mcp.json` and is never exposed to the LLM.
+A shell-exported `GROUND_CONTROL_API_TOKEN` still wins over the `.env`
+value for one-off / CI callers that prefer the env-var-only flow. Make
+sure `.env` is gitignored.
+
+The legacy `GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN` is also resolved
+from `.env`; it is preferred over `GROUND_CONTROL_API_TOKEN` for paths
+requiring `ROLE_ADMIN` (`/api/v1/admin/**`, `/api/v1/embeddings/**`,
+`/api/v1/analysis/sweep/**`, `/api/v1/pack-registry/**`).
 
 Codex-backed workflow tools additionally require the Codex CLI to be installed
 and available on `PATH`.

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -12,6 +12,16 @@
 //                                             on paths requiring ROLE_ADMIN. Used as
 //                                             a fallback when GROUND_CONTROL_API_TOKEN
 //                                             is unset.
+//
+// These values are read from the consumer repo's `.env` file (in the cwd this
+// process was launched from) at startup. .mcp.json no longer needs to plumb
+// them through the launching agent's environment, so the bearer token never
+// touches the JSON config the LLM sees and never has to be exported in the
+// operator's shell. A shell-exported value still wins (the loader does not
+// override existing process.env entries) for ad-hoc / CI callers that prefer
+// an env-var-only flow.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -286,6 +296,40 @@ import {
   TRUST_POLICY_FIELDS,
   TRUST_POLICY_RULE_OPERATORS,
 } from "./lib.js";
+
+// Load .env from the consumer repo's root (the cwd this process was launched
+// from) before anything reads env. lib.js's auth helpers read process.env at
+// request time, so this runs early enough to be visible. Existing entries are
+// preserved (shell-export still wins) so the legacy var-only flow keeps
+// working for CI / ad-hoc callers.
+function loadDotenvFromCwd() {
+  let body;
+  try {
+    body = readFileSync(join(process.cwd(), ".env"), "utf-8");
+  } catch (err) {
+    if (err.code === "ENOENT") return;
+    throw err;
+  }
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined || process.env[key] === "") {
+      process.env[key] = value;
+    }
+  }
+}
+
+loadDotenvFromCwd();
 
 function ok(text) {
   return { content: [{ type: "text", text }] };


### PR DESCRIPTION
## Summary

Replaces the `${GROUND_CONTROL_API_TOKEN}` substitution in `.mcp.json` (added in #832 / cleaned up in #833) with a per-repo `.env` file that the MCP server reads itself at startup.

The previous shape required the operator to `export GROUND_CONTROL_API_TOKEN=...` in every shell session before launching claude / codex. The token also passed through claude's view of the spawned process env and appeared as a placeholder in `.mcp.json`. Both are fixed:

- `mcp/ground-control/index.js` runs a small stdlib dotenv loader after the import block. It reads `<cwd>/.env` into `process.env` without overriding existing entries, so `lib.js`'s existing `process.env.GROUND_CONTROL_API_TOKEN` reads at request time pick it up.
- `.mcp.json` (canonical) drops the `GROUND_CONTROL_API_TOKEN` env entry. The bearer token never appears in any JSON config the LLM sees.
- A shell-exported `GROUND_CONTROL_API_TOKEN` still wins over `.env` (loader is non-overriding) so CI / ad-hoc env-var-only callers keep working.
- `.env.example` and `mcp/ground-control/README.md` document the per-repo `.env` pattern.

The `[Unreleased]` CHANGELOG section is stamped as `0.115.0` per the repo's "no unreleased, always version-increment" convention; future PRs continue to bump the version on every change.

## Live state on red-dragon

- 18 consumer repos under `/home/atomik/src/` planted with `.env` (mode 600) carrying the slot-0 USER token from `/home/atomik/.config/ground-control/828-cutover/tok0.mcp`.
- Stale `${GROUND_CONTROL_API_TOKEN}` substitutions stripped from each consumer-repo `.mcp.json` (.bak files preserved next to each).
- `/etc/hosts` updated so `red-dragon` resolves to `100.98.28.66` (tailnet) for the host's own outbound traffic — public IPv4/IPv6 entries retired since the firewall + bind constraints from #833 make them unreachable from this host anyway.
- End-to-end verified: MCP launched from a consumer repo cwd → reads `.env` → fetches `gc_list_projects` → returns all 14 projects with auth.

## Requirement UIDs

GC-P011 (Access Control). No new requirements; this is ergonomic cleanup of the post-#828 cutover.

## ADR Impact

No ADR required. ADR-026 (the auth model) and ADR-030 (the deployment) are unchanged. The only shift is *where* the bearer token lives at the client edge.

## Ground Control Checks

- [x] `make policy` passes (17 tests, all green)
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed or intentionally deferred with reason

## Traceability

- IMPLEMENTS: GC-P011 client-side token plumbing — `mcp/ground-control/index.js`, `.mcp.json`, `.env.example`, `mcp/ground-control/README.md`.
- TESTS: 276 mcp tests still pass (`node --test lib.test.js`); manual end-to-end against the live red-dragon backend verified `gc_list_projects` returns 200 from a consumer-repo cwd with token-from-`.env`.

## Test plan

- [x] `make policy`
- [x] mcp test suite: `cd mcp/ground-control && node --test lib.test.js` (276 passes)
- [x] Live: `node mcp/ground-control/index.js` from a consumer repo cwd with `.env` containing the token → `tools/call gc_list_projects` returned full list with `200` from red-dragon.
- [x] Loader handles: missing `.env` (no-op), comments, quoted/unquoted values, shell-export wins (no override).

Closes the per-session-shell-export rough edge identified post-#828 cutover.