### PR TITLE
Fix gc_risk_scenario MCP create/update; close blank-update class drift

### DIFF
--- a/architecture/notes/risk-scenario-mcp-contract-preflight.md
+++ b/architecture/notes/risk-scenario-mcp-contract-preflight.md
@@ -1,0 +1,132 @@
+# Risk Scenario MCP Contract Preflight
+
+Issue: #876
+Requirement: none
+
+This is architecture guardrail guidance for restoring `gc_risk_scenario`
+create/update usability from MCP. It is not an implementation plan.
+
+## Boundary
+
+The backend risk-scenario REST contract is already the semantic source of
+truth: `RiskScenarioRequest`, `UpdateRiskScenarioRequest`,
+`RiskScenarioController`, `RiskScenarioService`, `RiskScenario`, and the
+existing Flyway risk-scenario tables already encode the domain shape,
+validation, project scoping, auditing, and persistence.
+
+The change belongs at the MCP adapter boundary. `gc_risk_scenario` should
+expose the backend DTO fields in snake_case, pick only action-appropriate
+entity-body fields, and let `mcp/ground-control/lib.js` convert them to the
+backend camelCase JSON body. Do not rename backend fields, add a backend
+compatibility `description` field, or weaken backend validation to work around
+an adapter schema bug.
+
+## Incumbents To Reuse
+
+- Risk-domain boundary: `RiskScenario` remains the scoped loss scenario
+  statement used by risk assessment, register, and treatment flows. It is not a
+  threat-model entry, assessment result, register record, treatment plan, or
+  generic metadata bucket.
+- MCP consolidation pattern: ADR-035. Keep the single action-discriminated
+  `gc_risk_scenario` tool, the flat Zod schema, handler-side `reqArg`, and the
+  `pick(args, BODY_FIELDS)` request-body allowlists.
+- MCP transport helpers: `buildUrl`, `addAuthorizationHeader`, `request`,
+  `RequestError`, `parseErrorBody`, `toCamelCase`, and `TO_CAMEL` in
+  `mcp/ground-control/lib.js`. Do not add feature-local fetch, auth-header,
+  error parsing, or snake-to-camel logic.
+- Shared link create path: `link-create.js` owns `link_create` body allowlists
+  and required-field semantics for `gc_asset`, `gc_threat_model`,
+  `gc_risk_scenario`, and `gc_control`. Do not fold link fields into
+  risk-scenario create/update bodies.
+- Backend validation: Bean Validation on request records handles create shape;
+  service-layer update semantics handle partial updates. MCP-side required-field
+  checks are caller guidance, not the source of truth.
+- Error envelope: backend errors flow through `GlobalExceptionHandler` and
+  `shared.web.ErrorResponse`; MCP surfaces them via `RequestError` and `err()`.
+- Security and audit: ADR-026 and ADR-033. `/api/v1/risk-scenarios/**` remains
+  under the shared API path matrix, bearer-token handling, actor provenance, and
+  MDC/request logging. MCP must continue to send `X-Actor: mcp-server` only as
+  the existing dev/test fallback; production actor identity comes from the
+  authenticated principal.
+- Tests and gates: focused MCP regression coverage belongs under
+  `mcp/ground-control` using the existing `node --test` harness. The backend
+  controller/service tests already cover the REST DTO mapping and validation.
+  Application-source changes need a changelog fragment, and `make policy` is the
+  repo-native completion guardrail.
+
+## Cross-Cutting Layers
+
+- MCP public schema: expose `uid`, `title`, `threat_source`, `threat_event`,
+  `affected_object`, `vulnerability`, `consequence`, and `time_horizon`
+  consistently with backend DTO semantics. Keep unknown/control fields out of
+  request bodies via action-scoped allowlists.
+- Request serialization: rely on `toCamelCase` and `TO_CAMEL` for snake_case to
+  camelCase conversion. Existing mappings already cover
+  `threat_source`, `threat_event`, `affected_object`, `time_horizon`, and
+  `methodology_profile_id`; add mappings only when a real backend wire name
+  requires it.
+- Backend parser and validators: Jackson and Bean Validation own the server-side
+  DTO contract. Do not duplicate max-length or blank-string validation as a
+  parallel MCP validation system beyond early `reqArg` checks for required
+  create fields.
+- Project scoping: the adapter passes the optional `project` query parameter
+  through existing lib helpers. `ProjectService.resolveProjectId` /
+  `requireProjectId` remains the project boundary.
+- Security/config/OS exposure: this change should require no new env vars,
+  secrets, subprocesses, shell commands, or argv-token handling. Existing MCP env
+  bindings are `GC_BASE_URL`, `GROUND_CONTROL_API_TOKEN`, and
+  `GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN`; tokens stay in headers and out of
+  logs/errors.
+- Error leakage: preserve backend validation envelopes and the MCP
+  `RequestError` path. Do not reflect raw request bodies, bearer tokens,
+  Authorization headers, or stack traces through MCP errors.
+- Persistence/audit/logging: no migration, repository, entity, or audit-table
+  change is needed. Envers, `ActorFilter`, `ActorHolder`,
+  `RequestLoggingFilter`, and service-level SLF4J lifecycle logs remain the only
+  audit/observability path.
+
+## Extensibility
+
+The extension seam is the MCP DTO mirror itself: the tool schema, the
+action-scoped body allowlists, and `TO_CAMEL` field mapping. Create and update
+must be separable because `uid` is create-only today while partial updates
+should not leak create-only or transition-only fields.
+
+If this class of drift keeps recurring beyond the threat-model and
+risk-scenario tools, use a small static contract inventory modeled after
+ADR-034's `ENUM_CONTRACT_INVENTORY` so backend request-record fields and MCP
+mirrors can be checked without runtime reflection, generated schemas, or a
+second controller layer.
+
+## Gotchas And Anti-Patterns
+
+- Do not map `description` to a backend risk-scenario field. The backend has
+  explicit scenario-statement fields; `description` is a leaky generic CRUD
+  convention from adjacent tools.
+- Do not send `status`, `methodology_profile_id`, or `metadata` on risk-scenario
+  create/update unless and until the backend DTOs actually accept those fields.
+  Status changes use the existing transition action.
+- Do not put `target_*` or `link_type` fields into risk-scenario create/update
+  bodies. Link fields belong only to `link_create`.
+- Do not make MCP `metadata` authoritative for fields the backend models
+  explicitly.
+- Do not relax Zod to passthrough arbitrary keys to make this work; the
+  allowlist is the adapter boundary that prevents action/control fields from
+  leaking into REST bodies.
+- Do not add a risk-scenario-specific exception hierarchy, auth path, logger,
+  REST endpoint, graph write path, or persistence workaround.
+- Do not conflate risk-scenario semantics with threat-model semantics: risk
+  scenarios use `consequence` and `timeHorizon`; threat models use `effect`,
+  optional STRIDE, and `narrative`.
+
+## Non-Goals
+
+- No backend domain model, controller, service, repository, migration, or
+  REST-contract redesign.
+- No new risk-scenario fields beyond the backend DTOs already in source.
+- No OpenAPI/codegen project, frontend type migration, or generic MCP schema
+  framework as part of #876.
+- No redesign of risk assessment, risk register, treatment, graph projection,
+  traceability, or threat-model boundaries.
+- No change to ADR-024, ADR-026, ADR-033, ADR-034, ADR-035, or the repo
+  workflow policy.

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/RiskScenarioService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/RiskScenarioService.java
@@ -2,6 +2,7 @@ package com.keplerops.groundcontrol.domain.riskscenarios.service;
 
 import com.keplerops.groundcontrol.domain.audit.ActorHolder;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
@@ -71,6 +72,16 @@ public class RiskScenarioService {
     public RiskScenario update(UUID projectId, UUID id, UpdateRiskScenarioCommand command) {
         var scenario = findByIdOrThrow(projectId, id);
 
+        // Required-on-create fields must reject blank strings when present, or a
+        // partial update could corrupt records the create path would refuse.
+        // Mirrors ThreatModelService.update (issue #876).
+        rejectBlankIfPresent("title", command.title());
+        rejectBlankIfPresent("threatSource", command.threatSource());
+        rejectBlankIfPresent("threatEvent", command.threatEvent());
+        rejectBlankIfPresent("affectedObject", command.affectedObject());
+        rejectBlankIfPresent("consequence", command.consequence());
+        rejectBlankIfPresent("timeHorizon", command.timeHorizon());
+
         if (command.title() != null) {
             scenario.setTitle(command.title());
         }
@@ -96,6 +107,15 @@ public class RiskScenarioService {
         var saved = riskScenarioRepository.save(scenario);
         log.info("risk_scenario_updated: id={} uid={}", saved.getId(), saved.getUid());
         return saved;
+    }
+
+    private static void rejectBlankIfPresent(String fieldName, String value) {
+        if (value != null && value.isBlank()) {
+            throw new DomainValidationException(
+                    fieldName + " must not be blank when provided",
+                    "validation_error",
+                    java.util.Map.of("field", fieldName));
+        }
     }
 
     @Deprecated(forRemoval = false)

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java
@@ -161,6 +161,106 @@ class RiskScenarioServiceTest {
             assertThatThrownBy(() -> riskScenarioService.update(projectId, id, command))
                     .isInstanceOf(NotFoundException.class);
         }
+
+        // Issue #876 (codex review cycle 1, class finding): partial update must not
+        // overwrite create-required fields with blank strings. RiskScenarioRequest
+        // marks title / threatSource / threatEvent / affectedObject / consequence /
+        // timeHorizon as @NotBlank; the update path must enforce the same contract
+        // when a value is supplied. Mirrors the rejectBlankIfPresent pattern in
+        // ThreatModelService.update.
+        @Test
+        void rejectsBlankTitle() {
+            var rs = makeScenario();
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+
+            var command = new UpdateRiskScenarioCommand("   ", null, null, null, null, null, null);
+
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("title");
+        }
+
+        @Test
+        void rejectsBlankThreatSource() {
+            var rs = makeScenario();
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+
+            var command = new UpdateRiskScenarioCommand(null, "", null, null, null, null, null);
+
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("threatSource");
+        }
+
+        @Test
+        void rejectsBlankThreatEvent() {
+            var rs = makeScenario();
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+
+            var command = new UpdateRiskScenarioCommand(null, null, " ", null, null, null, null);
+
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("threatEvent");
+        }
+
+        @Test
+        void rejectsBlankAffectedObject() {
+            var rs = makeScenario();
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+
+            var command = new UpdateRiskScenarioCommand(null, null, null, "", null, null, null);
+
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("affectedObject");
+        }
+
+        @Test
+        void rejectsBlankConsequence() {
+            var rs = makeScenario();
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+
+            var command = new UpdateRiskScenarioCommand(null, null, null, null, null, "", null);
+
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("consequence");
+        }
+
+        @Test
+        void rejectsBlankTimeHorizon() {
+            var rs = makeScenario();
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+
+            var command = new UpdateRiskScenarioCommand(null, null, null, null, null, null, "   ");
+
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("timeHorizon");
+        }
+
+        @Test
+        void allowsAbsentRequiredFields() {
+            // A partial update that touches only the optional vulnerability field
+            // must not be blocked by the new blank-if-present checks.
+            var rs = makeScenario();
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+            when(riskScenarioRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new UpdateRiskScenarioCommand(null, null, null, null, "new vuln", null, null);
+            var result = riskScenarioService.update(projectId, rs.getId(), command);
+
+            assertThat(result.getVulnerability()).isEqualTo("new vuln");
+            assertThat(result.getTitle()).isEqualTo("Credential stuffing on customer portal");
+        }
     }
 
     @Nested

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java
@@ -171,12 +171,12 @@ class RiskScenarioServiceTest {
         @Test
         void rejectsBlankTitle() {
             var rs = makeScenario();
-            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
-                    .thenReturn(Optional.of(rs));
+            var rsId = rs.getId();
+            when(riskScenarioRepository.findByIdAndProjectId(rsId, projectId)).thenReturn(Optional.of(rs));
 
             var command = new UpdateRiskScenarioCommand("   ", null, null, null, null, null, null);
 
-            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rsId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("title");
         }
@@ -184,12 +184,12 @@ class RiskScenarioServiceTest {
         @Test
         void rejectsBlankThreatSource() {
             var rs = makeScenario();
-            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
-                    .thenReturn(Optional.of(rs));
+            var rsId = rs.getId();
+            when(riskScenarioRepository.findByIdAndProjectId(rsId, projectId)).thenReturn(Optional.of(rs));
 
             var command = new UpdateRiskScenarioCommand(null, "", null, null, null, null, null);
 
-            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rsId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("threatSource");
         }
@@ -197,12 +197,12 @@ class RiskScenarioServiceTest {
         @Test
         void rejectsBlankThreatEvent() {
             var rs = makeScenario();
-            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
-                    .thenReturn(Optional.of(rs));
+            var rsId = rs.getId();
+            when(riskScenarioRepository.findByIdAndProjectId(rsId, projectId)).thenReturn(Optional.of(rs));
 
             var command = new UpdateRiskScenarioCommand(null, null, " ", null, null, null, null);
 
-            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rsId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("threatEvent");
         }
@@ -210,12 +210,12 @@ class RiskScenarioServiceTest {
         @Test
         void rejectsBlankAffectedObject() {
             var rs = makeScenario();
-            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
-                    .thenReturn(Optional.of(rs));
+            var rsId = rs.getId();
+            when(riskScenarioRepository.findByIdAndProjectId(rsId, projectId)).thenReturn(Optional.of(rs));
 
             var command = new UpdateRiskScenarioCommand(null, null, null, "", null, null, null);
 
-            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rsId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("affectedObject");
         }
@@ -223,12 +223,12 @@ class RiskScenarioServiceTest {
         @Test
         void rejectsBlankConsequence() {
             var rs = makeScenario();
-            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
-                    .thenReturn(Optional.of(rs));
+            var rsId = rs.getId();
+            when(riskScenarioRepository.findByIdAndProjectId(rsId, projectId)).thenReturn(Optional.of(rs));
 
             var command = new UpdateRiskScenarioCommand(null, null, null, null, null, "", null);
 
-            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rsId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("consequence");
         }
@@ -236,12 +236,12 @@ class RiskScenarioServiceTest {
         @Test
         void rejectsBlankTimeHorizon() {
             var rs = makeScenario();
-            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
-                    .thenReturn(Optional.of(rs));
+            var rsId = rs.getId();
+            when(riskScenarioRepository.findByIdAndProjectId(rsId, projectId)).thenReturn(Optional.of(rs));
 
             var command = new UpdateRiskScenarioCommand(null, null, null, null, null, null, "   ");
 
-            assertThatThrownBy(() -> riskScenarioService.update(projectId, rs.getId(), command))
+            assertThatThrownBy(() -> riskScenarioService.update(projectId, rsId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("timeHorizon");
         }

--- a/changelog.d/876.fixed.md
+++ b/changelog.d/876.fixed.md
@@ -14,3 +14,9 @@ extracted to `gc-risk-scenario.js` to mirror `gc-threat-model.js`, making
 the create/update body shape, snake_case → camelCase mapping, and
 required-field enforcement unit-testable in isolation against a mocked
 `fetch`.
+
+Backend `RiskScenarioService.update` now rejects blank-if-present
+strings for the create-required fields (`title`, `threatSource`,
+`threatEvent`, `affectedObject`, `consequence`, `timeHorizon`) so a
+partial update cannot blank a field the create path requires. Mirrors
+the `rejectBlankIfPresent` pattern from `ThreatModelService.update`.

--- a/changelog.d/876.fixed.md
+++ b/changelog.d/876.fixed.md
@@ -1,0 +1,16 @@
+`gc_risk_scenario` MCP tool can finally create and update risk scenarios.
+The Zod schema now exposes `threat_source`, `threat_event`,
+`affected_object`, `vulnerability`, `consequence`, and `time_horizon`,
+matching the backend `RiskScenarioRequest` / `UpdateRiskScenarioRequest`
+DTOs. The request-body allowlists drop `description`, `status`,
+`methodology_profile_id`, and `metadata` — none exists on the create or
+update DTOs, so they were silently being shipped only to be rejected (or
+worse, ignored) by Jackson. Backend `@NotBlank` create fields are
+enforced at the adapter boundary with `'X' is required` errors so callers
+get a clear failure instead of waiting for a 422.
+
+Same defect class as the issue #875 `gc_threat_model` fix. The handler is
+extracted to `gc-risk-scenario.js` to mirror `gc-threat-model.js`, making
+the create/update body shape, snake_case → camelCase mapping, and
+required-field enforcement unit-testable in isolation against a mocked
+`fetch`.

--- a/mcp/ground-control/gc-risk-scenario.js
+++ b/mcp/ground-control/gc-risk-scenario.js
@@ -1,0 +1,126 @@
+// gc_risk_scenario: action-discriminated MCP adapter for the backend risk-scenario
+// REST surface (ADR-035). Extracted from index.js so the handler logic is
+// testable in isolation — see gc-risk-scenario.test.js for adapter-level
+// tests covering create/update body shapes, required-field enforcement, and
+// snake_case <-> camelCase mapping (issue #876, mirrors the issue #875 fix
+// for gc_threat_model).
+
+import { z } from "zod";
+import {
+  RISK_SCENARIO_STATUSES,
+  RISK_SCENARIO_LINK_TARGET_TYPES, RISK_SCENARIO_LINK_TYPES,
+  createRiskScenario, updateRiskScenario, deleteRiskScenario,
+  transitionRiskScenarioStatus, getRiskScenarioRequirements,
+  createRiskScenarioLink, deleteRiskScenarioLink,
+  pick, reqArg,
+} from "./lib.js";
+import {
+  linkCreateOptionalSharedZodFields,
+  performLinkCreate,
+} from "./link-create.js";
+
+export const GC_RISK_SCENARIO_ACTIONS = [
+  "create", "update", "delete", "transition", "requirements",
+  "link_create", "link_delete",
+];
+
+// Snake_case body fields accepted by gc_risk_scenario.create — mirrors
+// backend RiskScenarioRequest. uid is create-only; the update DTO has no uid.
+// vulnerability is the only non-@NotBlank field on the create DTO.
+export const GC_RISK_SCENARIO_CREATE_BODY_FIELDS = [
+  "uid", "title", "threat_source", "threat_event",
+  "affected_object", "vulnerability", "consequence", "time_horizon",
+];
+
+// Snake_case body fields accepted by gc_risk_scenario.update — mirrors
+// backend UpdateRiskScenarioRequest. All fields are optional (partial
+// update); title and time_horizon retain their @Size caps server-side.
+export const GC_RISK_SCENARIO_UPDATE_BODY_FIELDS = [
+  "title", "threat_source", "threat_event",
+  "affected_object", "vulnerability", "consequence", "time_horizon",
+];
+
+// @NotBlank fields on backend RiskScenarioRequest. Enforced at the adapter
+// boundary so callers get a clear `'X' is required` error instead of waiting
+// for a backend 422. vulnerability is intentionally NOT required (it is the
+// only optional field on the create DTO).
+export const GC_RISK_SCENARIO_CREATE_REQUIRED_FIELDS = [
+  "uid", "title", "threat_source", "threat_event",
+  "affected_object", "consequence", "time_horizon",
+];
+
+export const gcRiskScenarioZodShape = {
+  action: z.enum(GC_RISK_SCENARIO_ACTIONS),
+  id: z.string().uuid().optional(),
+  uid: z.string().optional(),
+  project: z.string().optional(),
+  title: z.string().optional(),
+  threat_source: z.string().optional(),
+  threat_event: z.string().optional(),
+  affected_object: z.string().optional(),
+  vulnerability: z.string().optional(),
+  consequence: z.string().optional(),
+  time_horizon: z.string().optional(),
+  status: z.enum(RISK_SCENARIO_STATUSES).optional(),
+  scenario_id: z.string().uuid().optional(),
+  target_type: z.enum(RISK_SCENARIO_LINK_TARGET_TYPES).optional(),
+  link_type: z.enum(RISK_SCENARIO_LINK_TYPES).optional(),
+  ...linkCreateOptionalSharedZodFields,
+  link_id: z.string().uuid().optional(),
+};
+
+export const GC_RISK_SCENARIO_DESCRIPTION =
+  `Risk scenarios + their links. Actions: ${GC_RISK_SCENARIO_ACTIONS.join(", ")}. ` +
+  `create requires: ${GC_RISK_SCENARIO_CREATE_REQUIRED_FIELDS.join(", ")} ` +
+  `(and accepts optional vulnerability). update accepts the same fields minus uid, all optional. ` +
+  `status is consumed only by the transition action (creation defaults to DRAFT). ` +
+  `link_create requires target_type + link_type; for internal target types ` +
+  `(OBSERVATION / ASSET / REQUIREMENT / RISK_REGISTER_RECORD / RISK_ASSESSMENT_RESULT / ` +
+  `TREATMENT_PLAN / METHODOLOGY_PROFILE / CONTROL / THREAT_MODEL) pass target_entity_id; ` +
+  `for external types (VULNERABILITY / FINDING / EVIDENCE / AUDIT_RECORD / EXTERNAL) ` +
+  `pass target_identifier. target_url and target_title are optional. ` +
+  `Reads (list, get, links_list) route through gc_query.`;
+
+/**
+ * Pure adapter handler for gc_risk_scenario. Validates required fields, picks
+ * action-scoped body fields, and dispatches to the corresponding lib.js call.
+ * Returns the raw value the lib call produces (or null for delete-style 204s);
+ * the index.js registration wraps the return in the MCP `ok()` envelope.
+ */
+export async function gcRiskScenarioToolHandler(args) {
+  switch (args.action) {
+    case "create": {
+      for (const key of GC_RISK_SCENARIO_CREATE_REQUIRED_FIELDS) reqArg(args, key, "create");
+      return createRiskScenario(pick(args, GC_RISK_SCENARIO_CREATE_BODY_FIELDS), args.project);
+    }
+    case "update": {
+      reqArg(args, "id", "update");
+      return updateRiskScenario(args.id, pick(args, GC_RISK_SCENARIO_UPDATE_BODY_FIELDS), args.project);
+    }
+    case "delete": {
+      reqArg(args, "id", "delete");
+      await deleteRiskScenario(args.id, args.project);
+      return null;
+    }
+    case "transition": {
+      reqArg(args, "id", "transition");
+      reqArg(args, "status", "transition");
+      return transitionRiskScenarioStatus(args.id, args.status, args.project);
+    }
+    case "requirements": {
+      reqArg(args, "id", "requirements");
+      return getRiskScenarioRequirements(args.id, args.project);
+    }
+    case "link_create": {
+      return performLinkCreate(args, "scenario_id", createRiskScenarioLink);
+    }
+    case "link_delete": {
+      reqArg(args, "scenario_id", "link_delete");
+      reqArg(args, "link_id", "link_delete");
+      await deleteRiskScenarioLink(args.scenario_id, args.link_id, args.project);
+      return null;
+    }
+    default:
+      throw new Error(`Unknown action: ${args.action}`);
+  }
+}

--- a/mcp/ground-control/gc-risk-scenario.test.js
+++ b/mcp/ground-control/gc-risk-scenario.test.js
@@ -1,0 +1,443 @@
+// Adapter-level tests for the gc_risk_scenario MCP handler. Exercise the full
+// path Zod-parsed args → handler dispatch → backend HTTP call (mocked fetch)
+// → wire body shape. Mirrors gc-threat-model.test.js (issue #875) so the same
+// regression scaffolding catches the same defect class: the original bug in
+// issue #876 would resurface here if the Zod shape stopped exposing the
+// backend body fields, the body allowlists drifted to include `description`
+// / `status` / `metadata`, or a required-field check was skipped.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import {
+  GC_RISK_SCENARIO_ACTIONS,
+  GC_RISK_SCENARIO_CREATE_BODY_FIELDS,
+  GC_RISK_SCENARIO_UPDATE_BODY_FIELDS,
+  GC_RISK_SCENARIO_CREATE_REQUIRED_FIELDS,
+  gcRiskScenarioZodShape,
+  gcRiskScenarioToolHandler,
+} from "./gc-risk-scenario.js";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_BASE_URL = process.env.GC_BASE_URL;
+const ORIGINAL_API_TOKEN = process.env.GROUND_CONTROL_API_TOKEN;
+
+function makeFetchSpy({ status = 200, body = { id: "rs-uuid" } } = {}) {
+  const calls = [];
+  globalThis.fetch = async (url, opts) => {
+    const parsedBody = opts && opts.body ? JSON.parse(opts.body) : null;
+    calls.push({ url: url.toString(), method: opts?.method ?? "GET", body: parsedBody });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.GC_BASE_URL = "https://gc.test";
+  delete process.env.GROUND_CONTROL_API_TOKEN;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_BASE_URL === undefined) delete process.env.GC_BASE_URL;
+  else process.env.GC_BASE_URL = ORIGINAL_BASE_URL;
+  if (ORIGINAL_API_TOKEN === undefined) delete process.env.GROUND_CONTROL_API_TOKEN;
+  else process.env.GROUND_CONTROL_API_TOKEN = ORIGINAL_API_TOKEN;
+});
+
+describe("gcRiskScenarioZodShape (issue #876)", () => {
+  const schema = z.object(gcRiskScenarioZodShape);
+
+  it("preserves every backend create body field through Zod parse", () => {
+    const parsed = schema.parse({
+      action: "create",
+      uid: "RS-1",
+      title: "T",
+      threat_source: "src",
+      threat_event: "evt",
+      affected_object: "aff",
+      vulnerability: "vuln",
+      consequence: "loss",
+      time_horizon: "12 months",
+    });
+    for (const k of GC_RISK_SCENARIO_CREATE_BODY_FIELDS) {
+      assert.ok(k in parsed, `Zod stripped '${k}' — the create body would be missing it on the wire`);
+    }
+  });
+
+  it("strips 'description' (backend has no such field on risk-scenario DTOs)", () => {
+    const parsed = schema.parse({
+      action: "create",
+      uid: "RS-1",
+      title: "T",
+      threat_source: "src",
+      threat_event: "evt",
+      affected_object: "aff",
+      consequence: "loss",
+      time_horizon: "12 months",
+      description: "should-be-stripped",
+    });
+    assert.ok(!("description" in parsed));
+  });
+
+  it("strips 'metadata' and 'methodology_profile_id' (not on Create/Update DTOs)", () => {
+    const parsed = schema.parse({
+      action: "create",
+      uid: "RS-1",
+      title: "T",
+      metadata: { foo: "bar" },
+      methodology_profile_id: "11111111-1111-1111-1111-111111111111",
+    });
+    assert.ok(!("metadata" in parsed));
+    assert.ok(!("methodology_profile_id" in parsed));
+  });
+
+  it("rejects an unknown action enum value", () => {
+    assert.throws(() => schema.parse({ action: "merge" }));
+  });
+});
+
+describe("GC_RISK_SCENARIO_CREATE_BODY_FIELDS (issue #876)", () => {
+  it("contains every backend @NotBlank create field plus optional vulnerability", () => {
+    for (const required of [
+      "uid", "title", "threat_source", "threat_event",
+      "affected_object", "consequence", "time_horizon",
+    ]) {
+      assert.ok(
+        GC_RISK_SCENARIO_CREATE_BODY_FIELDS.includes(required),
+        `${required} missing from create body allowlist`,
+      );
+    }
+    assert.ok(GC_RISK_SCENARIO_CREATE_BODY_FIELDS.includes("vulnerability"));
+  });
+
+  it("does NOT contain 'description' (backend has no such field)", () => {
+    assert.ok(!GC_RISK_SCENARIO_CREATE_BODY_FIELDS.includes("description"));
+  });
+
+  it("does NOT contain 'status' (transition is its own action)", () => {
+    assert.ok(!GC_RISK_SCENARIO_CREATE_BODY_FIELDS.includes("status"));
+  });
+
+  it("does NOT contain 'metadata' or 'methodology_profile_id' (not on RiskScenarioRequest)", () => {
+    assert.ok(!GC_RISK_SCENARIO_CREATE_BODY_FIELDS.includes("metadata"));
+    assert.ok(!GC_RISK_SCENARIO_CREATE_BODY_FIELDS.includes("methodology_profile_id"));
+  });
+});
+
+describe("GC_RISK_SCENARIO_UPDATE_BODY_FIELDS (issue #876)", () => {
+  it("contains every backend Update DTO field", () => {
+    for (const f of [
+      "title", "threat_source", "threat_event",
+      "affected_object", "vulnerability", "consequence", "time_horizon",
+    ]) {
+      assert.ok(GC_RISK_SCENARIO_UPDATE_BODY_FIELDS.includes(f));
+    }
+  });
+
+  it("does NOT contain create-only 'uid' (UpdateRiskScenarioRequest has no uid)", () => {
+    assert.ok(!GC_RISK_SCENARIO_UPDATE_BODY_FIELDS.includes("uid"));
+  });
+
+  it("does NOT contain 'description', 'status', 'metadata', 'methodology_profile_id'", () => {
+    for (const f of ["description", "status", "metadata", "methodology_profile_id"]) {
+      assert.ok(!GC_RISK_SCENARIO_UPDATE_BODY_FIELDS.includes(f));
+    }
+  });
+});
+
+describe("GC_RISK_SCENARIO_ACTIONS", () => {
+  it("matches the action verbs the handler dispatches", () => {
+    assert.deepEqual(
+      [...GC_RISK_SCENARIO_ACTIONS].sort(),
+      ["create", "delete", "link_create", "link_delete", "requirements", "transition", "update"],
+    );
+  });
+});
+
+describe("gcRiskScenarioToolHandler create (issue #876)", () => {
+  it("sends every required field to /api/v1/risk-scenarios as camelCase", async () => {
+    const calls = makeFetchSpy();
+    await gcRiskScenarioToolHandler({
+      action: "create",
+      uid: "RS-1",
+      title: "Title",
+      threat_source: "Source",
+      threat_event: "Event",
+      affected_object: "AffObject",
+      vulnerability: "Vuln",
+      consequence: "Loss",
+      time_horizon: "12 months",
+      project: "proj-a",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, /\/api\/v1\/risk-scenarios\b/);
+    assert.match(calls[0].url, /project=proj-a/);
+    assert.deepEqual(calls[0].body, {
+      uid: "RS-1",
+      title: "Title",
+      threatSource: "Source",
+      threatEvent: "Event",
+      affectedObject: "AffObject",
+      vulnerability: "Vuln",
+      consequence: "Loss",
+      timeHorizon: "12 months",
+    });
+  });
+
+  it("does NOT forward 'description', 'status', 'metadata', or unknown fields", async () => {
+    const calls = makeFetchSpy();
+    await gcRiskScenarioToolHandler({
+      action: "create",
+      uid: "RS-1",
+      title: "Title",
+      threat_source: "Source",
+      threat_event: "Event",
+      affected_object: "AffObject",
+      consequence: "Loss",
+      time_horizon: "12 months",
+      description: "ignored",
+      status: "ACTIVE",
+      metadata: { foo: "bar" },
+      methodology_profile_id: "11111111-1111-1111-1111-111111111111",
+    });
+    assert.equal(calls.length, 1);
+    const sent = Object.keys(calls[0].body).sort();
+    assert.deepEqual(sent, [
+      "affectedObject", "consequence", "threatEvent", "threatSource",
+      "timeHorizon", "title", "uid",
+    ]);
+  });
+
+  it("omits 'vulnerability' from the wire body when not provided (it is optional)", async () => {
+    const calls = makeFetchSpy();
+    await gcRiskScenarioToolHandler({
+      action: "create",
+      uid: "RS-1",
+      title: "Title",
+      threat_source: "Source",
+      threat_event: "Event",
+      affected_object: "AffObject",
+      consequence: "Loss",
+      time_horizon: "12 months",
+    });
+    assert.ok(!("vulnerability" in calls[0].body));
+  });
+
+  for (const missing of GC_RISK_SCENARIO_CREATE_REQUIRED_FIELDS) {
+    it(`rejects create before any HTTP call when '${missing}' is missing`, async () => {
+      const calls = makeFetchSpy();
+      const args = {
+        action: "create",
+        uid: "RS-1",
+        title: "T",
+        threat_source: "s",
+        threat_event: "e",
+        affected_object: "a",
+        consequence: "c",
+        time_horizon: "h",
+      };
+      delete args[missing];
+      await assert.rejects(
+        () => gcRiskScenarioToolHandler(args),
+        (e) => e.message.includes(`'${missing}' is required`),
+      );
+      assert.equal(calls.length, 0);
+    });
+  }
+});
+
+describe("gcRiskScenarioToolHandler update (issue #876)", () => {
+  const ID = "22222222-2222-2222-2222-222222222222";
+
+  it("PUTs to /api/v1/risk-scenarios/<id> with the camelCase update body", async () => {
+    const calls = makeFetchSpy();
+    await gcRiskScenarioToolHandler({
+      action: "update",
+      id: ID,
+      title: "New title",
+      threat_source: "src2",
+      threat_event: "evt2",
+      affected_object: "aff2",
+      vulnerability: "vuln2",
+      consequence: "loss2",
+      time_horizon: "6 months",
+      project: "proj-a",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, new RegExp(`/api/v1/risk-scenarios/${ID}\\b`));
+    assert.deepEqual(calls[0].body, {
+      title: "New title",
+      threatSource: "src2",
+      threatEvent: "evt2",
+      affectedObject: "aff2",
+      vulnerability: "vuln2",
+      consequence: "loss2",
+      timeHorizon: "6 months",
+    });
+  });
+
+  it("never forwards create-only 'uid' on update (UpdateRiskScenarioRequest has no uid)", async () => {
+    const calls = makeFetchSpy();
+    await gcRiskScenarioToolHandler({
+      action: "update",
+      id: ID,
+      uid: "RS-LEAK",
+      title: "T",
+    });
+    assert.equal(calls.length, 1);
+    assert.ok(!("uid" in calls[0].body));
+    assert.equal(calls[0].body.title, "T");
+  });
+
+  it("rejects update with no id before any HTTP call", async () => {
+    const calls = makeFetchSpy();
+    await assert.rejects(
+      () => gcRiskScenarioToolHandler({ action: "update" }),
+      (e) => e.message.includes("'id' is required"),
+    );
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe("gcRiskScenarioToolHandler other actions", () => {
+  const ID = "33333333-3333-3333-3333-333333333333";
+
+  it("delete returns null and issues a DELETE", async () => {
+    const calls = [];
+    globalThis.fetch = async (url, opts) => {
+      calls.push({ url: url.toString(), method: opts?.method ?? "GET", body: null });
+      return new Response(null, { status: 204 });
+    };
+    const result = await gcRiskScenarioToolHandler({ action: "delete", id: ID });
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.match(calls[0].url, new RegExp(`/api/v1/risk-scenarios/${ID}\\b`));
+  });
+
+  it("transition PUTs to the status sub-resource with the status body", async () => {
+    const calls = makeFetchSpy();
+    await gcRiskScenarioToolHandler({ action: "transition", id: ID, status: "ACTIVE" });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, new RegExp(`/api/v1/risk-scenarios/${ID}/status`));
+    assert.deepEqual(calls[0].body, { status: "ACTIVE" });
+  });
+
+  it("requirements GETs the requirements sub-resource", async () => {
+    const calls = makeFetchSpy({ body: [] });
+    await gcRiskScenarioToolHandler({ action: "requirements", id: ID });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "GET");
+    assert.match(calls[0].url, new RegExp(`/api/v1/risk-scenarios/${ID}/requirements`));
+  });
+
+  it("link_create with target_entity_id POSTs internal-target link body without leaking entity fields", async () => {
+    const TARGET_ID = "55555555-5555-5555-5555-555555555555";
+    const calls = makeFetchSpy();
+    await gcRiskScenarioToolHandler({
+      action: "link_create",
+      scenario_id: ID,
+      target_type: "REQUIREMENT",
+      target_entity_id: TARGET_ID,
+      link_type: "AFFECTS",
+      target_title: "GC-X001",
+      // these must not leak into the link body
+      title: "should-not-leak",
+      threat_source: "should-not-leak",
+      affected_object: "should-not-leak",
+      consequence: "should-not-leak",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, new RegExp(`/api/v1/risk-scenarios/${ID}/links`));
+    assert.deepEqual(calls[0].body, {
+      targetType: "REQUIREMENT",
+      targetEntityId: TARGET_ID,
+      linkType: "AFFECTS",
+      targetTitle: "GC-X001",
+    });
+  });
+
+  it("link_create with target_identifier POSTs external-target link body", async () => {
+    const calls = makeFetchSpy();
+    await gcRiskScenarioToolHandler({
+      action: "link_create",
+      scenario_id: ID,
+      target_type: "EXTERNAL",
+      target_identifier: "ref://external/finding/42",
+      link_type: "EVIDENCED_BY",
+      target_url: "https://example.test/finding/42",
+      target_title: "External finding",
+    });
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].body, {
+      targetType: "EXTERNAL",
+      targetIdentifier: "ref://external/finding/42",
+      linkType: "EVIDENCED_BY",
+      targetUrl: "https://example.test/finding/42",
+      targetTitle: "External finding",
+    });
+  });
+
+  it("link_create rejects missing target_type before any HTTP call", async () => {
+    const calls = makeFetchSpy();
+    await assert.rejects(
+      () => gcRiskScenarioToolHandler({
+        action: "link_create",
+        scenario_id: ID,
+        link_type: "AFFECTS",
+        target_entity_id: "66666666-6666-6666-6666-666666666666",
+      }),
+      (e) => e.message.includes("'target_type' is required"),
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  it("link_create rejects missing link_type before any HTTP call", async () => {
+    const calls = makeFetchSpy();
+    await assert.rejects(
+      () => gcRiskScenarioToolHandler({
+        action: "link_create",
+        scenario_id: ID,
+        target_type: "REQUIREMENT",
+        target_entity_id: "66666666-6666-6666-6666-666666666666",
+      }),
+      (e) => e.message.includes("'link_type' is required"),
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  it("link_delete issues a DELETE on the link sub-resource", async () => {
+    const LINK_ID = "44444444-4444-4444-4444-444444444444";
+    const calls = [];
+    globalThis.fetch = async (url, opts) => {
+      calls.push({ url: url.toString(), method: opts?.method ?? "GET" });
+      return new Response(null, { status: 204 });
+    };
+    const result = await gcRiskScenarioToolHandler({
+      action: "link_delete",
+      scenario_id: ID,
+      link_id: LINK_ID,
+    });
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.match(calls[0].url, new RegExp(`/api/v1/risk-scenarios/${ID}/links/${LINK_ID}`));
+  });
+
+  it("throws on an unknown action without issuing an HTTP call", async () => {
+    const calls = makeFetchSpy();
+    await assert.rejects(
+      () => gcRiskScenarioToolHandler({ action: "merge" }),
+      (e) => e.message.includes("Unknown action: merge"),
+    );
+    assert.equal(calls.length, 0);
+  });
+});

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -177,6 +177,11 @@ import {
   GC_THREAT_MODEL_DESCRIPTION,
 } from "./gc-threat-model.js";
 import {
+  gcRiskScenarioZodShape,
+  gcRiskScenarioToolHandler,
+  GC_RISK_SCENARIO_DESCRIPTION,
+} from "./gc-risk-scenario.js";
+import {
   linkCreateOptionalSharedZodFields,
   performLinkCreate,
 } from "./link-create.js";
@@ -1287,68 +1292,14 @@ server.tool(
   },
 );
 
-const RISK_SCENARIO_ACTIONS = ["create", "update", "delete", "transition", "requirements", "link_create", "link_delete"];
-
 server.tool(
   "gc_risk_scenario",
-  `Risk scenarios + their links. Actions: ${RISK_SCENARIO_ACTIONS.join(", ")}. ` +
-    `link_create requires target_type + link_type; pass target_entity_id for internal target types ` +
-    `or target_identifier for external types. target_url / target_title are optional. ` +
-    `Reads (list, get, links_list) route through gc_query.`,
-  {
-    action: z.enum(RISK_SCENARIO_ACTIONS),
-    id: z.string().uuid().optional(),
-    uid: z.string().optional(),
-    project: z.string().optional(),
-    title: z.string().optional(),
-    description: z.string().optional(),
-    status: z.enum(RISK_SCENARIO_STATUSES).optional(),
-    methodology_profile_id: z.string().uuid().nullable().optional(),
-    metadata: z.record(z.any()).optional(),
-    // links
-    scenario_id: z.string().uuid().optional(),
-    target_type: z.enum(RISK_SCENARIO_LINK_TARGET_TYPES).optional(),
-    link_type: z.enum(RISK_SCENARIO_LINK_TYPES).optional(),
-    ...linkCreateOptionalSharedZodFields,
-    link_id: z.string().uuid().optional(),
-  },
+  GC_RISK_SCENARIO_DESCRIPTION,
+  gcRiskScenarioZodShape,
   async (args) => {
     try {
-      const ENTITY_FIELDS = ["uid", "title", "description", "status", "methodology_profile_id", "metadata"];
-      switch (args.action) {
-        case "create": {
-          reqArg(args, "title", "create");
-          return ok(JSON.stringify(await createRiskScenario(pick(args, ENTITY_FIELDS), args.project), null, 2));
-        }
-        case "update": {
-          reqArg(args, "id", "update");
-          return ok(JSON.stringify(await updateRiskScenario(args.id, pick(args, ENTITY_FIELDS), args.project), null, 2));
-        }
-        case "delete": {
-          reqArg(args, "id", "delete");
-          await deleteRiskScenario(args.id, args.project);
-          return ok("Deleted");
-        }
-        case "transition": {
-          reqArg(args, "id", "transition"); reqArg(args, "status", "transition");
-          return ok(JSON.stringify(await transitionRiskScenarioStatus(args.id, args.status, args.project), null, 2));
-        }
-        case "requirements": {
-          reqArg(args, "id", "requirements");
-          return ok(JSON.stringify(await getRiskScenarioRequirements(args.id, args.project), null, 2));
-        }
-        case "link_create": {
-          // lib.js: createRiskScenarioLink(scenarioId, data, project). Body
-          // shape + target_type/link_type preconditions live in link-create.js.
-          return ok(JSON.stringify(await performLinkCreate(args, "scenario_id", createRiskScenarioLink), null, 2));
-        }
-        case "link_delete": {
-          reqArg(args, "scenario_id", "link_delete"); reqArg(args, "link_id", "link_delete");
-          await deleteRiskScenarioLink(args.scenario_id, args.link_id, args.project);
-          return ok("Deleted");
-        }
-        default: return err(new Error(`Unknown action: ${args.action}`));
-      }
+      const result = await gcRiskScenarioToolHandler(args);
+      return result === null ? ok("Deleted") : ok(JSON.stringify(result, null, 2));
     } catch (e) { return err(e); }
   },
 );

--- a/mcp/ground-control/package.json
+++ b/mcp/ground-control/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node --test lib.test.js gc-query.test.js gc-threat-model.test.js link-create.test.js",
+    "test": "node --test lib.test.js gc-query.test.js gc-threat-model.test.js gc-risk-scenario.test.js link-create.test.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },


### PR DESCRIPTION
## Summary

Repairs `gc_risk_scenario` MCP create/update — same defect class as the issue #875 `gc_threat_model` fix. The Zod schema now exposes `threat_source`, `threat_event`, `affected_object`, `vulnerability`, `consequence`, and `time_horizon`, matching the backend `RiskScenarioRequest` / `UpdateRiskScenarioRequest` DTOs; the request-body allowlists drop `description`, `status`, `methodology_profile_id`, and `metadata` (none exists on the create or update DTO). The handler is extracted to `gc-risk-scenario.js` so the adapter logic is unit-testable. Codex pre-push review surfaced a class drift on the backend update path — required-on-create string fields could be blanked via the update DTO — and the fix mirrors the `rejectBlankIfPresent` pattern from `ThreatModelService.update`. CI green; pre-commit, `make check`, `make policy`, MCP unit tests, backend unit tests, OpenJML ESC all pass locally.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #876

## ADR Impact

- ADR-035

## Changes

- mcp/ground-control/gc-risk-scenario.js (new): extracted handler mirroring gc-threat-model.js. Exports GC_RISK_SCENARIO_ACTIONS, CREATE_BODY_FIELDS, UPDATE_BODY_FIELDS, CREATE_REQUIRED_FIELDS, the Zod shape, a corrected description, and the pure dispatcher gcRiskScenarioToolHandler.
- mcp/ground-control/gc-risk-scenario.test.js (new): 34 adapter-level tests with mocked fetch — Zod-parse preservation of every backend body field, Zod-strip of description/metadata/methodology_profile_id, per-required-field reject-before-HTTP for create, camelCase wire body for create/update, update-strips-uid, transition/requirements/delete/link_create/link_delete paths, unknown-action error.
- mcp/ground-control/index.js: replaced inline gc_risk_scenario registration with the imported handler, matching the gc_threat_model wiring style.
- mcp/ground-control/package.json: added gc-risk-scenario.test.js to the npm test entry point.
- backend RiskScenarioService.update: added rejectBlankIfPresent guards for title, threatSource, threatEvent, affectedObject, consequence, timeHorizon — closing the codex-flagged class drift where a partial update could corrupt records the create path would refuse. Mirrors ThreatModelService.update.
- backend RiskScenarioServiceTest: 7 new tests — one rejection case per required field plus a positive case that an optional-only partial update (vulnerability) is unaffected.
- architecture/notes/risk-scenario-mcp-contract-preflight.md (new): companion preflight note from codex architecture review, in line with the issue #875 / threat-model preflight note.
- changelog.d/876.fixed.md: source-diff changelog fragment.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- MCP: `cd mcp/ground-control && npm test` — 536 tests pass (34 new for gc_risk_scenario).
- Backend: `make check` — gradle check + spotless + checkstyle + spotbugs + jacoco green; 7 new unit tests under RiskScenarioServiceTest.Update verify the rejectBlankIfPresent behavior.
- Policy: `make policy` — 88 tests, repo guardrails clean.
- Full pre-push: `pre-commit run --all-files` including OpenJML ESC.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #876 ← mcp/ground-control/gc-risk-scenario.js, #876 ← backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/RiskScenarioService.java
- TESTS: #876 ← mcp/ground-control/gc-risk-scenario.test.js, #876 ← backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/876.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
