### PR TITLE
Fix red-dragon deploy pipeline + commit canonical artifacts

### DIFF
--- a/changelog.d/+deploy-pipeline-fix.fixed.md
+++ b/changelog.d/+deploy-pipeline-fix.fixed.md
@@ -1,0 +1,14 @@
+Fix the red-dragon deploy pipeline so CI-driven deploys actually roll out
+new backend builds. Two bugs landed together in `/opt/gc/.env` and
+`/opt/gc/deploy.sh` and silently broke deploys after #828: `GC_IMAGE` was
+digest-pinned to a stale SHA so `docker compose pull` never picked up new
+CI builds, and `deploy.sh`'s post-deploy health check `curl`ed
+`localhost:8000` even though the backend now binds to the tailnet IP only.
+The deploy job was failing on every push to `main`, the image was getting
+to red-dragon only by manual `docker compose pull` from a logged-in user,
+and CI was unable to report deploy success. Switch `GC_IMAGE` to the
+floating `...:main` tag, run the health check inside the backend container
+via `docker compose exec ... wget` (the JRE Alpine base image ships `wget`,
+not `curl`), and commit the canonical `deploy.sh` + `.env.example` +
+README under `deploy/docker/` so the two artifacts that previously lived
+only on red-dragon now have a tracked source of truth.

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -1,0 +1,69 @@
+# Template for /opt/gc/.env on the deploy host.
+#
+# Copy to `.env` on the deploy host (`/opt/gc/.env`, mode 600,
+# owner `gc-deploy:gc-deploy`), fill in the placeholders, and DO NOT commit
+# the filled-in file. The actual `.env` carries secrets (DB password, bearer
+# tokens) that must not leave the host.
+#
+# `GC_IMAGE` MUST be a floating tag (e.g. `...:main`), never a digest-pinned
+# reference. `deploy.sh` runs `docker compose pull` which resolves the tag to
+# whatever the CI docker job most recently pushed; pinning to a digest here
+# means CI builds will never roll out (see deploy/docker/deploy.sh comments).
+
+# ---------------------------------------------------------------------------
+# Backend image (must be a floating tag — see comment above)
+# ---------------------------------------------------------------------------
+GC_IMAGE=ghcr.io/keplerops/ground-control:main
+
+# ---------------------------------------------------------------------------
+# Database (Apache AGE / PostgreSQL)
+# ---------------------------------------------------------------------------
+POSTGRES_DB=groundcontrol
+POSTGRES_USER=groundcontrol
+POSTGRES_PASSWORD=<set-to-strong-random-value>
+GC_DATABASE_URL=jdbc:postgresql://db:5432/${POSTGRES_DB}
+GC_DATABASE_USER=${POSTGRES_USER}
+GC_DATABASE_PASSWORD=${POSTGRES_PASSWORD}
+
+# ---------------------------------------------------------------------------
+# Backend server
+# ---------------------------------------------------------------------------
+GC_SERVER_PORT=8000
+GC_CACHE_TYPE=none
+JAVA_TOOL_OPTIONS=-Xms256m -Xmx1024m
+
+# ---------------------------------------------------------------------------
+# Tailnet-only port bind (ADR-030 / #828 defense in depth)
+# ---------------------------------------------------------------------------
+# Set to the deploy host's tailnet IP so docker-proxy never listens on the
+# public interface. The backend container itself listens on all interfaces
+# inside its own namespace, so deploy.sh's `docker compose exec ... wget`
+# health check still works regardless of this value.
+GC_BIND_IP=<tailnet-ip>
+
+# ---------------------------------------------------------------------------
+# Embedding provider (optional)
+# ---------------------------------------------------------------------------
+GC_EMBEDDING_PROVIDER=none
+GC_EMBEDDING_API_KEY=
+
+# ---------------------------------------------------------------------------
+# ADR-026 access control. Five indexed credential slots + five indexed
+# CIDR slots; populate as many as the deployment needs and leave the rest
+# unset (compose's `- KEY` list-form skips the variable when unset; an
+# empty string would fail validation at startup per Spring's
+# SecurityProperties).
+# ---------------------------------------------------------------------------
+GC_SECURITY_ENABLED=true
+GC_SECURITY_OPENAPI_PUBLIC=false
+
+GROUNDCONTROL_SECURITY_CREDENTIALS_0_PRINCIPAL_NAME=<principal>
+GROUNDCONTROL_SECURITY_CREDENTIALS_0_TOKEN=<32-byte-hex>
+GROUNDCONTROL_SECURITY_CREDENTIALS_0_ROLE=USER
+# GROUNDCONTROL_SECURITY_CREDENTIALS_1_PRINCIPAL_NAME=
+# GROUNDCONTROL_SECURITY_CREDENTIALS_1_TOKEN=
+# GROUNDCONTROL_SECURITY_CREDENTIALS_1_ROLE=
+# ... slots 2-4 ...
+
+# GROUNDCONTROL_SECURITY_IP_ALLOWLIST_0=10.0.0.0/8
+# ... slots 1-4 ...

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,0 +1,49 @@
+# Production docker-compose deploy (red-dragon, ADR-030)
+
+The CI `deploy` job (`.github/workflows/ci.yml`) SSHes to `gc-deploy@red-dragon`
+over the tailnet on every push to `main`. The `gc-deploy` user's
+`authorized_keys` entry uses `command="/opt/gc/deploy.sh",restrict`, so the
+SSH session always runs `deploy.sh` regardless of argv.
+
+## Files in this directory
+
+| File | What it is |
+|---|---|
+| `docker-compose.prod.yml` | Canonical production compose file. Mirror of `/opt/gc/docker-compose.yml` on red-dragon. |
+| `deploy.sh` | Canonical deploy script. Mirror of `/opt/gc/deploy.sh` on red-dragon. |
+| `.env.example` | Template for `/opt/gc/.env`. The real `.env` carries secrets and is host-local; do not commit it. |
+
+## Image resolution
+
+`GC_IMAGE` in `/opt/gc/.env` MUST be a floating tag like
+`ghcr.io/keplerops/ground-control:main`. `deploy.sh` runs `docker compose
+pull` which resolves the tag to the current digest on GHCR, so each deploy
+picks up whatever the CI `docker` job most recently pushed. Pinning
+`GC_IMAGE` to a digest here freezes the deploy on that image forever — CI
+builds will succeed but never roll out.
+
+## Health check
+
+The backend's host port-binding is restricted to the tailnet IP only (per
+#828 / ADR-026 defense in depth), so a host-side `curl localhost:8000`
+can't reach the listener. The deploy script runs the health check INSIDE
+the backend container via `docker compose exec` + `wget` (the JRE Alpine
+base image ships `wget` but not `curl`). Inside the container the
+listener is on all interfaces of its own network namespace, so `wget
+http://localhost:8000` works regardless of the host bind.
+
+## Drift policy
+
+The two committed files (`deploy.sh`, `docker-compose.prod.yml`) and their
+red-dragon mirrors (`/opt/gc/deploy.sh`, `/opt/gc/docker-compose.yml`) are
+the same artifact. Changes go through the repo:
+
+1. Edit the repo copy on a feature branch.
+2. PR through dev → main per the normal workflow.
+3. After merge, SSH into red-dragon and copy the new file into `/opt/gc/`
+   (the deploy SSH path uses the forced-command `deploy.sh` only — there's
+   no general file-sync). Re-run with `sudo -u gc-deploy /opt/gc/deploy.sh`
+   to confirm.
+
+Improving this push step (and the deploy pipeline generally) is tracked on
+the followup issue linked from `architecture/adrs/030-*.md`.

--- a/deploy/docker/deploy.sh
+++ b/deploy/docker/deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Deploy script for the red-dragon docker-compose stack (ADR-030).
+#
+# Invoked as the SSH forced command for the `gc-deploy` user — the CI deploy
+# job SSHes to gc-deploy@red-dragon and the authorized_keys entry forces
+# /opt/gc/deploy.sh to run with no argv. SSH exit code is this script's
+# exit code, so the CI job's pass/fail reflects the deploy outcome.
+#
+# Contract:
+#   - `/opt/gc/.env` pins `GC_IMAGE` to a FLOATING tag (`...:main` for
+#     production). Each `docker compose pull` resolves that tag to whatever
+#     the CI `docker` job most recently pushed, so the deploy script does
+#     not need to be told the image SHA out-of-band.
+#   - `/opt/gc/docker-compose.yml` is the production compose file (this repo
+#     ships the canonical copy at `deploy/docker/docker-compose.prod.yml`).
+#   - Health check runs INSIDE the backend container via `docker compose
+#     exec` because the host port-binding is restricted to the tailnet IP
+#     (per #828 / ADR-026 defense in depth); a host-side `curl localhost:8000`
+#     can't reach the listener. The JRE Alpine base image ships `wget` but
+#     not `curl`, so this script uses `wget`.
+set -euo pipefail
+cd /opt/gc
+docker compose --env-file .env pull
+docker compose --env-file .env up -d
+echo "Waiting for health check..."
+for i in $(seq 1 30); do
+  if docker compose --env-file .env exec -T backend \
+       wget -q -O - http://localhost:8000/actuator/health 2>/dev/null \
+       | grep -q '"UP"'; then
+    echo "Deploy complete - application is UP"
+    exit 0
+  fi
+  sleep 2
+done
+echo "ERROR: Health check did not pass within 60s"
+docker compose --env-file .env logs --tail=50 backend
+exit 1


### PR DESCRIPTION
Closes nothing directly; **mitigates** #855 by getting the existing deploy mechanism working again, without changing the topology.

## Summary

CI deploys to red-dragon have been failing on every push to `main` since #828 (2026-04-12). Two independent bugs landed together in two host-only files (`/opt/gc/.env` and `/opt/gc/deploy.sh`) and silently broke the rollout. This PR fixes both and adds the canonical copies to the repo.

## Requirement UIDs

- GC-O007 — Gated Agentic Development Loop (the deploy step is the last gate in the workflow; broken deploy = workflow output never reaches the live environment).

## ADR Impact

No ADR added. ADR-030 (on-prem Hetzner deploy) is unchanged in intent. ADR-026 (REST API Access Control / tailnet bind) is preserved — the new in-container health check works *because* the host port is tailnet-bound, not despite it.

## Changes

### Live-state changes (already applied on red-dragon with sudo, byte-identical to the repo files)
- `/opt/gc/.env`: `GC_IMAGE` was digest-pinned to `sha256:3f118cd...` (a dev-build SHA from 2026-05-10 01:15 UTC). Changed to `ghcr.io/keplerops/ground-control:main` so `docker compose pull` resolves to whatever CI most recently pushed.
- `/opt/gc/deploy.sh`: health check switched from `curl http://localhost:8000/actuator/health` (host-side, unreachable because the host port binds only to the tailnet IP per #828) to `docker compose exec -T backend wget -q -O - http://localhost:8000/actuator/health` (inside the container, where the listener is on all interfaces). The JRE Alpine base image ships `wget` but not `curl`.

### Repo additions
- `deploy/docker/deploy.sh` — canonical copy, byte-identical to `/opt/gc/deploy.sh`.
- `deploy/docker/.env.example` — template with placeholders for the deploy-host `.env`.
- `deploy/docker/README.md` — explains the structure and drift policy.

`docker-compose.prod.yml` was already in the repo and matches `/opt/gc/docker-compose.yml`; verified by `diff`.

## Verification

- `sudo -u gc-deploy /opt/gc/deploy.sh` — exit 0, "Deploy complete - application is UP".
- Backend container now runs image `sha256:b362e32ede604e073` (today's actual `main` build, was `3f118cd58fdd...` from yesterday's dev build).
- CI deploy job re-run on PR #852's main push commit — success.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: `deploy/docker/deploy.sh`, `deploy/docker/.env.example`, `deploy/docker/README.md`
- TESTS: manual verification documented above (this is config + a 20-line shell script; the verification IS running it end-to-end against the live target).

## Followup

The fundamental architecture concern (SSH-forced-command pulling a floating tag, with no rollback / no drift detection / no observability) is tracked on #855. This PR is a tactical fix to get the existing mechanism working; the deeper rework lives on that issue.