### PR TITLE
Fix gc_threat_model MCP create/update; close link_create class drift + ControlLinkService gap

### DIFF
--- a/architecture/notes/threat-model-mcp-contract-preflight.md
+++ b/architecture/notes/threat-model-mcp-contract-preflight.md
@@ -1,0 +1,123 @@
+# Threat Model MCP Contract Preflight
+
+Issue: #875
+Requirement: none
+
+This is architecture guardrail guidance for restoring
+`gc_threat_model` create/update usability. It is not an implementation plan.
+
+## Boundary
+
+The backend threat-model REST contract is already the semantic source of truth:
+`ThreatModelRequest`, `UpdateThreatModelRequest`, `ThreatModelController`,
+`ThreatModelService`, `ThreatModel`, and the Flyway threat-model tables already
+encode the domain shape, validation, project scoping, auditing, and persistence.
+
+The change belongs at the MCP adapter boundary. `gc_threat_model` should expose
+the backend DTO fields in snake_case, pick only allowed entity-body fields, and
+let `mcp/ground-control/lib.js` convert them to the backend camelCase JSON body.
+Do not rename backend fields, add a backend compatibility `description` field,
+or weaken backend validation to work around an adapter schema bug.
+
+## Incumbents To Reuse
+
+- Threat-model boundary: ADR-024. Threat models stay distinct from risk
+  scenarios, risk assessments, treatment plans, and risk register records.
+- MCP consolidation pattern: ADR-035. Keep the single action-discriminated
+  `gc_threat_model` tool, the flat Zod schema, handler-side `reqArg`, and the
+  `pick(args, ENTITY_FIELDS)` request-body allowlist.
+- MCP transport helpers: `buildUrl`, `addAuthorizationHeader`, `request`,
+  `RequestError`, `parseErrorBody`, `toCamelCase`, and `TO_CAMEL` in
+  `mcp/ground-control/lib.js`. The adapter should not add feature-local fetch,
+  auth-header, error parsing, or snake-to-camel logic.
+- Backend validation: Bean Validation on request records plus
+  `ThreatModelService` semantic validation for partial update blank rejection.
+  MCP-side required-field checks are caller guidance, not the source of truth.
+- Error envelope: backend errors flow through `GlobalExceptionHandler` and
+  `ErrorResponse`; MCP surfaces them via `RequestError` and `err()`.
+- Security and audit: ADR-026 and ADR-033. `/api/v1/threat-models/**` remains
+  under the shared API path matrix, bearer-token handling, actor provenance, and
+  MDC/request logging. MCP must continue to send `X-Actor: mcp-server` only as
+  the existing dev/test fallback; production actor identity comes from the
+  authenticated principal.
+- Tests and gates: focused MCP regression coverage belongs under
+  `mcp/ground-control` using the existing `node --test` harness. The backend
+  controller/service tests already cover the REST DTO mapping and validation.
+  Application-source changes need a changelog fragment, and `make policy` is the
+  repo-native completion guardrail.
+
+## Cross-Cutting Layers
+
+- MCP public schema: expose `threat_source`, `threat_event`, `effect`,
+  `narrative`, and the existing clear flags consistently with backend DTO
+  semantics. Keep unknown/control fields out of request bodies via the
+  `ENTITY_FIELDS` allowlist.
+- Request serialization: rely on `toCamelCase` and `TO_CAMEL` for snake_case to
+  camelCase conversion. Add field mappings only where names actually differ
+  (`threat_source`, `threat_event`, `stride_category`, `clear_*`); do not create
+  a second serializer.
+- Backend parser and validators: Jackson enum binding handles STRIDE values;
+  `@NotBlank` / `@Size` handle create shape; service-level
+  `rejectBlankIfPresent` handles update shape. Do not duplicate these rules as a
+  parallel validation system in MCP.
+- Project scoping: the adapter passes the optional `project` query parameter
+  through existing lib helpers. `ProjectService.resolveProjectId` remains the
+  project boundary.
+- Security/config/OS exposure: this change should require no new env vars,
+  secrets, subprocesses, shell commands, or argv-token handling. Existing MCP
+  env bindings are `GC_BASE_URL`, `GROUND_CONTROL_API_TOKEN`, and
+  `GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN`; tokens stay in headers and out of
+  logs/errors.
+- Error leakage: preserve the existing 401/403 stable messages and backend
+  validation envelopes. Do not reflect raw request bodies, bearer tokens, or
+  Authorization headers through MCP errors.
+- Persistence/audit/logging: no migration, repository, entity, or audit-table
+  change is needed. Envers, `ActorFilter`, `ActorHolder`, `RequestLoggingFilter`,
+  and service-level SLF4J lifecycle logs remain the only audit/observability
+  path.
+
+## Extensibility
+
+The extension seam is the MCP DTO mirror itself: the tool schema, the
+per-entity body allowlist, and `TO_CAMEL` field mapping. If this class of drift
+is generalized beyond #875, use a small static contract inventory modeled after
+ADR-034's `ENUM_CONTRACT_INVENTORY` so backend request-record fields and MCP
+mirrors can be checked without adding runtime reflection, generated schemas, or
+a second controller layer.
+
+Adjacent risk-scenario MCP create/update fields appear to carry a similar DTO
+mirror risk. Treat that as a separate scoped repair unless #875 is explicitly
+expanded; do not accidentally conflate threat-model semantics with risk-scenario
+semantics while touching nearby consolidated-tool code.
+
+## Gotchas And Anti-Patterns
+
+- Do not map `description` to a new backend field. Threat models have
+  `narrative`; `description` is a leaky generic CRUD convention from other
+  entities.
+- Do not send `status` on create as a substitute for lifecycle transition.
+  Creation defaults to `DRAFT`; status changes use the existing transition
+  action.
+- Do not put `target_identifier` into threat-model create/update bodies.
+  Link fields belong only to `link_create`.
+- Do not make MCP `metadata` authoritative for fields the backend models
+  explicitly.
+- Do not relax Zod to passthrough arbitrary keys to make this work; the allowlist
+  is the adapter boundary that prevents action/control fields from leaking into
+  REST bodies.
+- Do not add a threat-model-specific exception hierarchy, auth path, logger,
+  REST endpoint, graph write path, or persistence workaround.
+- Do not broaden enum or DTO contract policy casually. ADR-034 currently covers
+  selected enums; a DTO-shape gate should be explicit and inventory-driven.
+
+## Non-Goals
+
+- No backend domain model, controller, service, repository, migration, or
+  REST-contract redesign.
+- No new threat-model fields beyond the backend DTOs already in source.
+- No OpenAPI/codegen project, frontend type migration, or generic MCP schema
+  framework as part of #875.
+- No remediation of adjacent `gc_risk_scenario` contract drift unless it is
+  taken on as a separate issue or an explicit scope expansion.
+- No change to ADR-024, ADR-026, ADR-033, ADR-034, ADR-035, or the repo
+  workflow policy.

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/service/ControlLinkService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/service/ControlLinkService.java
@@ -5,6 +5,7 @@ import com.keplerops.groundcontrol.domain.controls.repository.ControlLinkReposit
 import com.keplerops.groundcontrol.domain.controls.state.ControlLinkTargetType;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.graph.service.GraphTargetResolverService;
 import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
