### PR TITLE
Add security-enabled audit-actor provenance coverage; align actor MDC key (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.115.3] - 2026-05-10
+
+### Security
+
+- **Audit actor provenance is now verified end-to-end under security-enabled
+  conditions** (issue #431). ADR-033 (*Authenticated Audit Actor Provenance*)
+  pins the contract: when `groundcontrol.security.enabled=true` the Envers
+  revision actor resolves from the authenticated `SecurityContext` principal
+  only; the `X-Actor` request header is inert (it survives solely as a
+  security-disabled dev/test convenience); and an unauthenticated
+  mutation/audit-relevant request is rejected by the security chain (401
+  `authentication_required`) before any controller runs, so no `anonymous`
+  revision is written. The real authentication boundary, the
+  `ActorFilter → ActorHolder → GroundControlRevisionListener` path, and the
+  trusted-service-identity credential model were already in place (issue #243 /
+  ADR-026); this change documents the audit-specific narrowing and adds the
+  missing provenance coverage.
+
+### Fixed
+
+- **Actor now appears in production structured logs** (issue #431). `ActorFilter`
+  wrote the calling actor under MDC key `actor`, but `logback-spring.xml`'s
+  production JSON appender only includes `actor_id` — so the actor was silently
+  dropped from prod logs. The key is aligned to `actor_id` (matching the sibling
+  `request_id` / `tenant_id` correlation keys), and `ActorFilterTest` now pins
+  the key `ActorFilter` writes. ADR-033 §4 records the contract.
+
+### Added
+
+- **`AuditActorProvenanceIntegrationTest`** (issue #431) — security-enabled
+  integration coverage proving (a) an authenticated mutation records the
+  configured principal name as the Envers actor, (b) a spoofed `X-Actor` header
+  does not override that principal, and (c) an unauthenticated mutation returns
+  the standard 401 envelope and creates no requirement (hence no audit
+  revision). `AuditHistoryIntegrationTest` and `ComplianceIntegrationTest` gain
+  class-level Javadoc clarifying they are controller slice tests under the
+  security-disabled `test` profile and, per ADR-033 §5, are not the
+  audit-provenance evidence for #431.
+
 ## [0.115.2] - 2026-05-10
 
 ### Security

--- a/architecture/adrs/033-authenticated-audit-actor-provenance.md
+++ b/architecture/adrs/033-authenticated-audit-actor-provenance.md
@@ -1,0 +1,135 @@
+# ADR-033: Authenticated Audit Actor Provenance
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-10
+
+## Context
+
+Issue #431 documents that audit actor identity must not come from a caller-controlled
+`X-Actor` header. Ground Control is audit- and compliance-heavy: Envers revisions,
+timeline exports, `createdBy` fields, pack-registry install records, and future
+authorization decisions all depend on actor provenance being trustworthy.
+
+ADR-026 already establishes the REST API access-control boundary:
+`ApiSecurityConfig` owns the Spring Security filter chain, bearer-token credentials
+are bound through `groundcontrol.security.*`, and `ActorFilter` runs after
+authorization. This ADR narrows the audit-specific contract so future changes do not
+reintroduce header-sourced identity or a second authentication model.
+
+## Decision
+
+### 1. The authenticated principal is the canonical audit actor
+
+When `groundcontrol.security.enabled=true`, audit actor identity MUST resolve from the
+Spring Security `SecurityContext` principal. `ActorFilter` remains the boundary that
+copies that principal into `ActorHolder` and MDC for the lifetime of the request.
+`GroundControlRevisionListener` persists only the value already in `ActorHolder`.
+
+`ActorHolder` is propagation state, not an authentication mechanism. Domain services
+may read it for audited fields such as `createdBy`, but controllers and services must
+not authenticate callers by setting it directly.
+
+### 2. `X-Actor` is development fallback only
+
+`X-Actor` MUST NOT be trusted when security is enabled. It may remain only as a
+security-disabled dev/test convenience so local tools can produce readable audit
+records without minting tokens.
+
+In production, `anonymous` is valid only for explicitly anonymous, non-mutating
+surfaces such as health/info probes and static SPA delivery. A production mutation or
+audit-relevant API request without an authenticated principal must be rejected by the
+security chain instead of writing an `anonymous` Envers revision.
+
+### 3. Trusted service identity uses the same credential path
+
+Automation and service-to-service callers are represented as configured
+`groundcontrol.security.credentials[]` principals with `USER` or `ADMIN` role. Their
+principal names are the values written to audit records.
+
+Do not add an actor override header, request-body actor field, or feature-local token
+store for service callers. A future OIDC, mTLS, or signed-service-identity adapter may
+replace `BearerTokenAuthFilter`, but it must still populate `SecurityContext` with the
+canonical principal and authorities consumed by `ActorFilter`.
+
+### 4. Cross-cutting guards stay shared
+
+- `ApiSecurityConfig` is the primary authorization boundary: it performs authentication
+  and the `ROLE_USER` / `ROLE_ADMIN` path matrix. The single deliberate exception is
+  `PackRegistryAccessGuard.requireAdminActor()`, a defense-in-depth bridge invoked per
+  pack-registry endpoint. It does *not* introduce a parallel auth model — when security is
+  enabled it re-derives the admin principal from the same `SecurityContext` (never from
+  headers or request bodies), re-asserts `ROLE_ADMIN`, and throws `AuthenticationException`
+  if no authenticated admin principal is in scope, so a misconfiguration that left the
+  pack-registry path out of the security matrix fails closed. When
+  `groundcontrol.security.enabled=false` (dev/test profile) the guard, like `ActorFilter`,
+  falls back to `ActorHolder` (`X-Actor` or `anonymous`) — the same explicit dev
+  convenience described in §2, not a production path. New controllers must not add their
+  own auth checks; they rely on `ApiSecurityConfig`, and where they need the principal as
+  an audit field they read it from the `SecurityContext` (or, in the security-disabled dev
+  profile, from `ActorHolder`).
+- Credential shape and startup validation stay in `SecurityProperties`. New credential
+  attributes must extend that configuration model instead of adding a duplicate schema.
+- 401/403 responses stay on `ApiAuthenticationEntryPoint` and
+  `ApiAccessDeniedHandler`, using the shared `ErrorResponse` envelope and stable
+  messages that do not echo tokens or parser details.
+- IP gating stays in `IpAllowlistFilter`, which uses `remoteAddr` and intentionally
+  does not trust `X-Forwarded-For`.
+- Audit persistence stays on Envers plus `GroundControlRevisionListener`; do not create
+  a second revision table or feature-local audit writer.
+- Logging stays on `RequestLoggingFilter`, `ActorFilter`, MDC, and Logback. Tokens and
+  raw authorization headers must never be logged. The actor MDC key is `actor_id` —
+  `ActorFilter` writes it and `logback-spring.xml`'s production JSON appender lists it
+  under `<includeMdcKeyName>`; the two must stay in sync (`ActorFilterTest` pins the key
+  `ActorFilter` writes), and the `_id` suffix matches the sibling correlation keys
+  `request_id` / `tenant_id`.
+
+### 5. Tests must prove provenance under security-enabled conditions
+
+Security-disabled controller tests may continue to focus on controller behavior, but
+they are not evidence for issue #431. Audit provenance tests for this issue must enable
+`groundcontrol.security.enabled=true`, configure test credentials, send
+`Authorization: Bearer <token>`, and assert that:
+
+- Envers actor values come from the authenticated principal.
+- A spoofed `X-Actor` header does not override that principal.
+- Unauthenticated mutation requests receive the standard 401 envelope and do not create
+  audit revisions.
+
+Tests that keep `@AutoConfigureMockMvc(addFilters = false)` are acceptable only as
+slice tests; they must not be cited as security or audit-provenance coverage.
+
+## Consequences
+
+### Positive
+
+- The audit identity model is a thin projection of the authenticated principal, not a
+  parallel header contract.
+- Service automation, human operators, Envers revisions, `createdBy` fields, and audit
+  timeline filters all use the same principal namespace.
+- A future authentication backend can swap into the existing `SecurityContext` seam
+  without changing Envers, domain services, or audit DTOs.
+
+### Negative
+
+- Security-enabled audit integration tests must mint configured tokens and can no
+  longer rely on the simpler `X-Actor` test shortcut.
+- Operators must manage stable principal names as part of credential rotation because
+  those names become compliance-visible audit data.
+
+### Risks
+
+- If production scripts pass bearer tokens in command-line `curl -H` arguments, other
+  local users can read them through process inspection. Production automation should
+  use environment/secret stores or config-file descriptors, not argv, for token
+  material.
+- If the `actor_id` MDC key drifts between `ActorFilter` and `logback-spring.xml`,
+  structured logs stop showing the actor even though Envers stays correct. The key is now
+  aligned and `ActorFilterTest` asserts the value `ActorFilter` writes; any change must
+  update both sides together.
+- If future tests rely only on the `test` profile, they can accidentally re-normalize
+  the security-disabled `X-Actor` fallback as production behavior.

--- a/architecture/adrs/README.md
+++ b/architecture/adrs/README.md
@@ -49,5 +49,6 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [030](030-on-prem-hetzner-deployment.md) | On-prem Hetzner Deployment | Accepted |
 | [031](031-codex-review-stopping-model.md) | Severity Rubric and Stopping Model for Pre-Push Codex Review | Proposed |
 | [032](032-age-query-construction-boundary.md) | AGE Query Construction Boundary | Accepted |
+| [033](033-authenticated-audit-actor-provenance.md) | Authenticated Audit Actor Provenance | Accepted |
 
 Prior ADRs from the old project frame are archived in `archive/architecture/adrs/`.

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ActorFilter.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/web/ActorFilter.java
@@ -39,7 +39,15 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class ActorFilter extends OncePerRequestFilter {
 
     private static final String ACTOR_HEADER = "X-Actor";
-    private static final String MDC_ACTOR = "actor";
+
+    /**
+     * MDC key for the calling actor. Must match the {@code <includeMdcKeyName>} entry in
+     * {@code logback-spring.xml}'s production JSON appender ({@code actor_id}) so structured logs
+     * actually carry the actor. The {@code _id} suffix mirrors the sibling correlation keys
+     * ({@code request_id}, {@code tenant_id}).
+     */
+    private static final String MDC_ACTOR = "actor_id";
+
     private static final String DEFAULT_ACTOR = "anonymous";
 
     private final SecurityProperties securityProperties;

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/AuditActorProvenanceIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/AuditActorProvenanceIntegrationTest.java
@@ -1,0 +1,189 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Audit-actor provenance under security-enabled conditions — the evidence for issue #431 and
+ * ADR-033.
+ *
+ * <p>Flips {@code groundcontrol.security.enabled=true} for this test only (the rest of the
+ * integration suite runs with security disabled — the {@code test} profile default), configures
+ * test credentials, and drives mutations with {@code Authorization: Bearer <token>}. Asserts the
+ * cardinal contracts of #431:
+ *
+ * <ul>
+ *   <li>Envers revision actor is the authenticated principal name, never a client-supplied
+ *       string.
+ *   <li>A spoofed {@code X-Actor} header does not override the authenticated principal.
+ *   <li>An unauthenticated mutation is rejected by the security chain (401) before any controller
+ *       runs, so neither a live row nor an {@code anonymous} Envers audit row is written — proven
+ *       by querying {@code requirement} and {@code requirement_audit} directly, not by an
+ *       (absence-based) live read.
+ * </ul>
+ *
+ * <p>This test deliberately does <em>not</em> use {@code @Transactional}: Envers flushes audit
+ * rows at transaction completion, so reading audit data back requires each request's transaction
+ * to commit. Rows created here are removed in {@link #cleanup()}.
+ */
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestPropertySource(
+        properties = {
+            "groundcontrol.security.enabled=true",
+            "groundcontrol.security.openapi-public=false",
+            "groundcontrol.security.credentials[0].principal-name=alice",
+            "groundcontrol.security.credentials[0].token=user-token-aaa",
+            "groundcontrol.security.credentials[0].role=USER",
+            "groundcontrol.security.credentials[1].principal-name=admin-bob",
+            "groundcontrol.security.credentials[1].token=admin-token-bbb",
+            "groundcontrol.security.credentials[1].role=ADMIN",
+            "groundcontrol.security.ip-allowlist[0]=127.0.0.0/8",
+            "groundcontrol.security.ip-allowlist[1]=::1/128"
+        })
+class AuditActorProvenanceIntegrationTest extends BaseIntegrationTest {
+
+    private static final String USER_TOKEN = "Bearer user-token-aaa";
+    private static final String ADMIN_TOKEN = "Bearer admin-token-bbb";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @AfterAll
+    void cleanup() throws Exception {
+        try (var conn = dataSource.getConnection();
+                var stmt = conn.createStatement()) {
+            stmt.executeUpdate("DELETE FROM requirement_audit WHERE uid LIKE 'AUTHPROV-%'");
+            stmt.executeUpdate("DELETE FROM requirement WHERE uid LIKE 'AUTHPROV-%'");
+        }
+    }
+
+    @Test
+    void authenticatedMutation_recordsAuthenticatedPrincipalAsAuditActor() throws Exception {
+        var id = createRequirement("AUTHPROV-001", USER_TOKEN, /* spoofedActor= */ null);
+
+        mockMvc.perform(get("/api/v1/requirements/" + id + "/history").header("Authorization", USER_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()", is(1)))
+                .andExpect(jsonPath("$[0].revisionType", is("ADD")))
+                .andExpect(jsonPath("$[0].timestamp", notNullValue()))
+                .andExpect(jsonPath("$[0].actor", is("alice")));
+
+        // Belt-and-suspenders: the Envers audit row itself carries the authenticated principal.
+        assertThat(auditActors("AUTHPROV-001")).containsExactly("alice");
+    }
+
+    @Test
+    void spoofedXActorHeader_doesNotOverrideAuthenticatedPrincipal() throws Exception {
+        var id = createRequirement("AUTHPROV-002", USER_TOKEN, /* spoofedActor= */ "attacker");
+
+        mockMvc.perform(get("/api/v1/requirements/" + id + "/history").header("Authorization", USER_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].actor", is("alice")));
+
+        assertThat(auditActors("AUTHPROV-002")).containsExactly("alice").doesNotContain("attacker");
+    }
+
+    @Test
+    void unauthenticatedMutation_isRejected_andWritesNoAuditRevision() throws Exception {
+        var createBody = Map.of(
+                "uid", "AUTHPROV-003",
+                "title", "Should never be persisted",
+                "statement", "Unauthenticated mutation must be rejected before the controller runs",
+                "requirementType", "FUNCTIONAL",
+                "priority", "MUST");
+        mockMvc.perform(post("/api/v1/requirements")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createBody)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code", is("authentication_required")));
+
+        // The security chain rejected the call before any controller ran: no live row AND no
+        // Envers audit row (so no `anonymous` revision). Asserted directly against the tables,
+        // not inferred from a live read (a missing live requirement would also hide an orphaned
+        // audit row, so absence-of-live is the wrong observable for this contract).
+        assertThat(count("SELECT COUNT(*) FROM requirement WHERE uid = ?", "AUTHPROV-003"))
+                .isZero();
+        assertThat(count("SELECT COUNT(*) FROM requirement_audit WHERE uid = ?", "AUTHPROV-003"))
+                .isZero();
+
+        // And the live read path agrees.
+        mockMvc.perform(get("/api/v1/requirements/uid/AUTHPROV-003").header("Authorization", ADMIN_TOKEN))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code", is("not_found")));
+    }
+
+    private UUID createRequirement(String uid, String bearerToken, String spoofedActor) throws Exception {
+        var createBody = Map.of(
+                "uid", uid,
+                "title", "Provenance test " + uid,
+                "statement", "Created under security-enabled conditions for #431 provenance coverage",
+                "requirementType", "FUNCTIONAL",
+                "priority", "MUST");
+        var request = post("/api/v1/requirements")
+                .header("Authorization", bearerToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createBody));
+        if (spoofedActor != null) {
+            request = request.header("X-Actor", spoofedActor);
+        }
+        var result = mockMvc.perform(request).andExpect(status().isCreated()).andReturn();
+        return UUID.fromString(objectMapper
+                .readTree(result.getResponse().getContentAsString())
+                .get("id")
+                .asText());
+    }
+
+    /** Distinct Envers actor values recorded against a requirement uid, joined through {@code revinfo}. */
+    private List<String> auditActors(String uid) throws Exception {
+        var actors = new ArrayList<String>();
+        try (var conn = dataSource.getConnection();
+                var ps = conn.prepareStatement("SELECT DISTINCT r.actor FROM requirement_audit ra "
+                        + "JOIN revinfo r ON ra.rev = r.rev WHERE ra.uid = ? ORDER BY r.actor")) {
+            ps.setString(1, uid);
+            try (var rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    actors.add(rs.getString(1));
+                }
+            }
+        }
+        return actors;
+    }
+
+    private long count(String sql, String uid) throws Exception {
+        try (var conn = dataSource.getConnection();
+                var ps = conn.prepareStatement(sql)) {
+            ps.setString(1, uid);
+            try (var rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/AuditHistoryIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/AuditHistoryIntegrationTest.java
@@ -25,6 +25,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * Audit-history <em>controller</em> coverage (history / timeline / diff endpoints). Runs under the
+ * security-disabled {@code test} profile, where {@code X-Actor} is the legacy convenience for
+ * setting a readable audit actor (see {@code ActorFilter}). Per ADR-033 §5 this is a controller
+ * slice test and is <em>not</em> the audit-actor-provenance evidence for issue #431 — see
+ * {@link AuditActorProvenanceIntegrationTest} for the security-enabled provenance contracts.
+ */
 @AutoConfigureMockMvc
 @TestMethodOrder(OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/ComplianceIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/ComplianceIntegrationTest.java
@@ -26,6 +26,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * Compliance/audit-export <em>controller</em> coverage (timeline filtering, CSV export). Runs under
+ * the security-disabled {@code test} profile, where {@code X-Actor} is the legacy convenience for
+ * setting a readable audit actor (see {@code ActorFilter}). Per ADR-033 §5 this is a controller
+ * slice test and is <em>not</em> the audit-actor-provenance evidence for issue #431 — see
+ * {@link AuditActorProvenanceIntegrationTest} for the security-enabled provenance contracts.
+ */
 @AutoConfigureMockMvc
 @TestMethodOrder(OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ActorFilterTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ActorFilterTest.java
@@ -127,7 +127,7 @@ class ActorFilterTest {
             filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
 
             assertThat(ActorHolder.get()).isNull();
-            assertThat(MDC.get("actor")).isNull();
+            assertThat(MDC.get("actor_id")).isNull();
         }
     }
 
@@ -206,7 +206,8 @@ class ActorFilterTest {
         @Override
         public void doFilter(ServletRequest req, ServletResponse res) {
             capturedActor = ActorHolder.get();
-            capturedMdc = MDC.get("actor");
+            // Must match ActorFilter's MDC key (and logback-spring.xml's <includeMdcKeyName>).
+            capturedMdc = MDC.get("actor_id");
         }
     }
 }

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -117,13 +117,18 @@ opt out), every request passes through:
 IpAllowlistFilter           # CIDR check (skipped if allowlist empty)
   → BearerTokenAuthFilter   # Authorization: Bearer <token> → SecurityContext
     → AuthorizationFilter   # path-matrix / ROLE_USER / ROLE_ADMIN
-      → ActorFilter         # populates ActorHolder + MDC actor=<principal>
+      → ActorFilter         # populates ActorHolder + MDC actor_id=<principal>
         → controllers
 ```
 
 Authorization is centralized in `ApiSecurityConfig` (ADR-026); controllers
-do not perform per-method auth checks. `ActorFilter` runs after the
-security chain so audit identity tracks the authenticated principal.
+do not perform per-method auth checks — the one deliberate exception,
+`PackRegistryAccessGuard`, is a defense-in-depth bridge that re-derives the
+admin principal from the same `SecurityContext` and re-asserts `ROLE_ADMIN`
+(see ADR-033 §4). `ActorFilter` runs after the security chain so audit
+identity tracks the authenticated principal; it writes the principal to MDC
+key `actor_id`, the key `logback-spring.xml`'s production JSON appender
+exports (alongside `request_id` / `tenant_id`). See [ADR-033](../../architecture/adrs/033-authenticated-audit-actor-provenance.md).
 
 ## What Exists vs. What Doesn't
 
@@ -141,7 +146,9 @@ security chain so audit identity tracks the authenticated principal.
 
 ### Does not exist yet
 
-- Auth flows
+- Interactive login / OIDC flows (the REST API access-control boundary exists
+  via ADR-026; browser login UX and external identity-provider integration do
+  not)
 - Redis integration (Redis is in docker-compose.yml but nothing in the app uses it)
 - Production deployment infrastructure (local Docker Compose + EC2 via CDK)
 - Multi-tenancy

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -275,14 +275,15 @@ within seconds. Order matters; do not skip ahead.
      backend's structured logs and confirm the request appears with the
      expected principal name (`ground-control-mcp`, `operator-admin`,
      `automation`). The principal name comes from `ActorFilter` /
-     `ActorHolder` and is logged via the per-request MDC, NOT the bearer
-     token itself. This proves token delivery without the token ever
-     leaving the server-side process boundary, so the captured output is
-     safe to keep around for review:
+     `ActorHolder` and is logged via the per-request MDC key `actor_id`
+     (matching `logback-spring.xml`'s production JSON appender), NOT the
+     bearer token itself. This proves token delivery without the token
+     ever leaving the server-side process boundary, so the captured
+     output is safe to keep around for review:
      ```bash
      docker compose -f deploy/docker/docker-compose.prod.yml \
        --env-file "${dryrun_env}" logs --tail=200 backend | \
-       grep -E '"actor"|"principal"'
+       grep '"actor_id"'
      ```
    Do NOT capture wire-level traces (e.g. `curl --trace-ascii`,
    `tcpdump`, agent debug stdout) for this verification: those formats


### PR DESCRIPTION
## Summary

Closes the remaining gap on #431 (P0 security/audit finding from the 2026-03-28 review). The real authentication boundary, the `ActorFilter -> ActorHolder -> GroundControlRevisionListener` audit path, and the trusted-service credential model already shipped under #243 / ADR-026 — so this PR adds the missing **security-enabled audit-actor provenance evidence**, pins the audit-specific contract in an ADR, and fixes a latent log-key bug surfaced while doing so.

## Requirement UIDs

- None — this is a P0 security/audit bug fix (issue #431); no formal Ground Control requirement is in scope. DoD items 1–4 were already implemented under #243 / ADR-026; this PR closes DoD item 5 (provenance test coverage) plus ADR-033.

## Related Issues

Closes #431

## ADR Impact

- ADR-033 — Authenticated Audit Actor Provenance (new; `Accepted`). Indexed in `architecture/adrs/README.md`; `docs/architecture/ARCHITECTURE.md` filter-chain section updated to match.

## Changes

- **ADR-033 — Authenticated Audit Actor Provenance**: the authenticated `SecurityContext` principal is the canonical audit actor; `X-Actor` is honored *only* when `groundcontrol.security.enabled=false` (dev/test convenience); a production mutation/audit-relevant request without an authenticated principal is rejected by the security chain (401), not persisted as `anonymous`; trusted-service callers use `groundcontrol.security.credentials[]` — no actor override header or DTO field; a future OIDC/mTLS adapter must populate the same `SecurityContext` seam. `PackRegistryAccessGuard.requireAdminActor()` is documented as the one deliberate defense-in-depth exception (re-derives the admin principal from the same `SecurityContext`, never from headers/DTOs; falls back to `ActorHolder` only in the security-disabled dev profile).
- **`AuditActorProvenanceIntegrationTest`** (new): flips `groundcontrol.security.enabled=true` with test credentials and asserts — (a) an authenticated mutation records the configured principal name as the Envers actor (verified via the `/history` API and directly via `requirement_audit` joined to `revinfo`); (b) a spoofed `X-Actor` header does not override the authenticated principal; (c) an unauthenticated mutation returns the 401 `authentication_required` envelope and writes no `requirement` or `requirement_audit` row (asserted directly against the tables). `AuditHistoryIntegrationTest` / `ComplianceIntegrationTest` gain class-level Javadoc clarifying they are controller slice tests under the security-disabled `test` profile and, per ADR-033 §5, are not the audit-provenance evidence for #431.
- **Fix actor MDC key drift**: `ActorFilter` wrote MDC key `actor`, but `logback-spring.xml`'s production JSON appender only includes `actor_id` — so the actor was silently dropped from prod structured logs. Aligned the runtime key to `actor_id` (matching the sibling `request_id` / `tenant_id` correlation keys), pinned it in `ActorFilterTest`, and propagated the contract to ADR-033 §4, the `docs/deployment/DEPLOYMENT.md` runbook log-verification grep, and `docs/architecture/ARCHITECTURE.md`.
- **CHANGELOG**: `0.115.3` — `Security` / `Fixed` / `Added` entries.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: `architecture/adrs/033-authenticated-audit-actor-provenance.md` (issue #431)
- TESTS: `backend/src/test/java/com/keplerops/groundcontrol/integration/AuditActorProvenanceIntegrationTest.java` (issue #431)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable (no new entities)
- [x] CHANGELOG.md updated
- [x] Architectural docs updated if stack, package structure, or key behaviors changed (`docs/architecture/ARCHITECTURE.md`, ADR-033, `docs/deployment/DEPLOYMENT.md`)
