### PR TITLE
Resolve SonarCloud findings from PR #875 merge (S1192 + S125)

### DIFF
--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/service/ControlLinkService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/service/ControlLinkService.java
@@ -35,11 +35,9 @@ public class ControlLinkService {
     public ControlLink create(UUID projectId, UUID controlId, CreateControlLinkCommand command) {
         var control = controlService.getById(projectId, controlId);
 
-        // Validate the target before persisting: internal target types require a
-        // project-scoped targetEntityId that resolves to an existing entity;
-        // external target types require a nonblank targetIdentifier. Without
-        // this gate ControlLinkService.create() previously persisted whatever
-        // the caller supplied — including cross-project entity IDs.
+        // Project-scoped target validation closes the cross-project gap the create path
+        // had before PR #875 (a caller could otherwise persist a link to an entity in
+        // another tenant's project). The resolver owns the internal-vs-external dispatch.
         var target = graphTargetResolverService.validateControlTarget(
                 projectId, command.targetType(), command.targetEntityId(), command.targetIdentifier());
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java
@@ -24,6 +24,22 @@ public class GraphTargetResolverService {
 
     public record ValidatedTarget(UUID targetEntityId, String targetIdentifier, boolean internal) {}
 
+    // Human-readable labels used by internalTarget to format DomainValidationException
+    // messages. Each label is reused across multiple validate*Target methods; defining
+    // them here keeps the wire-shape of validation errors stable and avoids the literal
+    // duplication that triggers Sonar S1192.
+    private static final String LABEL_REQUIREMENT = "Requirement";
+    private static final String LABEL_ASSET = "Asset";
+    private static final String LABEL_OBSERVATION = "Observation";
+    private static final String LABEL_RISK_SCENARIO = "Risk scenario";
+    private static final String LABEL_RISK_REGISTER_RECORD = "Risk register record";
+    private static final String LABEL_RISK_ASSESSMENT_RESULT = "Risk assessment result";
+    private static final String LABEL_TREATMENT_PLAN = "Treatment plan";
+    private static final String LABEL_METHODOLOGY_PROFILE = "Methodology profile";
+    private static final String LABEL_CONTROL = "Control";
+    private static final String LABEL_THREAT_MODEL = "Threat model";
+    private static final String LABEL_VERIFICATION_RESULT = "Verification result";
+
     private final RequirementRepository requirementRepository;
     private final OperationalAssetRepository assetRepository;
     private final ObservationRepository observationRepository;
@@ -67,41 +83,41 @@ public class GraphTargetResolverService {
             case REQUIREMENT -> internalTarget(
                     targetEntityId,
                     requirementRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Requirement");
+                    LABEL_REQUIREMENT);
             case RISK_SCENARIO -> internalTarget(
                     targetEntityId,
                     riskScenarioRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Risk scenario");
+                    LABEL_RISK_SCENARIO);
             case RISK_REGISTER_RECORD -> internalTarget(
                     targetEntityId,
                     riskRegisterRecordRepository
                             .findByIdAndProjectIdWithScenarios(targetEntityId, projectId)
                             .isPresent(),
-                    "Risk register record");
+                    LABEL_RISK_REGISTER_RECORD);
             case RISK_ASSESSMENT_RESULT -> internalTarget(
                     targetEntityId,
                     riskAssessmentResultRepository
                             .findByIdAndProjectIdWithObservations(targetEntityId, projectId)
                             .isPresent(),
-                    "Risk assessment result");
+                    LABEL_RISK_ASSESSMENT_RESULT);
             case TREATMENT_PLAN -> internalTarget(
                     targetEntityId,
                     treatmentPlanRepository
                             .findByIdAndProjectId(targetEntityId, projectId)
                             .isPresent(),
-                    "Treatment plan");
+                    LABEL_TREATMENT_PLAN);
             case METHODOLOGY_PROFILE -> internalTarget(
                     targetEntityId,
                     methodologyProfileRepository
                             .findByIdAndProjectId(targetEntityId, projectId)
                             .isPresent(),
-                    "Methodology profile");
+                    LABEL_METHODOLOGY_PROFILE);
             case CONTROL -> internalTarget(
-                    targetEntityId, controlRepository.existsByIdAndProjectId(targetEntityId, projectId), "Control");
+                    targetEntityId, controlRepository.existsByIdAndProjectId(targetEntityId, projectId), LABEL_CONTROL);
             case THREAT_MODEL_ENTRY -> internalTarget(
                     targetEntityId,
                     threatModelRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Threat model");
+                    LABEL_THREAT_MODEL);
             case FINDING, EVIDENCE, AUDIT, ISSUE, CODE, CONFIGURATION, EXTERNAL -> externalTarget(targetIdentifier);
         };
     }
@@ -114,43 +130,43 @@ public class GraphTargetResolverService {
                     observationRepository
                             .findByIdWithAssetAndProjectId(targetEntityId, projectId)
                             .isPresent(),
-                    "Observation");
+                    LABEL_OBSERVATION);
             case ASSET -> internalTarget(
-                    targetEntityId, assetRepository.existsByIdAndProjectId(targetEntityId, projectId), "Asset");
+                    targetEntityId, assetRepository.existsByIdAndProjectId(targetEntityId, projectId), LABEL_ASSET);
             case REQUIREMENT -> internalTarget(
                     targetEntityId,
                     requirementRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Requirement");
+                    LABEL_REQUIREMENT);
             case RISK_REGISTER_RECORD -> internalTarget(
                     targetEntityId,
                     riskRegisterRecordRepository
                             .findByIdAndProjectIdWithScenarios(targetEntityId, projectId)
                             .isPresent(),
-                    "Risk register record");
+                    LABEL_RISK_REGISTER_RECORD);
             case RISK_ASSESSMENT_RESULT -> internalTarget(
                     targetEntityId,
                     riskAssessmentResultRepository
                             .findByIdAndProjectIdWithObservations(targetEntityId, projectId)
                             .isPresent(),
-                    "Risk assessment result");
+                    LABEL_RISK_ASSESSMENT_RESULT);
             case TREATMENT_PLAN -> internalTarget(
                     targetEntityId,
                     treatmentPlanRepository
                             .findByIdAndProjectId(targetEntityId, projectId)
                             .isPresent(),
-                    "Treatment plan");
+                    LABEL_TREATMENT_PLAN);
             case METHODOLOGY_PROFILE -> internalTarget(
                     targetEntityId,
                     methodologyProfileRepository
                             .findByIdAndProjectId(targetEntityId, projectId)
                             .isPresent(),
-                    "Methodology profile");
+                    LABEL_METHODOLOGY_PROFILE);
             case CONTROL -> internalTarget(
-                    targetEntityId, controlRepository.existsByIdAndProjectId(targetEntityId, projectId), "Control");
+                    targetEntityId, controlRepository.existsByIdAndProjectId(targetEntityId, projectId), LABEL_CONTROL);
             case THREAT_MODEL -> internalTarget(
                     targetEntityId,
                     threatModelRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Threat model");
+                    LABEL_THREAT_MODEL);
             case VULNERABILITY, FINDING, EVIDENCE, AUDIT_RECORD, EXTERNAL -> externalTarget(targetIdentifier);
         };
     }
@@ -159,45 +175,45 @@ public class GraphTargetResolverService {
             UUID projectId, ControlLinkTargetType targetType, UUID targetEntityId, String targetIdentifier) {
         return switch (targetType) {
             case ASSET -> internalTarget(
-                    targetEntityId, assetRepository.existsByIdAndProjectId(targetEntityId, projectId), "Asset");
+                    targetEntityId, assetRepository.existsByIdAndProjectId(targetEntityId, projectId), LABEL_ASSET);
             case REQUIREMENT -> internalTarget(
                     targetEntityId,
                     requirementRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Requirement");
+                    LABEL_REQUIREMENT);
             case RISK_SCENARIO -> internalTarget(
                     targetEntityId,
                     riskScenarioRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Risk scenario");
+                    LABEL_RISK_SCENARIO);
             case RISK_REGISTER_RECORD -> internalTarget(
                     targetEntityId,
                     riskRegisterRecordRepository
                             .findByIdAndProjectIdWithScenarios(targetEntityId, projectId)
                             .isPresent(),
-                    "Risk register record");
+                    LABEL_RISK_REGISTER_RECORD);
             case RISK_ASSESSMENT_RESULT -> internalTarget(
                     targetEntityId,
                     riskAssessmentResultRepository
                             .findByIdAndProjectIdWithObservations(targetEntityId, projectId)
                             .isPresent(),
-                    "Risk assessment result");
+                    LABEL_RISK_ASSESSMENT_RESULT);
             case TREATMENT_PLAN -> internalTarget(
                     targetEntityId,
                     treatmentPlanRepository
                             .findByIdAndProjectId(targetEntityId, projectId)
                             .isPresent(),
-                    "Treatment plan");
+                    LABEL_TREATMENT_PLAN);
             case METHODOLOGY_PROFILE -> internalTarget(
                     targetEntityId,
                     methodologyProfileRepository
                             .findByIdAndProjectId(targetEntityId, projectId)
                             .isPresent(),
-                    "Methodology profile");
+                    LABEL_METHODOLOGY_PROFILE);
             case OBSERVATION -> internalTarget(
                     targetEntityId,
                     observationRepository
                             .findByIdWithAssetAndProjectId(targetEntityId, projectId)
                             .isPresent(),
-                    "Observation");
+                    LABEL_OBSERVATION);
             case EVIDENCE, FINDING, CODE, CONFIGURATION, OPERATIONAL_ARTIFACT, EXTERNAL -> externalTarget(
                     targetIdentifier);
         };
@@ -207,33 +223,33 @@ public class GraphTargetResolverService {
             UUID projectId, ThreatModelLinkTargetType targetType, UUID targetEntityId, String targetIdentifier) {
         return switch (targetType) {
             case ASSET -> internalTarget(
-                    targetEntityId, assetRepository.existsByIdAndProjectId(targetEntityId, projectId), "Asset");
+                    targetEntityId, assetRepository.existsByIdAndProjectId(targetEntityId, projectId), LABEL_ASSET);
             case REQUIREMENT -> internalTarget(
                     targetEntityId,
                     requirementRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Requirement");
+                    LABEL_REQUIREMENT);
             case CONTROL -> internalTarget(
-                    targetEntityId, controlRepository.existsByIdAndProjectId(targetEntityId, projectId), "Control");
+                    targetEntityId, controlRepository.existsByIdAndProjectId(targetEntityId, projectId), LABEL_CONTROL);
             case RISK_SCENARIO -> internalTarget(
                     targetEntityId,
                     riskScenarioRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Risk scenario");
+                    LABEL_RISK_SCENARIO);
             case OBSERVATION -> internalTarget(
                     targetEntityId,
                     observationRepository
                             .findByIdWithAssetAndProjectId(targetEntityId, projectId)
                             .isPresent(),
-                    "Observation");
+                    LABEL_OBSERVATION);
             case RISK_ASSESSMENT_RESULT -> internalTarget(
                     targetEntityId,
                     riskAssessmentResultRepository
                             .findByIdAndProjectIdWithObservations(targetEntityId, projectId)
                             .isPresent(),
-                    "Risk assessment result");
+                    LABEL_RISK_ASSESSMENT_RESULT);
             case VERIFICATION_RESULT -> internalTarget(
                     targetEntityId,
                     verificationResultRepository.existsByIdAndProjectId(targetEntityId, projectId),
-                    "Verification result");
+                    LABEL_VERIFICATION_RESULT);
             case ARCHITECTURE_MODEL, CODE, ISSUE, EVIDENCE, EXTERNAL -> externalTarget(targetIdentifier);
         };
     }

--- a/changelog.d/+sonar-cleanup-post-875.changed.md
+++ b/changelog.d/+sonar-cleanup-post-875.changed.md
@@ -1,0 +1,1 @@
+Internal refactor: extract entity-name labels in `GraphTargetResolverService` into named constants (Sonar S1192) and tighten the `ControlLinkService.create` comment block that triggered S125. No behavior change.


### PR DESCRIPTION
## Summary

Clean up the seven SonarCloud findings that landed on `dev` after PR #875 merged. No behavior change — the diff extracts a set of human-readable entity-name labels in `GraphTargetResolverService` into named constants (S1192) and tightens the multi-line comment block in `ControlLinkService.create` that Sonar misread as commented-out code (S125). DomainValidationException wire messages are byte-identical to before.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Follow-up to #875 (post-merge SonarCloud cleanup; #875 is already closed and stays closed).

## ADR Impact

- ADR-026 (honored — the revised ControlLinkService comment reaffirms the REST API project-scoping gate; no behavior change)

## Changes

- `GraphTargetResolverService.java`: extract every entity-name label used by `internalTarget(...)` (Requirement, Asset, Observation, Risk scenario, Risk register record, Risk assessment result, Treatment plan, Methodology profile, Control, Threat model, Verification result) into `private static final String LABEL_*` constants. The 6 S1192 findings cluster around the labels each used 3+ times across the four `validate*Target` methods; extracting all 11 keeps the convention uniform rather than only the flagged ones.
- `ControlLinkService.java`: rewrite the 5-line identifier-heavy explanatory comment above the `validateControlTarget` call into a 3-line prose comment that captures the same security rationale (cross-project gap, pre-#875 behavior, dispatch ownership) without tripping Sonar S125's commented-out-code heuristic.
- Add `changelog.d/+sonar-cleanup-post-875.changed.md`: issue-free `+<slug>.<type>.md` form since this is repo-internal code-quality cleanup, not a user-visible fix tied to a specific tracking issue.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

No new tests — the diff is a refactor with no behavior change. The DomainValidationException messages produced by `internalTarget` are formatted via `label + " links require targetEntityId"` and `label + " target not found in the requested project"`; the existing `GraphTargetResolverServiceTest` assertions on those strings still pass (verified locally via `./gradlew test --tests GraphTargetResolverServiceTest --tests ControlLinkServiceTest`). `make policy` passes. `cd backend && ./gradlew spotlessCheck` passes.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/+sonar-cleanup-post-875.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