@@ -20,33 +21,39 @@ public class ControlLinkService {
 
     private final ControlLinkRepository controlLinkRepository;
     private final ControlService controlService;
+    private final GraphTargetResolverService graphTargetResolverService;
 
-    public ControlLinkService(ControlLinkRepository controlLinkRepository, ControlService controlService) {
+    public ControlLinkService(
+            ControlLinkRepository controlLinkRepository,
+            ControlService controlService,
+            GraphTargetResolverService graphTargetResolverService) {
         this.controlLinkRepository = controlLinkRepository;
         this.controlService = controlService;
+        this.graphTargetResolverService = graphTargetResolverService;
     }
 
     public ControlLink create(UUID projectId, UUID controlId, CreateControlLinkCommand command) {
         var control = controlService.getById(projectId, controlId);
 
-        if (command.targetEntityId() != null
-                && controlLinkRepository.existsByControlIdAndTargetTypeAndTargetEntityIdAndLinkType(
-                        controlId, command.targetType(), command.targetEntityId(), command.linkType())) {
-            throw new ConflictException("Duplicate control link");
-        }
-        if (command.targetEntityId() == null
-                && command.targetIdentifier() != null
-                && controlLinkRepository.existsByControlIdAndTargetTypeAndTargetIdentifierAndLinkType(
-                        controlId, command.targetType(), command.targetIdentifier(), command.linkType())) {
+        // Validate the target before persisting: internal target types require a
+        // project-scoped targetEntityId that resolves to an existing entity;
+        // external target types require a nonblank targetIdentifier. Without
+        // this gate ControlLinkService.create() previously persisted whatever
+        // the caller supplied — including cross-project entity IDs.
+        var target = graphTargetResolverService.validateControlTarget(
+                projectId, command.targetType(), command.targetEntityId(), command.targetIdentifier());
+
+        boolean exists = target.internal()
+                ? controlLinkRepository.existsByControlIdAndTargetTypeAndTargetEntityIdAndLinkType(
+                        controlId, command.targetType(), target.targetEntityId(), command.linkType())
+                : controlLinkRepository.existsByControlIdAndTargetTypeAndTargetIdentifierAndLinkType(
+                        controlId, command.targetType(), target.targetIdentifier(), command.linkType());
+        if (exists) {
             throw new ConflictException("Duplicate control link");
         }
 
         var link = new ControlLink(
-                control,
-                command.targetType(),
-                command.targetEntityId(),
-                command.targetIdentifier(),
-                command.linkType());
+                control, command.targetType(), target.targetEntityId(), target.targetIdentifier(), command.linkType());
         if (command.targetUrl() != null) {
             link.setTargetUrl(command.targetUrl());
         }
@@ -55,9 +62,10 @@ public class ControlLinkService {
         }
         link = controlLinkRepository.save(link);
         log.info(
-                "control_link_created: control={} targetType={} linkType={}",
+                "control_link_created: control={} targetType={} target={} linkType={}",
                 control.getUid(),
                 command.targetType(),
+                target.internal() ? target.targetEntityId() : target.targetIdentifier(),
                 command.linkType());
         return link;
     }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java
@@ -4,6 +4,7 @@ import com.keplerops.groundcontrol.domain.assets.repository.ObservationRepositor
 import com.keplerops.groundcontrol.domain.assets.repository.OperationalAssetRepository;
 import com.keplerops.groundcontrol.domain.assets.state.AssetLinkTargetType;
 import com.keplerops.groundcontrol.domain.controls.repository.ControlRepository;
+import com.keplerops.groundcontrol.domain.controls.state.ControlLinkTargetType;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.MethodologyProfileRepository;
@@ -151,6 +152,54 @@ public class GraphTargetResolverService {
                     threatModelRepository.existsByIdAndProjectId(targetEntityId, projectId),
                     "Threat model");
             case VULNERABILITY, FINDING, EVIDENCE, AUDIT_RECORD, EXTERNAL -> externalTarget(targetIdentifier);
+        };
+    }
+
+    public ValidatedTarget validateControlTarget(
+            UUID projectId, ControlLinkTargetType targetType, UUID targetEntityId, String targetIdentifier) {
+        return switch (targetType) {
+            case ASSET -> internalTarget(
+                    targetEntityId, assetRepository.existsByIdAndProjectId(targetEntityId, projectId), "Asset");
+            case REQUIREMENT -> internalTarget(
+                    targetEntityId,
+                    requirementRepository.existsByIdAndProjectId(targetEntityId, projectId),
+                    "Requirement");
+            case RISK_SCENARIO -> internalTarget(
+                    targetEntityId,
+                    riskScenarioRepository.existsByIdAndProjectId(targetEntityId, projectId),
+                    "Risk scenario");
+            case RISK_REGISTER_RECORD -> internalTarget(
+                    targetEntityId,
+                    riskRegisterRecordRepository
+                            .findByIdAndProjectIdWithScenarios(targetEntityId, projectId)
+                            .isPresent(),
+                    "Risk register record");
+            case RISK_ASSESSMENT_RESULT -> internalTarget(
+                    targetEntityId,
+                    riskAssessmentResultRepository
+                            .findByIdAndProjectIdWithObservations(targetEntityId, projectId)
+                            .isPresent(),
+                    "Risk assessment result");
+            case TREATMENT_PLAN -> internalTarget(
+                    targetEntityId,
+                    treatmentPlanRepository
+                            .findByIdAndProjectId(targetEntityId, projectId)
+                            .isPresent(),
+                    "Treatment plan");
+            case METHODOLOGY_PROFILE -> internalTarget(
+                    targetEntityId,
+                    methodologyProfileRepository
+                            .findByIdAndProjectId(targetEntityId, projectId)
+                            .isPresent(),
+                    "Methodology profile");
+            case OBSERVATION -> internalTarget(
+                    targetEntityId,
+                    observationRepository
+                            .findByIdWithAssetAndProjectId(targetEntityId, projectId)
+                            .isPresent(),
+                    "Observation");
+            case EVIDENCE, FINDING, CODE, CONFIGURATION, OPERATIONAL_ARTIFACT, EXTERNAL -> externalTarget(
+                    targetIdentifier);
         };
     }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlLinkServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlLinkServiceTest.java
@@ -16,7 +16,9 @@ import com.keplerops.groundcontrol.domain.controls.state.ControlFunction;
 import com.keplerops.groundcontrol.domain.controls.state.ControlLinkTargetType;
 import com.keplerops.groundcontrol.domain.controls.state.ControlLinkType;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.graph.service.GraphTargetResolverService;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +39,9 @@ class ControlLinkServiceTest {
 
     @Mock
     private ControlService controlService;
+
+    @Mock
+    private GraphTargetResolverService graphTargetResolverService;
 
     @InjectMocks
     private ControlLinkService controlLinkService;
@@ -61,23 +66,98 @@ class ControlLinkServiceTest {
         @Test
         void createsLinkWithExternalIdentifier() {
             when(controlService.getById(projectId, controlId)).thenReturn(control);
+            when(graphTargetResolverService.validateControlTarget(
+                            projectId, ControlLinkTargetType.EXTERNAL, null, "EXT-001"))
+                    .thenReturn(new GraphTargetResolverService.ValidatedTarget(null, "EXT-001", false));
             when(controlLinkRepository.existsByControlIdAndTargetTypeAndTargetIdentifierAndLinkType(
-                            controlId, ControlLinkTargetType.ASSET, "ASSET-001", ControlLinkType.PROTECTS))
+                            controlId, ControlLinkTargetType.EXTERNAL, "EXT-001", ControlLinkType.ASSOCIATED))
                     .thenReturn(false);
             when(controlLinkRepository.save(any(ControlLink.class))).thenAnswer(inv -> inv.getArgument(0));
 
             var command = new com.keplerops.groundcontrol.domain.controls.service.CreateControlLinkCommand(
-                    ControlLinkTargetType.ASSET, null, "ASSET-001", ControlLinkType.PROTECTS, null, null);
+                    ControlLinkTargetType.EXTERNAL, null, "EXT-001", ControlLinkType.ASSOCIATED, null, null);
+            var result = controlLinkService.create(projectId, controlId, command);
+
+            assertThat(result.getTargetType()).isEqualTo(ControlLinkTargetType.EXTERNAL);
+            assertThat(result.getTargetIdentifier()).isEqualTo("EXT-001");
+            assertThat(result.getLinkType()).isEqualTo(ControlLinkType.ASSOCIATED);
+        }
+
+        @Test
+        void createsLinkWithInternalEntityId() {
+            var assetId = UUID.randomUUID();
+            when(controlService.getById(projectId, controlId)).thenReturn(control);
+            when(graphTargetResolverService.validateControlTarget(
+                            projectId, ControlLinkTargetType.ASSET, assetId, null))
+                    .thenReturn(new GraphTargetResolverService.ValidatedTarget(assetId, null, true));
+            when(controlLinkRepository.existsByControlIdAndTargetTypeAndTargetEntityIdAndLinkType(
+                            controlId, ControlLinkTargetType.ASSET, assetId, ControlLinkType.PROTECTS))
+                    .thenReturn(false);
+            when(controlLinkRepository.save(any(ControlLink.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new com.keplerops.groundcontrol.domain.controls.service.CreateControlLinkCommand(
+                    ControlLinkTargetType.ASSET, assetId, null, ControlLinkType.PROTECTS, null, null);
             var result = controlLinkService.create(projectId, controlId, command);
 
             assertThat(result.getTargetType()).isEqualTo(ControlLinkTargetType.ASSET);
-            assertThat(result.getTargetIdentifier()).isEqualTo("ASSET-001");
+            assertThat(result.getTargetEntityId()).isEqualTo(assetId);
+            assertThat(result.getTargetIdentifier()).isNull();
             assertThat(result.getLinkType()).isEqualTo(ControlLinkType.PROTECTS);
+        }
+
+        @Test
+        void rejectsCrossProjectInternalTarget() {
+            // Issue #875: ControlLinkService used to persist targetEntityId
+            // without validating project scope. GraphTargetResolverService now
+            // does the existence/project check; a target from another project
+            // surfaces as DomainValidationException with "not found".
+            var foreignAssetId = UUID.randomUUID();
+            when(controlService.getById(projectId, controlId)).thenReturn(control);
+            when(graphTargetResolverService.validateControlTarget(
+                            projectId, ControlLinkTargetType.ASSET, foreignAssetId, null))
+                    .thenThrow(new DomainValidationException("Asset target not found in the requested project"));
+
+            var command = new com.keplerops.groundcontrol.domain.controls.service.CreateControlLinkCommand(
+                    ControlLinkTargetType.ASSET, foreignAssetId, null, ControlLinkType.PROTECTS, null, null);
+            assertThatThrownBy(() -> controlLinkService.create(projectId, controlId, command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("not found in the requested project");
+        }
+
+        @Test
+        void rejectsInternalTargetWithMissingEntityId() {
+            when(controlService.getById(projectId, controlId)).thenReturn(control);
+            when(graphTargetResolverService.validateControlTarget(
+                            projectId, ControlLinkTargetType.REQUIREMENT, null, null))
+                    .thenThrow(new DomainValidationException("Requirement links require targetEntityId"));
+
+            var command = new com.keplerops.groundcontrol.domain.controls.service.CreateControlLinkCommand(
+                    ControlLinkTargetType.REQUIREMENT, null, null, ControlLinkType.MITIGATES, null, null);
+            assertThatThrownBy(() -> controlLinkService.create(projectId, controlId, command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("require targetEntityId");
+        }
+
+        @Test
+        void rejectsExternalTargetWithBlankIdentifier() {
+            when(controlService.getById(projectId, controlId)).thenReturn(control);
+            when(graphTargetResolverService.validateControlTarget(
+                            projectId, ControlLinkTargetType.EXTERNAL, null, null))
+                    .thenThrow(new DomainValidationException("External or unmodeled links require targetIdentifier"));
+
+            var command = new com.keplerops.groundcontrol.domain.controls.service.CreateControlLinkCommand(
+                    ControlLinkTargetType.EXTERNAL, null, null, ControlLinkType.ASSOCIATED, null, null);
+            assertThatThrownBy(() -> controlLinkService.create(projectId, controlId, command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("require targetIdentifier");
         }
 
         @Test
         void throwsOnDuplicateLink() {
             when(controlService.getById(projectId, controlId)).thenReturn(control);
+            when(graphTargetResolverService.validateControlTarget(
+                            projectId, ControlLinkTargetType.EXTERNAL, null, "ext-1"))
+                    .thenReturn(new GraphTargetResolverService.ValidatedTarget(null, "ext-1", false));
             when(controlLinkRepository.existsByControlIdAndTargetTypeAndTargetIdentifierAndLinkType(
                             controlId, ControlLinkTargetType.EXTERNAL, "ext-1", ControlLinkType.ASSOCIATED))
                     .thenReturn(true);

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GraphTargetResolverServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GraphTargetResolverServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import com.keplerops.groundcontrol.domain.assets.repository.ObservationRepository;
 import com.keplerops.groundcontrol.domain.assets.repository.OperationalAssetRepository;
 import com.keplerops.groundcontrol.domain.assets.state.AssetLinkTargetType;
+import com.keplerops.groundcontrol.domain.controls.state.ControlLinkTargetType;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.graph.service.GraphTargetResolverService;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
@@ -255,6 +256,69 @@ class GraphTargetResolverServiceTest {
                 .hasMessageContaining("targetIdentifier");
     }
 
+    @ParameterizedTest
+    @EnumSource(
+            value = ControlLinkTargetType.class,
+            names = {
+                "ASSET",
+                "REQUIREMENT",
+                "RISK_SCENARIO",
+                "RISK_REGISTER_RECORD",
+                "RISK_ASSESSMENT_RESULT",
+                "TREATMENT_PLAN",
+                "METHODOLOGY_PROFILE",
+                "OBSERVATION"
+            })
+    void validateControlTargetAcceptsInternalTargets(ControlLinkTargetType targetType) {
+        stubControlInternalTarget(targetType, true);
+
+        var validated = graphTargetResolverService.validateControlTarget(projectId, targetType, targetId, null);
+
+        assertThat(validated.internal()).isTrue();
+        assertThat(validated.targetEntityId()).isEqualTo(targetId);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ControlLinkTargetType.class,
+            names = {"EVIDENCE", "FINDING", "CODE", "CONFIGURATION", "OPERATIONAL_ARTIFACT", "EXTERNAL"})
+    void validateControlTargetAcceptsExternalTargets(ControlLinkTargetType targetType) {
+        var validated = graphTargetResolverService.validateControlTarget(projectId, targetType, null, "ref://ext/1");
+
+        assertThat(validated.internal()).isFalse();
+        assertThat(validated.targetEntityId()).isNull();
+        assertThat(validated.targetIdentifier()).isEqualTo("ref://ext/1");
+    }
+
+    @Test
+    void validateControlTargetRejectsMissingInternalTargetEntityId() {
+        assertThatThrownBy(() -> graphTargetResolverService.validateControlTarget(
+                        projectId, ControlLinkTargetType.ASSET, null, null))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("targetEntityId");
+    }
+
+    @Test
+    void validateControlTargetRejectsCrossProjectInternalTarget() {
+        // Issue #875: an attacker passing a UUID from project B with the
+        // current control's project A used to silently persist a cross-project
+        // edge. The resolver now enforces project-scoped existence.
+        when(requirementRepository.existsByIdAndProjectId(targetId, projectId)).thenReturn(false);
+
+        assertThatThrownBy(() -> graphTargetResolverService.validateControlTarget(
+                        projectId, ControlLinkTargetType.REQUIREMENT, targetId, null))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("not found");
+    }
+
+    @Test
+    void validateControlTargetRejectsMissingExternalIdentifier() {
+        assertThatThrownBy(() -> graphTargetResolverService.validateControlTarget(
+                        projectId, ControlLinkTargetType.EXTERNAL, null, " "))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("targetIdentifier");
+    }
+
     private void stubAssetInternalTarget(AssetLinkTargetType targetType, boolean exists) {
         switch (targetType) {
             case REQUIREMENT -> when(requirementRepository.existsByIdAndProjectId(targetId, projectId))
@@ -377,6 +441,58 @@ class GraphTargetResolverServiceTest {
                     .thenReturn(exists);
             case ARCHITECTURE_MODEL, CODE, ISSUE, EVIDENCE, EXTERNAL -> throw new IllegalArgumentException(
                     "Not an internal target type");
+        }
+    }
+
+    private void stubControlInternalTarget(ControlLinkTargetType targetType, boolean exists) {
+        switch (targetType) {
+            case ASSET -> when(assetRepository.existsByIdAndProjectId(targetId, projectId))
+                    .thenReturn(exists);
+            case REQUIREMENT -> when(requirementRepository.existsByIdAndProjectId(targetId, projectId))
+                    .thenReturn(exists);
+            case RISK_SCENARIO -> when(riskScenarioRepository.existsByIdAndProjectId(targetId, projectId))
+                    .thenReturn(exists);
+            case RISK_REGISTER_RECORD -> when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(
+                            targetId, projectId))
+                    .thenReturn(
+                            exists
+                                    ? java.util.Optional.of(org.mockito.Mockito.mock(
+                                            com.keplerops.groundcontrol.domain.riskscenarios.model.RiskRegisterRecord
+                                                    .class))
+                                    : java.util.Optional.empty());
+            case RISK_ASSESSMENT_RESULT -> when(riskAssessmentResultRepository.findByIdAndProjectIdWithObservations(
+                            targetId, projectId))
+                    .thenReturn(
+                            exists
+                                    ? java.util.Optional.of(org.mockito.Mockito.mock(
+                                            com.keplerops.groundcontrol.domain.riskscenarios.model.RiskAssessmentResult
+                                                    .class))
+                                    : java.util.Optional.empty());
+            case TREATMENT_PLAN -> when(treatmentPlanRepository.findByIdAndProjectId(targetId, projectId))
+                    .thenReturn(
+                            exists
+                                    ? java.util.Optional.of(org.mockito.Mockito.mock(
+                                            com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan.class))
+                                    : java.util.Optional.empty());
+            case METHODOLOGY_PROFILE -> when(methodologyProfileRepository.findByIdAndProjectId(targetId, projectId))
+                    .thenReturn(
+                            exists
+                                    ? java.util.Optional.of(org.mockito.Mockito.mock(
+                                            com.keplerops.groundcontrol.domain.riskscenarios.model.MethodologyProfile
+                                                    .class))
+                                    : java.util.Optional.empty());
+            case OBSERVATION -> when(observationRepository.findByIdWithAssetAndProjectId(targetId, projectId))
+                    .thenReturn(
+                            exists
+                                    ? java.util.Optional.of(org.mockito.Mockito.mock(
+                                            com.keplerops.groundcontrol.domain.assets.model.Observation.class))
+                                    : java.util.Optional.empty());
+            case EVIDENCE,
+                    FINDING,
+                    CODE,
+                    CONFIGURATION,
+                    OPERATIONAL_ARTIFACT,
+                    EXTERNAL -> throw new IllegalArgumentException("Not an internal target type");
         }
     }
 }

--- a/changelog.d/875.fixed.md
+++ b/changelog.d/875.fixed.md
@@ -1,0 +1,27 @@
+`gc_threat_model` MCP tool can finally create and update threat models.
+The Zod schema now exposes `threat_source`, `threat_event`, `effect`,
+`narrative`, and the update-only `clear_stride` / `clear_narrative`
+flags, and `stride_category` is mapped to the backend's `stride` field
+on the wire (Jackson previously dropped it silently). `description` is
+removed from the request allowlist — `ThreatModelRequest` has no such
+field; use `narrative` instead.
+
+The same MCP-side drift in the consolidated `link_create` action — every
+backend link DTO accepts `target_entity_id`, `target_url`, and
+`target_title` in addition to `target_identifier`, but the MCP tools
+only exposed `target_identifier` and unconditionally required it —
+is repaired across `gc_asset`, `gc_threat_model`, `gc_risk_scenario`,
+and `gc_control`. A shared `performLinkCreate` adapter now drives every
+consolidated link_create surface, so internal-target links (REQUIREMENT,
+ASSET, CONTROL, RISK_SCENARIO, etc.) can finally be created via MCP
+using `target_entity_id`.
+
+Also closes a pre-existing security gap surfaced by the broadened MCP
+surface: `ControlLinkService.create` used to persist `targetEntityId`
+directly without project-scoped existence checks, so a tenant with
+link-create rights on a control in project A could persist a control
+link to an arbitrary entity UUID from project B. `ControlLinkService`
+now goes through a new `GraphTargetResolverService.validateControlTarget`
+mirror of the existing `validateAssetTarget` /
+`validateRiskScenarioTarget` / `validateThreatModelTarget` methods,
+matching the rest of the link-service family.

--- a/mcp/ground-control/gc-threat-model.js
+++ b/mcp/ground-control/gc-threat-model.js
@@ -1,0 +1,117 @@
+// gc_threat_model: action-discriminated MCP adapter for the backend threat-model
+// REST surface (ADR-024, ADR-035). Extracted from index.js so the handler logic
+// is testable in isolation — see lib.test.js and the gc-threat-model.test.js
+// adapter-level tests covering create/update body shapes, required-field
+// enforcement, and snake_case <-> camelCase mapping (issue #875).
+
+import { z } from "zod";
+import {
+  THREAT_MODEL_STATUSES, STRIDE_CATEGORIES,
+  THREAT_MODEL_LINK_TARGET_TYPES, THREAT_MODEL_LINK_TYPES,
+  createThreatModel, updateThreatModel, deleteThreatModel,
+  transitionThreatModelStatus, createThreatModelLink, deleteThreatModelLink,
+  pick, reqArg,
+} from "./lib.js";
+import {
+  linkCreateOptionalSharedZodFields,
+  performLinkCreate,
+} from "./link-create.js";
+
+export const GC_THREAT_MODEL_ACTIONS = [
+  "create", "update", "delete", "transition", "link_create", "link_delete",
+];
+
+// Snake_case body fields accepted by gc_threat_model.create — mirrors
+// backend ThreatModelRequest. uid is create-only; the update DTO has no uid.
+export const GC_THREAT_MODEL_CREATE_BODY_FIELDS = [
+  "uid", "title", "threat_source", "threat_event", "effect",
+  "stride_category", "narrative",
+];
+
+// Snake_case body fields accepted by gc_threat_model.update — mirrors
+// backend UpdateThreatModelRequest. clear_stride / clear_narrative are
+// update-only flags; the create DTO has no such fields.
+export const GC_THREAT_MODEL_UPDATE_BODY_FIELDS = [
+  "title", "threat_source", "threat_event", "effect",
+  "stride_category", "narrative", "clear_stride", "clear_narrative",
+];
+
+// @NotBlank fields on backend ThreatModelRequest. Enforced at the adapter
+// boundary so callers get a clear `'X' is required` error instead of waiting
+// for a backend 422.
+export const GC_THREAT_MODEL_CREATE_REQUIRED_FIELDS = [
+  "uid", "title", "threat_source", "threat_event", "effect",
+];
+
+export const gcThreatModelZodShape = {
+  action: z.enum(GC_THREAT_MODEL_ACTIONS),
+  id: z.string().uuid().optional(),
+  uid: z.string().optional(),
+  project: z.string().optional(),
+  title: z.string().optional(),
+  threat_source: z.string().optional(),
+  threat_event: z.string().optional(),
+  effect: z.string().optional(),
+  stride_category: z.enum(STRIDE_CATEGORIES).optional(),
+  narrative: z.string().optional(),
+  clear_stride: z.boolean().optional(),
+  clear_narrative: z.boolean().optional(),
+  status: z.enum(THREAT_MODEL_STATUSES).optional(),
+  threat_model_id: z.string().uuid().optional(),
+  target_type: z.enum(THREAT_MODEL_LINK_TARGET_TYPES).optional(),
+  link_type: z.enum(THREAT_MODEL_LINK_TYPES).optional(),
+  ...linkCreateOptionalSharedZodFields,
+  link_id: z.string().uuid().optional(),
+};
+
+export const GC_THREAT_MODEL_DESCRIPTION =
+  `Threat models + their links. Actions: ${GC_THREAT_MODEL_ACTIONS.join(", ")}. ` +
+  `create requires: ${GC_THREAT_MODEL_CREATE_REQUIRED_FIELDS.join(", ")} (and accepts ` +
+  `optional stride_category, narrative). update accepts the same fields minus uid plus ` +
+  `clear_stride / clear_narrative to explicitly null optional fields. ` +
+  `status is consumed only by the transition action (creation defaults to DRAFT). ` +
+  `link_create requires target_type + link_type; for internal target types ` +
+  `(ASSET / REQUIREMENT / CONTROL / RISK_SCENARIO / etc.) pass target_entity_id, ` +
+  `for external types (EXTERNAL / EVIDENCE / ISSUE / CODE / etc.) pass target_identifier. ` +
+  `target_url and target_title are optional. ` +
+  `Reads (list, get, links_list) route through gc_query.`;
+
+/**
+ * Pure adapter handler for gc_threat_model. Validates required fields, picks
+ * action-scoped body fields, and dispatches to the corresponding lib.js call.
+ * Returns the raw value the lib call produces (or null for delete-style 204s);
+ * the index.js registration wraps the return in the MCP `ok()` envelope.
+ */
+export async function gcThreatModelToolHandler(args) {
+  switch (args.action) {
+    case "create": {
+      for (const key of GC_THREAT_MODEL_CREATE_REQUIRED_FIELDS) reqArg(args, key, "create");
+      return createThreatModel(pick(args, GC_THREAT_MODEL_CREATE_BODY_FIELDS), args.project);
+    }
+    case "update": {
+      reqArg(args, "id", "update");
+      return updateThreatModel(args.id, pick(args, GC_THREAT_MODEL_UPDATE_BODY_FIELDS), args.project);
+    }
+    case "delete": {
+      reqArg(args, "id", "delete");
+      await deleteThreatModel(args.id, args.project);
+      return null;
+    }
+    case "transition": {
+      reqArg(args, "id", "transition");
+      reqArg(args, "status", "transition");
+      return transitionThreatModelStatus(args.id, args.status, args.project);
+    }
+    case "link_create": {
+      return performLinkCreate(args, "threat_model_id", createThreatModelLink);
+    }
+    case "link_delete": {
+      reqArg(args, "threat_model_id", "link_delete");
+      reqArg(args, "link_id", "link_delete");
+      await deleteThreatModelLink(args.threat_model_id, args.link_id, args.project);
+      return null;
+    }
+    default:
+      throw new Error(`Unknown action: ${args.action}`);
+  }
+}

--- a/mcp/ground-control/gc-threat-model.test.js
+++ b/mcp/ground-control/gc-threat-model.test.js
@@ -1,0 +1,385 @@
+// Adapter-level tests for the gc_threat_model MCP handler. Exercise the full
+// path Zod-parsed args → handler dispatch → backend HTTP call (mocked fetch)
+// → wire body shape. Together with lib.test.js's toCamelCase shape tests
+// they cover the regression in issue #875 end-to-end: the original bug would
+// resurface here if the handler stopped using the body allowlists, leaked
+// create-only fields into update bodies, or skipped a required-field check.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import {
+  GC_THREAT_MODEL_ACTIONS,
+  GC_THREAT_MODEL_CREATE_BODY_FIELDS,
+  GC_THREAT_MODEL_UPDATE_BODY_FIELDS,
+  GC_THREAT_MODEL_CREATE_REQUIRED_FIELDS,
+  gcThreatModelZodShape,
+  gcThreatModelToolHandler,
+} from "./gc-threat-model.js";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_BASE_URL = process.env.GC_BASE_URL;
+const ORIGINAL_API_TOKEN = process.env.GROUND_CONTROL_API_TOKEN;
+
+function makeFetchSpy({ status = 200, body = { id: "tm-uuid" } } = {}) {
+  const calls = [];
+  globalThis.fetch = async (url, opts) => {
+    const parsedBody = opts && opts.body ? JSON.parse(opts.body) : null;
+    calls.push({ url: url.toString(), method: opts?.method ?? "GET", body: parsedBody });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.GC_BASE_URL = "https://gc.test";
+  delete process.env.GROUND_CONTROL_API_TOKEN;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_BASE_URL === undefined) delete process.env.GC_BASE_URL;
+  else process.env.GC_BASE_URL = ORIGINAL_BASE_URL;
+  if (ORIGINAL_API_TOKEN === undefined) delete process.env.GROUND_CONTROL_API_TOKEN;
+  else process.env.GROUND_CONTROL_API_TOKEN = ORIGINAL_API_TOKEN;
+});
+
+describe("gcThreatModelZodShape (issue #875)", () => {
+  const schema = z.object(gcThreatModelZodShape);
+
+  it("preserves every backend create body field through Zod parse", () => {
+    const parsed = schema.parse({
+      action: "create",
+      uid: "TM-1",
+      title: "T",
+      threat_source: "src",
+      threat_event: "evt",
+      effect: "eff",
+      stride_category: "TAMPERING",
+      narrative: "n",
+    });
+    for (const k of GC_THREAT_MODEL_CREATE_BODY_FIELDS) {
+      assert.ok(k in parsed, `Zod stripped '${k}' — the create body would be missing it on the wire`);
+    }
+  });
+
+  it("preserves the update-only clear_* flags through Zod parse", () => {
+    const parsed = schema.parse({
+      action: "update",
+      id: "11111111-1111-1111-1111-111111111111",
+      clear_stride: true,
+      clear_narrative: false,
+    });
+    assert.equal(parsed.clear_stride, true);
+    assert.equal(parsed.clear_narrative, false);
+  });
+
+  it("strips 'description' (backend has no such field on threat-model DTOs)", () => {
+    const parsed = schema.parse({
+      action: "create",
+      uid: "TM-1",
+      title: "T",
+      threat_source: "src",
+      threat_event: "evt",
+      effect: "eff",
+      description: "should-be-stripped",
+    });
+    assert.ok(!("description" in parsed));
+  });
+
+  it("rejects an unknown action enum value", () => {
+    assert.throws(() => schema.parse({ action: "merge" }));
+  });
+});
+
+describe("GC_THREAT_MODEL_CREATE_BODY_FIELDS (issue #875)", () => {
+  it("contains every backend @NotBlank create field", () => {
+    for (const required of ["uid", "title", "threat_source", "threat_event", "effect"]) {
+      assert.ok(GC_THREAT_MODEL_CREATE_BODY_FIELDS.includes(required));
+    }
+  });
+
+  it("does NOT contain update-only clear_* flags", () => {
+    assert.ok(!GC_THREAT_MODEL_CREATE_BODY_FIELDS.includes("clear_stride"));
+    assert.ok(!GC_THREAT_MODEL_CREATE_BODY_FIELDS.includes("clear_narrative"));
+  });
+
+  it("does NOT contain 'description' (backend has no such field)", () => {
+    assert.ok(!GC_THREAT_MODEL_CREATE_BODY_FIELDS.includes("description"));
+  });
+});
+
+describe("GC_THREAT_MODEL_UPDATE_BODY_FIELDS (issue #875)", () => {
+  it("contains every backend Update DTO field", () => {
+    for (const f of ["title", "threat_source", "threat_event", "effect", "stride_category", "narrative", "clear_stride", "clear_narrative"]) {
+      assert.ok(GC_THREAT_MODEL_UPDATE_BODY_FIELDS.includes(f));
+    }
+  });
+
+  it("does NOT contain create-only 'uid' (UpdateThreatModelRequest has no uid)", () => {
+    assert.ok(!GC_THREAT_MODEL_UPDATE_BODY_FIELDS.includes("uid"));
+  });
+});
+
+describe("GC_THREAT_MODEL_ACTIONS", () => {
+  it("matches the action verbs the handler dispatches", () => {
+    assert.deepEqual(
+      [...GC_THREAT_MODEL_ACTIONS].sort(),
+      ["create", "delete", "link_create", "link_delete", "transition", "update"],
+    );
+  });
+});
+
+describe("gcThreatModelToolHandler create (issue #875)", () => {
+  it("sends every required field to /api/v1/threat-models as camelCase", async () => {
+    const calls = makeFetchSpy();
+    await gcThreatModelToolHandler({
+      action: "create",
+      uid: "TM-1",
+      title: "Title",
+      threat_source: "Source",
+      threat_event: "Event",
+      effect: "Effect",
+      stride_category: "TAMPERING",
+      narrative: "Note",
+      project: "proj-a",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, /\/api\/v1\/threat-models\b/);
+    assert.match(calls[0].url, /project=proj-a/);
+    assert.deepEqual(calls[0].body, {
+      uid: "TM-1",
+      title: "Title",
+      threatSource: "Source",
+      threatEvent: "Event",
+      effect: "Effect",
+      stride: "TAMPERING",
+      narrative: "Note",
+    });
+  });
+
+  it("does NOT forward update-only clear_* flags or unknown fields", async () => {
+    const calls = makeFetchSpy();
+    await gcThreatModelToolHandler({
+      action: "create",
+      uid: "TM-1",
+      title: "Title",
+      threat_source: "Source",
+      threat_event: "Event",
+      effect: "Effect",
+      clear_stride: true,
+      clear_narrative: true,
+      description: "ignored",
+      metadata: { foo: "bar" },
+    });
+    assert.equal(calls.length, 1);
+    const sent = Object.keys(calls[0].body).sort();
+    assert.deepEqual(sent, ["effect", "threatEvent", "threatSource", "title", "uid"]);
+  });
+
+  for (const missing of GC_THREAT_MODEL_CREATE_REQUIRED_FIELDS) {
+    it(`rejects create before any HTTP call when '${missing}' is missing`, async () => {
+      const calls = makeFetchSpy();
+      const args = {
+        action: "create",
+        uid: "TM-1",
+        title: "T",
+        threat_source: "s",
+        threat_event: "e",
+        effect: "f",
+      };
+      delete args[missing];
+      await assert.rejects(
+        () => gcThreatModelToolHandler(args),
+        (e) => e.message.includes(`'${missing}' is required`),
+      );
+      assert.equal(calls.length, 0);
+    });
+  }
+});
+
+describe("gcThreatModelToolHandler update (issue #875)", () => {
+  const ID = "22222222-2222-2222-2222-222222222222";
+
+  it("PUTs to /api/v1/threat-models/<id> with the camelCase update body", async () => {
+    const calls = makeFetchSpy();
+    await gcThreatModelToolHandler({
+      action: "update",
+      id: ID,
+      title: "New title",
+      threat_source: "src2",
+      threat_event: "evt2",
+      effect: "eff2",
+      stride_category: "SPOOFING",
+      narrative: "n2",
+      clear_stride: false,
+      clear_narrative: true,
+      project: "proj-a",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, new RegExp(`/api/v1/threat-models/${ID}\\b`));
+    assert.deepEqual(calls[0].body, {
+      title: "New title",
+      threatSource: "src2",
+      threatEvent: "evt2",
+      effect: "eff2",
+      stride: "SPOOFING",
+      narrative: "n2",
+      clearStride: false,
+      clearNarrative: true,
+    });
+  });
+
+  it("never forwards create-only 'uid' on update (UpdateThreatModelRequest has no uid)", async () => {
+    const calls = makeFetchSpy();
+    await gcThreatModelToolHandler({
+      action: "update",
+      id: ID,
+      uid: "TM-LEAK",
+      title: "T",
+    });
+    assert.equal(calls.length, 1);
+    assert.ok(!("uid" in calls[0].body));
+    assert.equal(calls[0].body.title, "T");
+  });
+
+  it("rejects update with no id before any HTTP call", async () => {
+    const calls = makeFetchSpy();
+    await assert.rejects(
+      () => gcThreatModelToolHandler({ action: "update" }),
+      (e) => e.message.includes("'id' is required"),
+    );
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("gcThreatModelToolHandler other actions", () => {
+  const ID = "33333333-3333-3333-3333-333333333333";
+
+  it("delete returns null and issues a DELETE", async () => {
+    const calls = makeFetchSpy({ status: 204, body: null });
+    globalThis.fetch = async (url, opts) => {
+      calls.push({ url: url.toString(), method: opts?.method ?? "GET", body: null });
+      return new Response(null, { status: 204 });
+    };
+    const result = await gcThreatModelToolHandler({ action: "delete", id: ID });
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.match(calls[0].url, new RegExp(`/api/v1/threat-models/${ID}\\b`));
+  });
+
+  it("transition PUTs to the status sub-resource with the status body", async () => {
+    const calls = makeFetchSpy();
+    await gcThreatModelToolHandler({ action: "transition", id: ID, status: "ACTIVE" });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, new RegExp(`/api/v1/threat-models/${ID}/status`));
+    assert.deepEqual(calls[0].body, { status: "ACTIVE" });
+  });
+
+  it("link_create with target_entity_id POSTs internal-target link body", async () => {
+    const TARGET_ID = "55555555-5555-5555-5555-555555555555";
+    const calls = makeFetchSpy();
+    await gcThreatModelToolHandler({
+      action: "link_create",
+      threat_model_id: ID,
+      target_type: "REQUIREMENT",
+      target_entity_id: TARGET_ID,
+      link_type: "AFFECTS",
+      target_title: "GC-X001",
+      title: "should-not-leak",
+      threat_source: "should-not-leak",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, new RegExp(`/api/v1/threat-models/${ID}/links`));
+    assert.deepEqual(calls[0].body, {
+      targetType: "REQUIREMENT",
+      targetEntityId: TARGET_ID,
+      linkType: "AFFECTS",
+      targetTitle: "GC-X001",
+    });
+  });
+
+  it("link_create with target_identifier POSTs external-target link body", async () => {
+    const calls = makeFetchSpy();
+    await gcThreatModelToolHandler({
+      action: "link_create",
+      threat_model_id: ID,
+      target_type: "EXTERNAL",
+      target_identifier: "ref://external/finding/42",
+      link_type: "DOCUMENTED_IN",
+      target_url: "https://example.test/finding/42",
+      target_title: "External finding",
+    });
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].body, {
+      targetType: "EXTERNAL",
+      targetIdentifier: "ref://external/finding/42",
+      linkType: "DOCUMENTED_IN",
+      targetUrl: "https://example.test/finding/42",
+      targetTitle: "External finding",
+    });
+  });
+
+  it("link_create rejects missing target_type before any HTTP call", async () => {
+    const calls = makeFetchSpy();
+    await assert.rejects(
+      () => gcThreatModelToolHandler({
+        action: "link_create",
+        threat_model_id: ID,
+        link_type: "AFFECTS",
+        target_entity_id: "66666666-6666-6666-6666-666666666666",
+      }),
+      (e) => e.message.includes("'target_type' is required"),
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  it("link_create rejects missing link_type before any HTTP call", async () => {
+    const calls = makeFetchSpy();
+    await assert.rejects(
+      () => gcThreatModelToolHandler({
+        action: "link_create",
+        threat_model_id: ID,
+        target_type: "REQUIREMENT",
+        target_entity_id: "66666666-6666-6666-6666-666666666666",
+      }),
+      (e) => e.message.includes("'link_type' is required"),
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  it("link_delete issues a DELETE on the link sub-resource", async () => {
+    const LINK_ID = "44444444-4444-4444-4444-444444444444";
+    const calls = [];
+    globalThis.fetch = async (url, opts) => {
+      calls.push({ url: url.toString(), method: opts?.method ?? "GET" });
+      return new Response(null, { status: 204 });
+    };
+    const result = await gcThreatModelToolHandler({
+      action: "link_delete",
+      threat_model_id: ID,
+      link_id: LINK_ID,
+    });
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.match(calls[0].url, new RegExp(`/api/v1/threat-models/${ID}/links/${LINK_ID}`));
+  });
+
+  it("throws on an unknown action without issuing an HTTP call", async () => {
+    const calls = makeFetchSpy();
+    await assert.rejects(
+      () => gcThreatModelToolHandler({ action: "merge" }),
+      (e) => e.message.includes("Unknown action: merge"),
+    );
+    assert.equal(calls.length, 0);
+  });
+});

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -160,6 +160,7 @@ import {
   PACK_TYPES, PACK_IMPORT_FORMATS, CATALOG_STATUSES,
   TRUST_OUTCOMES, INSTALL_OUTCOMES,
   TRUST_POLICY_FIELDS, TRUST_POLICY_RULE_OPERATORS,
+  pick, reqArg,
 } from "./lib.js";
 import {
   executeGcQuery,
@@ -170,6 +171,15 @@ import {
   GC_QUERY_PATH_ALLOWLIST,
   GC_QUERY_PATH_DENYLIST,
 } from "./gc-query.js";
+import {
+  gcThreatModelZodShape,
+  gcThreatModelToolHandler,
+  GC_THREAT_MODEL_DESCRIPTION,
+} from "./gc-threat-model.js";
+import {
+  linkCreateOptionalSharedZodFields,
+  performLinkCreate,
+} from "./link-create.js";
 
 // Load .env from cwd before any auth header is composed.
 function loadDotenvFromCwd() {
@@ -213,27 +223,9 @@ function err(e) {
   return { content: [{ type: "text", text }], isError: true };
 }
 
-function reqArg(args, key, action) {
-  const v = args[key];
-  if (v === undefined || v === null || v === "") {
-    throw new Error(`'${key}' is required for action='${action}'`);
-  }
-  return v;
-}
-
-/**
- * Build the backend DTO for create/update actions by picking ONLY the listed
- * entity fields from the MCP args. This is the adapter boundary — MCP control
- * fields (action, kind, mode, subsystem, entity, id, project, paging filters,
- * etc.) must NOT leak into request bodies.
- */
-function pick(args, keys) {
-  const out = {};
-  for (const k of keys) {
-    if (args[k] !== undefined) out[k] = args[k];
-  }
-  return out;
-}
+// pick / reqArg moved to lib.js so the extracted per-tool modules
+// (gc-query.js, gc-threat-model.js, link-create.js) share the same helpers
+// without coupling to this module (which boots the MCP server at import).
 
 // Admin gating: gc_admin and gc_pack expose ROLE_ADMIN-only write/mutating
 // operations. They register only when GC_MCP_ADMIN is set, so a default MCP
@@ -1137,6 +1129,8 @@ const ASSET_ACTIONS = [
 server.tool(
   "gc_asset",
   `Operational asset operations incl. relations, links, external IDs. Actions: ${ASSET_ACTIONS.join(", ")}. ` +
+    `link_create requires target_type + link_type; pass target_entity_id for internal target types ` +
+    `or target_identifier for external types. target_url / target_title are optional. ` +
     `Reads (list, get, get_by_uid, find_by_external_id, links, external_ids) route through gc_query.`,
   {
     action: z.enum(ASSET_ACTIONS),
@@ -1155,8 +1149,8 @@ server.tool(
     // links
     asset_id: z.string().uuid().optional(),
     target_type: z.enum(ASSET_LINK_TARGET_TYPES).optional(),
-    target_identifier: z.string().optional(),
     link_type: z.enum(ASSET_LINK_TYPES).optional(),
+    ...linkCreateOptionalSharedZodFields,
     link_id: z.string().uuid().optional(),
     // external IDs
     namespace: z.string().optional(),
@@ -1169,7 +1163,6 @@ server.tool(
     try {
       const ASSET_FIELDS = ["name", "description", "asset_type", "parent_id"];
       const RELATION_FIELDS = ["source_id", "target_id", "relation_type"];
-      const LINK_FIELDS = ["target_type", "target_identifier", "link_type"];
       const EXT_ID_FIELDS = ["namespace", "external_id"];
       switch (args.action) {
         case "create": {
@@ -1210,9 +1203,12 @@ server.tool(
           return ok(JSON.stringify(await extractAssetSubgraph({ roots: args.roots, maxDepth: args.max_depth }, args.project), null, 2));
         }
         case "link_create": {
-          // lib.js: createAssetLink(assetId, data, project)
-          reqArg(args, "asset_id", "link_create"); reqArg(args, "target_type", "link_create"); reqArg(args, "target_identifier", "link_create"); reqArg(args, "link_type", "link_create");
-          return ok(JSON.stringify(await createAssetLink(args.asset_id, pick(args, LINK_FIELDS), args.project), null, 2));
+          // lib.js: createAssetLink(assetId, data, project). Body shape +
+          // target_type/link_type preconditions live in link-create.js so
+          // every consolidated link_create surface stays in sync with the
+          // backend link DTO (target_entity_id, target_identifier, target_url,
+          // target_title are all forwarded).
+          return ok(JSON.stringify(await performLinkCreate(args, "asset_id", createAssetLink), null, 2));
         }
         case "link_delete": {
           // lib.js: deleteAssetLink(assetId, linkId, project)
@@ -1296,6 +1292,8 @@ const RISK_SCENARIO_ACTIONS = ["create", "update", "delete", "transition", "requ
 server.tool(
   "gc_risk_scenario",
   `Risk scenarios + their links. Actions: ${RISK_SCENARIO_ACTIONS.join(", ")}. ` +
+    `link_create requires target_type + link_type; pass target_entity_id for internal target types ` +
+    `or target_identifier for external types. target_url / target_title are optional. ` +
     `Reads (list, get, links_list) route through gc_query.`,
   {
     action: z.enum(RISK_SCENARIO_ACTIONS),
@@ -1310,14 +1308,13 @@ server.tool(
     // links
     scenario_id: z.string().uuid().optional(),
     target_type: z.enum(RISK_SCENARIO_LINK_TARGET_TYPES).optional(),
-    target_identifier: z.string().optional(),
     link_type: z.enum(RISK_SCENARIO_LINK_TYPES).optional(),
+    ...linkCreateOptionalSharedZodFields,
     link_id: z.string().uuid().optional(),
   },
   async (args) => {
     try {
       const ENTITY_FIELDS = ["uid", "title", "description", "status", "methodology_profile_id", "metadata"];
-      const LINK_FIELDS = ["target_type", "target_identifier", "link_type"];
       switch (args.action) {
         case "create": {
           reqArg(args, "title", "create");
@@ -1341,9 +1338,9 @@ server.tool(
           return ok(JSON.stringify(await getRiskScenarioRequirements(args.id, args.project), null, 2));
         }
         case "link_create": {
-          // lib.js: createRiskScenarioLink takes (scenarioId, data, project) per consistency with asset patterns; verify by spot-check
-          reqArg(args, "scenario_id", "link_create"); reqArg(args, "target_type", "link_create"); reqArg(args, "target_identifier", "link_create"); reqArg(args, "link_type", "link_create");
-          return ok(JSON.stringify(await createRiskScenarioLink(args.scenario_id, pick(args, LINK_FIELDS), args.project), null, 2));
+          // lib.js: createRiskScenarioLink(scenarioId, data, project). Body
+          // shape + target_type/link_type preconditions live in link-create.js.
+          return ok(JSON.stringify(await performLinkCreate(args, "scenario_id", createRiskScenarioLink), null, 2));
         }
         case "link_delete": {
           reqArg(args, "scenario_id", "link_delete"); reqArg(args, "link_id", "link_delete");
@@ -1356,62 +1353,14 @@ server.tool(
   },
 );
 
-const THREAT_MODEL_ACTIONS = ["create", "update", "delete", "transition", "link_create", "link_delete"];
-
 server.tool(
   "gc_threat_model",
-  `Threat models + their links. Actions: ${THREAT_MODEL_ACTIONS.join(", ")}. ` +
-    `Reads (list, get, links_list) route through gc_query.`,
-  {
-    action: z.enum(THREAT_MODEL_ACTIONS),
-    id: z.string().uuid().optional(),
-    uid: z.string().optional(),
-    project: z.string().optional(),
-    title: z.string().optional(),
-    description: z.string().optional(),
-    status: z.enum(THREAT_MODEL_STATUSES).optional(),
-    stride_category: z.enum(STRIDE_CATEGORIES).optional(),
-    metadata: z.record(z.any()).optional(),
-    // links
-    threat_model_id: z.string().uuid().optional(),
-    target_type: z.enum(THREAT_MODEL_LINK_TARGET_TYPES).optional(),
-    target_identifier: z.string().optional(),
-    link_type: z.enum(THREAT_MODEL_LINK_TYPES).optional(),
-    link_id: z.string().uuid().optional(),
-  },
+  GC_THREAT_MODEL_DESCRIPTION,
+  gcThreatModelZodShape,
   async (args) => {
     try {
-      const ENTITY_FIELDS = ["uid", "title", "description", "status", "stride_category", "metadata"];
-      const LINK_FIELDS = ["target_type", "target_identifier", "link_type"];
-      switch (args.action) {
-        case "create": {
-          reqArg(args, "title", "create");
-          return ok(JSON.stringify(await createThreatModel(pick(args, ENTITY_FIELDS), args.project), null, 2));
-        }
-        case "update": {
-          reqArg(args, "id", "update");
-          return ok(JSON.stringify(await updateThreatModel(args.id, pick(args, ENTITY_FIELDS), args.project), null, 2));
-        }
-        case "delete": {
-          reqArg(args, "id", "delete");
-          await deleteThreatModel(args.id, args.project);
-          return ok("Deleted");
-        }
-        case "transition": {
-          reqArg(args, "id", "transition"); reqArg(args, "status", "transition");
-          return ok(JSON.stringify(await transitionThreatModelStatus(args.id, args.status, args.project), null, 2));
-        }
-        case "link_create": {
-          reqArg(args, "threat_model_id", "link_create"); reqArg(args, "target_type", "link_create"); reqArg(args, "target_identifier", "link_create"); reqArg(args, "link_type", "link_create");
-          return ok(JSON.stringify(await createThreatModelLink(args.threat_model_id, pick(args, LINK_FIELDS), args.project), null, 2));
-        }
-        case "link_delete": {
-          reqArg(args, "threat_model_id", "link_delete"); reqArg(args, "link_id", "link_delete");
-          await deleteThreatModelLink(args.threat_model_id, args.link_id, args.project);
-          return ok("Deleted");
-        }
-        default: return err(new Error(`Unknown action: ${args.action}`));
-      }
+      const result = await gcThreatModelToolHandler(args);
+      return result === null ? ok("Deleted") : ok(JSON.stringify(result, null, 2));
     } catch (e) { return err(e); }
   },
 );
@@ -1421,6 +1370,8 @@ const CONTROL_ACTIONS = ["create", "update", "delete", "transition", "link_creat
 server.tool(
   "gc_control",
   `Controls + their links. Actions: ${CONTROL_ACTIONS.join(", ")}. ` +
+    `link_create requires target_type + link_type; pass target_entity_id for internal target types ` +
+    `or target_identifier for external types. target_url / target_title are optional. ` +
     `Reads (list, get, links_list) route through gc_query.`,
   {
     action: z.enum(CONTROL_ACTIONS),
@@ -1435,14 +1386,13 @@ server.tool(
     // links
     control_id: z.string().uuid().optional(),
     target_type: z.enum(CONTROL_LINK_TARGET_TYPES).optional(),
-    target_identifier: z.string().optional(),
     link_type: z.enum(CONTROL_LINK_TYPES).optional(),
+    ...linkCreateOptionalSharedZodFields,
     link_id: z.string().uuid().optional(),
   },
   async (args) => {
     try {
       const ENTITY_FIELDS = ["uid", "title", "description", "status", "control_function", "metadata"];
-      const LINK_FIELDS = ["target_type", "target_identifier", "link_type"];
       switch (args.action) {
         case "create": {
           reqArg(args, "title", "create");
@@ -1462,8 +1412,9 @@ server.tool(
           return ok(JSON.stringify(await transitionControlStatus(args.id, args.status, args.project), null, 2));
         }
         case "link_create": {
-          reqArg(args, "control_id", "link_create"); reqArg(args, "target_type", "link_create"); reqArg(args, "target_identifier", "link_create"); reqArg(args, "link_type", "link_create");
-          return ok(JSON.stringify(await createControlLink(args.control_id, pick(args, LINK_FIELDS), args.project), null, 2));
+          // lib.js: createControlLink(controlId, data, project). Body shape +
+          // target_type/link_type preconditions live in link-create.js.
+          return ok(JSON.stringify(await performLinkCreate(args, "control_id", createControlLink), null, 2));
         }
         case "link_delete": {
           reqArg(args, "control_id", "link_delete"); reqArg(args, "link_id", "link_delete");

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -328,6 +328,42 @@ export const THREAT_MODEL_LINK_TYPES = [
   "DOCUMENTED_IN",
   "ASSOCIATED",
 ];
+// Body field allowlists for gc_threat_model — see gc-threat-model.js.
+
+// ---------------------------------------------------------------------------
+// MCP adapter helpers — pick / reqArg
+// ---------------------------------------------------------------------------
+// Moved out of index.js so the extracted per-tool modules (gc-query.js,
+// gc-threat-model.js, link-create.js, future extractions) can share the same
+// implementation without re-implementing or coupling to the module that runs
+// the MCP server.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a backend DTO body by picking ONLY the listed snake_case fields from
+ * the MCP args object. MCP control fields (action, kind, mode, subsystem,
+ * entity, id, project, paging filters, etc.) MUST NOT leak into request
+ * bodies, so every tool registration enumerates its body allowlist explicitly.
+ */
+export function pick(args, keys) {
+  const out = {};
+  for (const k of keys) {
+    if (args[k] !== undefined) out[k] = args[k];
+  }
+  return out;
+}
+
+/**
+ * Require a field on the MCP args object before dispatching. Throws with a
+ * stable, action-scoped message used by every consolidated tool handler.
+ */
+export function reqArg(args, key, action) {
+  const v = args[key];
+  if (v === undefined || v === null || v === "") {
+    throw new Error(`'${key}' is required for action='${action}'`);
+  }
+  return v;
+}
 
 // ---------------------------------------------------------------------------
 // Field name mapping (snake_case MCP <-> camelCase API)
@@ -442,6 +478,10 @@ const TO_CAMEL = {
   observation_id: "observationId",
   threat_source: "threatSource",
   threat_event: "threatEvent",
+  // Backend ThreatModelRequest uses `stride` (typed StrideCategory) on the wire;
+  // the MCP surface keeps `stride_category` for clarity. Mapping is needed to
+  // bridge the rename; without it Jackson silently dropped the field (issue #875).
+  stride_category: "stride",
   clear_stride: "clearStride",
   clear_narrative: "clearNarrative",
   affected_object: "affectedObject",
@@ -520,7 +560,7 @@ const TO_CAMEL = {
 
 const TO_SNAKE = Object.fromEntries(Object.entries(TO_CAMEL).map(([k, v]) => [v, k]));
 
-function toCamelCase(obj) {
+export function toCamelCase(obj) {
   if (obj === null || obj === undefined || typeof obj !== "object") return obj;
   if (Array.isArray(obj)) return obj.map(toCamelCase);
   const out = {};

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -82,6 +82,7 @@ import {
   ARTIFACT_TYPES,
   LINK_TYPES,
   toSnakeCase,
+  toCamelCase,
 } from "./lib.js";
 
 // ---------------------------------------------------------------------------
@@ -145,6 +146,49 @@ describe("toSnakeCase", () => {
     assert.equal(toSnakeCase(null), null);
     assert.equal(toSnakeCase(42), 42);
     assert.deepEqual(toSnakeCase({ alreadyPlain: 1 }), { alreadyPlain: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toCamelCase — request body normalization (issue #875)
+//
+// Pure-function shape tests for the snake_case → camelCase rewrite that runs
+// on every outbound request body. Adapter-level coverage of the
+// gc_threat_model handler (Zod schema, action dispatch, body allowlists) lives
+// in gc-threat-model.test.js.
+// ---------------------------------------------------------------------------
+
+describe("toCamelCase", () => {
+  it("renders a threat_model create body to the backend camelCase shape", () => {
+    const out = toCamelCase({
+      uid: "TM-1",
+      title: "Title",
+      threat_source: "Source",
+      threat_event: "Event",
+      effect: "Effect",
+      stride_category: "TAMPERING",
+      narrative: "Note",
+    });
+    assert.deepEqual(out, {
+      uid: "TM-1",
+      title: "Title",
+      threatSource: "Source",
+      threatEvent: "Event",
+      effect: "Effect",
+      stride: "TAMPERING",
+      narrative: "Note",
+    });
+  });
+
+  it("rewrites the threat-model update clearStride / clearNarrative flags", () => {
+    const out = toCamelCase({ clear_stride: true, clear_narrative: false });
+    assert.deepEqual(out, { clearStride: true, clearNarrative: false });
+  });
+
+  it("passes unknown keys through unchanged and tolerates null/scalars", () => {
+    assert.equal(toCamelCase(null), null);
+    assert.equal(toCamelCase(42), 42);
+    assert.deepEqual(toCamelCase({ already_camel: 1 }), { already_camel: 1 });
   });
 });
 

--- a/mcp/ground-control/link-create.js
+++ b/mcp/ground-control/link-create.js
@@ -1,0 +1,73 @@
+// Shared link_create surface for every consolidated MCP tool that exposes a
+// link_create action (gc_asset, gc_threat_model, gc_risk_scenario, gc_control).
+//
+// All four backend link DTOs share an identical shape:
+//   @NotNull TargetType targetType,
+//   UUID targetEntityId,                       (optional on the wire)
+//   @Size(max = 500) String targetIdentifier,  (optional on the wire)
+//   @NotNull LinkType linkType,
+//   @Size(max = 2000) String targetUrl,        (optional on the wire)
+//   @Size(max = 255) String targetTitle        (optional on the wire)
+//
+// GraphTargetResolverService then enforces per-target-type semantics:
+//   - internal target types (REQUIREMENT, ASSET, CONTROL, RISK_SCENARIO,
+//     OBSERVATION, THREAT_MODEL, RISK_ASSESSMENT_RESULT, VERIFICATION_RESULT,
+//     etc.) → targetEntityId required
+//   - external target types (EXTERNAL, EVIDENCE, FINDING, ISSUE, CODE, AUDIT,
+//     CONFIGURATION, etc.)                         → targetIdentifier required
+//
+// The MCP layer does NOT mirror that dispatch (the preflight for #875 ruled out
+// duplicating backend validators). It exposes both target_entity_id and
+// target_identifier as optional and forwards whichever the caller supplies; the
+// backend surfaces a stable DomainValidationException envelope when the caller
+// picks the wrong one for the chosen target type.
+
+import { z } from "zod";
+import { pick, reqArg } from "./lib.js";
+
+// Snake_case body fields forwarded to the backend on every link_create.
+export const LINK_CREATE_BODY_FIELDS = [
+  "target_type",
+  "target_entity_id",
+  "target_identifier",
+  "link_type",
+  "target_url",
+  "target_title",
+];
+
+// MCP-side preconditions: target_type + link_type are @NotNull on every link
+// DTO. target_entity_id vs target_identifier is the backend's choice.
+export const LINK_CREATE_REQUIRED_FIELDS = ["target_type", "link_type"];
+
+// Shared optional Zod field shapes. Each tool's Zod object spreads these in
+// alongside its own action-discriminated fields; target_type / link_type stay
+// tool-local because each consolidated tool has a different enum vocabulary.
+export const linkCreateOptionalSharedZodFields = {
+  target_entity_id: z.string().uuid().optional(),
+  target_identifier: z.string().optional(),
+  target_url: z.string().optional(),
+  target_title: z.string().optional(),
+};
+
+/**
+ * Run a consolidated tool's link_create action: validate parent-id +
+ * target_type + link_type, then forward the link body fields to `createFn`.
+ *
+ * Centralizing this guarantees every link_create surface uses the same
+ * allowlist and the same required-field semantics. A regression that drops
+ * target_entity_id, target_url, or target_title from the wire — or skips the
+ * target_type / link_type preconditions — fails this module's tests for every
+ * caller at once.
+ *
+ * @param {object}  args            The Zod-parsed tool args.
+ * @param {string}  parentIdField   Snake_case key of the parent entity id
+ *                                  (asset_id, threat_model_id, scenario_id,
+ *                                  control_id).
+ * @param {function} createFn      lib.js createXLink(parentId, body, project).
+ * @returns {Promise<any>}          The created link payload from the backend.
+ */
+export async function performLinkCreate(args, parentIdField, createFn) {
+  reqArg(args, parentIdField, "link_create");
+  for (const k of LINK_CREATE_REQUIRED_FIELDS) reqArg(args, k, "link_create");
+  return createFn(args[parentIdField], pick(args, LINK_CREATE_BODY_FIELDS), args.project);
+}

--- a/mcp/ground-control/link-create.test.js
+++ b/mcp/ground-control/link-create.test.js
@@ -1,0 +1,152 @@
+// Tests for the shared link_create surface (issue #875 follow-on).
+//
+// The four consolidated tools that expose link_create (gc_asset,
+// gc_threat_model, gc_risk_scenario, gc_control) share the same backend link
+// DTO shape and the same MCP-side body allowlist + required-field rules. This
+// module is the single point of repair; regressing target_entity_id forwarding,
+// target_url / target_title forwarding, or the target_type / link_type
+// preconditions in any consolidated tool fails these tests.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  LINK_CREATE_BODY_FIELDS,
+  LINK_CREATE_REQUIRED_FIELDS,
+  linkCreateOptionalSharedZodFields,
+  performLinkCreate,
+} from "./link-create.js";
+
+describe("LINK_CREATE_BODY_FIELDS", () => {
+  it("matches the snake_case shape of every backend link DTO", () => {
+    // AssetLinkRequest, ThreatModelLinkRequest, RiskScenarioLinkRequest,
+    // ControlLinkRequest all carry the same six fields.
+    assert.deepEqual(
+      [...LINK_CREATE_BODY_FIELDS].sort(),
+      [
+        "link_type",
+        "target_entity_id",
+        "target_identifier",
+        "target_title",
+        "target_type",
+        "target_url",
+      ],
+    );
+  });
+});
+
+describe("LINK_CREATE_REQUIRED_FIELDS", () => {
+  it("requires the two @NotNull backend fields", () => {
+    assert.deepEqual([...LINK_CREATE_REQUIRED_FIELDS].sort(), ["link_type", "target_type"]);
+  });
+});
+
+describe("linkCreateOptionalSharedZodFields", () => {
+  it("covers every link DTO field except the per-tool enums", () => {
+    assert.deepEqual(
+      Object.keys(linkCreateOptionalSharedZodFields).sort(),
+      ["target_entity_id", "target_identifier", "target_title", "target_url"],
+    );
+  });
+});
+
+describe("performLinkCreate", () => {
+  function makeCreateFnSpy(returnValue = { id: "link-uuid" }) {
+    const calls = [];
+    return {
+      calls,
+      fn: async (parentId, body, project) => {
+        calls.push({ parentId, body, project });
+        return returnValue;
+      },
+    };
+  }
+
+  it("validates parentIdField, target_type, link_type, then forwards every body field", async () => {
+    const spy = makeCreateFnSpy();
+    const PARENT = "11111111-1111-1111-1111-111111111111";
+    const TARGET = "22222222-2222-2222-2222-222222222222";
+    const result = await performLinkCreate(
+      {
+        action: "link_create",
+        scenario_id: PARENT,
+        target_type: "REQUIREMENT",
+        target_entity_id: TARGET,
+        link_type: "AFFECTS",
+        target_url: "https://example.test/r",
+        target_title: "Example",
+        project: "proj-a",
+        // Noise that must NOT leak into the body.
+        id: "should-not-leak",
+        title: "should-not-leak",
+        random_extra: "should-not-leak",
+      },
+      "scenario_id",
+      spy.fn,
+    );
+    assert.deepEqual(result, { id: "link-uuid" });
+    assert.equal(spy.calls.length, 1);
+    assert.equal(spy.calls[0].parentId, PARENT);
+    assert.equal(spy.calls[0].project, "proj-a");
+    assert.deepEqual(spy.calls[0].body, {
+      target_type: "REQUIREMENT",
+      target_entity_id: TARGET,
+      link_type: "AFFECTS",
+      target_url: "https://example.test/r",
+      target_title: "Example",
+    });
+  });
+
+  it("forwards target_identifier (external-target path) without target_entity_id", async () => {
+    const spy = makeCreateFnSpy();
+    await performLinkCreate(
+      {
+        asset_id: "33333333-3333-3333-3333-333333333333",
+        target_type: "EXTERNAL",
+        target_identifier: "ref://x/y",
+        link_type: "ASSOCIATED",
+      },
+      "asset_id",
+      spy.fn,
+    );
+    assert.deepEqual(spy.calls[0].body, {
+      target_type: "EXTERNAL",
+      target_identifier: "ref://x/y",
+      link_type: "ASSOCIATED",
+    });
+  });
+
+  for (const required of ["target_type", "link_type"]) {
+    it(`rejects when '${required}' is missing before any backend call`, async () => {
+      const spy = makeCreateFnSpy();
+      const base = {
+        threat_model_id: "44444444-4444-4444-4444-444444444444",
+        target_type: "REQUIREMENT",
+        target_entity_id: "55555555-5555-5555-5555-555555555555",
+        link_type: "AFFECTS",
+      };
+      delete base[required];
+      await assert.rejects(
+        () => performLinkCreate(base, "threat_model_id", spy.fn),
+        (e) => e.message.includes(`'${required}' is required`),
+      );
+      assert.equal(spy.calls.length, 0);
+    });
+  }
+
+  it("rejects when the parentIdField is missing before any backend call", async () => {
+    const spy = makeCreateFnSpy();
+    await assert.rejects(
+      () => performLinkCreate(
+        {
+          target_type: "REQUIREMENT",
+          link_type: "AFFECTS",
+          target_entity_id: "66666666-6666-6666-6666-666666666666",
+        },
+        "control_id",
+        spy.fn,
+      ),
+      (e) => e.message.includes("'control_id' is required"),
+    );
+    assert.equal(spy.calls.length, 0);
+  });
+});

--- a/mcp/ground-control/package.json
+++ b/mcp/ground-control/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node --test lib.test.js gc-query.test.js",
+    "test": "node --test lib.test.js gc-query.test.js gc-threat-model.test.js link-create.test.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },


### PR DESCRIPTION
## Summary

Fixes #875. The MCP `gc_threat_model` tool could not create or update threat models because its Zod schema and entity-field allowlist were missing every backend `@NotBlank` field. The same drift was present across every consolidated `link_create` action (`gc_asset`, `gc_threat_model`, `gc_risk_scenario`, `gc_control`), which only exposed `target_identifier` while the backend link DTOs accept `target_entity_id`, `target_url`, and `target_title`. Broadening the MCP surface also revealed a pre-existing backend security gap: `ControlLinkService` persisted `targetEntityId` without project-scoped existence checks, letting a tenant with link-create rights in project A persist a cross-project link to an entity in project B.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #875

## ADR Impact

- ADR-024 (referenced — threat-model boundary, unchanged)
- ADR-035 (referenced — consolidated MCP tool pattern, unchanged)

## Changes

- MCP `gc_threat_model` schema + handler extracted to `mcp/ground-control/gc-threat-model.js`. Exposes `threat_source`, `threat_event`, `effect`, `narrative`, `clear_stride`, `clear_narrative`; drops `description` (no backend field). `stride_category` now maps to backend `stride` via `TO_CAMEL`. Required-field enforcement at the adapter boundary for `uid`, `title`, `threat_source`, `threat_event`, `effect`.
- Shared `mcp/ground-control/link-create.js` adapter with `LINK_CREATE_BODY_FIELDS`, `LINK_CREATE_REQUIRED_FIELDS`, `linkCreateOptionalSharedZodFields`, and `performLinkCreate(args, parentIdField, createFn)`. `gc_asset`, `gc_risk_scenario`, `gc_control`, and `gc_threat_model` `link_create` paths now spread the shared Zod fields and dispatch through `performLinkCreate`, so `target_entity_id`, `target_url`, and `target_title` are forwarded uniformly.
- Hoisted `pick` and `reqArg` to `mcp/ground-control/lib.js` so the extracted modules share the same helpers without coupling to the MCP server module.
- Backend: new `GraphTargetResolverService.validateControlTarget` mirroring `validateAssetTarget` / `validateRiskScenarioTarget` / `validateThreatModelTarget`. `ControlLinkService.create` now routes through it, so internal target types require a project-scoped `targetEntityId` and external types require a nonblank `targetIdentifier`. Closes the pre-existing cross-project link gap for both MCP and REST callers (closes ADR-024 / ADR-035 alignment).
- New tests: `gc-threat-model.test.js` (22 adapter-level tests covering Zod parse, body shape, required-field rejection, all six actions); `link-create.test.js` (constants + `performLinkCreate` behavior); `ControlLinkServiceTest` gains internal-target, cross-project, missing-entity-id, and blank-external-identifier cases; `GraphTargetResolverServiceTest` gains parameterized internal/external acceptance plus rejection cases for `validateControlTarget`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- MCP suite: `cd mcp/ground-control && npm test` (502 tests across 4 test files).
- Backend suite: `cd backend && ./gradlew test` (full Java unit + property + ArchUnit suite).
- Full completion gate: `make check` (build + tests + static analysis + spotless + checkstyle + spotbugs + jacoco) and `make policy` (88 policy unit tests + assert-backup-policy + bin/policy).

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (\`docs/CODING_STANDARDS.md\`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers \`@Audited\` on new entities if applicable
- [x] Changelog fragment added at \`changelog.d/875.fixed.md\`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed