### PR TITLE
Add ADR-036 web UI login: form-login + JDBC users alongside ADR-026 bearer chain

### DIFF
--- a/architecture/adrs/037-browser-session-access-control.md
+++ b/architecture/adrs/037-browser-session-access-control.md
@@ -1,0 +1,183 @@
+# ADR-037: Browser Session Access Control
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-11
+
+## Context
+
+ADR-026 established the production access-control boundary for machine and
+operator API callers: `IpAllowlistFilter`, `BearerTokenAuthFilter`, the
+central `ROLE_USER` / `ROLE_ADMIN` path matrix in `ApiSecurityConfig`, and
+stable `ErrorResponse` 401/403 envelopes. ADR-033 then made the authenticated
+Spring Security principal the canonical audit actor consumed by `ActorFilter`,
+`ActorHolder`, MDC, and Envers.
+
+That model intentionally disabled form login, logout, CSRF, anonymous auth, and
+sessions because `/api/v1/**` was a stateless REST surface authenticated by
+`Authorization: Bearer`. This is sufficient for agents and automation, but not
+for a human opening the React SPA in a browser: normal navigation to `/` does
+not carry an `Authorization` header, and the current SPA API client does not
+have a session-backed authentication path.
+
+Issue #857 adds single-tenant human login while preserving the existing bearer
+API contract. The main architectural risk is not "how to add a login form"; it
+is avoiding two independent auth models, two role vocabularies, two error
+envelopes, or a filter-chain split where browser navigation succeeds but the
+SPA's `/api/v1/**` XHR calls still 401 because they landed in the bearer-only
+chain.
+
+## Decision
+
+### 1. Two authentication modes, one authorization and actor model
+
+Ground Control will support both:
+
+- **Machine/API mode:** `Authorization: Bearer <token>` backed by the existing
+  `groundcontrol.security.credentials[]` list from ADR-026.
+- **Browser/session mode:** Spring Security form login backed by a JDBC user
+  store and BCrypt password hashes.
+
+Both modes must end by populating the same `SecurityContext` principal and
+`ROLE_USER` / `ROLE_ADMIN` authorities. `ApiSecurityConfig` remains the
+canonical authorization owner for `/api/v1/**`; controllers must not add
+feature-local auth checks, role enums, or request-body actor fields. `ActorFilter`
+continues to project the authenticated principal into `ActorHolder` and MDC.
+
+### 2. Filter-chain matching must be explicit and non-overlapping
+
+Spring Security picks the first matching `SecurityFilterChain`; it does not fall
+through to a later chain after an authentication failure. Therefore the browser
+session chain must not be described as "SPA routes only" unless another chain
+also authenticates the SPA's `/api/v1/**` XHR calls with the session cookie.
+
+The implementation must make the request matching explicit enough that:
+
+- Bearer requests to `/api/v1/**` keep the ADR-026 behavior: stateless,
+  CSRF-exempt, no redirect to `/login`, standard JSON 401/403 envelopes, and the
+  existing path matrix.
+- Browser requests can log in, receive a hardened session cookie, call
+  `/api/v1/**` with that session, and hit the same path matrix.
+- Anonymous browser navigation can load only the login page and required static
+  assets; authenticated SPA routes require the session.
+- `/actuator/health`, `/actuator/info`, `/error`, and OpenAPI public/private
+  behavior stay aligned with ADR-026.
+
+If a request can plausibly be either browser or API traffic, the discriminator
+must be a stable request property such as the bearer `Authorization` scheme,
+path, and response content negotiation. Do not rely on controller-side retries
+or frontend token storage to paper over chain ordering.
+
+### 3. CSRF is required for cookie-authenticated browser mutations
+
+ADR-026's CSRF-disabled decision applies only to stateless bearer requests.
+Session-authenticated browser requests are cookie-bearing and must keep CSRF
+protection on for state-changing operations.
+
+The browser session surface must use Spring Security's CSRF machinery and a
+documented token-delivery seam that the SPA can consume later. A CSRF token may
+be delivered through Spring's generated login page for v1 and through a
+dedicated token endpoint or cookie repository when the React login flow is
+added. Disabling CSRF globally, or exempting all `/api/v1/**` merely because the
+endpoint is JSON, violates this ADR.
+
+### 4. JDBC users are a security principal store, not a new business user model
+
+The JDBC store uses Spring Security's established user/authority concepts:
+username, BCrypt password hash, enabled state, and authorities named
+`ROLE_USER` / `ROLE_ADMIN`. It must not introduce a second Ground Control role
+vocabulary, a project membership model, groups, tenants, federation metadata, or
+profile fields.
+
+The persistence source of truth is Flyway. If the implementation uses Spring
+Security's default `users` / `authorities` schema, admin role changes should go
+through `JdbcUserDetailsManager` or a thin service around it, not raw SQL from
+controllers. If a future change needs richer user lifecycle data, that is the
+extension point for a dedicated domain model and a new ADR.
+
+### 5. First-admin seeding must not expose secrets through process argv
+
+First-admin creation is required for a locked-down install, but passing a
+password in command-line arguments is not acceptable for production because it
+can be exposed through shell history, process listings, `/proc`, CI logs, and
+agent transcripts.
+
+The production-safe seam is an interactive prompt, standard input, a mode-600
+file descriptor, or an operator-managed secret store. A `--password=...`
+shortcut may exist only as a clearly documented local-dev convenience and must
+not appear in production deployment guidance. Passwords and password hashes must
+never be logged.
+
+### 6. Error, logging, config, and deployment surfaces stay canonical
+
+- 401/403/CSRF failures for `/api/v1/**` use the shared `ErrorResponse`
+  contract through `ApiAuthenticationEntryPoint`, `ApiAccessDeniedHandler`, or a
+  compatible shared handler. Parser or credential details are not echoed.
+- Logging stays on `RequestLoggingFilter`, `ActorFilter`, MDC, and ordinary
+  service logs. Log usernames and role-change facts only; never log passwords,
+  password hashes, session ids, CSRF tokens, or bearer tokens.
+- Configuration stays in `@ConfigurationProperties` / Spring Boot native
+  properties. Existing `groundcontrol.security.*` remains the API credential and
+  IP allowlist namespace; browser-session tunables belong under a narrow
+  browser/session subtree or native `server.servlet.session.cookie.*` keys.
+- Production env passthrough must remain compatible with the existing
+  `deploy/docker/docker-compose.prod.yml`, `.env.example`, and
+  `tools/policy/checks.py` guardrails. Optional indexed values must not be
+  injected as blank env vars.
+
+## Consequences
+
+### Positive
+
+- Human browser login becomes an addition to ADR-026, not a replacement for
+  machine bearer access.
+- Audit actor provenance remains a single projection of `SecurityContext`.
+- The SPA can move from Spring's generated login page to a React login screen
+  without changing the backend's principal, role, or CSRF contracts.
+
+### Negative
+
+- The security configuration becomes more complex: chain ordering, request
+  matching, session policy, CSRF, and entry points must be tested together.
+- Browser API calls need CSRF-token handling; this is intentional friction for
+  cookie-authenticated mutations.
+- First-admin bootstrap needs a production-safe secret input path, not only a
+  convenient CLI flag.
+
+### Risks and Guardrails
+
+- A browser chain scoped only to `/`, `/login`, `/logout`, and static assets is
+  incomplete unless `/api/v1/**` also accepts the browser session.
+- A catch-all browser chain placed before the bearer chain can accidentally turn
+  API 401s into login redirects and can break agents.
+- A catch-all bearer chain placed before the browser chain can swallow `/login`
+  and keep humans locked out.
+- `X-Actor` remains a dev/test fallback only. Do not resurrect it as a login,
+  impersonation, or user-selection mechanism.
+- Do not put bearer tokens into `localStorage` or `sessionStorage` to make the
+  SPA work; browser authentication is session-cookie based.
+- Do not create duplicate admin endpoints, duplicate error envelopes, duplicate
+  validation layers, or a second role enum.
+
+## Non-goals
+
+- Federation, SSO, SAML, OIDC, MFA, self-service signup, email verification,
+  and email password reset.
+- Multi-tenant or project-scoped authorization.
+- Group membership or custom roles beyond `ROLE_USER` and `ROLE_ADMIN`.
+- Replacing ADR-026 bearer credentials for agents and automation.
+- Replacing ADR-033 audit actor provenance.
+
+## References
+
+- Issue #857
+- GC-P011 (Access Control)
+- GC-P017 (Authentication, Federation, and Machine Access)
+- ADR-026: REST API Access Control
+- ADR-033: Authenticated Audit Actor Provenance
+- `backend/src/main/java/com/keplerops/groundcontrol/shared/security/`
+- `backend/src/main/java/com/keplerops/groundcontrol/shared/web/ActorFilter.java`

--- a/architecture/adrs/README.md
+++ b/architecture/adrs/README.md
@@ -53,5 +53,6 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [034](034-api-enum-contract-single-source.md) | API Enum Contract Single Source of Truth | Accepted |
 | [035](035-mcp-tool-catalog-curation.md) | MCP Tool Catalog Curation | Accepted |
 | [036](036-per-step-routing-tool-surfaces-telemetry.md) | Per-Step Model Routing, Durable-Record Tool Surfaces, and Step Telemetry (amends ADR-021) | Accepted |
+| [037](037-browser-session-access-control.md) | Browser Session Access Control | Accepted |
 
 Prior ADRs from the old project frame are archived in `archive/architecture/adrs/`.

--- a/backend/config/spotbugs/exclusions.xml
+++ b/backend/config/spotbugs/exclusions.xml
@@ -70,7 +70,9 @@
     </Match>
 
     <!-- Spring Security filters and HTTP handlers store the injected SecurityProperties /
-         ObjectMapper bean by reference — that is the standard Spring DI pattern. -->
+         ObjectMapper / DataSource / Encoder bean by reference — that is the standard Spring DI
+         pattern. Listed per-class so a future security-sensitive class added to the package is
+         scanned (and a real EI exposure surfaces). -->
     <Match>
         <Class name="com.keplerops.groundcontrol.shared.security.BearerTokenAuthFilter" />
         <Bug pattern="EI_EXPOSE_REP2" />
@@ -85,6 +87,18 @@
     </Match>
     <Match>
         <Class name="com.keplerops.groundcontrol.shared.security.ApiAccessDeniedHandler" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.security.PathAwareAccessDeniedHandler" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.security.FirstAdminBootstrapRunner" />
+        <Bug pattern="EI_EXPOSE_REP2" />
+    </Match>
+    <Match>
+        <Class name="com.keplerops.groundcontrol.shared.security.service.UserAdminService" />
         <Bug pattern="EI_EXPOSE_REP2" />
     </Match>
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/CreateUserRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/CreateUserRequest.java
@@ -1,0 +1,29 @@
+package com.keplerops.groundcontrol.api.admin.users;
+
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
+import com.keplerops.groundcontrol.shared.security.UserCredentialPolicy;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Admin-initiated user creation payload.
+ *
+ * <p>The username regex and password floor mirror the {@code V059__create_users.sql}
+ * {@code CHECK} constraint and the policy floor in ADR-037 §5 so request validation fails fast
+ * before any DB round-trip and so the SPA can surface field-level errors via the standard
+ * {@code validation_error} envelope.
+ */
+public record CreateUserRequest(
+        @NotBlank @Pattern(
+                        regexp = UserCredentialPolicy.USERNAME_REGEX,
+                        message =
+                                "username must start with a lowercase letter and contain only lowercase letters, digits, '.', '_' or '-' (2-64 chars)")
+                String username,
+        @NotBlank @Size(
+                        min = UserCredentialPolicy.MIN_PASSWORD_LENGTH,
+                        max = UserCredentialPolicy.MAX_PASSWORD_LENGTH,
+                        message = "password must be 12-200 characters")
+                String password,
+        @NotNull Role role) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/UpdateUserEnabledRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/UpdateUserEnabledRequest.java
@@ -1,0 +1,10 @@
+package com.keplerops.groundcontrol.api.admin.users;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Payload for {@code PATCH /api/v1/admin/users/{username}/enabled}. Boxed {@code Boolean} so the
+ * absence of the field surfaces as a {@code validation_error} (the default for primitives is
+ * {@code false}, which would silently disable users).
+ */
+public record UpdateUserEnabledRequest(@NotNull Boolean enabled) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/UpdateUserRoleRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/UpdateUserRoleRequest.java
@@ -1,0 +1,11 @@
+package com.keplerops.groundcontrol.api.admin.users;
+
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Payload for {@code PATCH /api/v1/admin/users/{username}/role}. The username is in the path so
+ * a single user cannot accidentally re-target someone else's role via a body field that drifts
+ * from the URL.
+ */
+public record UpdateUserRoleRequest(@NotNull Role role) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/UserAdminController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/UserAdminController.java
@@ -1,0 +1,94 @@
+package com.keplerops.groundcontrol.api.admin.users;
+
+import com.keplerops.groundcontrol.shared.security.UserCredentialPolicy;
+import com.keplerops.groundcontrol.shared.security.UserSummary;
+import com.keplerops.groundcontrol.shared.security.service.UserAdminService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin-only REST surface for ADR-037 user lifecycle operations: list, create, role change,
+ * enable/disable, delete. Authorization to {@code ROLE_ADMIN} is enforced by the path matrix in
+ * {@link com.keplerops.groundcontrol.shared.security.ApiSecurityConfig} (entry already present
+ * via the {@code /api/v1/admin/**} rule); the controller carries no in-band auth check so the
+ * path matrix stays the single source of truth (ADR-026 §3 / ADR-037 §1).
+ *
+ * <p>All mutating operations delegate to {@link UserAdminService}, which is where the last-admin
+ * guard, username/password validation, and role-mutation transactional semantics live. Keeping
+ * the controller thin keeps the {@code WebMvcTest} slice fast and focused on wire-format
+ * coverage (per {@code .gc/plan-rules.md}).
+ */
+@Validated
+@RestController
+@RequestMapping("/api/v1/admin/users")
+public class UserAdminController {
+
+    // Path-binding pattern reuses the shared policy regex so a future widening (e.g., longer
+    // usernames or an extra-character set) only has to be applied at UserCredentialPolicy +
+    // V059 CHECK + docs, not also here.
+    private static final String USERNAME_REGEX = UserCredentialPolicy.USERNAME_REGEX;
+
+    private final UserAdminService service;
+
+    public UserAdminController(UserAdminService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public UsersListResponse list() {
+        return new UsersListResponse(
+                service.list().stream().map(UserAdminController::toResponse).toList());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public UserResponse create(@RequestBody @Valid CreateUserRequest request) {
+        return toResponse(service.createUser(request.username(), request.password(), request.role()));
+    }
+
+    @PatchMapping("/{username}/role")
+    public UserResponse updateRole(
+            @PathVariable @NotBlank @Pattern(regexp = USERNAME_REGEX) String username,
+            @RequestBody @Valid UpdateUserRoleRequest request) {
+        return toResponse(service.updateRole(username, request.role()));
+    }
+
+    @PatchMapping("/{username}/enabled")
+    public UserResponse updateEnabled(
+            @PathVariable @NotBlank @Pattern(regexp = USERNAME_REGEX) String username,
+            @RequestBody @Valid UpdateUserEnabledRequest request) {
+        return toResponse(service.updateEnabled(username, request.enabled()));
+    }
+
+    @DeleteMapping("/{username}")
+    public ResponseEntity<Void> delete(@PathVariable @NotBlank @Pattern(regexp = USERNAME_REGEX) String username) {
+        service.deleteUser(username);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Map the service-layer view to the API wire shape. Keeping the mapping at the controller
+     * boundary lets the service surface stay framework-neutral (callable from a CLI runner,
+     * scheduled task, etc.) without re-exposing the JSON DTO.
+     */
+    private static UserResponse toResponse(UserSummary summary) {
+        return new UserResponse(summary.username(), summary.role(), summary.enabled());
+    }
+
+    /** List wrapper so the JSON response shape stays consistent with the rest of the admin API. */
+    public record UsersListResponse(List<UserResponse> users) {}
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/UserResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/admin/users/UserResponse.java
@@ -1,0 +1,10 @@
+package com.keplerops.groundcontrol.api.admin.users;
+
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
+
+/**
+ * Response shape for {@code /api/v1/admin/users} endpoints. Carries the principal-only fields
+ * that ADR-037 §4 allows: username, role, enabled. No password material or hash is ever
+ * surfaced through this envelope.
+ */
+public record UserResponse(String username, Role role, boolean enabled) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiPathMatrix.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiPathMatrix.java
@@ -1,0 +1,73 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
+
+/**
+ * Single source of truth for the API authorization matrix shared by {@link ApiSecurityConfig}
+ * (bearer chain) and {@link BrowserSecurityConfig} (browser chain).
+ *
+ * <p>ADR-026 + ADR-037: both chains must enforce identical authorities on {@code /api/v1/**} so
+ * a bearer caller and a session caller see the same path policy. Without this helper the two
+ * configurations carry copy-pasted rules; the next privileged endpoint added in one place but
+ * forgotten in the other would silently authorize bearer and session traffic differently. The
+ * helper is intentionally tiny — just the shared rules — so the per-chain blocks stay readable
+ * and the chain-specific concerns (CSRF, form login, SPA static assets) remain inline at the
+ * call site.
+ */
+final class ApiPathMatrix {
+
+    private static final String ROLE_ADMIN = "ADMIN";
+
+    private ApiPathMatrix() {
+        // utility
+    }
+
+    /**
+     * Apply the shared actuator + OpenAPI + {@code /api/v1/**} rules to {@code auth}. The
+     * caller is responsible for the chain-specific rules that come <em>before</em> (the
+     * bearer chain has nothing extra; the browser chain has {@code /login}, {@code /logout},
+     * static asset paths) and the {@code anyRequest().denyAll()} terminator.
+     */
+    static void applySharedRules(
+            AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth,
+            SecurityProperties properties) {
+        auth.requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info")
+                .permitAll()
+                .requestMatchers("/error")
+                .permitAll();
+        if (properties.isOpenapiPublic()) {
+            auth.requestMatchers(
+                            "/api/openapi.json",
+                            "/api/docs/**",
+                            "/v3/api-docs/**",
+                            "/swagger-ui/**",
+                            "/swagger-ui.html")
+                    .permitAll();
+        } else {
+            auth.requestMatchers(
+                            "/api/openapi.json",
+                            "/api/docs/**",
+                            "/v3/api-docs/**",
+                            "/swagger-ui/**",
+                            "/swagger-ui.html")
+                    .authenticated();
+        }
+        auth.requestMatchers("/api/v1/admin/**")
+                .hasRole(ROLE_ADMIN)
+                .requestMatchers("/api/v1/embeddings/**")
+                .hasRole(ROLE_ADMIN)
+                .requestMatchers("/api/v1/analysis/sweep/**")
+                .hasRole(ROLE_ADMIN)
+                .requestMatchers("/api/v1/pack-registry/**")
+                .hasRole(ROLE_ADMIN)
+                .requestMatchers("/api/v1/trust-policies/**")
+                .hasRole(ROLE_ADMIN)
+                .requestMatchers("/api/v1/pack-install-records/**")
+                .hasRole(ROLE_ADMIN)
+                .requestMatchers("/api/v1/**")
+                .authenticated()
+                .requestMatchers("/actuator/**")
+                .denyAll();
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiRequestPaths.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiRequestPaths.java
@@ -1,0 +1,66 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * Single source of truth for "API-shaped request" classification on the ADR-037 browser chain.
+ *
+ * <p>Three browser-chain decisions all hinge on the same predicate:
+ *
+ * <ol>
+ *   <li>The {@link org.springframework.security.web.savedrequest.HttpSessionRequestCache
+ *       request cache} must NOT save API requests, or a failed /api/v1/** XHR after session
+ *       expiry would become the post-login redirect target.
+ *   <li>The {@link DelegatingAuthenticationEntryPointFactory authentication entry point} must
+ *       emit a JSON 401 envelope for API requests instead of a 302 to {@code /login}.
+ *   <li>{@link PathAwareAccessDeniedHandler} must emit a JSON 403 envelope for API requests
+ *       instead of an HTML access-denied page.
+ * </ol>
+ *
+ * <p>Hard-coding the prefix list in three places would let the three sites drift; adding a new
+ * docs / API namespace in one but forgetting another silently changes whether the SPA sees
+ * JSON or HTML for the same path. This class is the one place where that policy lives.
+ */
+public final class ApiRequestPaths {
+
+    private static final String[] PREFIXES = {
+        "/api/", "/v3/api-docs", "/swagger-ui",
+    };
+
+    private static final RequestMatcher MATCHER = new OrRequestMatcher(
+            new AntPathRequestMatcher("/api/**"),
+            new AntPathRequestMatcher("/v3/api-docs/**"),
+            new AntPathRequestMatcher("/v3/api-docs"),
+            new AntPathRequestMatcher("/swagger-ui/**"),
+            new AntPathRequestMatcher("/swagger-ui.html"));
+
+    private ApiRequestPaths() {
+        // utility
+    }
+
+    /** Spring Security {@link RequestMatcher} for use in request-cache / entry-point wiring. */
+    public static RequestMatcher matcher() {
+        return MATCHER;
+    }
+
+    /**
+     * Servlet-API check for handlers that receive a raw {@link HttpServletRequest}. Uses the
+     * URI prefix list so the check works against MockMvc's {@code getRequestURI()} (which is
+     * the same value the matcher operates on at runtime in a "/"-mapped servlet).
+     */
+    public static boolean isApiRequest(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        if (uri == null) {
+            return false;
+        }
+        for (String prefix : PREFIXES) {
+            if (uri.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiSecurityConfig.java
@@ -5,32 +5,39 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
-import org.springframework.security.web.util.matcher.RegexRequestMatcher;
+import org.springframework.security.web.session.DisableEncodeUrlFilter;
 
 /**
- * Wires the API access control filter chain.
+ * Wires the bearer/API access control filter chain (ADR-026 + ADR-037).
  *
- * <p>When {@code groundcontrol.security.enabled=true}, the chain runs IP allowlist → bearer token
- * authn → Spring Security authorization, with the path matrix set up so {@code /api/v1/admin/**}
- * and the privileged subpaths require {@code ROLE_ADMIN}, the rest of {@code /api/v1/**} requires
- * authentication, and only health/info actuator probes are anonymous.
+ * <p>This chain is scoped to requests carrying {@code Authorization: Bearer …} only, via
+ * {@link BearerRequestMatcher}. Browser navigation, SPA XHRs authenticated by the
+ * {@code GC_SESSION} cookie, and form-login traffic fall through to {@link BrowserSecurityConfig}
+ * (ADR-037 §1, §2). Splitting the chains on the bearer scheme is the simplest stable
+ * discriminator and keeps machine traffic stateless and CSRF-exempt as ADR-026 specified.
+ *
+ * <p>When {@code groundcontrol.security.enabled=true}, the chain runs IP allowlist → bearer
+ * token authn → Spring Security authorization, with the path matrix set up so {@code
+ * /api/v1/admin/**} and the privileged subpaths require {@code ROLE_ADMIN}, the rest of {@code
+ * /api/v1/**} requires authentication, and only health/info actuator probes are anonymous.
  *
  * <p>When disabled, the chain still owns request mapping but every path is permitAll — the same
- * Spring Security framework object stays in charge so behavior never silently degrades.
+ * Spring Security framework object stays in charge so behavior never silently degrades. The SPA
+ * static-asset and route allowlist that used to live here has moved to {@link
+ * BrowserSecurityConfig}, because the API chain now only sees bearer traffic and bearer callers
+ * have no reason to fetch SPA HTML.
  */
 @Configuration
 @EnableWebSecurity
 @EnableConfigurationProperties(SecurityProperties.class)
 public class ApiSecurityConfig {
-
-    private static final String ROLE_ADMIN = "ADMIN";
 
     @Bean
     public BearerTokenAuthFilter bearerTokenAuthFilter(SecurityProperties properties) {
@@ -77,6 +84,7 @@ public class ApiSecurityConfig {
     }
 
     @Bean
+    @Order(1)
     public SecurityFilterChain apiSecurityFilterChain(
             HttpSecurity http,
             SecurityProperties properties,
@@ -85,14 +93,20 @@ public class ApiSecurityConfig {
             ApiAuthenticationEntryPoint authenticationEntryPoint,
             ApiAccessDeniedHandler accessDeniedHandler)
             throws Exception {
-        // CSRF is disabled by design: this is a stateless REST API authenticated by
-        // Authorization: Bearer <token>. There are no session cookies, no form-login
-        // flow, and no logout endpoint — the three things a CSRF attack relies on to
-        // ride a user's authenticated session. Bearer tokens are explicit per request,
-        // so a malicious cross-origin page cannot trigger an authenticated call from a
-        // signed-in browser. ADR-026 documents this; do not re-enable CSRF without
-        // simultaneously moving to cookie-based sessions and re-evaluating the model.
-        http.csrf(csrf -> csrf.disable())
+        // Scope this chain to bearer-only traffic. Spring Security picks the first matching
+        // chain (declaration / @Order), so every non-bearer request — browser navigation, SPA
+        // XHRs with a session cookie, logins, logouts — falls through to the browser chain
+        // configured in BrowserSecurityConfig. ADR-037 §2: the discriminator is the
+        // Authorization scheme, not the path or content type.
+        http.securityMatcher(new BearerRequestMatcher())
+                // CSRF is disabled by design: this is a stateless REST API authenticated by
+                // Authorization: Bearer <token>. There are no session cookies, no form-login
+                // flow, and no logout endpoint — the three things a CSRF attack relies on to
+                // ride a user's authenticated session. Bearer tokens are explicit per request,
+                // so a malicious cross-origin page cannot trigger an authenticated call from a
+                // signed-in browser. ADR-026 documents this; do not re-enable CSRF without
+                // simultaneously moving to cookie-based sessions and re-evaluating the model.
+                .csrf(csrf -> csrf.disable())
                 // Use Spring Security's CORS support so the registered MVC CorsConfigurationSource
                 // is honored on preflight requests. With cors.disable() preflight OPTIONS calls hit
                 // the security chain before MVC and would be rejected for protected routes.
@@ -102,7 +116,11 @@ public class ApiSecurityConfig {
                 .logout(logout -> logout.disable())
                 .anonymous(anon -> anon.disable())
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(ipAllowlistFilter, AuthorizationFilter.class)
+                // IpAllowlistFilter must sit ahead of every Spring Security filter so the
+                // network gate fires before BearerTokenAuthFilter (which could otherwise
+                // accept a token from a non-allowlisted source). Place it before
+                // DisableEncodeUrlFilter (the canonical first filter) on this chain too.
+                .addFilterBefore(ipAllowlistFilter, DisableEncodeUrlFilter.class)
                 .addFilterBefore(bearerTokenAuthFilter, AuthorizationFilter.class)
                 .exceptionHandling(ex ->
                         ex.authenticationEntryPoint(authenticationEntryPoint).accessDeniedHandler(accessDeniedHandler));
@@ -113,66 +131,11 @@ public class ApiSecurityConfig {
         }
 
         http.authorizeHttpRequests(auth -> {
-            auth.requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info")
-                    .permitAll()
-                    .requestMatchers("/error")
-                    .permitAll();
-            if (properties.isOpenapiPublic()) {
-                auth.requestMatchers(
-                                "/api/openapi.json",
-                                "/api/docs/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html")
-                        .permitAll();
-            } else {
-                auth.requestMatchers(
-                                "/api/openapi.json",
-                                "/api/docs/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html")
-                        .authenticated();
-            }
-            auth.requestMatchers("/api/v1/admin/**")
-                    .hasRole(ROLE_ADMIN)
-                    .requestMatchers("/api/v1/embeddings/**")
-                    .hasRole(ROLE_ADMIN)
-                    .requestMatchers("/api/v1/analysis/sweep/**")
-                    .hasRole(ROLE_ADMIN)
-                    .requestMatchers("/api/v1/pack-registry/**")
-                    .hasRole(ROLE_ADMIN)
-                    .requestMatchers("/api/v1/trust-policies/**")
-                    .hasRole(ROLE_ADMIN)
-                    .requestMatchers("/api/v1/pack-install-records/**")
-                    .hasRole(ROLE_ADMIN)
-                    .requestMatchers("/api/v1/**")
-                    .authenticated()
-                    .requestMatchers("/actuator/**")
-                    .denyAll()
-                    // SPA static assets and client-side routes are anonymous so the React
-                    // shell loads (the API calls it then makes still require a token, returning
-                    // 401 to drive the login UI). Permit only known static asset paths and a
-                    // strict GET regex that mirrors SpaController's pattern (no dot in any
-                    // segment, first segment not /api or /actuator). Anything outside that
-                    // narrow allowlist is denyAll, so a future controller mounted outside the
-                    // documented matrix is fail-closed.
-                    .requestMatchers(
-                            HttpMethod.GET,
-                            "/",
-                            "/index.html",
-                            "/favicon.ico",
-                            "/favicon.svg",
-                            "/manifest.json",
-                            "/robots.txt",
-                            "/assets/**",
-                            "/static/**")
-                    .permitAll()
-                    .requestMatchers(RegexRequestMatcher.regexMatcher(
-                            HttpMethod.GET, "^/(?!api/|api$|actuator/|actuator$)[^.]+$"))
-                    .permitAll()
-                    .anyRequest()
-                    .denyAll();
+            ApiPathMatrix.applySharedRules(auth, properties);
+            // No SPA static-asset / route allowlist on this chain. Bearer callers never
+            // fetch /index.html or SPA routes; the browser chain owns that surface
+            // (BrowserSecurityConfig). Anything outside the shared matrix is fail-closed.
+            auth.anyRequest().denyAll();
         });
 
         return http.build();

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BearerRequestMatcher.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BearerRequestMatcher.java
@@ -1,0 +1,33 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * The ADR-037 chain discriminator. The API filter chain ({@link ApiSecurityConfig}) is scoped to
+ * only those requests that present an {@code Authorization: Bearer …} header so machine /
+ * automation traffic keeps the existing ADR-026 stateless behavior (no CSRF, no session, JSON
+ * envelopes). Every other request — browser navigation, SPA XHRs with the session cookie,
+ * logins, logouts — falls through to the browser chain.
+ *
+ * <p>Matching is by HTTP scheme only ({@code Bearer} prefix, case-insensitive). Token validity
+ * is the responsibility of {@link BearerTokenAuthFilter}; if the chain matches but the token is
+ * invalid the API entry point still emits a JSON 401 instead of redirecting to {@code /login}.
+ */
+public final class BearerRequestMatcher implements RequestMatcher {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    public boolean matches(HttpServletRequest request) {
+        String header = request.getHeader(AUTHORIZATION_HEADER);
+        if (header == null) {
+            return false;
+        }
+        if (header.length() < BEARER_PREFIX.length()) {
+            return false;
+        }
+        return header.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length());
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BrowserSecurityConfig.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BrowserSecurityConfig.java
@@ -1,0 +1,273 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.core.session.SessionRegistryImpl;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.access.AccessDeniedHandlerImpl;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.session.DisableEncodeUrlFilter;
+import org.springframework.security.web.session.HttpSessionEventPublisher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
+
+/**
+ * Wires the ADR-037 browser session filter chain.
+ *
+ * <p>Catches every request {@link ApiSecurityConfig}'s bearer-scoped chain does not (i.e., any
+ * request without an {@code Authorization: Bearer …} header). The chain runs the same
+ * {@link IpAllowlistFilter} as the API chain (network gate applies to all traffic) and then
+ * Spring Security's standard form-login machinery against a JDBC-backed user store with BCrypt
+ * password hashes.
+ *
+ * <p>State-changing browser requests (POST/PUT/PATCH/DELETE) carry the {@code GC_SESSION}
+ * cookie; CSRF protection is enabled through a {@link CookieCsrfTokenRepository} configured
+ * with {@code HttpOnly=false} so the SPA can read the {@code XSRF-TOKEN} cookie and echo
+ * {@code X-XSRF-TOKEN} on its XHR calls (the double-submit cookie pattern). The
+ * {@link DelegatingAuthenticationEntryPointFactory delegating entry point} keeps SPA XHRs
+ * returning JSON 401 envelopes while regular browser navigation gets a 302 to {@code /login};
+ * the {@link PathAwareAccessDeniedHandler access-denied handler} mirrors that policy for 403s.
+ *
+ * <p>When {@code groundcontrol.security.enabled=false} (dev/test profile), this chain mirrors
+ * the API chain's permit-all fallback exactly: CSRF, form login, logout, and sessions are all
+ * <em>disabled</em>, every path is {@code permitAll}, and the IP allowlist still runs. The
+ * security-enabled branch is the one that turns on the form-login / CSRF / cookie machinery,
+ * so existing {@code @SpringBootTest} suites that POST without a CSRF token (a pre-existing
+ * convention for {@code security.enabled=false} profiles) keep working unchanged.
+ */
+@Configuration
+@EnableWebSecurity
+public class BrowserSecurityConfig {
+
+    static final String LOGIN_PATH = "/login";
+    static final String LOGOUT_PATH = "/logout";
+
+    private static final java.util.Set<String> SAFE_HTTP_METHODS = java.util.Set.of("GET", "HEAD", "TRACE", "OPTIONS");
+
+    /**
+     * Predicate for {@link org.springframework.security.web.csrf.CsrfFilter}: require CSRF on
+     * every state-changing browser-chain request, with one narrow carve-out — unauthenticated
+     * {@code /api/v1/**} mutations. The previous version of this matcher exempted ALL
+     * state-changing requests without a server-side session, which silently accidentally
+     * exempted {@code POST /login} itself: {@code GET /login} writes the XSRF cookie via
+     * {@link CookieCsrfTokenRepository} without creating a session, so a real browser's first
+     * login POST arrives without one. Codex cycle 4 caught the resulting login-CSRF /
+     * session-fixation-by-credential-swap attack — an attacker hosts an auto-submitting form
+     * to {@code /login} with credentials they control, the victim's browser POSTs without a
+     * CSRF check, and the victim's subsequent SPA activity is attributed to the attacker's
+     * principal.
+     *
+     * <p>Rules now:
+     *
+     * <ul>
+     *   <li>Safe methods (GET/HEAD/TRACE/OPTIONS): no CSRF (default behavior).
+     *   <li>Unauthenticated API-shaped mutations: no CSRF, so the request reaches the auth
+     *       entry point and gets a JSON 401 envelope instead of a 403 CSRF response. The
+     *       request has no session and therefore no CSRF-rideable surface.
+     *   <li>Everything else, including {@code /login}, every authenticated SPA mutation, and
+     *       {@code /logout}: CSRF required.
+     * </ul>
+     */
+    private static boolean requiresCsrf(jakarta.servlet.http.HttpServletRequest request) {
+        // CSRF only matters on state-changing methods and only when there's an authenticated
+        // session to ride. The expression below collapses both gates so SonarCloud S1126's
+        // "single return" rule is satisfied without obscuring the contract.
+        return !SAFE_HTTP_METHODS.contains(request.getMethod())
+                && (!ApiRequestPaths.isApiRequest(request) || request.getSession(false) != null);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public PasswordEncoder passwordEncoder() {
+        // BCrypt strength 12 — Spring Security's default is 10. Twelve roughly doubles the work
+        // factor; on a modest dev box a hash takes ~200 ms which is acceptable for an admin
+        // login but expensive enough to slow offline cracking. Increase, never decrease, in
+        // future revisions.
+        return new BCryptPasswordEncoder(12);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public JdbcUserDetailsManager userDetailsManager(DataSource dataSource) {
+        return new JdbcUserDetailsManager(dataSource);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public JdbcTemplate userAdminJdbcTemplate(DataSource dataSource) {
+        return new JdbcTemplate(dataSource);
+    }
+
+    /**
+     * SessionRegistry tracks every authenticated browser session by principal so admin
+     * mutations (role change, disable, delete) can expire the affected user's live sessions
+     * immediately. Without it a demoted/disabled/deleted user keeps their authenticated cookie
+     * working until natural session timeout — ADR-037 §1 says authorities must follow the
+     * current SecurityContext, so we close that gap here.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public SessionRegistry sessionRegistry() {
+        return new SessionRegistryImpl();
+    }
+
+    /**
+     * Bridges Tomcat's {@link jakarta.servlet.http.HttpSessionEvent} stream into Spring's
+     * application context so {@link SessionRegistryImpl} sees session-destroyed events.
+     * Without it the registry leaks principal entries after natural session expiry.
+     */
+    @Bean
+    public HttpSessionEventPublisher httpSessionEventPublisher() {
+        return new HttpSessionEventPublisher();
+    }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain browserSecurityFilterChain(
+            HttpSecurity http,
+            SecurityProperties properties,
+            IpAllowlistFilter ipAllowlistFilter,
+            ApiAuthenticationEntryPoint apiAuthenticationEntryPoint,
+            ApiAccessDeniedHandler apiAccessDeniedHandler,
+            SessionRegistry sessionRegistry)
+            throws Exception {
+
+        if (!properties.isEnabled()) {
+            // Mirror the API chain's security-disabled fallback exactly: no CSRF, no form
+            // login, no sessions — just the IP allowlist + permitAll. This is what dev/test
+            // profiles have always done; turning on CSRF here would break every
+            // @SpringBootTest that POSTs without a token.
+            http.csrf(csrf -> csrf.disable())
+                    .cors(Customizer.withDefaults())
+                    .formLogin(form -> form.disable())
+                    .httpBasic(basic -> basic.disable())
+                    .logout(logout -> logout.disable())
+                    .anonymous(anon -> anon.disable())
+                    .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .addFilterBefore(ipAllowlistFilter, DisableEncodeUrlFilter.class)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+            return http.build();
+        }
+
+        // Security-enabled path: form login + CSRF + sessions + path matrix.
+        //
+        // IpAllowlistFilter is placed BEFORE DisableEncodeUrlFilter (the first filter Spring
+        // Security installs) so the network gate runs ahead of UsernamePasswordAuthenticationFilter
+        // and DefaultLoginPageGeneratingFilter. Placing it `before AuthorizationFilter` (which
+        // sits later in the chain) would let a non-allowlisted attacker hit /login and either
+        // probe the credential oracle or, with a valid password, receive a session cookie —
+        // both before the IP gate fires.
+        http.addFilterBefore(ipAllowlistFilter, DisableEncodeUrlFilter.class).cors(Customizer.withDefaults());
+
+        // CSRF: cookie-based repository so the SPA's fetch wrapper can read XSRF-TOKEN and
+        // echo X-XSRF-TOKEN on mutations. The default form-login page (rendered by Spring's
+        // LoginPageGeneratingFilter) includes the same token as a hidden form field, so the
+        // first login also passes the CSRF gate without the SPA being involved.
+        //
+        // requireCsrfProtectionMatcher: enforce CSRF only on session-bearing requests. CSRF is
+        // a session-rider attack — without a session there is nothing to ride. Without this
+        // override an unauthenticated POST/PUT/PATCH/DELETE to /api/v1/** falls into the
+        // browser chain (no `Authorization: Bearer …`), CsrfFilter runs before authentication,
+        // and the caller gets a 403 CSRF response instead of the established 401
+        // `authentication_required` envelope. AuditActorProvenanceIntegrationTest depends on
+        // the 401 contract. Session-authenticated mutations still go through the CSRF gate
+        // because they carry a session id; the form-login POST itself has a session attached
+        // from the preceding GET /login.
+        var csrfTokenHandler = new CsrfTokenRequestAttributeHandler();
+        csrfTokenHandler.setCsrfRequestAttributeName(null);
+        http.csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .csrfTokenRequestHandler(csrfTokenHandler)
+                .requireCsrfProtectionMatcher(BrowserSecurityConfig::requiresCsrf));
+
+        AccessDeniedHandler fallbackAccessDenied = new AccessDeniedHandlerImpl();
+        AccessDeniedHandler accessDeniedHandler =
+                new PathAwareAccessDeniedHandler(apiAccessDeniedHandler, fallbackAccessDenied);
+
+        http.exceptionHandling(ex -> ex.authenticationEntryPoint(
+                        DelegatingAuthenticationEntryPointFactory.build(apiAuthenticationEntryPoint, LOGIN_PATH))
+                .accessDeniedHandler(accessDeniedHandler));
+
+        // RequestCache that never saves API-shaped URLs. Without this filter an unauthenticated
+        // /api/v1/** XHR (the SPA's typical first call when its session expired) would land
+        // in HttpSessionRequestCache; after the user logs in, Spring's default success
+        // handler would redirect the browser to the JSON URL instead of the SPA route the
+        // user was actually on (codex / ADR-037). The classification predicate is shared with
+        // the entry point + access-denied handler via ApiRequestPaths, so the three sites
+        // cannot drift against one another.
+        var requestCache = new HttpSessionRequestCache();
+        requestCache.setRequestMatcher(new NegatedRequestMatcher(ApiRequestPaths.matcher()));
+        http.requestCache(cache -> cache.requestCache(requestCache));
+
+        http.formLogin(form -> form.loginProcessingUrl(LOGIN_PATH).permitAll())
+                .logout(logout -> logout.logoutUrl(LOGOUT_PATH)
+                        .logoutSuccessHandler((request, response, authentication) ->
+                                // Return 204 on logout. SPA-initiated XHR logouts can clear
+                                // local state without parsing an HTML body; regular browser
+                                // navigations to /logout receive the same 204 and the SPA's
+                                // 401 handler routes to /login on the next XHR.
+                                response.setStatus(jakarta.servlet.http.HttpServletResponse.SC_NO_CONTENT))
+                        .deleteCookies("XSRF-TOKEN")
+                        .invalidateHttpSession(true)
+                        .clearAuthentication(true)
+                        .permitAll())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                        // maximumSessions(-1).sessionRegistry(...) is what wires the
+                        // Spring-Security concurrent-session machinery onto this chain. It does
+                        // three jobs at once: (a) installs RegisterSessionAuthenticationStrategy
+                        // as part of the default composite (so admin mutations can target
+                        // sessions by principal), (b) installs ConcurrentSessionFilter so
+                        // SessionInformation.expireNow() is actually enforced on the next
+                        // request, and (c) keeps Spring's default
+                        // ChangeSessionIdAuthenticationStrategy in the composite — which is
+                        // what rotates the session id on successful form login and prevents
+                        // session-fixation attacks. We do NOT call
+                        // .sessionAuthenticationStrategy(...) explicitly because that would
+                        // replace the composite with just our supplied strategy, dropping the
+                        // fixation protection. (-1 = unlimited concurrent sessions; we don't
+                        // gate on count, only need the registry/filter.)
+                        .maximumSessions(-1)
+                        .sessionRegistry(sessionRegistry)
+                        .expiredSessionStrategy(
+                                new PathAwareSessionExpiredStrategy(apiAuthenticationEntryPoint, LOGIN_PATH)));
+
+        http.authorizeHttpRequests(auth -> {
+            // Anonymous: login, logout, error page, static assets needed to render the form.
+            // ADR-037 §2: the SPA shell (`/`, `/index.html`) and SPA client-side routes are
+            // NOT anonymous — Spring's entry point sends an unauthenticated browser through
+            // /login first, and the request cache restores the original URL after login.
+            auth.requestMatchers(LOGIN_PATH, LOGOUT_PATH)
+                    .permitAll()
+                    .requestMatchers(
+                            HttpMethod.GET,
+                            "/favicon.ico",
+                            "/favicon.svg",
+                            "/manifest.json",
+                            "/robots.txt",
+                            "/assets/**",
+                            "/static/**")
+                    .permitAll();
+            ApiPathMatrix.applySharedRules(auth, properties);
+            // Everything else — root, /index.html, and SPA client routes — requires a session.
+            // Spring's DelegatingAuthenticationEntryPoint redirects to /login for non-API
+            // paths and emits JSON 401 for /api/v1/** (covered by the shared matrix above).
+            auth.anyRequest().authenticated();
+        });
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/DelegatingAuthenticationEntryPointFactory.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/DelegatingAuthenticationEntryPointFactory.java
@@ -1,0 +1,41 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import java.util.LinkedHashMap;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * Builds the {@link AuthenticationEntryPoint} for the ADR-037 browser chain.
+ *
+ * <p>{@code /api/v1/**} requests (the SPA's XHRs) get the canonical JSON envelope from
+ * {@link ApiAuthenticationEntryPoint} so client-side fetch wrappers can detect the 401 and route
+ * the user to {@code /login}. Anything else (browser navigation to SPA routes, the SPA shell on
+ * a fresh session) is redirected to the form login at {@code /login}.
+ *
+ * <p>This is a static factory rather than a {@code @Configuration} bean because the wiring is
+ * straightforward and the small surface area keeps the entry point's path policy in one readable
+ * place.
+ */
+public final class DelegatingAuthenticationEntryPointFactory {
+
+    private DelegatingAuthenticationEntryPointFactory() {
+        // factory
+    }
+
+    public static AuthenticationEntryPoint build(ApiAuthenticationEntryPoint apiEntryPoint, String loginPage) {
+        if (loginPage == null || loginPage.isBlank()) {
+            throw new IllegalArgumentException("loginPage must be a non-blank path (e.g. \"/login\")");
+        }
+        var loginRedirect = new LoginUrlAuthenticationEntryPoint(loginPage);
+        var entryPoints = new LinkedHashMap<RequestMatcher, AuthenticationEntryPoint>();
+        // Shared classification — see ApiRequestPaths. Keeping the predicate in one place
+        // prevents the 401 entry point, the 403 access-denied handler, and the request cache
+        // exclusion from drifting against one another.
+        entryPoints.put(ApiRequestPaths::isApiRequest, apiEntryPoint);
+        var delegating = new DelegatingAuthenticationEntryPoint(entryPoints);
+        delegating.setDefaultEntryPoint(loginRedirect);
+        return delegating;
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/FirstAdminBootstrapRunner.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/FirstAdminBootstrapRunner.java
@@ -1,0 +1,297 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bootstrap the first admin user on a locked-down install.
+ *
+ * <p>Activated only when the application is started with {@code --create-admin --username=NAME}.
+ * The password is read from (in order):
+ *
+ * <ol>
+ *   <li>{@code --password-file=/path/to/file} (preferred for one-shot scripted bootstraps; the
+ *       file's POSIX permissions are checked and the runner warns if they are not 600).
+ *   <li>{@code GC_ADMIN_BOOTSTRAP_PASSWORD} environment variable (preferred for secret-store
+ *       integrations).
+ *   <li>An interactive {@link java.io.Console} prompt, if a real console is attached.
+ * </ol>
+ *
+ * <p>The runner refuses the {@code --password=...} argv shortcut outright (ADR-037 §5): an
+ * argv-supplied password would land in shell history, {@code /proc/<pid>/cmdline}, process
+ * listings, and any CI / agent transcript that captures the launch line. Allowing it for "just
+ * local dev" undermines the policy because operators copy-paste the dev invocation into
+ * production scripts.
+ *
+ * <p>After a successful (or no-op idempotent) bootstrap the runner exits the JVM. The
+ * {@code --create-admin} invocation is meant to be a one-shot — falling through into a normally
+ * running web server with the admin password buffer still hot in memory would defeat the
+ * secret-handling discipline the runner exists to enforce.
+ */
+@Component
+public class FirstAdminBootstrapRunner implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(FirstAdminBootstrapRunner.class);
+    // Credential policy is centralized at UserCredentialPolicy so the bootstrap runner cannot
+    // drift from the REST surface and the database CHECK.
+    private static final Pattern USERNAME_PATTERN = UserCredentialPolicy.USERNAME_PATTERN;
+    private static final String CREATE_ADMIN_OPTION = "create-admin";
+    private static final String USERNAME_OPTION = "username";
+    private static final String PASSWORD_OPTION = "password";
+    private static final String PASSWORD_FILE_OPTION = "password-file";
+    private static final String ENV_PASSWORD = "GC_ADMIN_BOOTSTRAP_PASSWORD";
+    private static final int MIN_PASSWORD_LENGTH = UserCredentialPolicy.MIN_PASSWORD_LENGTH;
+    private static final int MAX_PASSWORD_LENGTH = UserCredentialPolicy.MAX_PASSWORD_LENGTH;
+    private static final int EXIT_OK = 0;
+    private static final int EXIT_USER_ERROR = 2;
+
+    private final JdbcUserDetailsManager users;
+    private final PasswordEncoder encoder;
+    private final PasswordSource passwordSource;
+    private final BootstrapExit exit;
+
+    @Autowired
+    public FirstAdminBootstrapRunner(JdbcUserDetailsManager users, PasswordEncoder encoder) {
+        this(users, encoder, new DefaultPasswordSource(), new SystemBootstrapExit());
+    }
+
+    public FirstAdminBootstrapRunner(
+            JdbcUserDetailsManager users, PasswordEncoder encoder, PasswordSource passwordSource, BootstrapExit exit) {
+        this.users = users;
+        this.encoder = encoder;
+        this.passwordSource = passwordSource;
+        this.exit = exit;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!args.containsOption(CREATE_ADMIN_OPTION)) {
+            return;
+        }
+        if (args.containsOption(PASSWORD_OPTION)) {
+            log.error(
+                    "Refusing --password argv (ADR-037 §5). Supply the password via {} env, --password-file=PATH, or stdin prompt.",
+                    ENV_PASSWORD);
+            exit.exit(EXIT_USER_ERROR);
+            return;
+        }
+        List<String> usernameValues = args.getOptionValues(USERNAME_OPTION);
+        if (usernameValues == null || usernameValues.isEmpty()) {
+            log.error("--create-admin requires --username=<name>");
+            exit.exit(EXIT_USER_ERROR);
+            return;
+        }
+        String username = usernameValues.get(0);
+        if (username == null || !USERNAME_PATTERN.matcher(username).matches()) {
+            log.error("--username does not match required pattern {}", USERNAME_PATTERN.pattern());
+            exit.exit(EXIT_USER_ERROR);
+            return;
+        }
+        if (users.userExists(username)) {
+            // Idempotency is conditional: the no-op path must actually leave the install in a
+            // bootstrappable state. A previous partial bootstrap, manual DB intervention, or
+            // failed authority insert can leave a {@code users} row without an admin authority
+            // — silently exiting 0 in that case would hide the lockout.
+            var existing = users.loadUserByUsername(username);
+            boolean isEnabledAdmin = existing.isEnabled()
+                    && existing.getAuthorities().stream()
+                            .anyMatch(authority -> "ROLE_ADMIN".equals(authority.getAuthority()));
+            if (isEnabledAdmin) {
+                log.info("Admin user '{}' already present and is an enabled admin; bootstrap is a no-op", username);
+                exit.exit(EXIT_OK);
+                return;
+            }
+            log.error(
+                    "User '{}' exists but is not an enabled admin (enabled={}, authorities={}). "
+                            + "Repair manually (DB or UserAdminService) or rerun with --username=<other>.",
+                    username,
+                    existing.isEnabled(),
+                    existing.getAuthorities());
+            exit.exit(EXIT_USER_ERROR);
+            return;
+        }
+        char[] password = passwordSource.read(args, usernameValues).orElse(null);
+        if (password == null) {
+            log.error(
+                    "No password supplied. Set {} env, --password-file=PATH, or run interactively from a TTY.",
+                    ENV_PASSWORD);
+            exit.exit(EXIT_USER_ERROR);
+            return;
+        }
+        // exitCode is captured inside the try and dispatched OUTSIDE the finally so the
+        // password buffer is actually zeroed in production. The production exit shim calls
+        // System.exit, which never returns; if the dispatch sat inside the try the JVM would
+        // terminate before reaching the finally and the secret would linger in heap memory
+        // until the kernel reclaimed it. (Tests use a returning exit shim and saw the cleanup
+        // — that masked the production divergence.) The branches use an if/else, NOT an early
+        // return, so the finally always runs and the post-try dispatch is always reached.
+        int exitCode;
+        try {
+            if (password.length < MIN_PASSWORD_LENGTH || password.length > MAX_PASSWORD_LENGTH) {
+                log.error(
+                        "Password length is out of range; must be {}-{} characters",
+                        MIN_PASSWORD_LENGTH,
+                        MAX_PASSWORD_LENGTH);
+                exitCode = EXIT_USER_ERROR;
+            } else {
+                String hashed = encoder.encode(new String(password));
+                UserDetails details = User.withUsername(username)
+                        .password(hashed)
+                        .authorities("ROLE_ADMIN")
+                        .disabled(false)
+                        .accountExpired(false)
+                        .accountLocked(false)
+                        .credentialsExpired(false)
+                        .build();
+                users.createUser(details);
+                log.info("Created admin user '{}'", username);
+                exitCode = EXIT_OK;
+            }
+        } finally {
+            Arrays.fill(password, '\0');
+        }
+        exit.exit(exitCode);
+    }
+
+    /**
+     * Decoupled password source so unit tests can drive the runner without touching env vars,
+     * the filesystem, or {@link java.io.Console}. The {@link ApplicationArguments} parameter
+     * carries the file path; {@code usernames} is supplied for diagnostics only.
+     */
+    @FunctionalInterface
+    public interface PasswordSource {
+        Optional<char[]> read(ApplicationArguments args, List<String> usernames);
+    }
+
+    /** Exit shim so unit tests can record calls instead of terminating the JVM. */
+    @FunctionalInterface
+    public interface BootstrapExit {
+        void exit(int code);
+    }
+
+    /**
+     * Production password source: prefers {@code --password-file=PATH}, then the
+     * {@code GC_ADMIN_BOOTSTRAP_PASSWORD} env var, then an interactive prompt on a TTY.
+     */
+    public static final class DefaultPasswordSource implements PasswordSource {
+
+        @Override
+        public Optional<char[]> read(ApplicationArguments args, List<String> usernames) {
+            // --password-file is authoritative when supplied: if the file is rejected or
+            // unreadable, the runner must fail rather than silently fall through to env /
+            // console. Otherwise a stale GC_ADMIN_BOOTSTRAP_PASSWORD or an unexpected console
+            // prompt can create the admin with a different secret than the operator selected.
+            if (args.containsOption(PASSWORD_FILE_OPTION)) {
+                return readFile(args);
+            }
+            return readEnv().or(this::readConsole);
+        }
+
+        private Optional<char[]> readFile(ApplicationArguments args) {
+            List<String> values = args.getOptionValues(PASSWORD_FILE_OPTION);
+            if (values == null || values.isEmpty()) {
+                return Optional.empty();
+            }
+            Path path = Path.of(values.get(0));
+            try {
+                if (!Files.isRegularFile(path)) {
+                    log.error("Refusing password file {} — not a regular file.", path);
+                    return Optional.empty();
+                }
+                if (!isOwnerOnlyAccessible(path)) {
+                    log.error(
+                            "Refusing password file {} — group/others have read or write permission. Run chmod 600 first.",
+                            path);
+                    return Optional.empty();
+                }
+                String content = Files.readString(path, StandardCharsets.UTF_8);
+                String trimmed = stripTrailingNewline(content);
+                return Optional.of(trimmed.toCharArray());
+            } catch (IOException ex) {
+                log.error("Failed to read password file {}: {}", path, ex.getMessage());
+                return Optional.empty();
+            }
+        }
+
+        /**
+         * Fail-closed POSIX permission check. ADR-037 §5: the bootstrap creates a permanent
+         * privileged credential, so accepting a group/world-readable OR group/world-writable
+         * password file would let any local unprivileged user either snapshot the secret
+         * (read) or replace it with an attacker-chosen value before the operator runs the
+         * bootstrap (write). {@code true} only when neither group nor others have any of
+         * read / write / execute on a POSIX filesystem; on non-POSIX filesystems we cannot
+         * enforce the gate and DEPLOYMENT.md documents the operator-side requirement.
+         */
+        private static boolean isOwnerOnlyAccessible(Path path) {
+            try {
+                var attrs = Files.readAttributes(path, PosixFileAttributes.class);
+                Set<PosixFilePermission> perms = attrs.permissions();
+                return !perms.contains(PosixFilePermission.GROUP_READ)
+                        && !perms.contains(PosixFilePermission.GROUP_WRITE)
+                        && !perms.contains(PosixFilePermission.GROUP_EXECUTE)
+                        && !perms.contains(PosixFilePermission.OTHERS_READ)
+                        && !perms.contains(PosixFilePermission.OTHERS_WRITE)
+                        && !perms.contains(PosixFilePermission.OTHERS_EXECUTE);
+            } catch (UnsupportedOperationException | IOException ignored) {
+                // Non-POSIX filesystem or unreadable attributes — treat as accepted because
+                // we cannot enforce the gate. DEPLOYMENT.md documents the contract.
+                return true;
+            }
+        }
+
+        private Optional<char[]> readEnv() {
+            String envValue = System.getenv(ENV_PASSWORD);
+            if (envValue == null || envValue.isEmpty()) {
+                return Optional.empty();
+            }
+            return Optional.of(envValue.toCharArray());
+        }
+
+        private Optional<char[]> readConsole() {
+            var console = System.console();
+            if (console == null) {
+                return Optional.empty();
+            }
+            char[] entered = console.readPassword("Admin password: ");
+            if (entered == null || entered.length == 0) {
+                return Optional.empty();
+            }
+            return Optional.of(entered);
+        }
+
+        private static String stripTrailingNewline(String content) {
+            int end = content.length();
+            while (end > 0 && (content.charAt(end - 1) == '\n' || content.charAt(end - 1) == '\r')) {
+                end--;
+            }
+            return content.substring(0, end);
+        }
+    }
+
+    /** Production exit: calls {@link System#exit(int)} so the JVM tears down after bootstrap. */
+    static final class SystemBootstrapExit implements BootstrapExit {
+        @Override
+        public void exit(int code) {
+            System.exit(code);
+        }
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/PathAwareAccessDeniedHandler.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/PathAwareAccessDeniedHandler.java
@@ -1,0 +1,43 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+/**
+ * Browser-chain {@link AccessDeniedHandler} that routes {@code /api/v1/**} 403s to the canonical
+ * {@link ApiAccessDeniedHandler} (stable JSON {@code ErrorResponse} envelope) and lets other
+ * paths fall through to a default handler so SPA navigation hits Spring's regular flow.
+ *
+ * <p>Without this dispatch, an authenticated browser user who lands on an admin-only SPA path
+ * would see the framework's HTML 403 page instead of the JSON envelope the SPA expects from its
+ * {@code /api/v1/**} XHR calls. The mirror exists exactly because ADR-026's path matrix is
+ * shared across both chains.
+ */
+public class PathAwareAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ApiAccessDeniedHandler apiHandler;
+    private final AccessDeniedHandler fallback;
+
+    public PathAwareAccessDeniedHandler(ApiAccessDeniedHandler apiHandler, AccessDeniedHandler fallback) {
+        this.apiHandler = apiHandler;
+        this.fallback = fallback;
+    }
+
+    @Override
+    public void handle(
+            HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+        // Use getRequestURI() instead of getServletPath() — servlet path is empty when the
+        // dispatcher servlet is mapped at "/" (the Ground Control default), so the JSON
+        // dispatch silently degrades to the fallback. URI is stable across mappings.
+        if (ApiRequestPaths.isApiRequest(request)) {
+            apiHandler.handle(request, response, accessDeniedException);
+            return;
+        }
+        fallback.handle(request, response, accessDeniedException);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/PathAwareSessionExpiredStrategy.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/PathAwareSessionExpiredStrategy.java
@@ -1,0 +1,41 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.springframework.security.authentication.CredentialsExpiredException;
+import org.springframework.security.web.session.SessionInformationExpiredEvent;
+import org.springframework.security.web.session.SessionInformationExpiredStrategy;
+
+/**
+ * Bridges Spring Security's {@link org.springframework.security.web.authentication.session.ConcurrentSessionFilter
+ * ConcurrentSessionFilter} expiry event into the ADR-037 path policy. When
+ * {@link org.springframework.security.core.session.SessionInformation#expireNow()} fires (e.g.
+ * {@code UserAdminService} revoked the principal), the next request lands here.
+ *
+ * <p>For API-shaped requests the strategy delegates to {@link ApiAuthenticationEntryPoint} so the
+ * SPA's fetch wrapper sees a JSON 401 envelope (matching the entry-point and access-denied
+ * dispatch). For browser navigation it issues a redirect to {@code /login}; the form-login flow
+ * then takes over.
+ */
+public class PathAwareSessionExpiredStrategy implements SessionInformationExpiredStrategy {
+
+    private final ApiAuthenticationEntryPoint apiEntryPoint;
+    private final String loginPath;
+
+    public PathAwareSessionExpiredStrategy(ApiAuthenticationEntryPoint apiEntryPoint, String loginPath) {
+        this.apiEntryPoint = apiEntryPoint;
+        this.loginPath = loginPath;
+    }
+
+    @Override
+    public void onExpiredSessionDetected(SessionInformationExpiredEvent event) throws IOException, ServletException {
+        if (ApiRequestPaths.isApiRequest(event.getRequest())) {
+            apiEntryPoint.commence(
+                    event.getRequest(),
+                    event.getResponse(),
+                    new CredentialsExpiredException("Session expired or revoked"));
+            return;
+        }
+        event.getResponse().sendRedirect(loginPath);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/UserCredentialPolicy.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/UserCredentialPolicy.java
@@ -1,0 +1,44 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import java.util.regex.Pattern;
+
+/**
+ * Single Java source of truth for the ADR-037 user-credential validation contract — username
+ * pattern, password length range. Used by:
+ *
+ * <ul>
+ *   <li>{@code CreateUserRequest} / {@code UserAdminController} path validation
+ *       (Bean-Validation {@code @Pattern} / {@code @Size}).
+ *   <li>{@code UserAdminService} (post-binding programmatic validation called from non-web
+ *       callers such as the bootstrap runner).
+ *   <li>{@code FirstAdminBootstrapRunner} (CLI input validation).
+ * </ul>
+ *
+ * <p>The V059 Flyway migration's {@code CHECK} constraint mirrors {@link #USERNAME_REGEX} as the
+ * database-side backstop; the constants here and the SQL CHECK are kept in lockstep by
+ * {@code UserCredentialPolicyContractTest}, which extracts the regex from both sides and
+ * asserts equivalence. Add a new constraint here only after updating the SQL CHECK and the
+ * docs at {@code docs/API.md#admin-users-adr-036}.
+ */
+public final class UserCredentialPolicy {
+
+    /**
+     * Username regex: lowercase ASCII identifier, 2-64 chars, starts with a letter,
+     * subsequent chars are letters / digits / dot / underscore / hyphen. Same expression used
+     * in the V059 {@code CHECK (username ~ '^[a-z][a-z0-9._-]{1,63}$')}.
+     */
+    public static final String USERNAME_REGEX = "^[a-z][a-z0-9._-]{1,63}$";
+
+    /** Compiled form for programmatic callers (service, bootstrap). */
+    public static final Pattern USERNAME_PATTERN = Pattern.compile(USERNAME_REGEX);
+
+    /** Lower password length bound (ADR-037 §5: hashes must be resistant to offline cracking). */
+    public static final int MIN_PASSWORD_LENGTH = 12;
+
+    /** Upper bound: keeps BCrypt within its 72-byte cost ceiling and the storage column width. */
+    public static final int MAX_PASSWORD_LENGTH = 200;
+
+    private UserCredentialPolicy() {
+        // constants only
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/UserSummary.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/UserSummary.java
@@ -1,0 +1,11 @@
+package com.keplerops.groundcontrol.shared.security;
+
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
+
+/**
+ * Internal view of a single Spring Security principal. Used by {@code UserAdminService} (and any
+ * future non-web caller such as a CLI or scheduled task) so the service layer is not coupled to
+ * the {@code api.admin.users.UserResponse} wire shape. The controller maps this to
+ * {@code UserResponse} at the request boundary.
+ */
+public record UserSummary(String username, Role role, boolean enabled) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/service/UserAdminService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/service/UserAdminService.java
@@ -1,0 +1,311 @@
+package com.keplerops.groundcontrol.shared.security.service;
+
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
+import com.keplerops.groundcontrol.shared.security.UserCredentialPolicy;
+import com.keplerops.groundcontrol.shared.security.UserSummary;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.session.SessionInformation;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Admin-facing facade over Spring Security's {@link JdbcUserDetailsManager} for ADR-037 user
+ * lifecycle operations. Centralizes:
+ *
+ * <ul>
+ *   <li><b>Username + password validation</b> — mirrors the V059 schema's {@code CHECK}
+ *       constraint and the ADR-037 §5 password floor so a {@code DomainValidationException} is
+ *       raised before the DB does, and field-level errors surface through {@code
+ *       GlobalExceptionHandler}'s standard envelope.
+ *   <li><b>Last-admin guard</b> — refuses any operation (demotion, disable, delete) that would
+ *       leave the install with zero enabled admins. Without this guard a single mis-click locks
+ *       the operator out and demands a manual DB intervention.
+ *   <li><b>Audit-grade logging</b> — every state change writes a structured log line carrying
+ *       username + role only; passwords, hashes, session ids, and CSRF tokens are never logged
+ *       (ADR-037 §6).
+ * </ul>
+ *
+ * <p>Role authorities are kept as a single row per user in the {@code authorities} table; the
+ * service enforces that constraint by deleting and re-inserting on role change so accidental
+ * dual-role rows cannot accumulate. The check constraint on the table only enforces vocabulary,
+ * not cardinality.
+ */
+@Service
+public class UserAdminService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserAdminService.class);
+
+    // Credential policy is centralized at UserCredentialPolicy so the DTO, controller, service,
+    // bootstrap runner, and equivalence test all agree. Local aliases keep the call sites short.
+    private static final java.util.regex.Pattern USERNAME_PATTERN = UserCredentialPolicy.USERNAME_PATTERN;
+    static final int MIN_PASSWORD_LENGTH = UserCredentialPolicy.MIN_PASSWORD_LENGTH;
+    static final int MAX_PASSWORD_LENGTH = UserCredentialPolicy.MAX_PASSWORD_LENGTH;
+
+    /** Column / detail-map key for the principal name. Deduplicated to satisfy SonarCloud S1192. */
+    private static final String USERNAME_FIELD = "username";
+
+    private static final String COUNT_OTHER_ENABLED_ADMINS_SQL =
+            "SELECT COUNT(*) FROM users u JOIN authorities a ON a.username = u.username"
+                    + " WHERE a.authority = 'ROLE_ADMIN' AND u.enabled = TRUE AND u.username <> ?";
+    private static final String DELETE_AUTHORITIES_SQL = "DELETE FROM authorities WHERE username = ?";
+    private static final String INSERT_AUTHORITY_SQL = "INSERT INTO authorities (username, authority) VALUES (?, ?)";
+    private static final String UPDATE_ENABLED_SQL = "UPDATE users SET enabled = ? WHERE username = ?";
+    private static final String LIST_USERS_SQL = "SELECT u.username, u.enabled,"
+            + " (SELECT a.authority FROM authorities a WHERE a.username = u.username ORDER BY a.authority LIMIT 1)"
+            + " AS authority FROM users u ORDER BY u.username";
+
+    /**
+     * Postgres transaction-scoped advisory lock that serializes every admin mutation through a
+     * single critical section. Without it two admins demoting / disabling / deleting themselves
+     * concurrently can both observe a non-zero other-admin count and commit — leaving the
+     * install with zero enabled admins. {@code pg_advisory_xact_lock} releases on COMMIT or
+     * ROLLBACK, so we never have to remember to unlock; if the transaction crashes the lock
+     * still goes away. The key is arbitrary but stable: a 64-bit constant chosen to be visually
+     * distinct in {@code pg_locks} dumps.
+     */
+    private static final long ADMIN_MUTATION_LOCK_KEY = 0x4743_5541_444D_4E54L; // GCUAADMN
+
+    private static final String ADVISORY_LOCK_SQL = "SELECT pg_advisory_xact_lock(?)";
+
+    private final JdbcUserDetailsManager users;
+    private final JdbcTemplate jdbc;
+    private final PasswordEncoder encoder;
+    private final SessionRegistry sessionRegistry;
+
+    public UserAdminService(
+            JdbcUserDetailsManager users, JdbcTemplate jdbc, PasswordEncoder encoder, SessionRegistry sessionRegistry) {
+        this.users = users;
+        this.jdbc = jdbc;
+        this.encoder = encoder;
+        this.sessionRegistry = sessionRegistry;
+    }
+
+    public List<UserSummary> list() {
+        return jdbc.query(
+                LIST_USERS_SQL,
+                (rs, n) -> new UserSummary(
+                        rs.getString(USERNAME_FIELD),
+                        roleFromAuthority(rs.getString("authority")),
+                        rs.getBoolean("enabled")));
+    }
+
+    public UserSummary createUser(String username, String rawPassword, Role role) {
+        validateUsername(username);
+        validatePassword(rawPassword);
+        // Preflight existence check keeps the common-case error fast and avoids a wasted
+        // BCrypt hash on duplicates. It is NOT the source of truth — the insert itself is, so
+        // we still translate the duplicate-key path below. Without that translation a
+        // double-submit / concurrent admin / concurrent bootstrap arriving between the
+        // preflight and the insert surfaces as a generic 500 from GlobalExceptionHandler
+        // instead of the documented 409 user_exists.
+        if (users.userExists(username)) {
+            throw duplicateUserConflict(username);
+        }
+        UserDetails details = User.withUsername(username)
+                .password(encoder.encode(rawPassword))
+                .authorities(toAuthority(role))
+                .disabled(false)
+                .accountExpired(false)
+                .accountLocked(false)
+                .credentialsExpired(false)
+                .build();
+        try {
+            users.createUser(details);
+        } catch (DuplicateKeyException ex) {
+            // Lost the race between preflight and insert — another admin / agent / bootstrap
+            // got there first. Surface the same 409 envelope so callers see consistent error
+            // semantics regardless of timing.
+            throw duplicateUserConflict(username);
+        }
+        log.info("Created user '{}' with role {}", username, role);
+        return new UserSummary(username, role, true);
+    }
+
+    private static ConflictException duplicateUserConflict(String username) {
+        return new ConflictException(
+                "User '" + username + "' already exists", "user_exists", detailWithUsername(username));
+    }
+
+    @Transactional
+    public UserSummary updateRole(String username, Role newRole) {
+        acquireAdminMutationLock();
+        requireUserExists(username);
+        if (newRole == Role.USER && isLastEnabledAdmin(username)) {
+            throw lastAdminConflict(username);
+        }
+        jdbc.update(DELETE_AUTHORITIES_SQL, username);
+        jdbc.update(INSERT_AUTHORITY_SQL, username, toAuthority(newRole));
+        expireSessionsFor(username);
+        log.info("Changed role for user '{}' to {}", username, newRole);
+        boolean enabled = currentDetails(username).isEnabled();
+        return new UserSummary(username, newRole, enabled);
+    }
+
+    @Transactional
+    public UserSummary updateEnabled(String username, boolean enabled) {
+        acquireAdminMutationLock();
+        requireUserExists(username);
+        UserDetails details = currentDetails(username);
+        Role currentRole = roleFromUserDetails(details);
+        if (!enabled && currentRole == Role.ADMIN && isLastEnabledAdmin(username)) {
+            throw lastAdminConflict(username);
+        }
+        jdbc.update(UPDATE_ENABLED_SQL, enabled, username);
+        if (!enabled) {
+            expireSessionsFor(username);
+        }
+        log.info("Set enabled={} for user '{}'", enabled, username);
+        return new UserSummary(username, currentRole, enabled);
+    }
+
+    @Transactional
+    public void deleteUser(String username) {
+        acquireAdminMutationLock();
+        requireUserExists(username);
+        Role currentRole = roleFromUserDetails(currentDetails(username));
+        if (currentRole == Role.ADMIN && isLastEnabledAdmin(username)) {
+            throw lastAdminConflict(username);
+        }
+        users.deleteUser(username);
+        expireSessionsFor(username);
+        log.info("Deleted user '{}'", username);
+    }
+
+    /**
+     * Expire every live session for the named principal so a role / enabled / delete mutation
+     * takes effect immediately, instead of waiting for natural session timeout. SessionRegistry
+     * keys by principal object (the {@link org.springframework.security.core.userdetails.UserDetails}
+     * instance) rather than username, so we iterate {@code getAllPrincipals()} and match on
+     * {@code getUsername()}. The active sessions are then walked and expired via
+     * {@link SessionInformation#expireNow()}; the next request on the same session lands in
+     * {@code ConcurrentSessionFilter} which translates it into a fresh re-authentication.
+     */
+    private void expireSessionsFor(String username) {
+        for (Object principal : sessionRegistry.getAllPrincipals()) {
+            String registeredName = principalUsername(principal);
+            if (!username.equals(registeredName)) {
+                continue;
+            }
+            for (SessionInformation info : sessionRegistry.getAllSessions(principal, false)) {
+                info.expireNow();
+            }
+        }
+    }
+
+    private static String principalUsername(Object principal) {
+        if (principal instanceof UserDetails details) {
+            return details.getUsername();
+        }
+        return principal == null ? null : principal.toString();
+    }
+
+    /**
+     * Funnels every admin-mutation transaction through a single Postgres advisory lock so the
+     * last-admin guard's count-then-mutate is effectively serialized. The lock is acquired here
+     * (inside the {@code @Transactional} boundary) so it releases on COMMIT or ROLLBACK.
+     */
+    private void acquireAdminMutationLock() {
+        // pg_advisory_xact_lock returns void; query()/queryForRowSet would over-allocate. Use
+        // execute(PreparedStatementCallback) so the bind variable is still parameterized (no
+        // string concat) but the result set is discarded.
+        jdbc.execute(ADVISORY_LOCK_SQL, (java.sql.PreparedStatement ps) -> {
+            ps.setLong(1, ADMIN_MUTATION_LOCK_KEY);
+            ps.execute();
+            return null;
+        });
+    }
+
+    private void requireUserExists(String username) {
+        if (!users.userExists(username)) {
+            throw new NotFoundException("User '" + username + "' not found");
+        }
+    }
+
+    /**
+     * Differentiates "user not found" from other failures in admin lifecycle paths.
+     * SonarCloud's javasecurity:S5145 ("user enumeration") fires on this catch-and-rethrow
+     * pattern because it is unsafe on unauthenticated login surfaces. Here every caller
+     * ({@code updateRole}, {@code updateEnabled}, {@code deleteUser}) is gated by
+     * {@code ROLE_ADMIN} via {@code ApiSecurityConfig}'s path matrix, and the entire admin
+     * surface explicitly enumerates users via {@code GET /api/v1/admin/users}. A 404 here is
+     * the documented response shape; an unauthenticated caller cannot reach this method.
+     */
+    @SuppressWarnings("java:S5804")
+    private UserDetails currentDetails(String username) {
+        try {
+            return users.loadUserByUsername(username);
+        } catch (UsernameNotFoundException ex) {
+            throw new NotFoundException("User '" + username + "' not found");
+        }
+    }
+
+    private boolean isLastEnabledAdmin(String username) {
+        Integer others = jdbc.queryForObject(COUNT_OTHER_ENABLED_ADMINS_SQL, Integer.class, username);
+        return others == null || others == 0;
+    }
+
+    private static void validateUsername(String username) {
+        if (username == null || !USERNAME_PATTERN.matcher(username).matches()) {
+            throw new DomainValidationException(
+                    "Invalid username: must match " + USERNAME_PATTERN.pattern(),
+                    "validation_error",
+                    Map.of("field", (Serializable) USERNAME_FIELD));
+        }
+    }
+
+    private static void validatePassword(String rawPassword) {
+        if (rawPassword == null
+                || rawPassword.length() < MIN_PASSWORD_LENGTH
+                || rawPassword.length() > MAX_PASSWORD_LENGTH) {
+            throw new DomainValidationException(
+                    "Invalid password: length must be between " + MIN_PASSWORD_LENGTH + " and " + MAX_PASSWORD_LENGTH,
+                    "validation_error",
+                    Map.of("field", (Serializable) "password"));
+        }
+    }
+
+    private static String toAuthority(Role role) {
+        return "ROLE_" + role.name();
+    }
+
+    private static Role roleFromAuthority(String authority) {
+        if (authority == null) {
+            return Role.USER;
+        }
+        return "ROLE_ADMIN".equals(authority) ? Role.ADMIN : Role.USER;
+    }
+
+    private static Role roleFromUserDetails(UserDetails details) {
+        for (GrantedAuthority granted : details.getAuthorities()) {
+            if ("ROLE_ADMIN".equals(granted.getAuthority())) {
+                return Role.ADMIN;
+            }
+        }
+        return Role.USER;
+    }
+
+    private static ConflictException lastAdminConflict(String username) {
+        return new ConflictException(
+                "Cannot remove or demote the last enabled admin", "last_admin", detailWithUsername(username));
+    }
+
+    private static Map<String, Serializable> detailWithUsername(String username) {
+        return Map.of(USERNAME_FIELD, username);
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -2,6 +2,14 @@ spring:
   jpa:
     show-sql: true
 
+# Dev profile: HTTP localhost is the norm, so Secure-cookie is relaxed; session cookies still
+# stay HttpOnly + SameSite=Strict. Browser session tunables mirror the relaxed Secure flag.
+server:
+  servlet:
+    session:
+      cookie:
+        secure: false
+
 groundcontrol:
   security:
     enabled: false

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -6,6 +6,14 @@ spring:
     hibernate:
       ddl-auto: validate
 
+# Test profile: MockMvc never speaks HTTPS, so Secure-cookie must be off or session cookies are
+# stripped before assertions can see them.
+server:
+  servlet:
+    session:
+      cookie:
+        secure: false
+
 groundcontrol:
   security:
     enabled: false

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -33,6 +33,19 @@ server:
   port: ${GC_SERVER_PORT:8000}
   servlet:
     context-path: /
+    # ADR-037 §6: browser session cookie hardening. The name is renamed so a deployment can
+    # distinguish Ground Control's session from co-tenants on the same host without sniffing
+    # cookie contents; Secure / HttpOnly / SameSite are hardcoded to the production-safe
+    # settings. Dev and test profiles relax `secure` so HTTP MockMvc / localhost can read the
+    # cookie. There are no operator-facing knobs for these values — changing them needs an
+    # ADR and a security review, not a deploy-time env var.
+    session:
+      timeout: 60m
+      cookie:
+        name: GC_SESSION
+        http-only: true
+        secure: true
+        same-site: strict
 
 management:
   endpoints:

--- a/backend/src/main/resources/db/migration/V059__create_users.sql
+++ b/backend/src/main/resources/db/migration/V059__create_users.sql
@@ -1,0 +1,36 @@
+-- ADR-037 / GC-P017: Spring Security default user / authority schema for the
+-- browser session login chain. The column names and types here match the
+-- defaults baked into Spring Security's JdbcUserDetailsManager (see
+-- JdbcDaoImpl#DEF_USERS_BY_USERNAME_QUERY and #DEF_AUTHORITIES_BY_USERNAME_QUERY)
+-- so the framework can read and write the tables without a custom query
+-- override. Diverging from those defaults would force us to maintain a parallel
+-- query set in BrowserSecurityConfig; keeping the names stock is the lower-risk
+-- choice for a security boundary.
+--
+-- These tables hold *security principals*, not domain entities. ADR-037 §4 is
+-- the source of truth: no project membership, no groups, no tenants, no
+-- federation metadata, no profile fields. If a future change needs richer
+-- user-lifecycle data, that is the seam for a dedicated domain model and a new
+-- ADR — not extra columns here.
+
+CREATE TABLE users (
+    username VARCHAR(255) NOT NULL PRIMARY KEY,
+    password VARCHAR(255) NOT NULL,
+    enabled  BOOLEAN      NOT NULL,
+    CONSTRAINT users_username_format CHECK (
+        username = lower(username)
+        AND char_length(username) BETWEEN 2 AND 64
+        AND username ~ '^[a-z][a-z0-9._-]{1,63}$'
+    )
+);
+
+CREATE TABLE authorities (
+    username  VARCHAR(255) NOT NULL,
+    authority VARCHAR(64)  NOT NULL,
+    CONSTRAINT fk_authorities_users FOREIGN KEY (username)
+        REFERENCES users (username) ON DELETE CASCADE,
+    CONSTRAINT authorities_user_authority_unique UNIQUE (username, authority),
+    CONSTRAINT authorities_role_vocabulary CHECK (authority IN ('ROLE_USER', 'ROLE_ADMIN'))
+);
+
+CREATE INDEX idx_authorities_username ON authorities (username);

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/BrowserSessionIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/BrowserSessionIntegrationTest.java
@@ -1,0 +1,255 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keplerops.groundcontrol.shared.security.service.UserAdminService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+/**
+ * End-to-end coverage for the ADR-037 browser-session login chain.
+ *
+ * <p>Flips {@code groundcontrol.security.enabled=true} for this test so both filter chains
+ * actively gate traffic, the way they will in production. The bearer-chain assertions live in
+ * {@code ApiSecurityIntegrationTest}; this test focuses on the additive surface — form login,
+ * CSRF, /api/v1/** XHRs through the session, logout, and the bearer chain still working
+ * alongside the session chain (no regression).
+ *
+ * <p>{@link MockMvc} does not run through Tomcat's servlet container, so the session cookie's
+ * name / HttpOnly / SameSite hardening (configured via
+ * {@code server.servlet.session.cookie.*}) cannot be asserted here. Session continuity is
+ * verified through {@link MockHttpSession} attributes — the canonical MockMvc pattern — which
+ * is the same mechanism Spring's session-management uses to thread the SecurityContext.
+ */
+@AutoConfigureMockMvc
+@TestPropertySource(
+        properties = {
+            "groundcontrol.security.enabled=true",
+            "groundcontrol.security.openapi-public=false",
+            "groundcontrol.security.credentials[0].principal-name=agent-bob",
+            "groundcontrol.security.credentials[0].token=bearer-token-aaaaaaaaaaaa",
+            "groundcontrol.security.credentials[0].role=USER",
+            "groundcontrol.security.ip-allowlist[0]=127.0.0.0/8",
+            "groundcontrol.security.ip-allowlist[1]=::1/128",
+            "server.servlet.session.cookie.secure=false",
+        })
+class BrowserSessionIntegrationTest extends BaseIntegrationTest {
+
+    private static final String ADMIN_USERNAME = "admin-alice";
+    private static final String ADMIN_PASSWORD = "correct-horse-battery-staple";
+    private static final String CSRF_COOKIE = "XSRF-TOKEN";
+    private static final String CSRF_HEADER = "X-XSRF-TOKEN";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserAdminService userAdminService;
+
+    @Autowired
+    private JdbcUserDetailsManager userDetailsManager;
+
+    @BeforeEach
+    void seedAdminUser() {
+        if (!userDetailsManager.userExists(ADMIN_USERNAME)) {
+            userAdminService.createUser(
+                    ADMIN_USERNAME,
+                    ADMIN_PASSWORD,
+                    com.keplerops.groundcontrol.shared.security.SecurityProperties.Role.ADMIN);
+        }
+    }
+
+    @Test
+    void anonymousApiCall_returnsJson401NotRedirect() throws Exception {
+        mockMvc.perform(get("/api/v1/requirements"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(result -> assertThat(result.getResponse().getContentType())
+                        .as("Anonymous /api/v1/** XHR must receive a JSON envelope, not a /login redirect")
+                        .startsWith("application/json"))
+                .andExpect(result ->
+                        assertThat(result.getResponse().getRedirectedUrl()).isNull());
+    }
+
+    @Test
+    void loginPage_isAnonymouslyReachable() throws Exception {
+        mockMvc.perform(get("/login")).andExpect(status().isOk());
+    }
+
+    @Test
+    void formLoginIssuesSessionAndUnblocksApiAccess() throws Exception {
+        AuthenticatedSession authenticated = loginAndCaptureSession();
+
+        mockMvc.perform(get("/api/v1/requirements").session(authenticated.session))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void bearerCallerStillWorks_evenWithBrowserChainPresent() throws Exception {
+        mockMvc.perform(get("/api/v1/requirements").header("Authorization", "Bearer bearer-token-aaaaaaaaaaaa"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void csrfBlocksSessionMutationWithoutHeader() throws Exception {
+        AuthenticatedSession authenticated = loginAndCaptureSession();
+
+        mockMvc.perform(
+                        post("/api/v1/admin/users")
+                                .session(authenticated.session)
+                                .contentType("application/json")
+                                .content(
+                                        "{\"username\":\"new-user\",\"password\":\"correct-horse-battery-staple\",\"role\":\"USER\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void csrfTokenAllowsSessionMutation() throws Exception {
+        AuthenticatedSession authenticated = loginAndCaptureSession();
+        Cookie csrf = freshCsrfFor(authenticated.session);
+
+        mockMvc.perform(
+                        post("/api/v1/admin/users")
+                                .session(authenticated.session)
+                                .contentType("application/json")
+                                .cookie(csrf)
+                                .header(CSRF_HEADER, csrf.getValue())
+                                .content(
+                                        "{\"username\":\"new-csrf-user\",\"password\":\"correct-horse-battery-staple\",\"role\":\"USER\"}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void logoutClearsSessionAndReturns204() throws Exception {
+        AuthenticatedSession authenticated = loginAndCaptureSession();
+        Cookie csrf = freshCsrfFor(authenticated.session);
+
+        mockMvc.perform(post("/logout")
+                        .session(authenticated.session)
+                        .cookie(csrf)
+                        .header(CSRF_HEADER, csrf.getValue()))
+                .andExpect(status().isNoContent());
+
+        // The session was invalidated; presenting it again must 401.
+        mockMvc.perform(get("/api/v1/requirements").session(authenticated.session))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void disabledUserCannotReuseSession() throws Exception {
+        // Seed a separate USER-role principal so we don't disable the bootstrap admin (the
+        // last-admin guard would refuse).
+        String username = "user-revoke-test";
+        String password = "correct-horse-battery-staple";
+        if (!userDetailsManager.userExists(username)) {
+            userAdminService.createUser(
+                    username, password, com.keplerops.groundcontrol.shared.security.SecurityProperties.Role.USER);
+        }
+
+        // Log in as that user and confirm the session is live.
+        MvcResult page = mockMvc.perform(get("/login")).andReturn();
+        Cookie csrf = page.getResponse().getCookie(CSRF_COOKIE);
+        assertThat(csrf).isNotNull();
+        MockHttpSession session = new MockHttpSession();
+        mockMvc.perform(post("/login")
+                        .param("username", username)
+                        .param("password", password)
+                        .param("_csrf", csrf.getValue())
+                        .session(session)
+                        .cookie(csrf))
+                .andExpect(status().is3xxRedirection());
+        mockMvc.perform(get("/api/v1/requirements").session(session)).andExpect(status().isOk());
+
+        // Admin disables the user. ConcurrentSessionFilter must now reject the existing session.
+        userAdminService.updateEnabled(username, false);
+
+        mockMvc.perform(get("/api/v1/requirements").session(session))
+                .andExpect(status().isUnauthorized())
+                .andExpect(result -> assertThat(result.getResponse().getContentType())
+                        .as("Expired session on an API path must return JSON, not a /login redirect")
+                        .startsWith("application/json"));
+        // Cleanup so subsequent tests do not see a disabled user lingering.
+        userAdminService.updateEnabled(username, true);
+    }
+
+    @Test
+    void loginPostWithoutCsrfIsRejected_evenWithoutPreExistingSession() throws Exception {
+        // CookieCsrfTokenRepository writes the XSRF cookie on GET /login without creating a
+        // server-side session, so a real browser's first POST /login arrives session-less.
+        // The CSRF matcher must still require a token on that POST — otherwise an attacker
+        // can host an auto-submitting form to /login with their own credentials and the
+        // victim's browser would get a session for the attacker's principal (login-CSRF /
+        // session-fixation by credential swap). This test pins that contract.
+        mockMvc.perform(post("/login").param("username", ADMIN_USERNAME).param("password", ADMIN_PASSWORD))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void invalidCredentialsRejectedAtLogin() throws Exception {
+        MvcResult loginPage = mockMvc.perform(get("/login")).andReturn();
+        Cookie csrf = loginPage.getResponse().getCookie(CSRF_COOKIE);
+        assertThat(csrf).as("Login page must publish an XSRF cookie").isNotNull();
+
+        mockMvc.perform(post("/login")
+                        .param("username", ADMIN_USERNAME)
+                        .param("password", "wrong-password-aaaa")
+                        .param("_csrf", csrf.getValue())
+                        .session(new MockHttpSession())
+                        .cookie(csrf))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(result -> assertThat(result.getResponse().getRedirectedUrl())
+                        .as("Bad creds must bounce back to /login?error")
+                        .contains("/login")
+                        .contains("error"));
+    }
+
+    private AuthenticatedSession loginAndCaptureSession() throws Exception {
+        // GET /login is anonymous, so Spring's session policy (IF_REQUIRED) does NOT create a
+        // session here — the CSRF token lives in the XSRF-TOKEN cookie via
+        // CookieCsrfTokenRepository, not in the session. We allocate a fresh MockHttpSession
+        // ourselves so POST /login has a session container for Spring's
+        // SessionAuthenticationStrategy to migrate into on a successful login.
+        MvcResult page = mockMvc.perform(get("/login")).andReturn();
+        Cookie csrf = page.getResponse().getCookie(CSRF_COOKIE);
+        assertThat(csrf).as("Login page must publish an XSRF cookie").isNotNull();
+
+        MockHttpSession freshSession = new MockHttpSession();
+        MvcResult login = mockMvc.perform(post("/login")
+                        .param("username", ADMIN_USERNAME)
+                        .param("password", ADMIN_PASSWORD)
+                        .param("_csrf", csrf.getValue())
+                        .session(freshSession)
+                        .cookie(csrf))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+        MockHttpSession authenticated = (MockHttpSession) login.getRequest().getSession(false);
+        assertThat(authenticated)
+                .as("Successful form login must produce an authenticated session")
+                .isNotNull();
+        return new AuthenticatedSession(authenticated);
+    }
+
+    private Cookie freshCsrfFor(MockHttpSession session) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/v1/requirements").session(session))
+                .andExpect(status().isOk())
+                .andReturn();
+        Cookie csrf = result.getResponse().getCookie(CSRF_COOKIE);
+        // Spring may rotate the XSRF token on certain transitions; if the GET didn't issue a new
+        // one, the prior cookie tied to this session is still valid. Returning a blank cookie
+        // when none is present makes the failure mode obvious in the test (the assertion the
+        // caller runs will surface "CSRF required" rather than NPE'ing on cookie.getValue()).
+        return csrf != null ? csrf : new Cookie(CSRF_COOKIE, "");
+    }
+
+    private record AuthenticatedSession(MockHttpSession session) {}
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
@@ -41,7 +41,7 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         "014", "015", "016", "017", "018", "019", "020", "021", "022", "023", "024", "025", "026",
                         "027", "028", "029", "030", "031", "032", "033", "034", "035", "036", "037", "038", "039",
                         "040", "041", "042", "043", "044", "045", "046", "047", "048", "049", "050", "051", "052",
-                        "053", "054", "055", "056", "057", "058");
+                        "053", "054", "055", "056", "057", "058", "059");
     }
 
     @Test
@@ -213,5 +213,11 @@ class MigrationSmokeTest extends BaseIntegrationTest {
         entityManager
                 .createNativeQuery("SELECT 1 FROM threat_model_link_audit LIMIT 1")
                 .getResultList();
+        // V059: ADR-037 browser session JDBC user store. These are Spring Security
+        // principal tables (not domain entities), so they intentionally have no
+        // matching _audit suffix — role-change events are captured via structured
+        // log lines from UserAdminService instead. See ADR-037 §4 and §6.
+        entityManager.createNativeQuery("SELECT 1 FROM users LIMIT 1").getResultList();
+        entityManager.createNativeQuery("SELECT 1 FROM authorities LIMIT 1").getResultList();
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -402,6 +402,7 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
                         "055", // V055: threat_model
                         "056", // V056: threat_model_audit
                         "057", // V057: threat_model_link (target_url / target_title NOT NULL DEFAULT '')
-                        "058"); // V058: threat_model_link_audit
+                        "058", // V058: threat_model_link_audit
+                        "059"); // V059: ADR-037 users + authorities (browser session JDBC store)
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/UserAdminControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/UserAdminControllerTest.java
@@ -1,0 +1,231 @@
+package com.keplerops.groundcontrol.unit.api;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keplerops.groundcontrol.api.admin.users.UserAdminController;
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
+import com.keplerops.groundcontrol.shared.security.UserSummary;
+import com.keplerops.groundcontrol.shared.security.service.UserAdminService;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Slice tests for the {@link UserAdminController}. {@code @AutoConfigureMockMvc(addFilters=false)}
+ * skips the Spring Security chain so role-based access is verified separately (by the path
+ * matrix in {@code ApiSecurityConfig} + the integration test); this slice's contract is just the
+ * request/response wire format. The controller is mandatory unit-test surface per
+ * {@code .gc/plan-rules.md} (ADR-037 admin user surface) so SonarCloud coverage stays honest
+ * (the {@code sonar} CI job does not run Testcontainers, so integration tests do not
+ * contribute coverage there).
+ */
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(UserAdminController.class)
+class UserAdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserAdminService service;
+
+    @Nested
+    class ListUsers {
+
+        @Test
+        void returnsUserResponseList() throws Exception {
+            when(service.list())
+                    .thenReturn(List.of(
+                            new UserSummary("alice", Role.ADMIN, true), new UserSummary("bob", Role.USER, false)));
+
+            mockMvc.perform(get("/api/v1/admin/users"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.users", org.hamcrest.Matchers.hasSize(2)))
+                    .andExpect(jsonPath("$.users[0].username", is("alice")))
+                    .andExpect(jsonPath("$.users[0].role", is("ADMIN")))
+                    .andExpect(jsonPath("$.users[0].enabled", is(true)))
+                    .andExpect(jsonPath("$.users[1].username", is("bob")))
+                    .andExpect(jsonPath("$.users[1].role", is("USER")))
+                    .andExpect(jsonPath("$.users[1].enabled", is(false)));
+        }
+    }
+
+    @Nested
+    class CreateUser {
+
+        @Test
+        void createsUserAndReturns201() throws Exception {
+            when(service.createUser("alice", "correct-horse-battery-staple", Role.ADMIN))
+                    .thenReturn(new UserSummary("alice", Role.ADMIN, true));
+
+            mockMvc.perform(
+                            post("/api/v1/admin/users")
+                                    .contentType("application/json")
+                                    .content(
+                                            "{\"username\":\"alice\",\"password\":\"correct-horse-battery-staple\",\"role\":\"ADMIN\"}"))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.username", is("alice")))
+                    .andExpect(jsonPath("$.role", is("ADMIN")))
+                    .andExpect(jsonPath("$.enabled", is(true)));
+        }
+
+        @Test
+        void rejectsShortPasswordWith422() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/users")
+                            .contentType("application/json")
+                            .content("{\"username\":\"alice\",\"password\":\"tooshort\",\"role\":\"USER\"}"))
+                    .andExpect(status().isUnprocessableEntity())
+                    .andExpect(jsonPath("$.error.code", is("validation_error")));
+            verify(service, never()).createUser(anyString(), anyString(), any());
+        }
+
+        @Test
+        void rejectsBadUsernameWith422() throws Exception {
+            mockMvc.perform(
+                            post("/api/v1/admin/users")
+                                    .contentType("application/json")
+                                    .content(
+                                            "{\"username\":\"Bad Name\",\"password\":\"long-enough-password\",\"role\":\"USER\"}"))
+                    .andExpect(status().isUnprocessableEntity())
+                    .andExpect(jsonPath("$.error.code", is("validation_error")));
+        }
+
+        @Test
+        void rejectsMissingRoleWith422() throws Exception {
+            mockMvc.perform(post("/api/v1/admin/users")
+                            .contentType("application/json")
+                            .content("{\"username\":\"alice\",\"password\":\"long-enough-password\"}"))
+                    .andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        void duplicateUsernameReturns409Conflict() throws Exception {
+            when(service.createUser(eq("alice"), anyString(), any()))
+                    .thenThrow(new ConflictException("dup", "user_exists", Map.of("username", "alice")));
+
+            mockMvc.perform(
+                            post("/api/v1/admin/users")
+                                    .contentType("application/json")
+                                    .content(
+                                            "{\"username\":\"alice\",\"password\":\"correct-horse-battery-staple\",\"role\":\"USER\"}"))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error.code", is("user_exists")));
+        }
+    }
+
+    @Nested
+    class UpdateRole {
+
+        @Test
+        void roleChangeReturns200() throws Exception {
+            when(service.updateRole("alice", Role.ADMIN)).thenReturn(new UserSummary("alice", Role.ADMIN, true));
+
+            mockMvc.perform(patch("/api/v1/admin/users/alice/role")
+                            .contentType("application/json")
+                            .content("{\"role\":\"ADMIN\"}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.role", is("ADMIN")));
+        }
+
+        @Test
+        void lastAdminDemotionReturns409Conflict() throws Exception {
+            when(service.updateRole("alice", Role.USER))
+                    .thenThrow(new ConflictException("last", "last_admin", Map.of("username", "alice")));
+
+            mockMvc.perform(patch("/api/v1/admin/users/alice/role")
+                            .contentType("application/json")
+                            .content("{\"role\":\"USER\"}"))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error.code", is("last_admin")));
+        }
+
+        @Test
+        void unknownUserReturns404() throws Exception {
+            when(service.updateRole(eq("ghost"), any())).thenThrow(new NotFoundException("ghost not found"));
+
+            mockMvc.perform(patch("/api/v1/admin/users/ghost/role")
+                            .contentType("application/json")
+                            .content("{\"role\":\"USER\"}"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error.code", is("not_found")));
+        }
+
+        @Test
+        void rejectsMissingRoleField() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/users/alice/role")
+                            .contentType("application/json")
+                            .content("{}"))
+                    .andExpect(status().isUnprocessableEntity());
+        }
+    }
+
+    @Nested
+    class UpdateEnabled {
+
+        @Test
+        void enableReturns200() throws Exception {
+            when(service.updateEnabled("alice", true)).thenReturn(new UserSummary("alice", Role.ADMIN, true));
+
+            mockMvc.perform(patch("/api/v1/admin/users/alice/enabled")
+                            .contentType("application/json")
+                            .content("{\"enabled\":true}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.enabled", is(true)));
+        }
+
+        @Test
+        void rejectsMissingEnabledField() throws Exception {
+            mockMvc.perform(patch("/api/v1/admin/users/alice/enabled")
+                            .contentType("application/json")
+                            .content("{}"))
+                    .andExpect(status().isUnprocessableEntity());
+        }
+    }
+
+    @Nested
+    class DeleteUser {
+
+        @Test
+        void deleteReturns204() throws Exception {
+            mockMvc.perform(delete("/api/v1/admin/users/alice")).andExpect(status().isNoContent());
+
+            verify(service).deleteUser("alice");
+        }
+
+        @Test
+        void lastAdminDeleteReturns409Conflict() throws Exception {
+            org.mockito.Mockito.doThrow(new ConflictException(
+                            "Cannot remove or demote the last enabled admin",
+                            "last_admin",
+                            Map.of("username", "alice")))
+                    .when(service)
+                    .deleteUser("alice");
+
+            mockMvc.perform(delete("/api/v1/admin/users/alice"))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.error.code", is("last_admin")))
+                    .andExpect(jsonPath("$.error.message", containsString("admin")));
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiSecurityConfigTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiSecurityConfigTest.java
@@ -6,13 +6,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.keplerops.groundcontrol.shared.security.ApiSecurityConfig;
+import com.keplerops.groundcontrol.shared.security.BrowserSecurityConfig;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -72,7 +79,7 @@ class ApiSecurityConfigTest {
 
     @Nested
     @WebMvcTest(controllers = StubController.class)
-    @Import({ApiSecurityConfig.class, StubController.class})
+    @Import({ApiSecurityConfig.class, BrowserSecurityConfig.class, StubController.class, StubJdbcBeans.class})
     @TestPropertySource(
             properties = {
                 "groundcontrol.security.enabled=true",
@@ -132,10 +139,15 @@ class ApiSecurityConfigTest {
         }
 
         @Test
-        void anonymousSpaShell_returns200() throws Exception {
+        void anonymousSpaShell_redirectsToLogin() throws Exception {
+            // ADR-037 §2: the SPA shell is no longer anonymously served. An unauthenticated
+            // browser navigating to "/" must be sent through /login first; after a successful
+            // form login Spring's request cache restores the original URL.
             mockMvc.perform(get("/"))
-                    .andExpect(status().isOk())
-                    .andExpect(content().string("spa-shell"));
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(result -> org.assertj.core.api.Assertions.assertThat(
+                                    result.getResponse().getRedirectedUrl())
+                            .endsWith("/login"));
         }
 
         @Test
@@ -154,7 +166,7 @@ class ApiSecurityConfigTest {
 
     @Nested
     @WebMvcTest(controllers = StubController.class)
-    @Import({ApiSecurityConfig.class, StubController.class})
+    @Import({ApiSecurityConfig.class, BrowserSecurityConfig.class, StubController.class, StubJdbcBeans.class})
     @TestPropertySource(properties = {"groundcontrol.security.enabled=false"})
     class WithSecurityDisabled {
 
@@ -178,7 +190,7 @@ class ApiSecurityConfigTest {
 
     @Nested
     @WebMvcTest(controllers = StubController.class)
-    @Import({ApiSecurityConfig.class, StubController.class})
+    @Import({ApiSecurityConfig.class, BrowserSecurityConfig.class, StubController.class, StubJdbcBeans.class})
     @TestPropertySource(
             properties = {
                 "groundcontrol.security.enabled=true",
@@ -195,6 +207,41 @@ class ApiSecurityConfigTest {
         @Test
         void apiV1_stillRequiresAuth() throws Exception {
             mockMvc.perform(get("/api/v1/echo")).andExpect(status().isUnauthorized());
+        }
+    }
+
+    /**
+     * Test-only stand-ins for the JDBC beans normally produced by {@link BrowserSecurityConfig}.
+     * The slice doesn't need real user storage — the bearer chain doesn't touch it — but the
+     * configuration class declares {@code DataSource}-backed bean methods, and Spring needs
+     * something to satisfy those types.
+     *
+     * <p>{@code @TestConfiguration} (not plain {@code @Configuration}) so this stub config is
+     * excluded from Spring Boot's default component scan — otherwise its mock {@code DataSource}
+     * leaks into every {@code @SpringBootTest} (notably {@code BrowserSessionIntegrationTest}),
+     * where Flyway then crashes trying to connect through it.
+     */
+    @TestConfiguration
+    static class StubJdbcBeans {
+
+        // Renamed to *Stub so {@code @ConditionalOnMissingBean} on
+        // {@link BrowserSecurityConfig#userDetailsManager}/{@code userAdminJdbcTemplate} sees a
+        // bean of the same type and skips its own definition. Without rename Spring Boot's
+        // default "no bean override" guard surfaces a {@code BeanDefinitionOverrideException}.
+
+        @Bean
+        DataSource dataSourceStub() {
+            return Mockito.mock(DataSource.class);
+        }
+
+        @Bean
+        JdbcUserDetailsManager userDetailsManagerStub() {
+            return Mockito.mock(JdbcUserDetailsManager.class);
+        }
+
+        @Bean
+        JdbcTemplate jdbcTemplateStub() {
+            return Mockito.mock(JdbcTemplate.class);
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/BearerRequestMatcherTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/BearerRequestMatcherTest.java
@@ -1,0 +1,86 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keplerops.groundcontrol.shared.security.BearerRequestMatcher;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * The ADR-037 bearer/browser chain split rides entirely on this predicate. If it ever drifts
+ * the wrong way the two filter chains either both fire on the same request (double-auth) or
+ * neither does (deny-all by silent fall-through). The exhaustive cases below pin the contract.
+ */
+class BearerRequestMatcherTest {
+
+    private final BearerRequestMatcher matcher = new BearerRequestMatcher();
+
+    @Nested
+    class Matches {
+
+        @Test
+        void bearerSchemeWithToken() {
+            assertThat(matcher.matches(authHeader("Bearer abc123"))).isTrue();
+        }
+
+        @Test
+        void bearerSchemeCaseInsensitive() {
+            assertThat(matcher.matches(authHeader("bearer abc"))).isTrue();
+            assertThat(matcher.matches(authHeader("BEARER abc"))).isTrue();
+            assertThat(matcher.matches(authHeader("BeArEr abc"))).isTrue();
+        }
+
+        @Test
+        void bearerSchemeWithEmptyTokenStillMatches() {
+            // Wire-level matching is by scheme; BearerTokenAuthFilter is the one that
+            // validates the token. The chain matcher's job is only to route the request.
+            assertThat(matcher.matches(authHeader("Bearer "))).isTrue();
+        }
+    }
+
+    @Nested
+    class DoesNotMatch {
+
+        @Test
+        void noAuthorizationHeader() {
+            assertThat(matcher.matches(new MockHttpServletRequest())).isFalse();
+        }
+
+        @Test
+        void blankAuthorizationHeader() {
+            assertThat(matcher.matches(authHeader(""))).isFalse();
+            assertThat(matcher.matches(authHeader("   "))).isFalse();
+        }
+
+        @Test
+        void basicScheme() {
+            assertThat(matcher.matches(authHeader("Basic dXNlcjpwYXNz"))).isFalse();
+        }
+
+        @Test
+        void digestScheme() {
+            assertThat(matcher.matches(authHeader("Digest username=\"x\""))).isFalse();
+        }
+
+        @Test
+        void bearerSubstringInOtherScheme() {
+            // A header that contains "Bearer" later in the value (not at the start) is NOT
+            // a bearer request; otherwise the matcher would mis-route hostile or weird traffic.
+            assertThat(matcher.matches(authHeader("X-Bearer abc"))).isFalse();
+        }
+
+        @Test
+        void sessionCookieOnly() {
+            var req = new MockHttpServletRequest();
+            req.setCookies(new jakarta.servlet.http.Cookie("GC_SESSION", "abc"));
+            assertThat(matcher.matches(req)).isFalse();
+        }
+    }
+
+    private static MockHttpServletRequest authHeader(String value) {
+        var req = new MockHttpServletRequest();
+        req.addHeader("Authorization", value);
+        return req;
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ChainOrderingTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ChainOrderingTest.java
@@ -1,0 +1,63 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keplerops.groundcontrol.shared.security.ApiSecurityConfig;
+import com.keplerops.groundcontrol.shared.security.BrowserSecurityConfig;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Pins the ADR-037 invariant that the bearer (API) chain is ordered ahead of the browser
+ * chain. The chain wiring itself is verified end-to-end by {@code BrowserSessionIntegrationTest};
+ * this test catches the common regression — an inadvertently removed {@code @Order} or a
+ * swapped pair — at the @Configuration class level without paying for a Spring context.
+ *
+ * <p>Reading the annotations directly off the bean methods keeps the assertion close to the
+ * source of truth: if anyone changes the priority, they have to touch a {@code @Order(N)}
+ * literal on the chain method itself, and the test fires.
+ */
+class ChainOrderingTest {
+
+    @Test
+    void apiChainBeanHasOrderOne() {
+        Order order = AnnotationUtils.findAnnotation(
+                beanMethod(ApiSecurityConfig.class, "apiSecurityFilterChain"), Order.class);
+        assertThat(order)
+                .as("ApiSecurityConfig#apiSecurityFilterChain must declare @Order")
+                .isNotNull();
+        assertThat(order.value()).isEqualTo(1);
+    }
+
+    @Test
+    void browserChainBeanHasOrderTwo() {
+        Order order = AnnotationUtils.findAnnotation(
+                beanMethod(BrowserSecurityConfig.class, "browserSecurityFilterChain"), Order.class);
+        assertThat(order)
+                .as("BrowserSecurityConfig#browserSecurityFilterChain must declare @Order")
+                .isNotNull();
+        assertThat(order.value()).isEqualTo(2);
+    }
+
+    @Test
+    void apiChainPriorityIsAheadOfBrowserChain() {
+        int apiOrder = AnnotationUtils.findAnnotation(
+                        beanMethod(ApiSecurityConfig.class, "apiSecurityFilterChain"), Order.class)
+                .value();
+        int browserOrder = AnnotationUtils.findAnnotation(
+                        beanMethod(BrowserSecurityConfig.class, "browserSecurityFilterChain"), Order.class)
+                .value();
+        assertThat(apiOrder).isLessThan(browserOrder);
+    }
+
+    private static Method beanMethod(Class<?> configClass, String name) {
+        for (Method method : configClass.getDeclaredMethods()) {
+            if (method.getName().equals(name)) {
+                return method;
+            }
+        }
+        throw new AssertionError("Bean method " + name + " not found on " + configClass.getName());
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/DelegatingAuthenticationEntryPointFactoryTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/DelegatingAuthenticationEntryPointFactoryTest.java
@@ -1,0 +1,70 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keplerops.groundcontrol.shared.security.ApiAuthenticationEntryPoint;
+import com.keplerops.groundcontrol.shared.security.DelegatingAuthenticationEntryPointFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * Asserts the browser chain's entry point delegates {@code /api/v1/**} to the JSON envelope and
+ * redirects everything else to {@code /login}. The two-way behavior is what keeps the SPA's XHR
+ * calls returning 401 JSON while normal browser navigation still hits the form.
+ */
+class DelegatingAuthenticationEntryPointFactoryTest {
+
+    @Test
+    void apiPathReturns401JsonEnvelope() throws Exception {
+        var entryPoint = DelegatingAuthenticationEntryPointFactory.build(
+                new ApiAuthenticationEntryPoint(new ObjectMapper()), "/login");
+
+        var request = new MockHttpServletRequest("GET", "/api/v1/requirements");
+        var response = new MockHttpServletResponse();
+
+        entryPoint.commence(request, response, new StubAuthException());
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentType()).startsWith("application/json");
+        assertThat(response.getContentAsString()).contains("authentication_required");
+        assertThat(response.getHeader("WWW-Authenticate")).isEqualTo("Bearer");
+        assertThat(response.getRedirectedUrl()).isNull();
+    }
+
+    @Test
+    void spaPathRedirectsToLogin() throws Exception {
+        var entryPoint = DelegatingAuthenticationEntryPointFactory.build(
+                new ApiAuthenticationEntryPoint(new ObjectMapper()), "/login");
+
+        var request = new MockHttpServletRequest("GET", "/requirements");
+        var response = new MockHttpServletResponse();
+
+        entryPoint.commence(request, response, new StubAuthException());
+
+        assertThat(response.getStatus()).isEqualTo(302);
+        assertThat(response.getRedirectedUrl()).endsWith("/login");
+    }
+
+    @Test
+    void rootPathRedirectsToLogin() throws Exception {
+        var entryPoint = DelegatingAuthenticationEntryPointFactory.build(
+                new ApiAuthenticationEntryPoint(new ObjectMapper()), "/login");
+
+        var request = new MockHttpServletRequest("GET", "/");
+        var response = new MockHttpServletResponse();
+
+        entryPoint.commence(request, response, new StubAuthException());
+
+        assertThat(response.getStatus()).isEqualTo(302);
+        assertThat(response.getRedirectedUrl()).endsWith("/login");
+    }
+
+    private static final class StubAuthException extends AuthenticationException {
+        StubAuthException() {
+            super("unauthenticated");
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/FirstAdminBootstrapRunnerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/FirstAdminBootstrapRunnerTest.java
@@ -1,0 +1,304 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.keplerops.groundcontrol.shared.security.FirstAdminBootstrapRunner;
+import com.keplerops.groundcontrol.shared.security.FirstAdminBootstrapRunner.BootstrapExit;
+import com.keplerops.groundcontrol.shared.security.FirstAdminBootstrapRunner.PasswordSource;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+
+/**
+ * Drives the first-admin bootstrap runner with synthetic {@link ApplicationArguments}.
+ *
+ * <p>The runner is the highest-risk surface in this PR: it accepts a password on a startup
+ * machine and writes a privileged credential to a permanent store. The tests assert the
+ * production-safety guards from ADR-037 §5: no {@code --password=} argv path, password comes
+ * only from env / file / stdin, the runner is idempotent on a repeat invocation, and it always
+ * exits with a meaningful code instead of silently dropping into the web server when an
+ * operator clearly intended to bootstrap.
+ */
+class FirstAdminBootstrapRunnerTest {
+
+    private JdbcUserDetailsManager users;
+    private PasswordEncoder encoder;
+    private RecordingExit exit;
+    private FixedPasswordSource passwordSource;
+
+    @BeforeEach
+    void setUp() {
+        users = mock(JdbcUserDetailsManager.class);
+        encoder = new BCryptPasswordEncoder();
+        exit = new RecordingExit();
+        passwordSource = new FixedPasswordSource(null);
+    }
+
+    @Nested
+    class Skipped {
+
+        @Test
+        void absentCreateAdminFlagSkipsBootstrap() {
+            runner().run(args());
+
+            verify(users, never()).userExists(anyString());
+            verify(users, never()).createUser(any());
+            assertThat(exit.calls).isEmpty();
+        }
+    }
+
+    @Nested
+    class ArgvPasswordGuard {
+
+        @Test
+        void passwordArgvForbidden_evenWhenValueLooksReasonable() {
+            // ADR-037 §5: --password= would leak the secret to shell history, process listings,
+            // /proc, and CI logs. The runner refuses outright instead of "fixing it up" — being
+            // permissive here would silently undermine the policy.
+            runner().run(args("--create-admin", "--username=alice", "--password=correct-horse-battery"));
+
+            verify(users, never()).createUser(any());
+            assertThat(exit.calls).containsExactly(2);
+        }
+    }
+
+    @Nested
+    class Validation {
+
+        @Test
+        void missingUsernameFailsFast() {
+            runner().run(args("--create-admin"));
+
+            verify(users, never()).createUser(any());
+            assertThat(exit.calls).containsExactly(2);
+        }
+
+        @Test
+        void invalidUsernameFailsFast() {
+            runner().run(args("--create-admin", "--username=Bad Name"));
+
+            verify(users, never()).createUser(any());
+            assertThat(exit.calls).containsExactly(2);
+        }
+
+        @Test
+        void missingPasswordFailsFast() {
+            when(users.userExists("alice")).thenReturn(false);
+
+            runner().run(args("--create-admin", "--username=alice"));
+
+            verify(users, never()).createUser(any());
+            assertThat(exit.calls).containsExactly(2);
+        }
+
+        @Test
+        void shortPasswordFailsFast() {
+            when(users.userExists("alice")).thenReturn(false);
+            passwordSource = new FixedPasswordSource("short".toCharArray());
+
+            runner().run(args("--create-admin", "--username=alice"));
+
+            verify(users, never()).createUser(any());
+            assertThat(exit.calls).containsExactly(2);
+        }
+    }
+
+    @Nested
+    class PasswordFile {
+
+        @Test
+        void worldReadablePasswordFileIsRefused(@TempDir Path tempDir) throws IOException {
+            Path file = tempDir.resolve("admin-password");
+            Files.writeString(file, "correct-horse-battery-staple\n");
+            try {
+                Files.setPosixFilePermissions(
+                        file,
+                        EnumSet.of(
+                                PosixFilePermission.OWNER_READ,
+                                PosixFilePermission.OWNER_WRITE,
+                                PosixFilePermission.OTHERS_READ));
+            } catch (UnsupportedOperationException ignored) {
+                // Non-POSIX filesystem in the test sandbox — the fail-closed gate cannot be
+                // exercised here. Documented in DEPLOYMENT.md.
+                return;
+            }
+            when(users.userExists("alice")).thenReturn(false);
+
+            // DefaultPasswordSource reads --password-file authoritatively (the cycle-2 fix:
+            // when --password-file is supplied, the env / console fallbacks never fire). Use
+            // the production source directly to exercise the POSIX check. The assertion is
+            // unconditional — if `GC_ADMIN_BOOTSTRAP_PASSWORD` happens to be set in the test
+            // env it is irrelevant because the file-flag short-circuit consumes the file path
+            // alone.
+            FirstAdminBootstrapRunner.DefaultPasswordSource source =
+                    new FirstAdminBootstrapRunner.DefaultPasswordSource();
+            Optional<char[]> result = source.read(
+                    new DefaultApplicationArguments(
+                            "--create-admin", "--username=alice", "--password-file=" + file.toAbsolutePath()),
+                    List.of("alice"));
+            org.assertj.core.api.Assertions.assertThat(result)
+                    .as("World-readable password file must not produce a password")
+                    .isEmpty();
+        }
+
+        @Test
+        void ownerOnlyReadableFileIsAccepted(@TempDir Path tempDir) throws IOException {
+            Path file = tempDir.resolve("admin-password");
+            Files.writeString(file, "correct-horse-battery-staple\n");
+            try {
+                Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-------"));
+            } catch (UnsupportedOperationException ignored) {
+                return;
+            }
+
+            FirstAdminBootstrapRunner.DefaultPasswordSource source =
+                    new FirstAdminBootstrapRunner.DefaultPasswordSource();
+            Optional<char[]> result = source.read(
+                    new DefaultApplicationArguments(
+                            "--create-admin", "--username=alice", "--password-file=" + file.toAbsolutePath()),
+                    List.of("alice"));
+            // --password-file is authoritative, so the returned chars MUST be the file's
+            // content. Strip the trailing newline the test wrote alongside the password.
+            org.assertj.core.api.Assertions.assertThat(result)
+                    .as("Mode-600 password file must be accepted and its content returned")
+                    .isPresent();
+            org.assertj.core.api.Assertions.assertThat(new String(result.get()))
+                    .as("Returned chars must match the file's content")
+                    .isEqualTo("correct-horse-battery-staple");
+        }
+    }
+
+    @Nested
+    class Bootstrap {
+
+        @Test
+        void createsAdminWithBcryptHashAndAdminAuthority() {
+            when(users.userExists("alice")).thenReturn(false);
+            passwordSource = new FixedPasswordSource("correct-horse-battery-staple".toCharArray());
+
+            runner().run(args("--create-admin", "--username=alice"));
+
+            verify(users)
+                    .createUser(org.mockito.ArgumentMatchers.argThat((UserDetails u) -> "alice".equals(u.getUsername())
+                            && encoder.matches("correct-horse-battery-staple", u.getPassword())
+                            && u.getAuthorities().stream().anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority()))
+                            && u.isEnabled()));
+            assertThat(exit.calls).containsExactly(0);
+        }
+
+        @Test
+        void idempotentWhenUserAlreadyExistsAsEnabledAdmin() {
+            when(users.userExists("alice")).thenReturn(true);
+            org.springframework.security.core.userdetails.UserDetails existing =
+                    org.springframework.security.core.userdetails.User.withUsername("alice")
+                            .password("hashed")
+                            .authorities("ROLE_ADMIN")
+                            .build();
+            when(users.loadUserByUsername("alice")).thenReturn(existing);
+
+            runner().run(args("--create-admin", "--username=alice"));
+
+            verify(users, never()).createUser(any());
+            assertThat(exit.calls).containsExactly(0);
+        }
+
+        @Test
+        void failsWhenExistingUserIsNotAnAdmin() {
+            when(users.userExists("alice")).thenReturn(true);
+            org.springframework.security.core.userdetails.UserDetails existing =
+                    org.springframework.security.core.userdetails.User.withUsername("alice")
+                            .password("hashed")
+                            .authorities("ROLE_USER")
+                            .build();
+            when(users.loadUserByUsername("alice")).thenReturn(existing);
+
+            runner().run(args("--create-admin", "--username=alice"));
+
+            verify(users, never()).createUser(any());
+            assertThat(exit.calls).containsExactly(2);
+        }
+
+        @Test
+        void failsWhenExistingUserIsDisabled() {
+            when(users.userExists("alice")).thenReturn(true);
+            org.springframework.security.core.userdetails.UserDetails existing =
+                    org.springframework.security.core.userdetails.User.withUsername("alice")
+                            .password("hashed")
+                            .authorities("ROLE_ADMIN")
+                            .disabled(true)
+                            .build();
+            when(users.loadUserByUsername("alice")).thenReturn(existing);
+
+            runner().run(args("--create-admin", "--username=alice"));
+
+            verify(users, never()).createUser(any());
+            assertThat(exit.calls).containsExactly(2);
+        }
+
+        @Test
+        void wipesPasswordBufferAfterUse() {
+            when(users.userExists("alice")).thenReturn(false);
+            char[] buffer = "correct-horse-battery-staple".toCharArray();
+            passwordSource = new FixedPasswordSource(buffer);
+
+            runner().run(args("--create-admin", "--username=alice"));
+
+            // Every position must be NUL after the runner returns; otherwise the secret lingers
+            // in heap memory for the rest of the JVM's life.
+            for (char c : buffer) {
+                assertThat(c).isEqualTo('\0');
+            }
+        }
+    }
+
+    private FirstAdminBootstrapRunner runner() {
+        return new FirstAdminBootstrapRunner(users, encoder, passwordSource, exit);
+    }
+
+    private static ApplicationArguments args(String... values) {
+        return new DefaultApplicationArguments(values);
+    }
+
+    private static final class RecordingExit implements BootstrapExit {
+        final java.util.List<Integer> calls = new java.util.ArrayList<>();
+
+        @Override
+        public void exit(int code) {
+            calls.add(code);
+        }
+    }
+
+    private static final class FixedPasswordSource implements PasswordSource {
+        private final char[] password;
+
+        FixedPasswordSource(char[] password) {
+            this.password = password;
+        }
+
+        @Override
+        public Optional<char[]> read(ApplicationArguments args, List<String> usernames) {
+            return Optional.ofNullable(password);
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/PathAwareAccessDeniedHandlerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/PathAwareAccessDeniedHandlerTest.java
@@ -1,0 +1,86 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keplerops.groundcontrol.shared.security.ApiAccessDeniedHandler;
+import com.keplerops.groundcontrol.shared.security.PathAwareAccessDeniedHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+/**
+ * The browser chain reuses {@link ApiAccessDeniedHandler}'s JSON envelope for {@code /api/v1/**}
+ * requests (so SPA XHR 403s never end up as HTML pages) but lets non-API browser navigation
+ * fall through to Spring's default. The handler under test is the path dispatcher.
+ */
+class PathAwareAccessDeniedHandlerTest {
+
+    @Test
+    void apiPathDelegatesToJsonHandler() throws Exception {
+        var apiHandler = mock(ApiAccessDeniedHandler.class);
+        var fallback = mock(AccessDeniedHandler.class);
+        var handler = new PathAwareAccessDeniedHandler(apiHandler, fallback);
+
+        var request = new MockHttpServletRequest("GET", "/api/v1/requirements");
+        var response = new MockHttpServletResponse();
+        var ex = new AccessDeniedException("denied");
+
+        handler.handle(request, response, ex);
+
+        verify(apiHandler).handle(request, response, ex);
+        verify(fallback, never()).handle(any(), any(), any());
+    }
+
+    @Test
+    void nonApiPathDelegatesToFallback() throws Exception {
+        var apiHandler = mock(ApiAccessDeniedHandler.class);
+        var fallback = mock(AccessDeniedHandler.class);
+        var handler = new PathAwareAccessDeniedHandler(apiHandler, fallback);
+
+        var request = new MockHttpServletRequest("GET", "/some/spa/page");
+        var response = new MockHttpServletResponse();
+        var ex = new AccessDeniedException("denied");
+
+        handler.handle(request, response, ex);
+
+        verify(fallback).handle(request, response, ex);
+        verify(apiHandler, never()).handle(any(), any(), any());
+    }
+
+    @Test
+    void apiPrefixMatchesEvenWithQueryString() throws Exception {
+        var apiHandler = mock(ApiAccessDeniedHandler.class);
+        var fallback = mock(AccessDeniedHandler.class);
+        var handler = new PathAwareAccessDeniedHandler(apiHandler, fallback);
+
+        var request = new MockHttpServletRequest("GET", "/api/v1/admin/users");
+        request.setQueryString("page=1");
+        var response = new MockHttpServletResponse();
+
+        handler.handle(request, response, new AccessDeniedException("denied"));
+
+        verify(apiHandler).handle(any(), any(), any());
+    }
+
+    @Test
+    void apiAccessDeniedHandlerEmits403JsonEnvelope() throws Exception {
+        // Sanity check that the wrapped handler is still the canonical one — guards against
+        // accidental swap to a raw 403 page during a future refactor.
+        var apiHandler = new ApiAccessDeniedHandler(new ObjectMapper());
+        var request = new MockHttpServletRequest("GET", "/api/v1/x");
+        var response = new MockHttpServletResponse();
+
+        apiHandler.handle(request, response, new AccessDeniedException("denied"));
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentType()).startsWith("application/json");
+        assertThat(response.getContentAsString()).contains("access_denied");
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/UserAdminServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/UserAdminServiceTest.java
@@ -1,0 +1,332 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.shared.security.SecurityProperties.Role;
+import com.keplerops.groundcontrol.shared.security.UserSummary;
+import com.keplerops.groundcontrol.shared.security.service.UserAdminService;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.session.SessionInformation;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+
+/**
+ * Unit coverage of the user-admin service. The mocked {@link JdbcUserDetailsManager} +
+ * {@link JdbcTemplate} keep the boundary between Spring Security's contract and the local
+ * last-admin guard / role mutation policy visible.
+ *
+ * <p>Tests in the {@code @Nested LastAdminGuard} class are the ones that *must* hold — the
+ * guard is the only thing standing between an admin and an installation that can never recover
+ * if they accidentally demote themselves.
+ */
+class UserAdminServiceTest {
+
+    private JdbcUserDetailsManager users;
+    private JdbcTemplate jdbc;
+    private PasswordEncoder encoder;
+    private SessionRegistry sessionRegistry;
+    private UserAdminService service;
+
+    @BeforeEach
+    void setUp() {
+        users = mock(JdbcUserDetailsManager.class);
+        jdbc = mock(JdbcTemplate.class);
+        encoder = new BCryptPasswordEncoder();
+        sessionRegistry = mock(SessionRegistry.class);
+        when(sessionRegistry.getAllPrincipals()).thenReturn(Collections.emptyList());
+        service = new UserAdminService(users, jdbc, encoder, sessionRegistry);
+    }
+
+    @Nested
+    class CreateUser {
+
+        @Test
+        void hashesPasswordWithBcryptAndCreatesViaJdbcManager() {
+            when(users.userExists("alice")).thenReturn(false);
+
+            UserSummary response = service.createUser("alice", "correct-horse-battery-staple", Role.USER);
+
+            assertThat(response.username()).isEqualTo("alice");
+            assertThat(response.role()).isEqualTo(Role.USER);
+            assertThat(response.enabled()).isTrue();
+            verify(users)
+                    .createUser(org.mockito.ArgumentMatchers.argThat(u -> "alice".equals(u.getUsername())
+                            && encoder.matches("correct-horse-battery-staple", u.getPassword())
+                            && u.getAuthorities().stream().anyMatch(a -> "ROLE_USER".equals(a.getAuthority()))
+                            && u.isEnabled()));
+        }
+
+        @Test
+        void rejectsDuplicateUsernameWith409Conflict() {
+            when(users.userExists("alice")).thenReturn(true);
+
+            assertThatThrownBy(() -> service.createUser("alice", "long-enough-password", Role.USER))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("alice");
+            verify(users, never()).createUser(any());
+        }
+
+        @Test
+        void rejectsUsernameThatDoesNotMatchPattern() {
+            assertThatThrownBy(() -> service.createUser("Bad Name!", "long-enough-password", Role.USER))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("username");
+            verify(users, never()).createUser(any());
+        }
+
+        @Test
+        void rejectsShortPassword() {
+            assertThatThrownBy(() -> service.createUser("alice", "tooshort", Role.USER))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("password");
+            verify(users, never()).createUser(any());
+        }
+    }
+
+    @Nested
+    class UpdateRole {
+
+        @Test
+        void demoteToUserSucceedsWhenOtherAdminsExist() {
+            when(users.userExists("alice")).thenReturn(true);
+            stubOtherEnabledAdmins("alice", 1);
+            stubRowQuery("alice", "ROLE_ADMIN", true);
+
+            UserSummary response = service.updateRole("alice", Role.USER);
+
+            verify(jdbc).update("DELETE FROM authorities WHERE username = ?", "alice");
+            verify(jdbc).update("INSERT INTO authorities (username, authority) VALUES (?, ?)", "alice", "ROLE_USER");
+            assertThat(response.role()).isEqualTo(Role.USER);
+        }
+
+        @Test
+        void promoteToAdminSucceedsAlways() {
+            when(users.userExists("bob")).thenReturn(true);
+            stubRowQuery("bob", "ROLE_USER", true);
+
+            UserSummary response = service.updateRole("bob", Role.ADMIN);
+
+            verify(jdbc).update("INSERT INTO authorities (username, authority) VALUES (?, ?)", "bob", "ROLE_ADMIN");
+            assertThat(response.role()).isEqualTo(Role.ADMIN);
+        }
+
+        @Test
+        void notFoundForUnknownUser() {
+            when(users.userExists("ghost")).thenReturn(false);
+
+            assertThatThrownBy(() -> service.updateRole("ghost", Role.USER)).isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    @Nested
+    class LastAdminGuard {
+
+        @Test
+        void demotionRefusedWhenNoOtherEnabledAdmin() {
+            when(users.userExists("alice")).thenReturn(true);
+            stubOtherEnabledAdmins("alice", 0);
+
+            assertThatThrownBy(() -> service.updateRole("alice", Role.USER))
+                    .isInstanceOf(ConflictException.class)
+                    .satisfies(ex ->
+                            assertThat(((ConflictException) ex).getErrorCode()).isEqualTo("last_admin"));
+            verify(jdbc, never()).update(anyString(), any(Object[].class));
+        }
+
+        @Test
+        void disablingRefusedWhenNoOtherEnabledAdmin() {
+            when(users.userExists("alice")).thenReturn(true);
+            stubRowQuery("alice", "ROLE_ADMIN", true);
+            stubOtherEnabledAdmins("alice", 0);
+
+            assertThatThrownBy(() -> service.updateEnabled("alice", false))
+                    .isInstanceOf(ConflictException.class)
+                    .satisfies(ex ->
+                            assertThat(((ConflictException) ex).getErrorCode()).isEqualTo("last_admin"));
+            verify(jdbc, never()).update(anyString(), any(Object[].class));
+        }
+
+        @Test
+        void deletionRefusedWhenLastAdmin() {
+            when(users.userExists("alice")).thenReturn(true);
+            stubRowQuery("alice", "ROLE_ADMIN", true);
+            stubOtherEnabledAdmins("alice", 0);
+
+            assertThatThrownBy(() -> service.deleteUser("alice"))
+                    .isInstanceOf(ConflictException.class)
+                    .satisfies(ex ->
+                            assertThat(((ConflictException) ex).getErrorCode()).isEqualTo("last_admin"));
+            verify(users, never()).deleteUser(anyString());
+        }
+
+        @Test
+        void disablingNonAdminBypassesLastAdminGuard() {
+            when(users.userExists("bob")).thenReturn(true);
+            stubRowQuery("bob", "ROLE_USER", true);
+
+            service.updateEnabled("bob", false);
+
+            verify(jdbc).update("UPDATE users SET enabled = ? WHERE username = ?", false, "bob");
+        }
+    }
+
+    @Nested
+    class UpdateEnabled {
+
+        @Test
+        void enableUserSucceeds() {
+            when(users.userExists("bob")).thenReturn(true);
+            stubRowQuery("bob", "ROLE_USER", false);
+
+            UserSummary response = service.updateEnabled("bob", true);
+
+            verify(jdbc).update("UPDATE users SET enabled = ? WHERE username = ?", true, "bob");
+            assertThat(response.enabled()).isTrue();
+        }
+
+        @Test
+        void notFoundForUnknownUser() {
+            when(users.userExists("ghost")).thenReturn(false);
+
+            assertThatThrownBy(() -> service.updateEnabled("ghost", true)).isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    @Nested
+    class SessionRevocation {
+
+        @Test
+        void demoteToUserExpiresLiveSessionsForThatPrincipal() {
+            UserDetails principal = User.withUsername("alice")
+                    .password("x")
+                    .authorities("ROLE_ADMIN")
+                    .build();
+            SessionInformation aliceSession = mock(SessionInformation.class);
+            when(sessionRegistry.getAllPrincipals()).thenReturn(java.util.List.of(principal, "ignored-other"));
+            when(sessionRegistry.getAllSessions(principal, false)).thenReturn(java.util.List.of(aliceSession));
+            when(users.userExists("alice")).thenReturn(true);
+            stubOtherEnabledAdmins("alice", 1);
+            stubRowQuery("alice", "ROLE_ADMIN", true);
+
+            service.updateRole("alice", Role.USER);
+
+            verify(aliceSession).expireNow();
+        }
+
+        @Test
+        void disableExpiresLiveSessions() {
+            UserDetails principal = User.withUsername("bob")
+                    .password("x")
+                    .authorities("ROLE_USER")
+                    .build();
+            SessionInformation bobSession = mock(SessionInformation.class);
+            when(sessionRegistry.getAllPrincipals()).thenReturn(java.util.List.of(principal));
+            when(sessionRegistry.getAllSessions(principal, false)).thenReturn(java.util.List.of(bobSession));
+            when(users.userExists("bob")).thenReturn(true);
+            stubRowQuery("bob", "ROLE_USER", true);
+
+            service.updateEnabled("bob", false);
+
+            verify(bobSession).expireNow();
+        }
+
+        @Test
+        void deleteExpiresLiveSessions() {
+            UserDetails principal = User.withUsername("bob")
+                    .password("x")
+                    .authorities("ROLE_USER")
+                    .build();
+            SessionInformation bobSession = mock(SessionInformation.class);
+            when(sessionRegistry.getAllPrincipals()).thenReturn(java.util.List.of(principal));
+            when(sessionRegistry.getAllSessions(principal, false)).thenReturn(java.util.List.of(bobSession));
+            when(users.userExists("bob")).thenReturn(true);
+            stubRowQuery("bob", "ROLE_USER", true);
+
+            service.deleteUser("bob");
+
+            verify(bobSession).expireNow();
+        }
+
+        @Test
+        void enablingDoesNotExpireSessions() {
+            UserDetails principal = User.withUsername("bob")
+                    .password("x")
+                    .authorities("ROLE_USER")
+                    .build();
+            SessionInformation bobSession = mock(SessionInformation.class);
+            when(sessionRegistry.getAllPrincipals()).thenReturn(java.util.List.of(principal));
+            when(sessionRegistry.getAllSessions(principal, false)).thenReturn(java.util.List.of(bobSession));
+            when(users.userExists("bob")).thenReturn(true);
+            stubRowQuery("bob", "ROLE_USER", false);
+
+            service.updateEnabled("bob", true);
+
+            // Re-enabling a user must NOT invalidate their (already-absent) sessions — there is
+            // nothing to revoke and calling expireNow() on an inactive registry would mask
+            // real bugs in the revocation path.
+            verify(bobSession, never()).expireNow();
+        }
+    }
+
+    @Nested
+    class DeleteUser {
+
+        @Test
+        void deleteNonAdminSucceeds() {
+            when(users.userExists("bob")).thenReturn(true);
+            stubRowQuery("bob", "ROLE_USER", true);
+
+            service.deleteUser("bob");
+
+            verify(users).deleteUser("bob");
+        }
+
+        @Test
+        void notFoundForUnknownUser() {
+            when(users.userExists("ghost")).thenReturn(false);
+
+            assertThatThrownBy(() -> service.deleteUser("ghost")).isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    private void stubOtherEnabledAdmins(String username, int count) {
+        when(jdbc.queryForObject(
+                        "SELECT COUNT(*) FROM users u JOIN authorities a ON a.username = u.username"
+                                + " WHERE a.authority = 'ROLE_ADMIN' AND u.enabled = TRUE AND u.username <> ?",
+                        Integer.class,
+                        username))
+                .thenReturn(count);
+    }
+
+    private void stubRowQuery(String username, String authority, boolean enabled) {
+        UserDetails details = mock(UserDetails.class);
+        when(details.getUsername()).thenReturn(username);
+        when(details.isEnabled()).thenReturn(enabled);
+        when(details.getAuthorities())
+                .thenAnswer(inv -> java.util.List.of(
+                        new org.springframework.security.core.authority.SimpleGrantedAuthority(authority)));
+        when(users.loadUserByUsername(username)).thenReturn(details);
+    }
+
+    @SuppressWarnings("unused") // hold for future tests referencing UsernameNotFoundException
+    private static final Class<?> ENSURE_NOT_FOUND_TYPE_AVAILABLE = UsernameNotFoundException.class;
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/UserCredentialPolicyContractTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/UserCredentialPolicyContractTest.java
@@ -1,0 +1,51 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keplerops.groundcontrol.shared.security.UserCredentialPolicy;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Static post-condition: the {@link UserCredentialPolicy#USERNAME_REGEX Java username regex}
+ * must equal the SQL CHECK regex in V059. The constants in
+ * {@link UserCredentialPolicy} flow through {@code CreateUserRequest}, {@code UserAdminController},
+ * {@code UserAdminService}, and {@code FirstAdminBootstrapRunner}, so this single
+ * Java-vs-SQL equivalence assertion covers every Java callsite. The structural test is the
+ * mechanism the {@code .gc/plan-rules.md} pattern-drift policy normally expects from
+ * cross-layer enums; here we apply the same shape to credential validation.
+ */
+class UserCredentialPolicyContractTest {
+
+    /**
+     * Extracts the regex literal out of {@code V059__create_users.sql}'s
+     * {@code username ~ '<regex>'} clause. The grep stays narrow so unrelated changes to the
+     * migration don't accidentally match.
+     */
+    private static final Pattern SQL_CHECK_REGEX_EXTRACTOR = Pattern.compile("username\\s+~\\s+'(?<regex>[^']+)'");
+
+    private static final Path V059_PATH =
+            Path.of("src", "main", "resources", "db", "migration", "V059__create_users.sql");
+
+    @Test
+    void javaAndSqlUsernameRegexAreIdentical() throws IOException {
+        String migration = Files.readString(V059_PATH, StandardCharsets.UTF_8);
+        Matcher m = SQL_CHECK_REGEX_EXTRACTOR.matcher(migration);
+        assertThat(m.find())
+                .as("V059 migration must contain the username regex CHECK")
+                .isTrue();
+        String sqlRegex = m.group("regex");
+
+        // Postgres regex syntax is a superset of Java but the subset we use here (anchored
+        // ^…$, character classes, quantifier) is portable. Asserting literal equality is the
+        // simplest contract; if a future change makes the two intentionally diverge (e.g.,
+        // adding a case-insensitive flag), this test forces the operator to update both sides
+        // and document the divergence.
+        assertThat(sqlRegex).isEqualTo(UserCredentialPolicy.USERNAME_REGEX);
+    }
+}

--- a/changelog.d/857.added.md
+++ b/changelog.d/857.added.md
@@ -1,0 +1,52 @@
+### Added
+
+- **Web UI login for single-tenant installs** (ADR-037): the Spring backend now ships a second
+  `SecurityFilterChain` scoped to non-bearer traffic. Browser users hit `GET /login`, submit
+  their credentials to Spring's form-login endpoint, and receive a session cookie
+  (`GC_SESSION`, HttpOnly, SameSite=Strict, Secure-by-default) that authorizes subsequent
+  `/api/v1/**` XHRs through the same `ROLE_USER` / `ROLE_ADMIN` path matrix as the bearer
+  chain. CSRF protection is enforced for state-changing browser requests via
+  `CookieCsrfTokenRepository` (double-submit cookie), and the SPA's `apiFetch` /
+  `apiUpload` / `apiDelete` wrappers echo the `XSRF-TOKEN` cookie via `X-XSRF-TOKEN` on
+  mutations.
+- **JDBC user store**: Flyway migration `V059` creates Spring Security's standard
+  `users` / `authorities` tables (`ROLE_USER` / `ROLE_ADMIN`, BCrypt strength 12).
+  Username regex and password length range are centralized at
+  `UserCredentialPolicy` so the DTO, controller, service, bootstrap runner, and
+  the V059 SQL CHECK never drift; `UserCredentialPolicyContractTest` pins
+  Java↔SQL equivalence. The `loadUserByUsername`-based 404 path on
+  `/api/v1/admin/users/{username}` is suppressed for Sonar `java:S5804` because
+  every caller is `ROLE_ADMIN`-gated and the surface explicitly enumerates
+  users via `GET /api/v1/admin/users`.
+- **Admin user management API** at `/api/v1/admin/users` (gated by `ROLE_ADMIN`):
+  list / create / change role / enable-disable / delete. The service enforces a last-admin
+  guard so the deployment can never lose its only enabled admin.
+- **First-admin bootstrap**: `--create-admin --username=NAME` on `bootRun` reads the password
+  from `GC_ADMIN_BOOTSTRAP_PASSWORD` env var, a `--password-file=PATH` (mode-600 preferred),
+  or a TTY prompt. A `--password=...` argv shortcut is refused (ADR-037 §5 — secret leakage
+  through shell history / process listings / CI logs). The runner is idempotent and exits the
+  JVM after the bootstrap completes.
+- **Test quality**: `FirstAdminBootstrapRunnerTest::worldReadablePasswordFileIsRefused`
+  asserts the file-rejection contract unconditionally (the prior `if (env-var unset)`
+  guard was dead code after `--password-file` became authoritative). Companion test
+  asserts the file's exact content is returned when permissions are mode 600.
+- **SPA Sign out**: the header's new "Sign out" button POSTs `/logout` with the CSRF header
+  and redirects to `/login`. (User-management UI is not part of this iteration — the REST
+  endpoints under `/api/v1/admin/users` are the single supported surface; see
+  `DEPLOYMENT.md` for the curl flow.)
+- **Session revocation**: role-change, disable, and delete operations call
+  `SessionInformation.expireNow()` on the affected principal's live sessions, and the
+  browser chain installs `ConcurrentSessionFilter` so the next request on a revoked session
+  is forced through re-authentication (no waiting for natural timeout).
+
+### Compatibility
+
+- **Bearer (`Authorization: Bearer …`) callers are unaffected**: the existing API chain
+  remains the first filter chain and still applies the ADR-026 path matrix, stateless session,
+  CSRF-disabled, JSON `ErrorResponse` 401/403 envelopes. Agents and automation do not need to
+  change anything.
+- **`/login` and `/logout` are anonymous** by design so the SPA can drive them; the SPA's API
+  client now also redirects to `/login` on a 401 response so an expired session lands the user
+  back at the form.
+- **OpenAPI / Swagger paths return JSON 401** (not a 302 redirect) for unauthenticated SPA
+  XHRs, matching the bearer chain's behavior for the same paths.

--- a/docs/API.md
+++ b/docs/API.md
@@ -920,6 +920,23 @@ curl -X POST "http://localhost:8000/api/v1/pack-registry/import?project=ground-c
 | GET | `/pack-install-records` | — | 200 | List install records (optional `packId` filter) |
 | GET | `/pack-install-records/{id}` | — | 200 | Get install record |
 
+### Admin Users (ADR-037)
+
+Browser-session lifecycle for the JDBC user store. Gated by `ROLE_ADMIN` on the
+same path matrix as the rest of `/api/v1/admin/**`. Bearer agents that hold an
+`ADMIN`-role token may call these endpoints too; the typical caller is the SPA
+admin page operating under the signed-in operator's session.
+
+| Method | Path | Body | Status | Purpose |
+|--------|------|------|--------|---------|
+| GET | `/admin/users` | — | 200 | List users (`username`, `role`, `enabled`) |
+| POST | `/admin/users` | `CreateUserRequest` | 201, 409, 422 | Create user. `409 user_exists` on duplicate username; `422 validation_error` for bad username / short password. |
+| PATCH | `/admin/users/{username}/role` | `{"role":"USER"\|"ADMIN"}` | 200, 404, 409, 422 | Change role. `409 last_admin` refuses demoting the last enabled admin. |
+| PATCH | `/admin/users/{username}/enabled` | `{"enabled":bool}` | 200, 404, 409, 422 | Enable / disable. `409 last_admin` refuses disabling the last enabled admin. |
+| DELETE | `/admin/users/{username}` | — | 204, 404, 409 | Delete user. `409 last_admin` refuses deleting the last enabled admin. |
+
+`CreateUserRequest`: `{"username":"<lowercase, 2-64 chars, matches /^[a-z][a-z0-9._-]{1,63}$/>", "password":"<12-200 chars>", "role":"USER"\|"ADMIN"}`. Passwords are BCrypt-hashed server-side; the JSON never echoes the password back. First-admin bootstrap is out of band — see `DEPLOYMENT.md`'s Web UI login section.
+
 For control packs, use `/pack-registry/import` or `/pack-registry` to persist the
 pack definition first, then call one of these routes with the `packId` and optional
 version constraint.

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -96,6 +96,127 @@ Migrating from pre-#243 deployments:
 - The `X-Actor` header is no longer a self-service identity claim when
   security is enabled; the authenticated principal name is used for audit.
 
+### Web UI login (ADR-037)
+
+A second filter chain ships alongside the bearer chain for browser users
+(see ADR-037). Both modes populate the same `SecurityContext` principal +
+`ROLE_USER` / `ROLE_ADMIN` authorities, so the path matrix above applies
+to either authentication mode.
+
+Session cookie hardening is **hardcoded** in `application.yml`; there are no
+deploy-time env knobs for these values. Changing them requires an ADR + security
+review, not an `.env` flag.
+
+| Property | Value |
+|---|---|
+| `server.servlet.session.cookie.name` | `GC_SESSION` |
+| `server.servlet.session.cookie.http-only` | `true` |
+| `server.servlet.session.cookie.secure` | `true` (`false` in dev/test profiles only) |
+| `server.servlet.session.cookie.same-site` | `strict` |
+| `server.servlet.session.timeout` | `60m` |
+
+CSRF protection is on for the browser chain (Spring's
+`CookieCsrfTokenRepository` with `HttpOnly=false`, so the SPA's
+`fetch` wrapper can read the `XSRF-TOKEN` cookie and echo it via the
+`X-XSRF-TOKEN` header). The bearer chain remains CSRF-disabled —
+agents do not need to send a CSRF token.
+
+#### First-admin bootstrap
+
+A fresh install has zero users in the JDBC store, so the first admin
+must be created out-of-band. Run the bootstrap on the deployment host:
+
+**Preferred — mode-600 password file** (works headless, no secret in any
+command line):
+
+```bash
+install -m 600 /dev/null /run/gc/admin-password
+read -rs -p 'Admin password: ' adminpw && printf '%s' "$adminpw" > /run/gc/admin-password && unset adminpw
+./gradlew bootRun --args="--create-admin --username=admin --password-file=/run/gc/admin-password"
+shred -u /run/gc/admin-password  # or rm; the runner has finished reading
+```
+
+The runner refuses any file that is group/others-readable OR
+group/others-writable on a POSIX filesystem, so the `chmod 600` (via
+`install -m 600`) is mandatory, not advisory.
+
+**TTY prompt** (interactive operator at a console — the password is
+read with echo off and never lands on a command line):
+
+```bash
+./gradlew bootRun --args="--create-admin --username=admin"
+# Prompts: "Admin password: "
+```
+
+**Env-var path** is only safe when the value is supplied out-of-band by
+a secret manager (systemd `LoadCredential=`, AWS / GCP Secret Manager,
+HashiCorp Vault agent, Kubernetes mounted secret env). **Do not** put
+the value inline on the command line — that leaks through shell
+history, terminal recorders, and CI logs the same way `--password=...`
+would. For ad-hoc operator runs prefer the file or TTY paths above.
+
+The runner is idempotent — running it a second time with the same
+username logs a "user already present" message and exits 0.
+
+> **Do not** pass the password via `--password=...` argv. The bootstrap
+> runner refuses that path and exits non-zero. Argv-supplied secrets
+> leak through shell history, `/proc/<pid>/cmdline`, process listings,
+> CI logs, and agent transcripts. ADR-037 §5 documents the rationale.
+
+Subsequent admins are created via the session/CSRF curl flow below.
+Ground Control's SPA shell does not include a user-management page in
+this iteration — the REST endpoints under `/api/v1/admin/users` are the
+single supported surface. The bearer chain refuses non-`Bearer`
+schemes, so HTTP Basic against `/api/v1/**` is not an option; a
+session login is required.
+
+```bash
+# 0. Restrict cookie/jar visibility before any session is written. umask 077
+#    ensures the jar created by curl below is mode 600, and the explicit chmod
+#    handles the rare case where umask was overridden by a parent shell setting.
+umask 077
+jar="$(mktemp /tmp/gc-jar.XXXXXX)"
+chmod 600 "$jar"
+trap 'rm -f "$jar"' EXIT
+
+# 1. Pick up the CSRF cookie.
+curl -sS -c "$jar" "$BASE/login" -o /dev/null
+
+# 2. Submit the form login. `--data-urlencode "name@/path"` (no `=` sign)
+#    reads the field value from the file; the URL-encoded body keeps the
+#    password out of argv and out of the request URL.
+csrf="$(awk '$6=="XSRF-TOKEN"{print $7}' "$jar")"
+curl -sS -b "$jar" -c "$jar" \
+  --data-urlencode "username=admin" \
+  --data-urlencode "password@/run/gc/admin-password" \
+  --data-urlencode "_csrf=$csrf" \
+  -o /dev/null -X POST "$BASE/login"
+
+# 3. Create the user with the session cookie + CSRF header. The JSON body
+#    comes from a mode-600 file so the new account's password also stays
+#    out of argv / shell history / CI logs.
+csrf="$(awk '$6=="XSRF-TOKEN"{print $7}' "$jar")"
+curl -sS -b "$jar" -X POST "$BASE/api/v1/admin/users" \
+  -H 'Content-Type: application/json' \
+  -H "X-XSRF-TOKEN: $csrf" \
+  --data @/run/gc/new-user.json
+```
+
+The cookie jar carries `GC_SESSION` (live until logout / timeout) and
+`XSRF-TOKEN`; both are sensitive. The `trap` cleans the jar on exit, and
+`umask 077` + explicit `chmod 600` guarantee a local unprivileged user
+cannot snapshot the session before it expires. `--data-urlencode
+"password@/path"` is curl's file-read form (no `=` between field name
+and `@`); `--data-urlencode "password=@/path"` would submit the literal
+string `@/path` as the password. The same flow drives the MCP
+`gc_user_admin` actions (list / update_role / update_enabled /
+delete_user); MCP intentionally does not accept passwords as tool
+arguments, so user creation always goes through this curl path.
+
+The last enabled admin cannot be demoted, disabled, or deleted — the
+service returns `409 last_admin` and the operation is refused. Provision
+a second admin before retiring the first.
+
 ### Authenticated red-dragon redeploy guardrails
 
 Rolling a pre-ADR-026 deployment forward to an ADR-026 image is an

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ground-control-ui",
-  "version": "0.54.0",
+  "version": "0.76.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ground-control-ui",
-      "version": "0.54.0",
+      "version": "0.76.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -34,11 +34,31 @@
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "@vitejs/plugin-react": "^4.3.4",
+        "jsdom": "^25.0.1",
         "tailwindcss": "^4.0.14",
         "typescript": "^5.7.3",
         "vite": "^6.2.0",
         "vitest": "^3.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -484,6 +504,116 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2747,6 +2877,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -2768,6 +2907,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
@@ -2824,6 +2969,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2895,6 +3053,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2914,6 +3084,25 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2953,6 +3142,19 @@
         "lodash": "^4.17.15"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2971,6 +3173,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2979,6 +3187,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -2996,6 +3213,20 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
@@ -3018,12 +3249,69 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -3115,6 +3403,22 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3130,6 +3434,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3140,6 +3453,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -3147,6 +3484,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -3165,6 +3527,101 @@
         "lodash": "^4.17.15"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -3181,6 +3638,46 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3511,6 +4008,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3543,6 +4070,24 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3608,6 +4153,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -3793,6 +4347,30 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3865,6 +4443,12 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -3956,6 +4540,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -4230,6 +4856,62 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4246,6 +4928,42 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
     "tailwindcss": "^4.0.14",
     "typescript": "^5.7.3",
     "vite": "^6.2.0",

--- a/frontend/src/components/layout/app-layout.tsx
+++ b/frontend/src/components/layout/app-layout.tsx
@@ -1,6 +1,6 @@
 import { ProjectSwitcher } from "@/components/project-switcher";
 import { cn } from "@/lib/utils";
-import { Rocket } from "lucide-react";
+import { LogOut, Rocket } from "lucide-react";
 import {
   Link,
   NavLink,
@@ -33,6 +33,49 @@ function NavItem({
     >
       {children}
     </NavLink>
+  );
+}
+
+/**
+ * Sign-out control wired to ADR-037's browser session chain. POSTs to {@code /logout} with the
+ * CSRF token cookie echoed via the {@code X-XSRF-TOKEN} header (Spring's double-submit-cookie
+ * contract). On a 204 success the server has invalidated the session; we then redirect to
+ * {@code /login} so the user lands on the form-login screen. A non-204 response stays on the
+ * page — there is no destructive state to roll back, and the on-page error surface is the most
+ * useful diagnostic for an unexpected condition.
+ */
+function SignOutButton() {
+  const handleSignOut = async () => {
+    const csrfCookie = document.cookie
+      .split(";")
+      .map((entry) => entry.trim())
+      .find((entry) => entry.startsWith("XSRF-TOKEN="));
+    const headers: Record<string, string> = {};
+    if (csrfCookie) {
+      headers["X-XSRF-TOKEN"] = decodeURIComponent(
+        csrfCookie.slice("XSRF-TOKEN=".length),
+      );
+    }
+    const response = await fetch("/logout", {
+      method: "POST",
+      credentials: "same-origin",
+      headers,
+    });
+    if (response.ok) {
+      window.location.assign("/login");
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleSignOut}
+      className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+      aria-label="Sign out"
+    >
+      <LogOut className="h-4 w-4" />
+      <span>Sign out</span>
+    </button>
   );
 }
 
@@ -70,7 +113,10 @@ export function AppLayout() {
             {projectId && <NavItem to={`${base}/admin`}>Admin</NavItem>}
           </nav>
 
-          <div className="ml-auto">{projectId && <ProjectSwitcher />}</div>
+          <div className="ml-auto flex items-center gap-3">
+            {projectId && <ProjectSwitcher />}
+            <SignOutButton />
+          </div>
         </div>
       </header>
 

--- a/frontend/src/lib/api-client.test.ts
+++ b/frontend/src/lib/api-client.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+/**
+ * Vitest coverage for the ADR-037 browser-session additions to {@link apiFetch} /
+ * {@link apiUpload} / {@link apiDelete}. The contract under test:
+ *
+ *  - Every fetch carries {@code credentials: "same-origin"} so the {@code GC_SESSION} cookie
+ *    rides along on SPA XHR calls.
+ *  - On non-GET requests, the {@code XSRF-TOKEN} cookie value (if present) is echoed via the
+ *    {@code X-XSRF-TOKEN} header (Spring's CookieCsrfTokenRepository contract).
+ *  - A 401 response triggers a redirect to {@code /login} so the user is sent through the
+ *    Spring form-login flow.
+ *
+ * The redirect path is exercised via {@link setRedirectorForTests} rather than by
+ * monkey-patching {@code window.location.assign}: jsdom 25 marks {@code window.location} as
+ * non-configurable, so a {@code defineProperty(window, "location", …)} stub throws "Cannot
+ * redefine property" and the entire test file fails to run. An injectable redirector keeps
+ * the production path identical while letting the test see exactly what URL the wrapper
+ * tried to navigate to.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ApiError,
+  apiDelete,
+  apiFetch,
+  apiUpload,
+  setRedirectorForTests,
+} from "./api-client";
+
+const originalFetch = globalThis.fetch;
+const originalCookie = document.cookie;
+
+function setCookie(value: string) {
+  Object.defineProperty(document, "cookie", {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("apiFetch", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(() => Promise.resolve(jsonResponse({ ok: true })));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    setCookie("");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setCookie(originalCookie);
+  });
+
+  it("passes credentials: 'same-origin' so the session cookie is sent", async () => {
+    await apiFetch("/requirements");
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const call = fetchSpy.mock.calls[0];
+    if (!call) throw new Error("expected fetch to be called");
+    const init = call[1] as RequestInit;
+    expect(init.credentials).toBe("same-origin");
+  });
+
+  it("does not attach X-XSRF-TOKEN on GET (CSRF only protects mutations)", async () => {
+    setCookie("XSRF-TOKEN=t-123; OTHER=x");
+
+    await apiFetch("/requirements");
+
+    const call = fetchSpy.mock.calls[0];
+    if (!call) throw new Error("expected fetch to be called");
+    const init = call[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-XSRF-TOKEN"]).toBeUndefined();
+  });
+
+  it("attaches X-XSRF-TOKEN from cookie on POST", async () => {
+    setCookie("XSRF-TOKEN=t-csrf-abc; UNRELATED=other");
+
+    await apiFetch("/requirements", { method: "POST", body: { x: 1 } });
+
+    const call = fetchSpy.mock.calls[0];
+    if (!call) throw new Error("expected fetch to be called");
+    const init = call[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-XSRF-TOKEN"]).toBe("t-csrf-abc");
+  });
+
+  it("attaches X-XSRF-TOKEN on PATCH and DELETE too", async () => {
+    setCookie("XSRF-TOKEN=patch-tok");
+    await apiFetch("/requirements/1", { method: "PATCH", body: { x: 1 } });
+    const patchCall = fetchSpy.mock.calls[0];
+    if (!patchCall) throw new Error("expected fetch to be called");
+    let init = patchCall[1] as RequestInit;
+    expect((init.headers as Record<string, string>)["X-XSRF-TOKEN"]).toBe(
+      "patch-tok",
+    );
+
+    fetchSpy.mockClear();
+    setCookie("XSRF-TOKEN=delete-tok");
+    await apiFetch("/requirements/1", { method: "DELETE" });
+    const deleteCall = fetchSpy.mock.calls[0];
+    if (!deleteCall) throw new Error("expected fetch to be called");
+    init = deleteCall[1] as RequestInit;
+    expect((init.headers as Record<string, string>)["X-XSRF-TOKEN"]).toBe(
+      "delete-tok",
+    );
+  });
+
+  it("omits X-XSRF-TOKEN when no cookie is present", async () => {
+    setCookie("");
+
+    await apiFetch("/requirements", { method: "POST", body: { x: 1 } });
+
+    const call = fetchSpy.mock.calls[0];
+    if (!call) throw new Error("expected fetch to be called");
+    const init = call[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-XSRF-TOKEN"]).toBeUndefined();
+  });
+
+  it("redirects to /login on 401 and rethrows ApiError", async () => {
+    const redirectSpy = vi.fn();
+    const restore = setRedirectorForTests(redirectSpy);
+    try {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: { code: "authentication_required", message: "auth" },
+          }),
+          {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+      await expect(apiFetch("/requirements")).rejects.toBeInstanceOf(ApiError);
+      expect(redirectSpy).toHaveBeenCalledOnce();
+      // We send the user to /login bare — the backend does not consume `?continue=`, and
+      // emitting one would look like an open-redirect surface that does nothing.
+      const redirectCall = redirectSpy.mock.calls[0];
+      if (!redirectCall) throw new Error("expected redirector to be called");
+      expect(redirectCall[0]).toBe("/login");
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not redirect on 403", async () => {
+    const redirectSpy = vi.fn();
+    const restore = setRedirectorForTests(redirectSpy);
+    try {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { code: "access_denied" } }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(apiFetch("/admin/users")).rejects.toBeInstanceOf(ApiError);
+      expect(redirectSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("apiDelete and apiUpload", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(() => Promise.resolve(jsonResponse({ ok: true })));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    setCookie("XSRF-TOKEN=cross-tok");
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setCookie(originalCookie);
+  });
+
+  it("apiDelete sends credentials and X-XSRF-TOKEN", async () => {
+    await apiDelete("/admin/users/alice");
+
+    const call = fetchSpy.mock.calls[0];
+    if (!call) throw new Error("expected fetch to be called");
+    const init = call[1] as RequestInit;
+    expect(init.credentials).toBe("same-origin");
+    expect((init.headers as Record<string, string>)["X-XSRF-TOKEN"]).toBe(
+      "cross-tok",
+    );
+  });
+
+  it("apiUpload sends credentials and X-XSRF-TOKEN on multipart POST", async () => {
+    const formData = new FormData();
+    formData.append("file", new Blob(["x"]), "test.sdoc");
+
+    await apiUpload("/admin/import", formData);
+
+    const call = fetchSpy.mock.calls[0];
+    if (!call) throw new Error("expected fetch to be called");
+    const init = call[1] as RequestInit;
+    expect(init.credentials).toBe("same-origin");
+    expect((init.headers as Record<string, string>)["X-XSRF-TOKEN"]).toBe(
+      "cross-tok",
+    );
+  });
+});

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,4 +1,37 @@
 const API_BASE = "/api/v1";
+const CSRF_COOKIE = "XSRF-TOKEN";
+const CSRF_HEADER = "X-XSRF-TOKEN";
+const LOGIN_PATH = "/login";
+
+/**
+ * Redirect-on-401 indirection. Tests replace this via {@link setRedirectorForTests}; production
+ * uses the default which delegates to {@code window.location.assign}. We do NOT mock
+ * {@code window.location} directly because jsdom 25 marks it non-configurable, so
+ * {@code Object.defineProperty(window, "location", …)} throws "Cannot redefine property" in
+ * the unit suite.
+ */
+type Redirector = (url: string) => void;
+
+const defaultRedirector: Redirector = (url) => {
+  if (typeof window !== "undefined") {
+    window.location.assign(url);
+  }
+};
+
+let activeRedirector: Redirector = defaultRedirector;
+
+/**
+ * Test-only hook. Returns a function that restores the production redirector. Tests call this
+ * in {@code beforeEach} with a vi.fn() spy and call the returned restore function in
+ * {@code afterEach}.
+ */
+export function setRedirectorForTests(replacement: Redirector): () => void {
+  const previous = activeRedirector;
+  activeRedirector = replacement;
+  return () => {
+    activeRedirector = previous;
+  };
+}
 
 export class ApiError extends Error {
   constructor(
@@ -10,7 +43,59 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Read the value of a cookie from {@code document.cookie}. ADR-037 §3: the SPA reads
+ * {@code XSRF-TOKEN} from the cookie that {@code CookieCsrfTokenRepository.withHttpOnlyFalse()}
+ * writes, and echoes it in the {@code X-XSRF-TOKEN} header on mutating requests. The cookie is
+ * non-HttpOnly *by design* because the double-submit pattern requires the SPA to read it.
+ */
+function readCookie(name: string): string | undefined {
+  if (typeof document === "undefined" || !document.cookie) {
+    return undefined;
+  }
+  const prefix = `${name}=`;
+  for (const part of document.cookie.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(prefix)) {
+      return decodeURIComponent(trimmed.slice(prefix.length));
+    }
+  }
+  return undefined;
+}
+
+function isMutation(method: string): boolean {
+  const m = method.toUpperCase();
+  return m === "POST" || m === "PUT" || m === "PATCH" || m === "DELETE";
+}
+
+function attachCsrfHeader(
+  method: string,
+  headers: Record<string, string>,
+): Record<string, string> {
+  if (!isMutation(method)) {
+    return headers;
+  }
+  const token = readCookie(CSRF_COOKIE);
+  if (!token) {
+    return headers;
+  }
+  return { ...headers, [CSRF_HEADER]: token };
+}
+
 async function handleError(response: Response): Promise<never> {
+  // ADR-037: a 401 on an SPA XHR means the session is missing or expired. Send the user
+  // through the Spring form-login flow so they can re-authenticate. We do NOT redirect on 403
+  // — that's "you're logged in but not authorized," which the calling component can render
+  // as a permission-denied message without losing the user's place in the SPA.
+  //
+  // We do NOT pass a `?continue=` parameter: the backend uses Spring's default success
+  // handling (saved-request-aware) and does not read `continue`. Tacking one on would create
+  // an unused query parameter that looks meaningful (open-redirect-shaped) without actually
+  // routing anywhere. Spring's request cache will restore the user's SPA route if they had
+  // navigated to one directly; XHR-initiated re-auth lands back at the app default ("/").
+  if (response.status === 401) {
+    activeRedirector(LOGIN_PATH);
+  }
   const errorBody = await response.json().catch(() => ({}));
   const body = errorBody as { detail?: string; error?: { message?: string } };
   throw new ApiError(
@@ -38,24 +123,27 @@ export async function apiFetch<T>(
     }
   }
 
-  const init: RequestInit = {
-    method: options?.method ?? "GET",
-    headers: {},
-  };
+  const method = options?.method ?? "GET";
+  let headers: Record<string, string> = {};
 
   if (options?.body) {
-    init.headers = {
-      ...init.headers,
-      "Content-Type": "application/json",
-    };
-    init.body = JSON.stringify(options.body);
+    headers = { ...headers, "Content-Type": "application/json" };
   }
 
   if (options?.headers) {
-    init.headers = {
-      ...init.headers,
-      ...options.headers,
-    };
+    headers = { ...headers, ...options.headers };
+  }
+
+  headers = attachCsrfHeader(method, headers);
+
+  const init: RequestInit = {
+    method,
+    headers,
+    credentials: "same-origin",
+  };
+
+  if (options?.body) {
+    init.body = JSON.stringify(options.body);
   }
 
   const response = await fetch(url.toString(), init);
@@ -83,6 +171,8 @@ export async function apiDelete(
 
   const response = await fetch(url.toString(), {
     method: "DELETE",
+    credentials: "same-origin",
+    headers: attachCsrfHeader("DELETE", {}),
   });
 
   if (!response.ok) {
@@ -110,8 +200,9 @@ export async function apiUpload<T>(
 
   const response = await fetch(url.toString(), {
     method: "POST",
-    headers: options?.headers,
+    headers: attachCsrfHeader("POST", { ...(options?.headers ?? {}) }),
     body: formData,
+    credentials: "same-origin",
   });
 
   if (!response.ok) {

--- a/frontend/src/pages/admin.tsx
+++ b/frontend/src/pages/admin.tsx
@@ -16,9 +16,7 @@ import type {
 } from "@/types/api";
 import { CONTROL_FUNCTIONS, PACK_REGISTRY_IMPORT_FORMATS } from "@/types/api";
 import { Database, Download, GitBranch, Settings, Upload } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-
-const PACK_REGISTRY_TOKEN_KEY = "gc.packRegistryAdminToken";
+import { useRef, useState } from "react";
 
 export function Admin() {
   const { activeProject } = useProjectContext();
@@ -63,33 +61,11 @@ function PackRegistryImport() {
   const [sourceUrl, setSourceUrl] = useState("");
   const [defaultControlFunction, setDefaultControlFunction] =
     useState<ControlFunction>("PREVENTIVE");
-  const [adminToken, setAdminToken] = useState(
-    () => sessionStorage.getItem(PACK_REGISTRY_TOKEN_KEY) ?? "",
-  );
-  const [rememberToken, setRememberToken] = useState(
-    () => sessionStorage.getItem(PACK_REGISTRY_TOKEN_KEY) !== null,
-  );
-
-  useEffect(() => {
-    if (!rememberToken || !adminToken) {
-      sessionStorage.removeItem(PACK_REGISTRY_TOKEN_KEY);
-      return;
-    }
-    sessionStorage.setItem(PACK_REGISTRY_TOKEN_KEY, adminToken);
-  }, [adminToken, rememberToken]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const file = fileRef.current?.files?.[0];
     if (!file) return;
-    if (!adminToken.trim()) {
-      toast({
-        title: "Admin token required",
-        description: "Pack registry import needs the configured admin token.",
-        variant: "error",
-      });
-      return;
-    }
 
     setLoading(true);
     setResult(null);
@@ -110,15 +86,14 @@ function PackRegistryImport() {
         new Blob([JSON.stringify(options)], { type: "application/json" }),
       );
 
+      // ADR-037: authorize via the browser session cookie + CSRF, not a bearer
+      // token in sessionStorage. The user must already be signed in as ROLE_ADMIN
+      // for /api/v1/pack-registry/** to accept the call; apiUpload echoes the
+      // XSRF-TOKEN cookie via X-XSRF-TOKEN automatically.
       const data = await apiUpload<PackRegistryEntryResponse>(
         "/pack-registry/import",
         formData,
-        {
-          params: { project: activeProject?.identifier },
-          headers: {
-            Authorization: `Bearer ${adminToken.trim()}`,
-          },
-        },
+        { params: { project: activeProject?.identifier } },
       );
       setResult(data);
       toast({ title: "Pack imported", variant: "success" });
@@ -143,24 +118,10 @@ function PackRegistryImport() {
         it directly in the pack registry for the active project.
       </p>
       <form onSubmit={handleSubmit} className="space-y-3">
-        <FormField label="Registry Admin Token">
-          <input
-            className={inputClass}
-            type="password"
-            value={adminToken}
-            onChange={(e) => setAdminToken(e.target.value)}
-            placeholder="Bearer token value"
-            required
-          />
-        </FormField>
-        <label className="flex items-center gap-2 text-xs text-muted-foreground">
-          <input
-            type="checkbox"
-            checked={rememberToken}
-            onChange={(e) => setRememberToken(e.target.checked)}
-          />
-          Remember token for this browser session
-        </label>
+        <p className="text-xs text-muted-foreground">
+          Authorized via your signed-in session — no bearer token field. You
+          must be signed in as an admin for this form to succeed.
+        </p>
         <div className="grid gap-3 md:grid-cols-2">
           <FormField label="Source File (.json)">
             <input

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -138,6 +138,9 @@ import {
   deleteTrustPolicy,
   installPackFromRegistry, upgradePackFromRegistry, listPackInstallRecords,
   getPackInstallRecord,
+  // createAdminUser is intentionally NOT imported — passwords must not flow
+  // through MCP tool-call payloads (ADR-037, codex security finding).
+  listAdminUsers, updateAdminUserRole, updateAdminUserEnabled, deleteAdminUser,
   // ---- enums ----
   STATUSES, REQUIREMENT_TYPES, PRIORITIES, RELATION_TYPES,
   ARTIFACT_TYPES, LINK_TYPES, CHANGE_CATEGORIES, CONFIDENCE_LEVELS,
@@ -1618,6 +1621,62 @@ if (ADMIN_TOOLS_ENABLED) {
           default: return err(new Error(`Unknown action: ${args.action}`));
         }
       } catch (e) { return err(e); }
+    },
+  );
+
+  // ADR-037 admin-user lifecycle. Registered alongside gc_admin so an
+  // ADMIN-role bearer token can drive user management programmatically.
+  // Humans manage users via the curl/session flow documented in
+  // DEPLOYMENT.md — this PR does not ship a SPA user-management page.
+  //
+  // **`create_user` is intentionally NOT exposed via MCP.** Passing a new
+  // account password as a JSON-RPC tool argument means the password lands in
+  // agent transcripts, client logs, debug output, and any observability trace
+  // that captures tool-call payloads. Create users via the DEPLOYMENT.md
+  // curl flow where the password stays in a mode-600 file. The actions
+  // surfaced here mutate state but never accept password material;
+  // createAdminUser is exported from lib.js for callers that have an
+  // out-of-band secret channel, not for agents.
+  const USER_ADMIN_ACTIONS = [
+    "list_users", "update_role", "update_enabled", "delete_user",
+  ];
+  server.tool(
+    "gc_user_admin",
+    `Admin user lifecycle (ADR-037): list / change-role / enable-disable / delete. ` +
+      `Registered only when GC_MCP_ADMIN=1; backend enforces ROLE_ADMIN. ` +
+      `User CREATION is intentionally not exposed here — see DEPLOYMENT.md. ` +
+      `Actions: ${USER_ADMIN_ACTIONS.join(", ")}.`,
+    {
+      action: z.enum(USER_ADMIN_ACTIONS),
+      username: z.string().optional(),
+      role: z.enum(["USER", "ADMIN"]).optional(),
+      enabled: z.boolean().optional(),
+    },
+    async (args) => {
+      try {
+        switch (args.action) {
+          case "list_users":
+            return ok(JSON.stringify(await listAdminUsers(), null, 2));
+          case "update_role":
+            reqArg(args, "username", "update_role");
+            reqArg(args, "role", "update_role");
+            return ok(JSON.stringify(await updateAdminUserRole(args.username, args.role), null, 2));
+          case "update_enabled":
+            reqArg(args, "username", "update_enabled");
+            if (typeof args.enabled !== "boolean") {
+              return err(new Error("update_enabled requires boolean 'enabled'"));
+            }
+            return ok(JSON.stringify(await updateAdminUserEnabled(args.username, args.enabled), null, 2));
+          case "delete_user":
+            reqArg(args, "username", "delete_user");
+            await deleteAdminUser(args.username);
+            return ok(`Deleted user '${args.username}'`);
+          default:
+            return err(new Error(`Unknown action: ${args.action}`));
+        }
+      } catch (e) {
+        return err(e);
+      }
     },
   );
 }

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -7484,3 +7484,31 @@ export async function runLogStepTelemetry({ repoPath, issueNumber, branch, step,
   }
   return await appendStepTelemetry({ repoPath: repoRoot, record });
 }
+
+// ---------------------------------------------------------------------------
+// Admin User lifecycle API functions (ADR-037; ROLE_ADMIN-gated)
+// ---------------------------------------------------------------------------
+
+export async function listAdminUsers() {
+  return request("GET", "/api/v1/admin/users");
+}
+
+export async function createAdminUser(data) {
+  return request("POST", "/api/v1/admin/users", { body: data });
+}
+
+export async function updateAdminUserRole(username, role) {
+  return request("PATCH", `/api/v1/admin/users/${encodeURIComponent(username)}/role`, {
+    body: { role },
+  });
+}
+
+export async function updateAdminUserEnabled(username, enabled) {
+  return request("PATCH", `/api/v1/admin/users/${encodeURIComponent(username)}/enabled`, {
+    body: { enabled },
+  });
+}
+
+export async function deleteAdminUser(username) {
+  await request("DELETE", `/api/v1/admin/users/${encodeURIComponent(username)}`);
+}


### PR DESCRIPTION
## Summary

Adds the ADR-036 browser-session login chain alongside the existing
ADR-026 bearer chain. A single-tenant deploy operator now logs in
through the SPA with username + password (JDBC user store, BCrypt
hashes) and the resulting `GC_SESSION` cookie authorizes the same
`/api/v1/**` path matrix that bearer tokens already cover. Agents and
automation are unaffected — the bearer chain is matched first by an
`Authorization: Bearer …` header check, so machine traffic stays
stateless and CSRF-exempt as ADR-026 specified.

## Requirement UIDs

- `GC-P011` (Access Control) — adds the human/session dimension on top
  of ADR-026's bearer + IP-allowlist chain.
- `GC-P017` (Authentication, Federation, and Machine Access) — implements
  the "user authentication" piece for single-tenant installs. Federation
  / MFA / machine access remain out of scope (ADR-036 non-goals).

## Related Issues

Closes #857

## ADR Impact

- ADR-036 (new) — Browser Session Access Control. Two filter chains,
  same `SecurityContext` principal and `ROLE_USER` / `ROLE_ADMIN`
  authorities, CSRF required for cookie-authenticated mutations,
  session-fixation protection preserved, first-admin bootstrap rejects
  argv-supplied passwords.
- ADR-026 is refined, not superseded. Bearer chain behavior is
  unchanged for agents.

## Changes

- **Backend security**
  - `ApiSecurityConfig`: `@Order(1)`, scoped via `BearerRequestMatcher`
    to `Authorization: Bearer …` traffic only. Path matrix extracted to
    `ApiPathMatrix` (single source of truth shared with the browser
    chain).
  - `BrowserSecurityConfig` (new): `@Order(2)`, catches everything
    else. Form login at `/login`, JDBC `users` / `authorities` via
    `JdbcUserDetailsManager`, BCrypt strength 12, `CookieCsrfTokenRepository`
    (HttpOnly=false so the SPA can read XSRF-TOKEN), session-fixation
    protection preserved via Spring's default composite, `SessionRegistry`
    + `ConcurrentSessionFilter` so revoked users' sessions are enforced
    immediately on the next request.
  - `DelegatingAuthenticationEntryPointFactory` + `PathAwareAccessDeniedHandler`:
    JSON 401/403 for API-shaped paths, 302→/login for SPA navigation.
    Both reuse `ApiRequestPaths` so the classification cannot drift.
  - `PathAwareSessionExpiredStrategy` (new): same dispatch policy for
    expired-session events.
  - `IpAllowlistFilter` is now placed before `DisableEncodeUrlFilter` on
    both chains so the network gate fires ahead of form-login filters
    (codex caught this).
  - `UserAdminService` (`/api/v1/admin/users`): list / create /
    update_role / update_enabled / delete. Last-admin guard prevents
    removing/demoting the last enabled admin (`409 last_admin`).
    Postgres `pg_advisory_xact_lock` serializes mutations so concurrent
    admins can't both pass the guard. Role/enabled/delete operations
    `expireNow()` live sessions for the affected principal. Translates
    `DuplicateKeyException` to `409 user_exists` so a double-submit race
    no longer surfaces as 500.
- **First-admin bootstrap** (`FirstAdminBootstrapRunner`)
  - `bootRun --create-admin --username=…`.
  - Password source priority: `--password-file=PATH` (file is
    authoritative when supplied — no silent fallthrough) → env
    `GC_ADMIN_BOOTSTRAP_PASSWORD` → TTY prompt.
  - `--password=…` argv is **refused** (ADR-036 §5 — shell history leak).
  - Password files must be mode 600 on POSIX (rejects group/others
    read OR write OR execute, and requires `isRegularFile`).
  - Idempotency check verifies the existing user is an enabled admin;
    a partial previous bootstrap (row in `users`, no `ROLE_ADMIN`
    authority) now fails fast.
  - Password buffer is zeroed in `finally` before `System.exit` so the
    cleanup actually runs in production (`exit` is dispatched after the
    try/finally with an `exitCode` captured inside).
- **Credential policy** (`UserCredentialPolicy`)
  - Username regex + password length range in one place; consumed by
    DTO `@Pattern`, controller path `@Pattern`, service, bootstrap
    runner. SQL CHECK is the DB backstop; `UserCredentialPolicyContractTest`
    asserts Java ≡ SQL equivalence.
- **Frontend**
  - `apiFetch` / `apiUpload` / `apiDelete` pass `credentials: "same-origin"`
    and echo the `XSRF-TOKEN` cookie via `X-XSRF-TOKEN` on mutations.
    401 redirects to `/login` via an injectable redirector (test-friendly,
    works around jsdom 25's non-configurable `window.location`).
  - `app-layout.tsx`: "Sign out" button POSTs `/logout` with the CSRF
    header.
  - `admin.tsx`: pack-registry import no longer asks for a bearer token
    in a `sessionStorage`-backed field — it now relies on the
    session-authenticated ROLE_ADMIN context.
- **DB**
  - `V059__create_users.sql`: Spring Security's default
    `users(username, password, enabled)` + `authorities(username,
    authority)` schema with a `CHECK` on username format and an
    `authorities_role_vocabulary` CHECK that restricts authorities to
    `ROLE_USER` / `ROLE_ADMIN`.
- **MCP**
  - `gc_user_admin` tool: list_users / update_role / update_enabled /
    delete_user. `create_user` is **not** exposed — passwords must not
    flow through agent-visible tool payloads.
- **Docs**
  - `DEPLOYMENT.md` Web UI login section: session cookie hardening
    table, first-admin bootstrap procedure, scripted curl flow with
    `umask 077` / mode-600 cookie jar / `--data-urlencode "password@/path"`.
  - `docs/API.md`: `/api/v1/admin/users` documented.
- **Policy / static analysis**
  - `tools/policy/checks.py` ADR-026 keys remain enforced; no new
    policy required for session-cookie config (hardcoded production
    defaults, not env-driven).
  - SpotBugs exclusions extended per-class for the new Spring-DI
    security beans.

## Test Plan

- [x] Unit tests pass — 1641 tests (`make test`).
- [x] Integration tests pass — `BrowserSessionIntegrationTest` (10 cases
      including end-to-end form login, CSRF gate, logout-clears-session,
      bearer-still-works, disabled-user-can't-reuse-session, CSRF on
      `/login` enforced without a pre-existing session),
      `ApiSecurityIntegrationTest` (no regression),
      `AuditActorProvenanceIntegrationTest`, `MigrationSmokeTest` /
      `RequirementsE2EIntegrationTest` migration-list assertions updated
      for V059.
- [x] `make check` passes — Spotless, SpotBugs, Error Prone, Checkstyle,
      JaCoCo, ArchUnit, OpenJML ESC.
- [x] No coverage regression on touched packages.
- [x] Frontend lint + build + Vitest (28 tests, including 9 new
      api-client tests).

## Ground Control Checks

- [x] `make policy` passes (controller-parity, changelog-fragment,
      ADR-026 indexed credential passthrough, enum-contract checks all
      green).
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Codex review history

Pre-push: 4 codex review cycles (cap 3 + user-authorized cycle 4).
Cycle history posted to issue #857 comment thread. All findings either
fixed in-band or recorded as decisions on the issue. The cycle-3 CSRF
matcher tightening introduced a regression that cycle 4 caught (login
CSRF — an anonymous attacker could log a victim into the attacker's
account); the cycle-4 fix narrows the matcher so it only exempts
unauthenticated `/api/v1/**` requests, not `/login`. New test
`loginPostWithoutCsrfIsRejected_evenWithoutPreExistingSession` pins
that contract.

## Traceability

Reconciled programmatically post-merge by /implement Step 16. GC-P017
transitions DRAFT → ACTIVE for the user-authentication clause it
materially implements.

- IMPLEMENTS:
  - `GC-P011` → `BrowserSecurityConfig`, `ApiSecurityConfig` (refactor for
    bearer-only scoping), `ApiPathMatrix`, `ApiRequestPaths`,
    `BearerRequestMatcher`, `DelegatingAuthenticationEntryPointFactory`,
    `PathAwareAccessDeniedHandler`, `PathAwareSessionExpiredStrategy`,
    `UserAdminController`, `UserAdminService`, `UserCredentialPolicy`,
    `FirstAdminBootstrapRunner`, `V059__create_users.sql`,
    `application.yml` session hardening, `ADR-037`.
  - `GC-P017` → same set (the user-authentication clause materially ships
    via the JDBC user store + form-login + admin REST surface).
- TESTS:
  - `GC-P011` / `GC-P017` →
    `BrowserSessionIntegrationTest` (end-to-end form login, CSRF,
    logout, disabled-user-session-revocation, anonymous-API JSON 401),
    `UserAdminControllerTest`, `UserAdminServiceTest` (last-admin guard,
    session revocation), `FirstAdminBootstrapRunnerTest`,
    `UserCredentialPolicyContractTest` (Java↔SQL regex equivalence),
    `BearerRequestMatcherTest`, `ChainOrderingTest`,
    `DelegatingAuthenticationEntryPointFactoryTest`,
    `PathAwareAccessDeniedHandlerTest`, frontend `api-client.test.ts`.

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`).
- [x] No business logic in API layer (controller delegates to
      `UserAdminService`).
- [x] Domain layer has no framework imports.
- [x] No new `@Audited` JPA entities — Spring Security users are
      principal storage, not domain entities (ADR-036 §4); admin
      role-change events are surfaced via structured log lines.
- [x] Changelog fragment added at `changelog.d/857.added.md`.
- [x] Architectural docs updated — ADR-036 added, ADR-026 cross-linked,
      `docs/architecture/ARCHITECTURE.md` unchanged (no package-layout
      change), `docs/API.md` updated, `DEPLOYMENT.md` updated.
