### PR TITLE
Fix gc_query MCP tool: signal injection + broken registration (#874)

### DIFF
--- a/architecture/adrs/035-mcp-tool-catalog-curation.md
+++ b/architecture/adrs/035-mcp-tool-catalog-curation.md
@@ -190,10 +190,16 @@ the body and canceling the reader once the cap is reached — the request
 does NOT buffer unbounded data before truncating. The cap covers the full
 request lifetime, not just header arrival.
 
-**Strict Zod schema.** `gc_query` is registered with a strict ZodObject so
-the MCP SDK's input validation rejects unknown keys (`headers`, `method`,
-etc.) at the protocol layer before the handler runs. The handler
-additionally enforces the same key allowlist as defense in depth.
+**Public argument boundary.** `gc_query`'s public contract is exactly
+`path` plus optional `params`; `headers`, `method`, `body`, caller-supplied
+tokens, and any other user-facing expansion remain rejected. Transport or SDK
+control fields injected outside the caller's JSON payload, such as an
+AbortController `signal`, are not part of that public contract and must be
+normalized away before the public-argument allowlist decides whether an
+unknown key is user supplied. This is the seam between MCP runtime plumbing
+and Ground Control's adapter contract: accepting a known internal control
+field must not become `.passthrough()` business logic for arbitrary keys, and
+unknown user keys must still fail with `invalid_query_args`.
 
 **Error semantics.** Validation errors are wrapped as `RequestError` with
 `status: 0` and codes `invalid_query_path`, `invalid_query_params`,
@@ -249,6 +255,12 @@ errors.
   the README documents this.
 - **Body truncation hides material data.** 1 MiB is ample for typical
   lookups; large exports use the dedicated `gc_admin` export actions.
+- **Runtime metadata drift.** MCP SDKs may add non-user control fields to
+  handler argument objects. The adapter must maintain a deliberately tiny
+  transport-metadata normalization seam instead of relaxing the public
+  contract for all unknown keys. Regression tests should cover both sides:
+  known internal metadata is ignored, while `headers` and `method` remain
+  rejected.
 
 ## Alternatives considered
 

--- a/architecture/notes/mcp-tool-catalog-surface-preflight.md
+++ b/architecture/notes/mcp-tool-catalog-surface-preflight.md
@@ -44,6 +44,10 @@ implementation plan.
 - **Validation:** MCP Zod schemas validate tool arguments only. Backend request
   DTOs, Bean Validation, Jackson enum binding, and domain services remain the
   authoritative validators for API semantics.
+- **Transport metadata:** SDK-injected control fields are not user-facing tool
+  arguments. Normalize only known runtime keys at the MCP adapter boundary, then
+  keep the public argument allowlist strict so `headers`, `method`, `body`, and
+  caller-supplied tokens still fail loudly.
 - **Enum contracts:** API enum mirrors in `mcp/ground-control/lib.js` remain
   governed by ADR-034 and `make policy`; do not introduce another enum registry
   for a curated catalog.
@@ -81,6 +85,10 @@ implementation plan.
 - **OS/process exposure:** no design should require users to pass bearer tokens
   on the command line or embed them in generated server args. Catalog selection
   may be an env/config value because it is not secret.
+- **MCP runtime plumbing:** known non-user fields injected by the SDK or
+  transport, such as an AbortController `signal`, must be consumed or ignored
+  only at the adapter boundary. Do not forward them to URL construction,
+  request params, headers, backend DTOs, logs, or error details.
 
 ## Extensibility Guardrail
 
@@ -103,6 +111,10 @@ MCP server or reimplementing auth, error handling, or Zod schema definitions.
 - Do not duplicate request schemas in a new catalog layer. Reuse existing Zod
   schemas or centralize registration metadata so descriptions and validators do
   not drift between curated and expanded modes.
+- Do not fix SDK-injected metadata by globally accepting arbitrary unknown
+  arguments. A narrow allowlist for runtime metadata is acceptable; a generic
+  passthrough that lets user-supplied `method`, `headers`, or `body` reach the
+  handler is not.
 - Do not split servers by copying `index.js` into multiple entrypoints with
   different hand-pruned tool lists. That preserves the current maintenance
   problem under more files.

