### PR TITLE
Close existence oracle on nested relation delete; cover ownership routes end-to-end (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.115.2] - 2026-05-10
+
+### Security
+
+- **`DELETE /requirements/{id}/relations/{relationId}` no longer leaks whether
+  a relation exists under a different requirement** (issue #432). The ownership
+  check previously rejected a mismatched parent with
+  `Relation <id> does not belong to requirement <parent>`, a message distinct
+  from the genuinely-missing `Relation not found: <id>` — an existence oracle on
+  a P0 security-boundary route. It now throws the identical "not found" message,
+  so an ownership mismatch is indistinguishable from a missing relation, matching
+  `getRelationHistory`, `getTraceabilityLinkHistory`, and `deleteLink`.
+
+### Added
+
+- **End-to-end coverage for parent-child ownership on nested requirement
+  routes** (issue #432). New `NestedRouteOwnershipIntegrationTest` exercises
+  `GET /requirements/{id}/relations/{relationId}/history`,
+  `GET /requirements/{id}/traceability/{linkId}/history`,
+  `DELETE /requirements/{id}/relations/{relationId}`, and
+  `DELETE /requirements/{id}/traceability/{linkId}`: when the child resource
+  belongs to a different requirement, each route returns the same 404 +
+  `ErrorResponse` envelope (down to `error.message`, with no `error.detail`
+  block) that a genuinely-missing child of the same id would produce, and the
+  targeted child is left intact. `AuditHistoryIntegrationTest` gains a positive
+  case confirming relation history resolves via the relation's *target*
+  requirement, keeping the source-or-target ownership rule consistent with
+  `GET /requirements/{id}/relations`. The history-route ownership checks shipped
+  in #451; this PR closes the issue's remaining integration-test requirement and
+  the message-leak above.
+
 ## [0.115.1] - 2026-05-10
 
 ### Added

--- a/architecture/notes/requirement-nested-route-ownership-preflight.md
+++ b/architecture/notes/requirement-nested-route-ownership-preflight.md
@@ -1,0 +1,91 @@
+# Requirement Nested Route Ownership Preflight
+
+Issue #432 is a security-boundary fix for requirement nested routes that carry
+both a requirement id and a child relation or traceability-link id. This note is
+preflight guidance only; it does not implement the controller, service, or test
+changes.
+
+## Boundary
+
+- Treat the `{id}` path variable on nested requirement routes as a security
+  scope, not a display hint. The child resource must be proven to belong to that
+  requirement before history is returned or a delete is performed.
+- Keep relation semantics consistent with the existing requirements API:
+  `RequirementService.getRelations(id)` returns both outgoing and incoming
+  relations, so relation child ownership means `{id}` is either `source.id` or
+  `target.id`. Do not make history source-only while delete remains
+  source-or-target, or vice versa.
+- Keep traceability semantics stricter: a `TraceabilityLink` belongs to exactly
+  one requirement via `link.requirement.id`; no alternate artifact identifier,
+  URL, title, or link type may establish ownership.
+- Preserve the 404 concealment pattern for mismatches. A child that exists under
+  a different requirement must be indistinguishable from a missing child at the
+  HTTP contract level unless a future authorization model explicitly replaces
+  this with a 403.
+
+## Incumbents to Reuse
+
+- `RequirementController` stays thin: pass both path ids to the owning domain
+  service and map returned domain objects to response records.
+- `RequirementService` owns `RequirementRelation` writes and deletes.
+  `AuditService` owns Envers-backed relation and traceability history reads.
+  `TraceabilityService` owns `TraceabilityLink` writes and deletes.
+- Use the existing repositories and entity associations
+  (`RequirementRelation.source`, `RequirementRelation.target`,
+  `TraceabilityLink.requirement`) as the source of truth. Do not add duplicate
+  ownership tables, DTO fields, or request-body parent ids.
+- Use `NotFoundException` and the `GlobalExceptionHandler` /
+  `ErrorResponse` envelope. Do not add endpoint-local exception handlers or new
+  exception types for ownership mismatches.
+- Use the existing test surfaces: `RequirementControllerTest` for WebMvc slice
+  behavior and the integration tests under `BaseIntegrationTest` for HTTP plus
+  persistence/audit behavior.
+
+## Cross-Cutting Layers
+
+- `ApiSecurityConfig`, `IpAllowlistFilter`, and `BearerTokenAuthFilter` remain
+  the authentication and authorization gate for `/api/v1/**`; nested ownership
+  is a domain authorization check after request authentication, not a
+  replacement for the path matrix.
+- `SecurityProperties.validate()` still owns credential and CIDR shape
+  validation. This issue must not introduce new security config keys or env
+  bindings.
+- `ActorFilter` and `RequestLoggingFilter` keep audit/log context. Ownership
+  mismatches should not log child ids with new ad hoc log events; rely on the
+  existing request and error paths unless a broader audit requirement appears.
+- Hibernate Envers remains the audit source for relation and traceability
+  history. Ownership must be checked before returning Envers revisions so audit
+  history cannot be used as a cross-resource read side channel.
+- Error responses must continue through `ErrorResponse` with stable
+  `error.code = "not_found"` for deterministic 404s. Do not echo unrelated
+  parent/child linkage details into response `detail`.
+
+## Extensibility
+
+If more nested requirement child resources are added, the reusable seam is a
+service-layer "load child belonging to parent" helper scoped to that service's
+owned entity. Parameterize the parent id and child id only; keep route shape,
+HTTP status mapping, and response envelope outside the helper.
+
+## Anti-Patterns
+
+- Controller-level repository lookups or ownership checks.
+- Checking only that the parent requirement exists, then loading the child by id.
+- Returning `403` for some child mismatches and `404` for others without a
+  centralized authorization decision.
+- Treating relation ownership as source-only while list/delete/history still
+  expose incoming relations elsewhere.
+- Using artifact identifiers, URLs, UIDs, or request-body fields as substitutes
+  for FK-based ownership checks.
+- Adding new schemas, exception hierarchies, audit models, logging conventions,
+  or security configuration for this narrow bug.
+
+## Non-Goals
+
+- No route redesign, API version change, or frontend contract change.
+- No database migration; the required ownership data already exists in foreign
+  keys.
+- No change to the requirement relation DAG model or traceability artifact
+  identifier conventions in ADR-011.
+- No change to ADR-026 access control, bearer token handling, IP allowlisting,
+  or OS/runtime secret exposure rules.

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/RequirementService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/RequirementService.java
@@ -231,7 +231,10 @@ public class RequirementService {
         var sourceId = relation.getSource().getId();
         var targetId = relation.getTarget().getId();
         if (!requirementId.equals(sourceId) && !requirementId.equals(targetId)) {
-            throw new NotFoundException("Relation " + relationId + " does not belong to requirement " + requirementId);
+            // Ownership mismatch must be indistinguishable from a missing relation: same message,
+            // no leak of the relation's real parent requirement. Mirrors getRelationHistory,
+            // getTraceabilityLinkHistory, and deleteLink.
+            throw new NotFoundException("Relation not found: " + relationId);
         }
         relationRepository.delete(relation);
     }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/AuditHistoryIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/AuditHistoryIntegrationTest.java
@@ -316,6 +316,20 @@ class AuditHistoryIntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$", hasSize(0)));
     }
 
+    @Test
+    @Order(12)
+    void relationHistory_resolvesViaTargetRequirement_returns200() throws Exception {
+        // Relation ownership is source-OR-target, consistent with GET /requirements/{id}/relations.
+        // The relation created in step 4 was AUDIT-001 -> AUDIT-003; here we look it up via the
+        // target requirement and expect the same ADD revision, not a 404.
+        mockMvc.perform(get("/api/v1/requirements/" + targetRequirementId + "/relations/" + relationId + "/history"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", is(1)))
+                .andExpect(jsonPath("$[0].revisionType", is("ADD")))
+                .andExpect(jsonPath("$[0].snapshot.sourceId", is(requirementId.toString())))
+                .andExpect(jsonPath("$[0].snapshot.targetId", is(targetRequirementId.toString())));
+    }
+
     // --- Version diff endpoint tests (builds on data from steps 1-5) ---
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/NestedRouteOwnershipIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/NestedRouteOwnershipIntegrationTest.java
@@ -1,0 +1,214 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Verifies the parent-child ownership boundary on the nested requirement relation/traceability
+ * routes end-to-end (issue #432): a child resource that belongs to a different requirement must be
+ * <em>indistinguishable</em> from a missing child — the same 404 and the same {@code ErrorResponse}
+ * envelope (down to the {@code error.message}, with no {@code error.detail} block and no mention of
+ * the child's real parent) — and the targeted child must be left intact. Each test issues both the
+ * ownership-mismatch request and a genuinely-missing-child request and asserts the two envelopes
+ * have the same shape.
+ *
+ * <p>The ownership checks live in {@code RequirementService.deleteRelation},
+ * {@code TraceabilityService.deleteLink}, and
+ * {@code AuditService.getRelationHistory}/{@code getTraceabilityLinkHistory}; this test pins their
+ * HTTP contract. The check runs before any Hibernate Envers read, so a {@code @Transactional}
+ * rollback is sufficient here.
+ */
+@AutoConfigureMockMvc
+@Transactional
+class NestedRouteOwnershipIntegrationTest extends BaseIntegrationTest {
+
+    private static final String RELATION_NOT_FOUND = "Relation not found: ";
+    private static final String LINK_NOT_FOUND = "Traceability link not found: ";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String createRequirement(String uid) throws Exception {
+        var body = Map.of(
+                "uid",
+                uid,
+                "title",
+                "Title for " + uid,
+                "statement",
+                "Statement for " + uid,
+                "requirementType",
+                "FUNCTIONAL",
+                "priority",
+                "MUST");
+        var result = mockMvc.perform(post("/api/v1/requirements")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return idOf(result);
+    }
+
+    private String createRelation(String sourceId, String targetId) throws Exception {
+        var body = Map.of("targetId", targetId, "relationType", "DEPENDS_ON");
+        var result = mockMvc.perform(post("/api/v1/requirements/" + sourceId + "/relations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return idOf(result);
+    }
+
+    private String createTraceabilityLink(String requirementId) throws Exception {
+        // DOCUMENTS links have no ACTIVE-status precondition, unlike IMPLEMENTS.
+        var body = Map.of(
+                "artifactType", "CODE_FILE",
+                "artifactIdentifier", "src/main/java/Owned.java",
+                "linkType", "DOCUMENTS");
+        var result = mockMvc.perform(post("/api/v1/requirements/" + requirementId + "/traceability")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return idOf(result);
+    }
+
+    private String idOf(MvcResult result) throws Exception {
+        return objectMapper
+                .readTree(result.getResponse().getContentAsString())
+                .get("id")
+                .asText();
+    }
+
+    private JsonNode errorBody(MvcResult result) throws Exception {
+        return objectMapper.readTree(result.getResponse().getContentAsString()).path("error");
+    }
+
+    /**
+     * Asserts the response carries exactly the {@code ErrorResponse} a genuinely-missing child of
+     * the same id would produce: HTTP 404, {@code error.code = "not_found"}, {@code error.message}
+     * equal to {@code "<typePrefix><childId>"}, and no {@code error.detail} block — so nothing about
+     * the child's real parent leaks.
+     */
+    private void assertMissingChildEnvelope(MvcResult result, String typePrefix, String childId) throws Exception {
+        assertThat(result.getResponse().getStatus()).isEqualTo(404);
+        var error = errorBody(result);
+        assertThat(error.path("code").asText()).isEqualTo("not_found");
+        assertThat(error.path("message").asText()).isEqualTo(typePrefix + childId);
+        assertThat(error.has("detail"))
+                .as("not_found envelope must not include a detail block")
+                .isFalse();
+    }
+
+    @Test
+    void relationHistory_whenRequirementDoesNotOwnRelation_isIndistinguishableFromMissingRelation() throws Exception {
+        var sourceId = createRequirement("NRO-RH-SRC");
+        var targetId = createRequirement("NRO-RH-TGT");
+        var outsiderId = createRequirement("NRO-RH-OUT");
+        var relationId = createRelation(sourceId, targetId);
+        var ghostRelationId = UUID.randomUUID().toString();
+
+        var mismatch = mockMvc.perform(
+                        get("/api/v1/requirements/" + outsiderId + "/relations/" + relationId + "/history"))
+                .andExpect(status().isNotFound())
+                .andReturn();
+        var missing = mockMvc.perform(
+                        get("/api/v1/requirements/" + outsiderId + "/relations/" + ghostRelationId + "/history"))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+        assertMissingChildEnvelope(mismatch, RELATION_NOT_FOUND, relationId);
+        assertMissingChildEnvelope(missing, RELATION_NOT_FOUND, ghostRelationId);
+    }
+
+    @Test
+    void deleteRelation_whenRequirementDoesNotOwnRelation_isIndistinguishableFromMissing_andRelationSurvives()
+            throws Exception {
+        var sourceId = createRequirement("NRO-RD-SRC");
+        var targetId = createRequirement("NRO-RD-TGT");
+        var outsiderId = createRequirement("NRO-RD-OUT");
+        var relationId = createRelation(sourceId, targetId);
+        var ghostRelationId = UUID.randomUUID().toString();
+
+        var mismatch = mockMvc.perform(delete("/api/v1/requirements/" + outsiderId + "/relations/" + relationId))
+                .andExpect(status().isNotFound())
+                .andReturn();
+        var missing = mockMvc.perform(delete("/api/v1/requirements/" + outsiderId + "/relations/" + ghostRelationId))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+        assertMissingChildEnvelope(mismatch, RELATION_NOT_FOUND, relationId);
+        assertMissingChildEnvelope(missing, RELATION_NOT_FOUND, ghostRelationId);
+
+        // The rejected delete must not have removed the relation from its real source requirement.
+        mockMvc.perform(get("/api/v1/requirements/" + sourceId + "/relations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id", is(relationId)));
+    }
+
+    @Test
+    void traceabilityLinkHistory_whenRequirementDoesNotOwnLink_isIndistinguishableFromMissingLink() throws Exception {
+        var ownerId = createRequirement("NRO-TH-OWN");
+        var outsiderId = createRequirement("NRO-TH-OUT");
+        var linkId = createTraceabilityLink(ownerId);
+        var ghostLinkId = UUID.randomUUID().toString();
+
+        var mismatch = mockMvc.perform(
+                        get("/api/v1/requirements/" + outsiderId + "/traceability/" + linkId + "/history"))
+                .andExpect(status().isNotFound())
+                .andReturn();
+        var missing = mockMvc.perform(
+                        get("/api/v1/requirements/" + outsiderId + "/traceability/" + ghostLinkId + "/history"))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+        assertMissingChildEnvelope(mismatch, LINK_NOT_FOUND, linkId);
+        assertMissingChildEnvelope(missing, LINK_NOT_FOUND, ghostLinkId);
+    }
+
+    @Test
+    void deleteTraceabilityLink_whenRequirementDoesNotOwnLink_isIndistinguishableFromMissing_andLinkSurvives()
+            throws Exception {
+        var ownerId = createRequirement("NRO-TD-OWN");
+        var outsiderId = createRequirement("NRO-TD-OUT");
+        var linkId = createTraceabilityLink(ownerId);
+        var ghostLinkId = UUID.randomUUID().toString();
+
+        var mismatch = mockMvc.perform(delete("/api/v1/requirements/" + outsiderId + "/traceability/" + linkId))
+                .andExpect(status().isNotFound())
+                .andReturn();
+        var missing = mockMvc.perform(delete("/api/v1/requirements/" + outsiderId + "/traceability/" + ghostLinkId))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+        assertMissingChildEnvelope(mismatch, LINK_NOT_FOUND, linkId);
+        assertMissingChildEnvelope(missing, LINK_NOT_FOUND, ghostLinkId);
+
+        // The rejected delete must not have removed the link from its real owner requirement.
+        mockMvc.perform(get("/api/v1/requirements/" + ownerId + "/traceability"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].id", is(linkId)));
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTest.java
@@ -386,6 +386,20 @@ class RequirementControllerTest {
             mockMvc.perform(delete("/api/v1/requirements/" + reqId + "/relations/" + relationId))
                     .andExpect(status().isNotFound());
         }
+
+        @Test
+        void mismatchedRequirement_returns404() throws Exception {
+            var wrongReqId = UUID.randomUUID();
+            var relationId = UUID.randomUUID();
+            doThrow(new NotFoundException("Relation not found: " + relationId))
+                    .when(requirementService)
+                    .deleteRelation(wrongReqId, relationId);
+
+            mockMvc.perform(delete("/api/v1/requirements/" + wrongReqId + "/relations/" + relationId))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error.code", is("not_found")))
+                    .andExpect(jsonPath("$.error.message", is("Relation not found: " + relationId)));
+        }
     }
 
     @Nested
@@ -449,7 +463,8 @@ class RequirementControllerTest {
 
             mockMvc.perform(delete("/api/v1/requirements/" + wrongReqId + "/traceability/" + linkId))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.error.code", is("not_found")));
+                    .andExpect(jsonPath("$.error.code", is("not_found")))
+                    .andExpect(jsonPath("$.error.message", is("Traceability link not found: " + linkId)));
         }
 
         @Test
@@ -653,7 +668,8 @@ class RequirementControllerTest {
 
             mockMvc.perform(get("/api/v1/requirements/" + wrongReqId + "/relations/" + relId + "/history"))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.error.code", is("not_found")));
+                    .andExpect(jsonPath("$.error.code", is("not_found")))
+                    .andExpect(jsonPath("$.error.message", is("Relation not found: " + relId)));
         }
     }
 
@@ -878,7 +894,8 @@ class RequirementControllerTest {
 
             mockMvc.perform(get("/api/v1/requirements/" + wrongReqId + "/traceability/" + linkId + "/history"))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.error.code", is("not_found")));
+                    .andExpect(jsonPath("$.error.code", is("not_found")))
+                    .andExpect(jsonPath("$.error.message", is("Traceability link not found: " + linkId)));
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RequirementServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RequirementServiceTest.java
@@ -726,7 +726,9 @@ class RequirementServiceTest {
             var relationId = UUID.randomUUID();
             when(relationRepository.findById(relationId)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.deleteRelation(reqId, relationId)).isInstanceOf(NotFoundException.class);
+            assertThatThrownBy(() -> service.deleteRelation(reqId, relationId))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("Relation not found: " + relationId);
         }
 
         @Test
@@ -742,7 +744,11 @@ class RequirementServiceTest {
 
             when(relationRepository.findById(relationId)).thenReturn(Optional.of(relation));
 
-            assertThatThrownBy(() -> service.deleteRelation(reqId, relationId)).isInstanceOf(NotFoundException.class);
+            // Indistinguishable from a missing relation: identical message, no leak of the
+            // relation's real source/target requirement.
+            assertThatThrownBy(() -> service.deleteRelation(reqId, relationId))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("Relation not found: " + relationId);
         }
     }
 }


### PR DESCRIPTION
## What

Closes the parent-child ownership requirement for the nested requirement relation/traceability routes (issue #432):

- `GET /requirements/{id}/relations/{relationId}/history`
- `GET /requirements/{id}/traceability/{linkId}/history`
- `DELETE /requirements/{id}/relations/{relationId}`
- `DELETE /requirements/{id}/traceability/{linkId}`

The ownership checks themselves (the child must belong to `{id}`, else 404) shipped in #451. This PR closes the two things that PR left open:

1. **Existence-oracle fix.** `RequirementService.deleteRelation` rejected an ownership mismatch with `Relation <id> does not belong to requirement <parent>` — a message distinct from the genuinely-missing `Relation not found: <id>`, so a client could probe which relation ids exist by reading the 404 text. It now throws the identical "not found" message, so an ownership mismatch is indistinguishable from a missing relation — matching `getRelationHistory`, `getTraceabilityLinkHistory`, and `deleteLink`, which were already uniform.
2. **Integration coverage.** New `NestedRouteOwnershipIntegrationTest` issues both the ownership-mismatch request and a genuinely-missing-child request on each of the four routes and asserts the two `ErrorResponse` envelopes have the same shape (`status 404`, `error.code = "not_found"`, `error.message = "<type> not found: <childId>"`, no `error.detail`), plus that the targeted child survives a rejected delete. `AuditHistoryIntegrationTest` gains a positive case confirming relation history resolves via the relation's *target* requirement (source-or-target ownership, consistent with `GET /requirements/{id}/relations`). The three `*_mismatchedRequirement_returns404` controller-slice tests and `RequirementServiceTest.DeleteRelation` are strengthened to assert `error.message` / the thrown message; a fourth slice test, `DeleteRelation.mismatchedRequirement_returns404`, is added for symmetry.

`AssetService.deleteRelation` (assets domain) is out of scope for #432 — the issue and the architecture preflight note scope this to the requirement nested routes — and is untouched.

## Requirement UIDs

None — issue #432 is a requirement-free P0 bug/security fix and is not linked to a Ground Control requirement. Related design records: ADR-026 (API access control / authorization) and ADR-011 (traceability link ownership), both honored as non-goals in `architecture/notes/requirement-nested-route-ownership-preflight.md`.

## ADR Impact

No new ADR. Behavior stays within ADR-026 (the nested ownership check is a domain authorization check after request authentication, not a change to the bearer-token / IP-allowlist gate) and ADR-011 (FK-based traceability ownership unchanged). The architecture preflight added `architecture/notes/requirement-nested-route-ownership-preflight.md` recording the boundary, incumbents, cross-cutting layers, and non-goals.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

(This PR changes backend code and tests only; it adds no Ground Control project data, so the GC project state and quality gates are unchanged. Traceability links are reconciled against the diff after CI/reviews are green.)

## Traceability

- IMPLEMENTS: n/a — requirement-free bug/security fix. Behavior change lands in `backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/RequirementService.java` (`deleteRelation` ownership-mismatch concealment).
- TESTS: `backend/src/test/java/com/keplerops/groundcontrol/integration/NestedRouteOwnershipIntegrationTest.java`; `backend/src/test/java/com/keplerops/groundcontrol/integration/AuditHistoryIntegrationTest.java` (`relationHistory_resolvesViaTargetRequirement_returns200`); `backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTest.java` (`DeleteRelation.mismatchedRequirement_returns404` + strengthened `*_mismatchedRequirement_returns404` slice tests); `backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RequirementServiceTest.java` (`DeleteRelation` message assertions).

## Test plan

- [x] `make check` (gradle `check`: unit + static analysis + coverage) — green
- [x] `make integration` (Testcontainers) — green
- [x] `make policy` — green
- [x] `pre-commit run --all-files` — green
- [x] Regression-detection verified: temporarily removing the `deleteRelation` and `getTraceabilityLinkHistory` ownership branches turns the corresponding new integration tests (and the existing unit tests) red; the branches were restored.

No DB migration, no new endpoints, no new `@Audited` entities — no `.gc/plan-rules.md` constraints triggered.

Plan & codex-review record: see the issue thread.

Closes #432