--- a/changelog.d/874.fixed.md
+++ b/changelog.d/874.fixed.md
@@ -1,0 +1,9 @@
+`gc_query` MCP tool no longer fails every read with `invalid_query_args`
+when the client/transport pipes an SDK-injected `AbortSignal` into the
+handler argument object. The handler now normalizes the documented runtime
+key (`signal`) away at the adapter boundary before its public-argument
+allowlist runs, so the public contract stays exactly `path` + optional
+`params` while `headers`, `method`, `body`, and other caller-supplied
+unknown keys still fail loudly. Restores the read fallback every
+consolidated tool's "Reads route through gc_query" description (ADR-035)
+relied on.

--- a/mcp/ground-control/gc-query.js
+++ b/mcp/ground-control/gc-query.js
@@ -324,14 +324,92 @@ export async function executeGcQuery(path, params, opts = {}) {
 }
 
 /**
+ * Recognizes a runtime `AbortSignal` value. The handler must only strip a
+ * `signal` key when the value really is SDK runtime plumbing; a caller-
+ * supplied plain object under the same name must fall through to the
+ * public-argument allowlist so the user-facing contract stays exactly
+ * `path` + optional `params`. Uses `instanceof` for the same-realm case
+ * and a duck-type fallback for cross-realm signals (workers, isolated
+ * module realms) so a legitimate AbortSignal originating elsewhere still
+ * matches.
+ */
+function isAbortSignalLike(v) {
+  if (typeof globalThis.AbortSignal === "function" && v instanceof globalThis.AbortSignal) {
+    return true;
+  }
+  return (
+    v !== null &&
+    typeof v === "object" &&
+    typeof v.aborted === "boolean" &&
+    typeof v.addEventListener === "function" &&
+    typeof v.removeEventListener === "function"
+  );
+}
+
+/**
+ * Map of key → predicate that recognizes the runtime/SDK-injected value
+ * shape for that key. The handler strips a key only when both the name AND
+ * the value shape match; this preserves the handler's defense-in-depth
+ * contract for arbitrary unknown user inputs.
+ */
+const SDK_INJECTED_KEY_PREDICATES = Object.freeze(
+  new Map([["signal", isAbortSignalLike]]),
+);
+
+/**
+ * Runtime keys that some MCP clients/transports pipe into the tool-handler
+ * `args` object even though they are not user-supplied arguments. `signal`
+ * (an `AbortSignal` used downstream for `AbortController` plumbing) is the
+ * documented case (issue #874). Stripping happens at the adapter boundary
+ * BEFORE the public-argument allowlist so the public contract stays exactly
+ * `path` + optional `params` while runtime plumbing is consumed harmlessly.
+ *
+ * ADR-035 "Public argument boundary"; preflight note
+ * `architecture/notes/mcp-tool-catalog-surface-preflight.md` "MCP runtime
+ * plumbing". Growing this set is a deliberate change — keep it narrow.
+ */
+export const GC_QUERY_SDK_INJECTED_KEYS = Object.freeze(
+  new Set(SDK_INJECTED_KEY_PREDICATES.keys()),
+);
+
+/**
+ * Return a shallow copy of `args` with the known SDK-injected runtime keys
+ * removed when their value matches the documented runtime shape. Does not
+ * mutate the input. Does NOT strip other unknown keys (e.g. `headers`,
+ * `method`): those are caller-facing and must still fail loudly via
+ * `gcQueryToolHandler`'s allowlist. A `signal` key whose value is NOT an
+ * AbortSignal also survives the strip and is rejected by the same allowlist
+ * — the per-key value predicate is what keeps the public contract intact.
+ */
+export function stripSdkInjectedKeys(args) {
+  if (args === undefined || args === null) return {};
+  const out = {};
+  for (const [k, v] of Object.entries(args)) {
+    const predicate = SDK_INJECTED_KEY_PREDICATES.get(k);
+    if (predicate && predicate(v)) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/**
  * MCP tool handler entrypoint for `gc_query`. Defense-in-depth on top of the
  * strict Zod schema below: explicitly rejects any args object key beyond
  * `path` and `params` so a future SDK relaxation can't silently let unknown
  * keys through.
+ *
+ * Some clients/transports (issue #874) inject runtime control fields like
+ * `signal` (an `AbortSignal`) into `args` outside the Zod-validated payload.
+ * Those keys are stripped via {@link stripSdkInjectedKeys} BEFORE the public
+ * allowlist runs, so the public contract stays `path` + optional `params`
+ * and the inbound SDK signal does not leak into URL construction, headers,
+ * or the outbound `AbortController.signal` (which `executeGcQuery` builds
+ * for its own 30s timeout — the two must not be conflated).
  */
 export async function gcQueryToolHandler(args, opts = {}) {
+  const userArgs = stripSdkInjectedKeys(args);
   const allowedKeys = new Set(["path", "params"]);
-  for (const k of Object.keys(args ?? {})) {
+  for (const k of Object.keys(userArgs)) {
     if (!allowedKeys.has(k)) {
       throw new RequestError({
         status: 0,
@@ -341,7 +419,7 @@ export async function gcQueryToolHandler(args, opts = {}) {
       });
     }
   }
-  return executeGcQuery(args?.path, args?.params, opts);
+  return executeGcQuery(userArgs.path, userArgs.params, opts);
 }
 
 /**

--- a/mcp/ground-control/gc-query.test.js
+++ b/mcp/ground-control/gc-query.test.js
@@ -13,11 +13,16 @@ import {
   GC_QUERY_TIMEOUT_MS,
   GC_QUERY_PATH_ALLOWLIST,
   GC_QUERY_PATH_DENYLIST,
+  GC_QUERY_SDK_INJECTED_KEYS,
+  stripSdkInjectedKeys,
   validateGcQueryPath,
   validateGcQueryParams,
   truncateBody,
 } from "./gc-query.js";
 import { RequestError } from "./lib.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -358,6 +363,205 @@ describe("gcQueryToolHandler", () => {
       );
     }),
   );
+
+  // Some MCP clients/transports pipe an AbortController `signal` into the
+  // tool-handler `args` object on every call (rather than only into the SDK's
+  // `extra`). That is runtime plumbing, not a user-supplied argument, so the
+  // handler must consume/ignore it at the adapter boundary BEFORE the public
+  // allowlist runs (ADR-035 "Public argument boundary"; preflight note
+  // architecture/notes/mcp-tool-catalog-surface-preflight.md "MCP runtime
+  // plumbing"). It must NOT broaden into a generic passthrough — every other
+  // unknown key still has to fail with invalid_query_args.
+  it(
+    "accepts an SDK-injected 'signal' arg silently (alongside path)",
+    withBaseUrl("http://localhost:8000", async () => {
+      let capturedUrl;
+      let capturedOptions;
+      const fetchImpl = async (url, options) => {
+        capturedUrl = url;
+        capturedOptions = options;
+        return fakeResponse({ body: '{"ok":true}' });
+      };
+      const ac = new AbortController();
+      const out = await gcQueryToolHandler(
+        { path: "/api/v1/requirements", signal: ac.signal },
+        { fetchImpl },
+      );
+      assert.equal(out.status, 200);
+      assert.equal(out.body, '{"ok":true}');
+      // The inbound SDK signal must NOT be reflected anywhere in the outbound
+      // request: not in the URL, not in the headers. (The outbound AbortSignal
+      // on the fetch options is the executor's own 30s-timeout signal, not
+      // the SDK-injected one — they must not be conflated.)
+      assert.ok(!capturedUrl.includes("signal"));
+      assert.equal(Object.prototype.hasOwnProperty.call(capturedOptions.headers, "signal"), false);
+      assert.notStrictEqual(capturedOptions.signal, ac.signal);
+    }),
+  );
+
+  it(
+    "accepts an SDK-injected 'signal' arg alongside path + params and forwards only path/params downstream",
+    withBaseUrl("http://localhost:8000", async () => {
+      let capturedUrl;
+      const fetchImpl = async (url) => {
+        capturedUrl = url;
+        return fakeResponse({ body: "{}" });
+      };
+      const ac = new AbortController();
+      await gcQueryToolHandler(
+        {
+          path: "/api/v1/requirements",
+          params: { status: "ACTIVE" },
+          signal: ac.signal,
+        },
+        { fetchImpl },
+      );
+      assert.equal(capturedUrl, "http://localhost:8000/api/v1/requirements?status=ACTIVE");
+    }),
+  );
+
+  it(
+    "still rejects 'headers' after the SDK-signal strip (regression: strip must not relax other rejections)",
+    withBaseUrl("http://localhost:8000", async () => {
+      const ac = new AbortController();
+      await assert.rejects(
+        () =>
+          gcQueryToolHandler(
+            {
+              path: "/api/v1/requirements",
+              headers: { Authorization: "Bearer evil" },
+              signal: ac.signal,
+            },
+            { fetchImpl: async () => fakeResponse({ body: "{}" }) },
+          ),
+        (err) => err instanceof RequestError && err.code === "invalid_query_args",
+      );
+    }),
+  );
+
+  it(
+    "still rejects 'method' after the SDK-signal strip (regression)",
+    withBaseUrl("http://localhost:8000", async () => {
+      const ac = new AbortController();
+      await assert.rejects(
+        () =>
+          gcQueryToolHandler(
+            {
+              path: "/api/v1/requirements",
+              method: "DELETE",
+              signal: ac.signal,
+            },
+            { fetchImpl: async () => fakeResponse({ body: "{}" }) },
+          ),
+        (err) => err instanceof RequestError && err.code === "invalid_query_args",
+      );
+    }),
+  );
+});
+
+describe("stripSdkInjectedKeys", () => {
+  it("exposes a deliberately tiny runtime-key set (currently just 'signal')", () => {
+    // This test exists so growing the runtime-key set is a deliberate change.
+    // Adding a key requires updating this assertion (and the ADR-035
+    // "Public argument boundary" prose).
+    assert.deepEqual([...GC_QUERY_SDK_INJECTED_KEYS].sort(), ["signal"]);
+  });
+
+  it("returns a shallow copy without the documented runtime keys when the value shape matches", () => {
+    const ac = new AbortController();
+    const input = { path: "/api/v1/requirements", signal: ac.signal, params: { a: 1 } };
+    const out = stripSdkInjectedKeys(input);
+    assert.deepEqual(Object.keys(out).sort(), ["params", "path"]);
+    assert.notStrictEqual(out, input, "must return a new object, not mutate input");
+    assert.ok("signal" in input, "must not mutate input");
+  });
+
+  it("is a no-op on undefined / null / empty", () => {
+    assert.deepEqual(stripSdkInjectedKeys(undefined), {});
+    assert.deepEqual(stripSdkInjectedKeys(null), {});
+    assert.deepEqual(stripSdkInjectedKeys({}), {});
+  });
+
+  it("does not drop other unknown keys (only the documented runtime set)", () => {
+    // 'headers' and 'method' are caller-facing unknowns; they survive the
+    // strip and are rejected later by the handler allowlist. Stripping them
+    // here would mask the rejection.
+    const out = stripSdkInjectedKeys({
+      path: "/api/v1/x",
+      headers: { x: 1 },
+      method: "DELETE",
+    });
+    assert.deepEqual(Object.keys(out).sort(), ["headers", "method", "path"]);
+  });
+
+  it("does NOT drop a 'signal' key whose value is not an AbortSignal (preserves the public contract)", () => {
+    // A caller-supplied plain object under the name `signal` would otherwise
+    // bypass the public-argument allowlist silently. The shape predicate is
+    // what keeps the handler's defense in depth intact for arbitrary user
+    // input — the name alone is not enough.
+    for (const bogus of [
+      { aborted: false }, // looks like a stub but missing addEventListener
+      "not a signal",
+      42,
+      true,
+      null,
+    ]) {
+      const out = stripSdkInjectedKeys({ path: "/api/v1/x", signal: bogus });
+      assert.deepEqual(
+        Object.keys(out).sort(),
+        ["path", "signal"],
+        `bogus signal value ${JSON.stringify(bogus)} must survive the strip`,
+      );
+    }
+  });
+
+  it("accepts a cross-realm AbortSignal-shaped object via the duck-type fallback", () => {
+    // The duck-type fallback exists so an AbortSignal coming from a worker
+    // or a different module realm (where `instanceof AbortSignal` fails)
+    // still matches. The contract is: same surface as the built-in
+    // AbortSignal (boolean `aborted`, `addEventListener`,
+    // `removeEventListener`).
+    const fakeSignal = {
+      aborted: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    };
+    const out = stripSdkInjectedKeys({ path: "/api/v1/x", signal: fakeSignal });
+    assert.deepEqual(Object.keys(out), ["path"]);
+  });
+});
+
+describe("gcQueryToolHandler still rejects non-AbortSignal 'signal' values", () => {
+  // Regression for the cycle-1 codex finding on #874: the SDK-signal strip
+  // must not weaken the public-argument allowlist for non-runtime values
+  // under the same key name.
+  it(
+    "rejects a plain-object 'signal' (not an AbortSignal) with invalid_query_args",
+    withBaseUrl("http://localhost:8000", async () => {
+      await assert.rejects(
+        () =>
+          gcQueryToolHandler(
+            { path: "/api/v1/requirements", signal: { aborted: false } },
+            { fetchImpl: async () => fakeResponse({ body: "{}" }) },
+          ),
+        (err) => err instanceof RequestError && err.code === "invalid_query_args",
+      );
+    }),
+  );
+
+  it(
+    "rejects a string 'signal' with invalid_query_args",
+    withBaseUrl("http://localhost:8000", async () => {
+      await assert.rejects(
+        () =>
+          gcQueryToolHandler(
+            { path: "/api/v1/requirements", signal: "not-a-signal" },
+            { fetchImpl: async () => fakeResponse({ body: "{}" }) },
+          ),
+        (err) => err instanceof RequestError && err.code === "invalid_query_args",
+      );
+    }),
+  );
 });
 
 describe("gcQuerySchema (Zod-level strict rejection)", () => {
@@ -526,6 +730,134 @@ describe("truncateBody", () => {
     assert.equal(out.truncated, true);
     assert.equal(out.original_byte_length, Buffer.byteLength(body, "utf8"));
   });
+});
+
+describe("gc_query MCP registration (issue #874 end-to-end wiring)", () => {
+  // The cycle-1 codex fix only touched the handler. Cycle 2 found that the
+  // root cause is upstream: `server.tool(name, desc, gcQuerySchema, cb)`
+  // routes a constructed `.strict()` ZodObject into the `annotations` slot
+  // (not `inputSchema`), so the SDK calls the registered callback with its
+  // `extra` object (which carries `signal`) in the args position. This
+  // suite exercises the real `McpServer` + `Client` + `InMemoryTransport`
+  // wiring so a future regression of the registration shape fails here,
+  // not in production.
+  async function registeredServerCallingItself({ handler }) {
+    const server = new McpServer({ name: "gc-query-registration-test", version: "1.0.0" });
+    server.registerTool(
+      "gc_query",
+      { description: "test wiring", inputSchema: gcQuerySchema },
+      handler,
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    return { server, client };
+  }
+
+  it(
+    "tools/list reports gcQuerySchema as the inputSchema (not as annotations)",
+    withBaseUrl("http://localhost:8000", async () => {
+      const { client } = await registeredServerCallingItself({
+        handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+      });
+      try {
+        const list = await client.listTools();
+        const tool = list.tools.find((t) => t.name === "gc_query");
+        assert.ok(tool, "gc_query must be present in tools/list");
+        // The strict schema must surface as a proper JSON Schema with the
+        // documented properties + additionalProperties: false; an empty
+        // `{type: "object"}` would mean the SDK treated the schema as
+        // annotations (the issue #874 failure mode).
+        assert.equal(tool.inputSchema.type, "object");
+        assert.deepEqual(Object.keys(tool.inputSchema.properties).sort(), ["params", "path"]);
+        assert.equal(tool.inputSchema.additionalProperties, false);
+        assert.deepEqual(tool.inputSchema.required, ["path"]);
+      } finally {
+        await client.close();
+      }
+    }),
+  );
+
+  it(
+    "tools/call with {path} succeeds and the handler receives args without an SDK-injected signal",
+    withBaseUrl("http://localhost:8000", async () => {
+      let capturedArgs;
+      const { client } = await registeredServerCallingItself({
+        handler: async (args) => {
+          capturedArgs = args;
+          return { content: [{ type: "text", text: JSON.stringify(args) }] };
+        },
+      });
+      try {
+        const out = await client.callTool({
+          name: "gc_query",
+          arguments: { path: "/api/v1/requirements" },
+        });
+        assert.equal(out.isError, undefined);
+        assert.deepEqual(Object.keys(capturedArgs).sort(), ["path"]);
+        assert.equal(
+          Object.prototype.hasOwnProperty.call(capturedArgs, "signal"),
+          false,
+          "the SDK-injected AbortSignal must remain in `extra`, never in `args`",
+        );
+      } finally {
+        await client.close();
+      }
+    }),
+  );
+
+  it(
+    "tools/call rejects an extra key from the client (schema-level enforcement)",
+    withBaseUrl("http://localhost:8000", async () => {
+      const { client } = await registeredServerCallingItself({
+        handler: async () => ({ content: [{ type: "text", text: "should not run" }] }),
+      });
+      try {
+        // The MCP client surfaces validation errors as McpError; either it
+        // throws or the SDK returns isError. Either is acceptable — what
+        // matters is that an unknown key from the client is REJECTED, not
+        // silently dropped.
+        let rejected = false;
+        try {
+          const out = await client.callTool({
+            name: "gc_query",
+            arguments: { path: "/api/v1/requirements", headers: { Authorization: "Bearer evil" } },
+          });
+          if (out.isError) rejected = true;
+        } catch {
+          rejected = true;
+        }
+        assert.equal(rejected, true, "unknown caller key must be rejected by schema or transport");
+      } finally {
+        await client.close();
+      }
+    }),
+  );
+
+  it(
+    "tools/call with {path, params} routes both to the handler unchanged",
+    withBaseUrl("http://localhost:8000", async () => {
+      let capturedArgs;
+      const { client } = await registeredServerCallingItself({
+        handler: async (args) => {
+          capturedArgs = args;
+          return { content: [{ type: "text", text: "ok" }] };
+        },
+      });
+      try {
+        await client.callTool({
+          name: "gc_query",
+          arguments: { path: "/api/v1/requirements", params: { status: "ACTIVE" } },
+        });
+        assert.deepEqual(capturedArgs, {
+          path: "/api/v1/requirements",
+          params: { status: "ACTIVE" },
+        });
+      } finally {
+        await client.close();
+      }
+    }),
+  );
 });
 
 describe("gc_query allowlist docs match the implemented constant", () => {

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -250,14 +250,26 @@ const server = new McpServer({ name: "ground-control", version: "1.0.0" });
 // WORKFLOW PRIMITIVES — kept by name; /implement and /ship skills call these.
 // ============================================================================
 
-server.tool(
+// `gc_query` is the only tool in this file registered with a constructed
+// `z.object(...).strict()` (rather than a raw shape) so the SDK preserves
+// the strict-rejection contract. The deprecated `server.tool(name, desc,
+// schema, cb)` overload routes a constructed Zod object into the
+// `annotations` slot instead of `inputSchema`, which makes the SDK call
+// the handler with its `extra` object (containing `signal`) in the args
+// position — issue #874's root cause. `server.registerTool` takes
+// `inputSchema` explicitly, so the strict schema actually gates the call
+// and `signal` stays in `extra` where it belongs.
+server.registerTool(
   "gc_query",
-  `Read-only ad-hoc GET against the Ground Control REST API (ADR-035). Use this when no curated tool covers the read you need. ` +
-    `Path must be a relative '/api/v1/...' string under one of the allowlisted prefixes: ${GC_QUERY_PATH_ALLOWLIST.join(", ")}. ` +
-    `Admin prefixes (${GC_QUERY_PATH_DENYLIST.join(", ")}) are rejected. ` +
-    `GET only; pass query params via the structured 'params' object (flat, primitive values only). ` +
-    `Body cap: ${GC_QUERY_BODY_BYTE_CAP} bytes; timeout: ${GC_QUERY_TIMEOUT_MS}ms.`,
-  gcQuerySchema,
+  {
+    description:
+      `Read-only ad-hoc GET against the Ground Control REST API (ADR-035). Use this when no curated tool covers the read you need. ` +
+      `Path must be a relative '/api/v1/...' string under one of the allowlisted prefixes: ${GC_QUERY_PATH_ALLOWLIST.join(", ")}. ` +
+      `Admin prefixes (${GC_QUERY_PATH_DENYLIST.join(", ")}) are rejected. ` +
+      `GET only; pass query params via the structured 'params' object (flat, primitive values only). ` +
+      `Body cap: ${GC_QUERY_BODY_BYTE_CAP} bytes; timeout: ${GC_QUERY_TIMEOUT_MS}ms.`,
+    inputSchema: gcQuerySchema,
+  },
   async (args) => {
     try { return ok(JSON.stringify(await gcQueryToolHandler(args), null, 2)); }
     catch (e) { return err(e); }


### PR DESCRIPTION
## Summary

Fixes #874 — `gc_query`, the read fallback for every consolidated MCP tool whose description says "Reads route through gc_query" (ADR-035), failed every call with `invalid_query_args` because the registered `server.tool(name, desc, gcQuerySchema, cb)` overload routed the constructed `.strict()` ZodObject into the SDK's `annotations` slot. With `inputSchema` undefined, the SDK called the handler with its `extra` object (carrying `signal`) in the args position, and the handler's defense-in-depth allowlist rejected it. Switched the registration to `server.registerTool(name, { description, inputSchema: gcQuerySchema }, cb)`, which preserves `.strict()` and keeps `signal` in `extra` where it belongs. Added a narrow adapter-boundary normalizer (`stripSdkInjectedKeys`) gated on an `AbortSignal` shape predicate, so a caller-supplied non-AbortSignal under the same key name still fails loudly via the public allowlist.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #874

## ADR Impact

- ADR-035 (amended)

## Changes

- mcp/ground-control/index.js: switch `gc_query` registration from the deprecated `server.tool(..., schema, cb)` overload to `server.registerTool(name, { description, inputSchema: gcQuerySchema }, cb)`. Inline comment captures the SDK overload pitfall so a future refactor doesn't regress.
- mcp/ground-control/gc-query.js: add `stripSdkInjectedKeys` + `GC_QUERY_SDK_INJECTED_KEYS` + the `isAbortSignalLike` shape predicate; wire the strip into `gcQueryToolHandler` BEFORE the public allowlist so the seam is a tiny normalizer, not a `.passthrough()` into business logic. Handler docstring + ADR-035 cross-reference document the boundary.
- mcp/ground-control/gc-query.test.js: handler-level tests (signal accepted as runtime metadata; non-AbortSignal `signal` rejected via allowlist; `headers`/`method` still rejected after the strip); strip-level tests (shape predicate, cross-realm duck-type fallback, no-op on null/undefined/empty); end-to-end registration tests using `McpServer` + `Client` + `InMemoryTransport` (tools/list reports the strict schema with `additionalProperties: false`; tools/call with `{path}` succeeds and the handler's args has no `signal`; unknown caller keys rejected; `{path, params}` routes unchanged).
- architecture/adrs/035-mcp-tool-catalog-curation.md (amended): replace the `Strict Zod schema` paragraph with a `Public argument boundary` section that carves the seam — `path` + `params` is the public contract; SDK runtime metadata like `signal` is normalized away at the adapter boundary; `headers`/`method`/`body`/caller tokens still fail loudly. Adds a `Runtime metadata drift` risk note covering future SDK behavior changes.
- architecture/notes/mcp-tool-catalog-surface-preflight.md: cross-cutting `Transport metadata` bullet + `MCP runtime plumbing` security-layer bullet documenting the same boundary; gotcha forbidding generic `.passthrough()`.
- changelog.d/874.fixed.md: user-facing fix note.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- 60 unit + 4 end-to-end registration tests in `mcp/ground-control/gc-query.test.js`. The end-to-end tests will fail loudly if the registration regresses to the broken overload — the inputSchema-as-annotations failure mode that issue #874's bug report and codex cycle-2 both surfaced.
- `make policy` + `make check` green locally before push (Java 21 toolchain).
- Direct live verification against the running MCP server is gated on a server restart (long-lived Node process). CI runs against a fresh `node` process so the registration fix exercises end-to-end.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/874.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed