### PR TITLE
Align gc_risk_governance allowlists to backend DTOs (#878/#879/#880)

### DIFF
--- a/architecture/notes/risk-assessment-result-preflight.md
+++ b/architecture/notes/risk-assessment-result-preflight.md
@@ -59,6 +59,13 @@ row unless the caller is explicitly editing that same result.
 - Audit and persistence: audited entities extend `BaseEntity`, use Envers,
   Flyway migrations, audit-table parity, project scope, indexes for primary
   read paths, and `AuditRetentionJob` updates when new audit tables are added.
+- MCP adapter shape: `gc_risk_governance` in
+  `mcp/ground-control/index.js`, the per-entity `GOVERNANCE_FIELDS`
+  allowlist, `pick`, `toCamelCase`, `addAuthorizationHeader`, `RequestError`,
+  and `validateGovernanceStatus` in `mcp/ground-control/lib.js`. The MCP
+  contract for `entity=risk_assessment_result` must mirror the backend
+  create/update DTO fields for this aggregate, not the generic register-record
+  or scenario fields.
 
 ## Cross-Cutting Layers
 
@@ -97,10 +104,44 @@ row unless the caller is explicitly editing that same result.
   calls, or CLI argv. Any future calculation or validation adapter that does
   must use `@ConfigurationProperties` with startup validation and keep secrets
   out of process argv, logs, and error envelopes.
+- MCP transport: Ground Control MCP write tools must continue to send requests
+  through `request()`, which applies the canonical snake_case to camelCase
+  translation, `X-Actor: mcp-server`, backend error-envelope preservation, and
+  bearer-token selection from `GROUND_CONTROL_API_TOKEN` /
+  `GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN`. Do not add per-tool HTTP clients,
+  caller-supplied headers, caller-supplied tokens, or ad hoc URL construction
+  for assessment results.
 - Tests and policy: controller changes need `@WebMvcTest`; semantic rules need
   service tests; approval-state rules need state-machine tests; graph/evidence
   behavior needs projection and resolver coverage; schema changes need migration
   smoke coverage. `make policy` remains the repo-native completion guardrail.
+
+## MCP Contract Guardrails
+
+Issue #878 is a contract-alignment fix at the MCP boundary. The backend
+`RiskAssessmentResultRequest` already names the authoritative create fields:
+`riskScenarioId`, `riskRegisterRecordId`, `methodologyProfileId`,
+`analystIdentity`, `assumptions`, `inputFactors`, `observationDate`,
+`assessmentAt`, `timeHorizon`, `confidence`, `uncertaintyMetadata`,
+`computedOutputs`, `evidenceRefs`, `notes`, and `observationIds`.
+
+The MCP surface should expose those fields in snake_case and rely on the
+existing `toCamelCase` map to produce the backend DTO. Prefer
+`risk_scenario_id` over adding a special-case `scenario_id` alias for assessment
+results: the explicit name matches the backend association, avoids conflating
+scenario-owned fields with assessment-owned fields, and reuses the existing
+`risk_scenario_id -> riskScenarioId` mapping. `scenario_id` may remain valid for
+entities whose backend DTOs actually own `scenarioId`, such as register records
+or treatment plans; do not force a repo-wide rename that would change those
+contracts without a separate compatibility decision.
+
+Drop `uid`, `title`, `description`, `quantitative_value`, and
+`qualitative_value` from the assessment-result allowlist and schema unless the
+backend DTO first grows those fields. They currently describe scenario,
+register-record, or score-summary concepts, not the durable methodology result.
+Unknown user fields should continue to be rejected by Zod or omitted by the
+per-entity allowlist before dispatch; they must not be tunneled through
+`metadata` to compensate for a mismatched typed contract.
 
 ## Extensibility
 
@@ -109,6 +150,12 @@ The primary extension seam is methodology-result validation keyed by
 If schema validation becomes in scope, keep it profile-driven so adding another
 methodology or version requires changing profile data and tests, not adding
 controller branches or new result columns.
+
+For MCP field evolution, the extension seam is the per-entity field registry
+plus the shared snake_case/camelCase mapping. Adding the next assessment-result
+field should require one allowlist/schema/mapping update and tests for the
+serialized backend body, not a new tool, a parallel DTO translator, or
+entity-specific request logic.
 
 The second extension seam is evidence identity: modeled observations should stay
 as project-scoped `Observation` links, while unmodeled external evidence stays
@@ -129,6 +176,15 @@ paths instead of adding assessment-only evidence tables.
   or `RiskScenario` fields.
 - Do not invent a duplicate JSON schema dialect, exception hierarchy, audit
   writer, auth guard, logging channel, graph materializer, or workflow engine.
+- Do not keep generic `uid` / `title` / `description` / qualitative or
+  quantitative score fields on the MCP assessment-result create/update path
+  unless the backend assessment-result DTO accepts them.
+- Do not route typed assessment fields through `metadata`; the backend has
+  first-class fields for methodology inputs, outputs, evidence, timing,
+  assumptions, and analyst identity.
+- Do not add a `scenario_id` mapping as a blanket workaround if the entity's
+  real backend association is `riskScenarioId`; prefer the explicit
+  `risk_scenario_id` field for assessment results.
 - Do not mark schema-validation behavior as satisfied merely because
   `MethodologyProfile.inputSchema` and `outputSchema` are persisted.
 - Do not let `analystIdentity` spoof or override the authenticated audit actor.

--- a/architecture/notes/risk-register-record-preflight.md
+++ b/architecture/notes/risk-register-record-preflight.md
@@ -52,6 +52,11 @@ assessment method or analysis run, it belongs on a linked
   `AuditRetentionJob` allowlist when new audit tables are introduced.
 - Migrations: Flyway remains the schema source of truth; preserve project scope,
   indexes, unique constraints, and audit-table parity.
+- MCP adapter: `gc_risk_governance` is the public tool surface for register
+  records under ADR-035. Reuse `pick`, `reqArg`, `toCamelCase`, the
+  per-entity field allowlist, and the same action-discriminated handler pattern
+  used by `gc_risk_scenario` and `gc_threat_model`; do not add a second mapper
+  or risk-register-only transport helper.
 
 ## Cross-Cutting Gates
 
@@ -77,6 +82,37 @@ assessment method or analysis run, it belongs on a linked
   disabled for slices, service unit tests for semantic rules, graph resolver and
   projection tests for link behavior, and migration/integration coverage when
   schema changes alter persistence contracts.
+- MCP validation: expose every backend create/update DTO field in the Zod shape
+  before the action body allowlist runs, then pick only action-appropriate body
+  fields. Keep `status` out of create/update bodies; status transitions stay on
+  the `/status` sub-resource through the `transition` action.
+
+## MCP Adapter Guardrails
+
+Issue #879 is an MCP adapter contract fix, not a backend model change. The
+backend already accepts `categoryTags`, `decisionMetadata`,
+`assetScopeSummary`, and multi-scenario `riskScenarioIds` on
+`RiskRegisterRecordRequest` and `UpdateRiskRegisterRecordRequest`.
+
+The MCP public contract must use snake_case names that map through the shared
+camel-case conversion:
+
+- `risk_scenario_ids` maps to backend `riskScenarioIds` and replaces the
+  incorrect single `scenario_id` field for register-record create/update.
+- `category_tags`, `decision_metadata`, and `asset_scope_summary` must be in
+  both the Zod shape and the register-record body allowlist when the backend DTO
+  accepts them.
+- `description` must not be accepted for register-record create/update because
+  the backend DTO has no such field.
+- `status` must not be accepted for register-record create/update because the
+  backend initializes records as `IDENTIFIED` and enforces later status changes
+  through the dedicated transition endpoint.
+
+Adapter tests should lock the same regression class already covered for
+`gc_risk_scenario` and `gc_threat_model`: Zod preserves all intended public
+fields, the body allowlist excludes fields the backend does not accept, create
+and update send camelCase DTO bodies, and transition sends only `{status}` to
+`/api/v1/risk-register-records/{id}/status`.
 
 ## Extensibility
 
@@ -90,6 +126,14 @@ Review cadence is currently a free-text field. If cadence semantics become
 machine-enforced, introduce one canonical cadence value object or enum and
 migrate all API, persistence, and validation surfaces together.
 
+For the MCP surface, the extension seam is the entity-specific field allowlist
+and Zod shape inside the consolidated `gc_risk_governance` tool. Add future
+register-record DTO fields there, then rely on shared snake_case-to-camelCase
+mapping unless the backend wire name intentionally diverges. If the governance
+handler grows more action-specific logic, extract a pure adapter module matching
+`gc-risk-scenario.js` instead of expanding duplicate validation inside
+`index.js`.
+
 ## Anti-Patterns
 
 - Treating a register record as the risk assessment result.
@@ -102,3 +146,9 @@ migrate all API, persistence, and validation surfaces together.
 - Returning ad hoc HTTP error bodies or leaking client-controlled identifiers in
   unexpected 500 responses.
 - Adding a workflow engine for the seven-value risk-register status lifecycle.
+- Reintroducing singular `scenario_id` for register records; the aggregate is
+  deliberately multi-scenario.
+- Mirroring backend DTOs with a hand-written mapper that bypasses `pick` and
+  `toCamelCase`.
+- Treating MCP `metadata` as an alias for `decision_metadata`; the register DTO
+  field is explicitly decision-audit metadata.

--- a/architecture/notes/risk-treatment-plan-preflight.md
+++ b/architecture/notes/risk-treatment-plan-preflight.md
@@ -58,6 +58,14 @@ link surfaces.
 - JSON text columns: `actionItems` and `reassessmentTriggers` use
   `JacksonTextCollectionConverters`. Do not add feature-local `ObjectMapper`
   parsing or a second JSON schema system.
+- MCP adapter shape: `gc_risk_governance` in
+  `mcp/ground-control/index.js`, the per-entity `GOVERNANCE_FIELDS`
+  allowlist, the flat Zod shape, `pick`, `reqArg`, `toCamelCase`,
+  `addAuthorizationHeader`, `RequestError`, and `validateGovernanceStatus` in
+  `mcp/ground-control/lib.js`. The MCP contract for
+  `entity=treatment_plan` must mirror the backend treatment-plan create/update
+  DTO fields for this aggregate, not generic CRUD fields from adjacent
+  governance entities.
 - Graph: treatment-plan nodes and `TREATS` edges belong in
   `RiskGraphProjectionContributor`, using `GraphEntityType` and `GraphIds`.
   Asset/control/scope edges should flow through the existing link projection
@@ -94,10 +102,48 @@ link surfaces.
   exposure. A future external-ticket or workflow integration must use
   `@ConfigurationProperties` with startup validation and keep secrets out of
   argv, logs, and error envelopes.
+- MCP transport: Ground Control MCP write tools must continue to send requests
+  through `request()`, which applies canonical snake_case to camelCase
+  translation, `X-Actor: mcp-server`, backend error-envelope preservation, and
+  bearer-token selection from `GROUND_CONTROL_API_TOKEN` /
+  `GROUND_CONTROL_PACK_REGISTRY_ADMIN_TOKEN`. Do not add treatment-plan-specific
+  HTTP clients, caller-supplied headers, caller-supplied tokens, or ad hoc URL
+  construction.
 - Tests and policy: controller changes need `@WebMvcTest`; semantic rules need
   service tests; graph/link behavior needs resolver and projection tests;
   schema changes need migration smoke coverage. `make policy` remains the
   completion guardrail.
+
+## MCP Contract Guardrails
+
+Issue #880 is an MCP adapter contract-alignment fix, not a backend model
+change. The backend `TreatmentPlanRequest` already names the authoritative
+create fields: `uid`, `title`, `riskRegisterRecordId`, `riskScenarioId`,
+`strategy`, `owner`, `rationale`, `dueDate`, `status`, `actionItems`, and
+`reassessmentTriggers`. `UpdateTreatmentPlanRequest` accepts the mutable subset:
+`title`, `riskScenarioId`, `strategy`, `owner`, `rationale`, `dueDate`,
+`actionItems`, and `reassessmentTriggers`.
+
+The MCP public surface should expose those fields in snake_case and rely on the
+existing `toCamelCase` map to produce the backend DTO. Prefer
+`risk_scenario_id` over a special-case `scenario_id` alias for treatment plans:
+the explicit name matches the backend association, avoids conflating
+scenario-owned fields with treatment-owned fields, and reuses the existing
+`risk_scenario_id -> riskScenarioId` mapping. Use `due_date`, not `due_at`,
+because the shared mapper already defines `due_date -> dueDate`.
+
+Drop `description` and `metadata` from treatment-plan create/update unless the
+backend DTO first grows those fields. Treatment-plan rationale is a first-class
+field, not a generic description, and action payloads belong in `action_items`,
+not an untyped metadata escape hatch. Keep `status` on create only if the
+backend create DTO continues to accept it; status changes after creation must
+stay on the existing transition action and `/status` backend sub-resource.
+
+Adapter tests should lock the same regression class covered for the adjacent
+MCP governance fixes: Zod admits every intended public field, the per-entity
+allowlist excludes fields the backend does not accept, create/update send the
+expected camelCase body, and transition sends only `{status}` to the status
+endpoint.
 
 ## Extensibility
 
@@ -115,6 +161,12 @@ methodology-specific trigger. The target-resolution seam belongs in
 `GraphTargetResolverService` and graph projections so API, MCP, and future
 analysis/sweep surfaces can reuse the same project-scoped validation.
 
+For MCP field evolution, the extension seam is the consolidated
+`gc_risk_governance` entity field registry plus the shared
+snake_case/camelCase mapping. Adding the next treatment-plan DTO field should
+require one schema/allowlist/mapping update and serialized-body tests, not a new
+tool, a parallel DTO translator, or entity-specific request plumbing.
+
 ## Gotchas And Anti-Patterns
 
 - Do not treat a treatment plan as satisfying asset scope or control mitigation
@@ -129,6 +181,13 @@ analysis/sweep surfaces can reuse the same project-scoped validation.
   `TreatmentPlanStatus` lifecycle.
 - Do not introduce endpoint-local exception mapping, security checks, JSON
   parsing, or logging conventions.
+- Do not keep `due_at` on the MCP treatment-plan path; it bypasses the existing
+  mapper and leaves backend `dueDate` null.
+- Do not accept `description` as a treatment-plan alias; use `rationale`.
+- Do not route `action_items`, `reassessment_triggers`, `rationale`, or
+  `due_date` through `metadata`; the backend has first-class fields.
+- Do not add a blanket `scenario_id` mapping if the backend association is
+  `riskScenarioId`; prefer explicit `risk_scenario_id`.
 - Do not transition GC-T004 to ACTIVE unless each clause is evidenced against
   the canonical artifacts, including asset/control linkage and reassessment
   trigger behavior.
@@ -138,6 +197,8 @@ analysis/sweep surfaces can reuse the same project-scoped validation.
 - Implementing GC-T004 gaps as part of verification issue #825.
 - Designing a generic workflow engine, ticketing integration, or background
   scheduler.
+- Changing backend treatment-plan DTOs, persistence, graph projection, or status
+  transition semantics just to compensate for an MCP adapter naming drift.
 - Replacing existing asset, control, scenario, risk-register, assessment, or
   traceability aggregates.
 - Defining first-class control effectiveness assessment behavior; that belongs

--- a/changelog.d/878.fixed.md
+++ b/changelog.d/878.fixed.md
@@ -6,5 +6,7 @@ action (create vs update), misnamed fields (`scenario_id`, `due_at`)
 are replaced with the explicit `risk_scenario_id` / `risk_scenario_ids`
 / `due_date` the backend accepts, and stale fields the backend has no
 column for (`description`, `quantitative_value`, `qualitative_value`,
-`uid` on assessments, `metadata` tunnels) are dropped. Closes #879
-and #880 together.
+`uid` on assessments, `metadata` tunnels) are dropped. Adapter-level
+regression suite at `mcp/ground-control/gc-risk-governance.test.js`
+asserts both the camelCased wire body and the absence of dropped
+fields on every entity.

--- a/changelog.d/878.fixed.md
+++ b/changelog.d/878.fixed.md
@@ -1,0 +1,10 @@
+`gc_risk_governance` create/update bodies for `risk_assessment_result`,
+`risk_register_record`, and `treatment_plan` now match the backend
+`RiskAssessmentResultRequest` / `RiskRegisterRecordRequest` /
+`TreatmentPlanRequest` records. Per-entity allowlists are split by
+action (create vs update), misnamed fields (`scenario_id`, `due_at`)
+are replaced with the explicit `risk_scenario_id` / `risk_scenario_ids`
+/ `due_date` the backend accepts, and stale fields the backend has no
+column for (`description`, `quantitative_value`, `qualitative_value`,
+`uid` on assessments, `metadata` tunnels) are dropped. Closes #879
+and #880 together.

--- a/changelog.d/878.fixed.md
+++ b/changelog.d/878.fixed.md
@@ -6,7 +6,10 @@ action (create vs update), misnamed fields (`scenario_id`, `due_at`)
 are replaced with the explicit `risk_scenario_id` / `risk_scenario_ids`
 / `due_date` the backend accepts, and stale fields the backend has no
 column for (`description`, `quantitative_value`, `qualitative_value`,
-`uid` on assessments, `metadata` tunnels) are dropped. Adapter-level
-regression suite at `mcp/ground-control/gc-risk-governance.test.js`
+`uid` on assessments, `metadata` tunnels) are dropped. The tool's
+handler is extracted into `mcp/ground-control/gc-risk-governance.js`
+(matching the `gc-risk-scenario.js` pattern) so the adapter is testable
+in isolation; `mcp/ground-control/gc-risk-governance.test.js` drives
+the full path raw args → Zod parse → handler → mocked fetch and
 asserts both the camelCased wire body and the absence of dropped
 fields on every entity.

--- a/mcp/ground-control/gc-risk-governance.js
+++ b/mcp/ground-control/gc-risk-governance.js
@@ -1,0 +1,168 @@
+// gc_risk_governance: entity- + action-discriminated MCP adapter for the
+// methodology profile, risk register record, risk assessment result, treatment
+// plan, and verification result REST surfaces (ADR-035). Extracted from
+// index.js so the handler logic is testable in isolation — see
+// gc-risk-governance.test.js for adapter-level tests that drive the full
+// path raw args → handler dispatch → backend HTTP call (mocked fetch). Issues
+// #878/#879/#880 are the regression locks: per-entity allowlists must mirror
+// the backend Request records, and the handler's `pick(args, ...)` is the
+// gate that drops stale fields — not test-side pre-filtering.
+
+import { z } from "zod";
+import {
+  METHODOLOGY_FAMILIES,
+  RISK_ASSESSMENT_APPROVAL_STATUSES,
+  TREATMENT_STRATEGIES,
+  ASSURANCE_LEVELS,
+  GOVERNANCE_FIELDS,
+  pick, reqArg, validateGovernanceStatus,
+  createMethodologyProfile, updateMethodologyProfile, deleteMethodologyProfile,
+  createRiskRegisterRecord, updateRiskRegisterRecord, deleteRiskRegisterRecord,
+  transitionRiskRegisterRecordStatus,
+  createRiskAssessmentResult, updateRiskAssessmentResult,
+  deleteRiskAssessmentResult, transitionRiskAssessmentApprovalState,
+  createTreatmentPlan, updateTreatmentPlan, deleteTreatmentPlan,
+  transitionTreatmentPlanStatus,
+  createVerificationResult, updateVerificationResult, deleteVerificationResult,
+} from "./lib.js";
+
+export const GC_RISK_GOVERNANCE_ENTITIES = [
+  "methodology_profile", "risk_register_record", "risk_assessment_result",
+  "treatment_plan", "verification_result",
+];
+export const GC_RISK_GOVERNANCE_ACTIONS = [
+  "create", "update", "delete", "transition", "transition_approval",
+];
+
+export const gcRiskGovernanceZodShape = {
+  entity: z.enum(GC_RISK_GOVERNANCE_ENTITIES),
+  action: z.enum(GC_RISK_GOVERNANCE_ACTIONS),
+  id: z.string().uuid().optional(),
+  project: z.string().optional(),
+  // Status vocabulary is per-entity; the handler validates it against
+  // GOVERNANCE_STATUS_ENUMS[args.entity] before any backend call. The Zod
+  // shape accepts any string here — a discriminated check at the schema
+  // level would require restructuring this tool into five entity-specific
+  // tools, which ADR-035 already rejected.
+  status: z.string().optional(),
+  approval_state: z.enum(RISK_ASSESSMENT_APPROVAL_STATUSES).optional(),
+  // Shared entity fields. Per-entity allowlist (GOVERNANCE_FIELDS) gates which
+  // ones reach the backend on create/update, so unrelated MCP control fields
+  // (action, entity, id, project) don't leak into the DTO.
+  uid: z.string().optional(),
+  name: z.string().optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  family: z.enum(METHODOLOGY_FAMILIES).optional(),
+  risk_scenario_id: z.string().uuid().optional(),
+  risk_scenario_ids: z.array(z.string().uuid()).optional(),
+  risk_register_record_id: z.string().uuid().optional(),
+  methodology_profile_id: z.string().uuid().optional(),
+  owner: z.string().optional(),
+  review_cadence: z.string().optional(),
+  next_review_at: z.string().optional(),
+  category_tags: z.array(z.string()).optional(),
+  decision_metadata: z.record(z.any()).optional(),
+  asset_scope_summary: z.string().optional(),
+  analyst_identity: z.string().optional(),
+  assumptions: z.string().optional(),
+  input_factors: z.record(z.any()).optional(),
+  observation_date: z.string().optional(),
+  assessment_at: z.string().optional(),
+  time_horizon: z.string().optional(),
+  confidence: z.string().optional(),
+  uncertainty_metadata: z.record(z.any()).optional(),
+  computed_outputs: z.record(z.any()).optional(),
+  evidence_refs: z.array(z.string()).optional(),
+  notes: z.string().optional(),
+  observation_ids: z.array(z.string().uuid()).optional(),
+  strategy: z.enum(TREATMENT_STRATEGIES).optional(),
+  rationale: z.string().optional(),
+  due_date: z.string().optional(),
+  action_items: z.array(z.record(z.any())).optional(),
+  reassessment_triggers: z.array(z.string()).optional(),
+  outcome: z.string().optional(),
+  assurance_level: z.enum(ASSURANCE_LEVELS).optional(),
+  verified_at: z.string().optional(),
+  metadata: z.record(z.any()).optional(),
+};
+
+export const GC_RISK_GOVERNANCE_DESCRIPTION =
+  `Methodology profiles, risk register records, risk assessments, treatment plans, verification results. ` +
+  `Entity: ${GC_RISK_GOVERNANCE_ENTITIES.join(", ")}. Actions: ${GC_RISK_GOVERNANCE_ACTIONS.join(", ")}. ` +
+  `Reads (list, get) route through gc_query. ` +
+  `Per-entity create fields (snake_case; round-trip to backend camelCase): ` +
+  `risk_register_record={uid,title,owner,review_cadence,next_review_at,category_tags,decision_metadata,asset_scope_summary,risk_scenario_ids}; ` +
+  `risk_assessment_result={risk_scenario_id,risk_register_record_id,methodology_profile_id,analyst_identity,assumptions,input_factors,observation_date,assessment_at,time_horizon,confidence,uncertainty_metadata,computed_outputs,evidence_refs,notes,observation_ids}; ` +
+  `treatment_plan={uid,title,risk_scenario_id,risk_register_record_id,strategy,owner,rationale,due_date,status,action_items,reassessment_triggers}. ` +
+  `Update DTOs drop create-only foreign keys (uid; risk_register_record_id for treatment_plan; risk_scenario_id for risk_assessment_result) and status fields whose changes go through the transition action. ` +
+  `Unknown fields are dropped — never tunneled through metadata.`;
+
+/**
+ * Pure adapter handler for gc_risk_governance. Validates per-entity status,
+ * picks action-scoped body fields, and dispatches to the corresponding lib.js
+ * call. Returns the raw value the lib call produces (or null for delete /
+ * 204 responses); the index.js registration wraps the return in the MCP `ok()`
+ * envelope. Throws Error on unknown action/entity combinations and on missing
+ * required args — same semantics as the previous inline handler.
+ */
+export async function gcRiskGovernanceToolHandler(args) {
+  validateGovernanceStatus(args.entity, args.status);
+  const fieldsForAction = GOVERNANCE_FIELDS[args.entity]?.[args.action] ?? [];
+  const data = pick(args, fieldsForAction);
+  switch (args.entity) {
+    case "methodology_profile": {
+      switch (args.action) {
+        case "create": return createMethodologyProfile(data, args.project);
+        case "update": reqArg(args, "id", "update"); return updateMethodologyProfile(args.id, data, args.project);
+        case "delete": reqArg(args, "id", "delete"); await deleteMethodologyProfile(args.id, args.project); return null;
+        default: throw new Error(`Action '${args.action}' not valid for methodology_profile`);
+      }
+    }
+    case "risk_register_record": {
+      switch (args.action) {
+        case "create": return createRiskRegisterRecord(data, args.project);
+        case "update": reqArg(args, "id", "update"); return updateRiskRegisterRecord(args.id, data, args.project);
+        case "delete": reqArg(args, "id", "delete"); await deleteRiskRegisterRecord(args.id, args.project); return null;
+        case "transition":
+          reqArg(args, "id", "transition");
+          reqArg(args, "status", "transition");
+          return transitionRiskRegisterRecordStatus(args.id, args.status, args.project);
+        default: throw new Error(`Action '${args.action}' not valid for risk_register_record`);
+      }
+    }
+    case "risk_assessment_result": {
+      switch (args.action) {
+        case "create": return createRiskAssessmentResult(data, args.project);
+        case "update": reqArg(args, "id", "update"); return updateRiskAssessmentResult(args.id, data, args.project);
+        case "delete": reqArg(args, "id", "delete"); await deleteRiskAssessmentResult(args.id, args.project); return null;
+        case "transition_approval":
+          reqArg(args, "id", "transition_approval");
+          reqArg(args, "approval_state", "transition_approval");
+          return transitionRiskAssessmentApprovalState(args.id, args.approval_state, args.project);
+        default: throw new Error(`Action '${args.action}' not valid for risk_assessment_result`);
+      }
+    }
+    case "treatment_plan": {
+      switch (args.action) {
+        case "create": return createTreatmentPlan(data, args.project);
+        case "update": reqArg(args, "id", "update"); return updateTreatmentPlan(args.id, data, args.project);
+        case "delete": reqArg(args, "id", "delete"); await deleteTreatmentPlan(args.id, args.project); return null;
+        case "transition":
+          reqArg(args, "id", "transition");
+          reqArg(args, "status", "transition");
+          return transitionTreatmentPlanStatus(args.id, args.status, args.project);
+        default: throw new Error(`Action '${args.action}' not valid for treatment_plan`);
+      }
+    }
+    case "verification_result": {
+      switch (args.action) {
+        case "create": return createVerificationResult(data, args.project);
+        case "update": reqArg(args, "id", "update"); return updateVerificationResult(args.id, data, args.project);
+        case "delete": reqArg(args, "id", "delete"); await deleteVerificationResult(args.id, args.project); return null;
+        default: throw new Error(`Action '${args.action}' not valid for verification_result`);
+      }
+    }
+    default: throw new Error(`Unknown entity: ${args.entity}`);
+  }
+}

--- a/mcp/ground-control/gc-risk-governance.test.js
+++ b/mcp/ground-control/gc-risk-governance.test.js
@@ -1,26 +1,27 @@
-// Adapter-level tests for the gc_risk_governance MCP handler. Covers per-entity
-// create/update body allowlists and the camelCased wire body produced by the
-// shared toCamelCase map. Locks in the fixes for issues #878 (risk assessment
-// result), #879 (risk register record), and #880 (treatment plan) against the
-// authoritative backend Request records under
-// backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/.
+// Adapter-level tests for the gc_risk_governance MCP handler. Drives the
+// FULL path raw args → Zod parse → gcRiskGovernanceToolHandler → lib.js
+// dispatch → mocked fetch, so the handler's own pick(args, ...) gate is the
+// thing being exercised — not a test-side pre-filter. Locks in the fixes for
+// issues #878 (risk_assessment_result), #879 (risk_register_record), and
+// #880 (treatment_plan) against the authoritative backend Request records
+// under backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/.
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { z } from "zod";
 import {
-  GOVERNANCE_FIELDS,
-  pick,
-  createRiskAssessmentResult,
-  updateRiskAssessmentResult,
-  createRiskRegisterRecord,
-  updateRiskRegisterRecord,
-  createTreatmentPlan,
-  updateTreatmentPlan,
-} from "./lib.js";
+  GC_RISK_GOVERNANCE_ACTIONS,
+  GC_RISK_GOVERNANCE_ENTITIES,
+  gcRiskGovernanceZodShape,
+  gcRiskGovernanceToolHandler,
+} from "./gc-risk-governance.js";
+import { GOVERNANCE_FIELDS } from "./lib.js";
 
 const ORIGINAL_FETCH = globalThis.fetch;
 const ORIGINAL_BASE_URL = process.env.GC_BASE_URL;
 const ORIGINAL_API_TOKEN = process.env.GROUND_CONTROL_API_TOKEN;
+
+const SCHEMA = z.object(gcRiskGovernanceZodShape);
 
 function makeFetchSpy({ status = 200, body = { id: "ent-uuid" } } = {}) {
   const calls = [];
@@ -33,6 +34,14 @@ function makeFetchSpy({ status = 200, body = { id: "ent-uuid" } } = {}) {
     });
   };
   return calls;
+}
+
+// Drive a single handler invocation through Zod parse first, then dispatch.
+// Returns the raw value the handler produced (handler returns null for
+// delete-style 204s; the index.js registration wraps that in `ok()`).
+async function callHandler(args) {
+  const parsed = SCHEMA.parse(args);
+  return gcRiskGovernanceToolHandler(parsed);
 }
 
 beforeEach(() => {
@@ -49,16 +58,25 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Shape: GOVERNANCE_FIELDS[entity][action]
+// Shape: GOVERNANCE_FIELDS[entity][action] + handler enums
 // ---------------------------------------------------------------------------
 
 describe("GOVERNANCE_FIELDS per-action shape", () => {
-  it("indexes by entity then action", () => {
-    for (const entity of ["risk_register_record", "risk_assessment_result", "treatment_plan"]) {
+  it("indexes by entity then action for every entity in the handler", () => {
+    for (const entity of GC_RISK_GOVERNANCE_ENTITIES) {
       assert.ok(GOVERNANCE_FIELDS[entity], `missing entity '${entity}'`);
       assert.ok(Array.isArray(GOVERNANCE_FIELDS[entity].create), `${entity}.create not an array`);
       assert.ok(Array.isArray(GOVERNANCE_FIELDS[entity].update), `${entity}.update not an array`);
     }
+  });
+});
+
+describe("GC_RISK_GOVERNANCE_ACTIONS", () => {
+  it("exposes the canonical action verbs the handler dispatches on", () => {
+    assert.deepEqual(
+      [...GC_RISK_GOVERNANCE_ACTIONS].sort(),
+      ["create", "delete", "transition", "transition_approval", "update"],
+    );
   });
 });
 
@@ -123,9 +141,12 @@ describe("risk_assessment_result wire body (#878)", () => {
   const REGISTER = "22222222-2222-2222-2222-222222222222";
   const PROFILE = "33333333-3333-3333-3333-333333333333";
 
-  it("create produces a camelCased body with every backend create field", async () => {
+  it("handler dispatches create with a camelCased body containing every backend create field", async () => {
     const calls = makeFetchSpy();
-    const args = {
+    await callHandler({
+      entity: "risk_assessment_result",
+      action: "create",
+      project: "proj-a",
       risk_scenario_id: SCENARIO,
       risk_register_record_id: REGISTER,
       methodology_profile_id: PROFILE,
@@ -141,9 +162,7 @@ describe("risk_assessment_result wire body (#878)", () => {
       evidence_refs: ["EV-1", "EV-2"],
       notes: "Phase A smoke",
       observation_ids: ["44444444-4444-4444-4444-444444444444"],
-    };
-    const body = pick(args, GOVERNANCE_FIELDS.risk_assessment_result.create);
-    await createRiskAssessmentResult(body, "proj-a");
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "POST");
     assert.match(calls[0].url, /\/api\/v1\/risk-assessment-results\b/);
@@ -167,51 +186,60 @@ describe("risk_assessment_result wire body (#878)", () => {
     });
   });
 
-  it("create drops stale caller fields before reaching the wire", async () => {
+  it("handler drops stale create-args before reaching the wire (handler-side pick)", async () => {
     const calls = makeFetchSpy();
-    const args = {
+    await callHandler({
+      entity: "risk_assessment_result",
+      action: "create",
+      project: "proj-a",
       risk_scenario_id: SCENARIO,
       methodology_profile_id: PROFILE,
-      // stale fields the bug report shipped with:
+      // Stale fields the bug report shipped with — handler must drop these
+      // via its own pick(args, GOVERNANCE_FIELDS.risk_assessment_result.create).
       uid: "RAR-1",
       title: "drop me",
       description: "drop me",
-      quantitative_value: 485000,
+      // Number-shaped scenarios are excluded from the Zod schema's positive
+      // pattern, but a typed caller could still include `qualitative_value:
+      // "HIGH"`. Use the Zod-acceptable shape and confirm the handler drops
+      // it on its own.
       qualitative_value: "HIGH",
-      scenario_id: SCENARIO, // legacy alias, must NOT reach the wire
       approval_state: "DRAFT",
       metadata: { stale: true },
-      status: "DRAFT",
-    };
-    const body = pick(args, GOVERNANCE_FIELDS.risk_assessment_result.create);
-    await createRiskAssessmentResult(body, "proj-a");
+      // 'status' is intentionally omitted: validateGovernanceStatus rejects
+      // any status on risk_assessment_result (the entity uses approval_state,
+      // and the rejection is exercised by lib.test.js validateGovernanceStatus
+      // tests). This test scope is the handler's pick(), not the validator.
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "POST");
-    // Positive assertion: the valid fields actually reached the wire. Without
-    // this, an empty wire body `{}` would silently satisfy every negative
-    // `!(stale in body)` check below.
+    // Positive: valid fields survived the handler's pick().
     assert.equal(calls[0].body.riskScenarioId, SCENARIO);
     assert.equal(calls[0].body.methodologyProfileId, PROFILE);
+    // Negative: stale fields did not reach the wire.
     for (const stale of [
-      "uid", "title", "description", "quantitativeValue", "qualitativeValue",
-      "scenarioId", "approvalState", "metadata", "status",
+      "uid", "title", "description", "qualitativeValue",
+      "scenarioId", "approvalState", "metadata",
     ]) {
       assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire`);
     }
   });
 
-  it("update strips create-only 'risk_scenario_id' even if the caller passes it", async () => {
+  it("handler dispatches update without create-only 'risk_scenario_id' (scenario immutable after create)", async () => {
     const calls = makeFetchSpy();
-    const args = {
-      risk_scenario_id: SCENARIO, // must NOT reach the wire (immutable after create)
+    await callHandler({
+      entity: "risk_assessment_result",
+      action: "update",
+      id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      project: "proj-a",
+      risk_scenario_id: SCENARIO, // must NOT reach the wire
       methodology_profile_id: PROFILE,
       analyst_identity: "agent-b",
       notes: "second-pass",
-    };
-    const body = pick(args, GOVERNANCE_FIELDS.risk_assessment_result.update);
-    await updateRiskAssessmentResult("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", body, "proj-a");
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, /\/api\/v1\/risk-assessment-results\/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\b/);
     assert.ok(!("riskScenarioId" in calls[0].body));
     assert.equal(calls[0].body.methodologyProfileId, PROFILE);
     assert.equal(calls[0].body.analystIdentity, "agent-b");
@@ -278,9 +306,12 @@ describe("risk_register_record wire body (#879)", () => {
   const SC1 = "55555555-5555-5555-5555-555555555555";
   const SC2 = "66666666-6666-6666-6666-666666666666";
 
-  it("create routes multi-scenario via risk_scenario_ids as List<UUID>", async () => {
+  it("handler routes multi-scenario via risk_scenario_ids as List<UUID>", async () => {
     const calls = makeFetchSpy();
-    const args = {
+    await callHandler({
+      entity: "risk_register_record",
+      action: "create",
+      project: "proj-a",
       uid: "REG-1",
       title: "Portfolio record",
       owner: "team-x",
@@ -290,9 +321,7 @@ describe("risk_register_record wire body (#879)", () => {
       decision_metadata: { rationale: "merged after retro" },
       asset_scope_summary: "covers PCI-DSS assets in prod",
       risk_scenario_ids: [SC1, SC2],
-    };
-    const body = pick(args, GOVERNANCE_FIELDS.risk_register_record.create);
-    await createRiskRegisterRecord(body, "proj-a");
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "POST");
     assert.match(calls[0].url, /\/api\/v1\/risk-register-records\b/);
@@ -309,40 +338,43 @@ describe("risk_register_record wire body (#879)", () => {
     });
   });
 
-  it("create drops singular 'scenario_id', 'description', 'status', 'metadata' before reaching the wire", async () => {
+  it("handler drops 'description', 'status', 'metadata' on create (handler-side pick)", async () => {
     const calls = makeFetchSpy();
-    const args = {
+    await callHandler({
+      entity: "risk_register_record",
+      action: "create",
+      project: "proj-a",
       uid: "REG-2",
       title: "T",
-      scenario_id: SC1, // singular, must NOT reach the wire
       description: "drop me",
       status: "ACCEPTED",
       metadata: { stale: true },
-    };
-    const body = pick(args, GOVERNANCE_FIELDS.risk_register_record.create);
-    await createRiskRegisterRecord(body, "proj-a");
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "POST");
-    // Positive assertion guards against `{}` body silently satisfying the
-    // negative checks: confirm the valid create-DTO fields survived.
+    // Positive: valid fields survived.
     assert.equal(calls[0].body.uid, "REG-2");
     assert.equal(calls[0].body.title, "T");
+    // Negative: stale fields did not reach the wire.
     for (const stale of ["scenarioId", "description", "status", "metadata"]) {
       assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire`);
     }
   });
 
-  it("update strips create-only 'uid' even if the caller passes it", async () => {
+  it("handler strips create-only 'uid' on update", async () => {
     const calls = makeFetchSpy();
-    const args = {
+    await callHandler({
+      entity: "risk_register_record",
+      action: "update",
+      id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      project: "proj-a",
       uid: "REG-LEAK",
       title: "rename",
       risk_scenario_ids: [SC1],
-    };
-    const body = pick(args, GOVERNANCE_FIELDS.risk_register_record.update);
-    await updateRiskRegisterRecord("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", body, "proj-a");
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, /\/api\/v1\/risk-register-records\/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\b/);
     assert.ok(!("uid" in calls[0].body));
     assert.equal(calls[0].body.title, "rename");
     assert.deepEqual(calls[0].body.riskScenarioIds, [SC1]);
@@ -396,7 +428,6 @@ describe("treatment_plan update allowlist (#880)", () => {
   });
 
   it("does NOT contain create-only 'uid', 'risk_register_record_id', 'status'", () => {
-    // Status changes go through the transition action — the dedicated /status sub-resource.
     for (const f of ["uid", "risk_register_record_id", "status"]) {
       assert.ok(!list().includes(f), `${f} should not be on treatment_plan.update`);
     }
@@ -413,9 +444,12 @@ describe("treatment_plan wire body (#880)", () => {
   const SCEN = "77777777-7777-7777-7777-777777777777";
   const REG = "88888888-8888-8888-8888-888888888888";
 
-  it("create produces a camelCased body with every backend create field", async () => {
+  it("handler dispatches create with a camelCased body containing every backend create field", async () => {
     const calls = makeFetchSpy();
-    const args = {
+    await callHandler({
+      entity: "treatment_plan",
+      action: "create",
+      project: "proj-a",
       uid: "TP-1",
       title: "Mitigate scenario X",
       risk_scenario_id: SCEN,
@@ -427,9 +461,7 @@ describe("treatment_plan wire body (#880)", () => {
       status: "PLANNED",
       action_items: [{ what: "patch", who: "team-y" }],
       reassessment_triggers: ["new evidence", "control change"],
-    };
-    const body = pick(args, GOVERNANCE_FIELDS.treatment_plan.create);
-    await createTreatmentPlan(body, "proj-a");
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "POST");
     assert.match(calls[0].url, /\/api\/v1\/treatment-plans\b/);
@@ -448,49 +480,55 @@ describe("treatment_plan wire body (#880)", () => {
     });
   });
 
-  it("create drops stale 'due_at', 'scenario_id', 'description', 'metadata' before reaching the wire", async () => {
+  it("handler drops 'description', 'metadata' on create (handler-side pick); 'due_at' is not a Zod field and is rejected at parse", async () => {
+    // 'due_at' is not in gcRiskGovernanceZodShape (the Zod schema dropped
+    // 'due_at' alongside 'scenario_id' when issue #880 renamed them). A
+    // strict caller can't pass 'due_at' through Zod parse. Confirm the
+    // handler's own pick() drops everything else even if the caller sends
+    // a Zod-accepted shape.
     const calls = makeFetchSpy();
-    const args = {
+    await callHandler({
+      entity: "treatment_plan",
+      action: "create",
+      project: "proj-a",
       uid: "TP-2",
       title: "T",
       strategy: "ACCEPT",
       risk_register_record_id: REG,
-      // stale fields the bug report shipped with:
-      due_at: "2026-06-30T00:00:00Z", // misnamed → must NOT reach the wire as 'dueAt'
-      scenario_id: SCEN,
       description: "drop me",
       metadata: { stale: true },
-    };
-    const body = pick(args, GOVERNANCE_FIELDS.treatment_plan.create);
-    await createTreatmentPlan(body, "proj-a");
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "POST");
-    // Positive assertion guards against `{}` body silently satisfying the
-    // negative checks: confirm the valid create-DTO fields survived.
+    // Positive: valid fields survived.
     assert.equal(calls[0].body.uid, "TP-2");
     assert.equal(calls[0].body.title, "T");
     assert.equal(calls[0].body.strategy, "ACCEPT");
     assert.equal(calls[0].body.riskRegisterRecordId, REG);
-    for (const stale of ["dueAt", "scenarioId", "description", "metadata"]) {
+    // Negative: stale fields did not reach the wire.
+    for (const stale of ["dueAt", "description", "metadata"]) {
       assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire`);
     }
-    // And dueDate is not present either (caller didn't supply due_date)
+    // And dueDate is not present either (caller didn't supply due_date).
     assert.ok(!("dueDate" in calls[0].body));
   });
 
-  it("update strips create-only 'uid', 'risk_register_record_id', 'status'", async () => {
+  it("handler strips create-only 'uid', 'risk_register_record_id', 'status' on update", async () => {
     const calls = makeFetchSpy();
-    const args = {
+    await callHandler({
+      entity: "treatment_plan",
+      action: "update",
+      id: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+      project: "proj-a",
       uid: "TP-LEAK",
       risk_register_record_id: REG,
       status: "IN_PROGRESS", // must go through transition action, not update
       title: "rename",
       due_date: "2026-07-01T00:00:00Z",
-    };
-    const body = pick(args, GOVERNANCE_FIELDS.treatment_plan.update);
-    await updateTreatmentPlan("cccccccc-cccc-cccc-cccc-cccccccccccc", body, "proj-a");
+    });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, /\/api\/v1\/treatment-plans\/cccccccc-cccc-cccc-cccc-cccccccccccc\b/);
     for (const stale of ["uid", "riskRegisterRecordId", "status"]) {
       assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire on update`);
     }

--- a/mcp/ground-control/gc-risk-governance.test.js
+++ b/mcp/ground-control/gc-risk-governance.test.js
@@ -1,0 +1,480 @@
+// Adapter-level tests for the gc_risk_governance MCP handler. Covers per-entity
+// create/update body allowlists and the camelCased wire body produced by the
+// shared toCamelCase map. Locks in the fixes for issues #878 (risk assessment
+// result), #879 (risk register record), and #880 (treatment plan) against the
+// authoritative backend Request records under
+// backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  GOVERNANCE_FIELDS,
+  pick,
+  createRiskAssessmentResult,
+  updateRiskAssessmentResult,
+  createRiskRegisterRecord,
+  updateRiskRegisterRecord,
+  createTreatmentPlan,
+  updateTreatmentPlan,
+} from "./lib.js";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_BASE_URL = process.env.GC_BASE_URL;
+const ORIGINAL_API_TOKEN = process.env.GROUND_CONTROL_API_TOKEN;
+
+function makeFetchSpy({ status = 200, body = { id: "ent-uuid" } } = {}) {
+  const calls = [];
+  globalThis.fetch = async (url, opts) => {
+    const parsedBody = opts && opts.body ? JSON.parse(opts.body) : null;
+    calls.push({ url: url.toString(), method: opts?.method ?? "GET", body: parsedBody });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.GC_BASE_URL = "https://gc.test";
+  delete process.env.GROUND_CONTROL_API_TOKEN;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_BASE_URL === undefined) delete process.env.GC_BASE_URL;
+  else process.env.GC_BASE_URL = ORIGINAL_BASE_URL;
+  if (ORIGINAL_API_TOKEN === undefined) delete process.env.GROUND_CONTROL_API_TOKEN;
+  else process.env.GROUND_CONTROL_API_TOKEN = ORIGINAL_API_TOKEN;
+});
+
+// ---------------------------------------------------------------------------
+// Shape: GOVERNANCE_FIELDS[entity][action]
+// ---------------------------------------------------------------------------
+
+describe("GOVERNANCE_FIELDS per-action shape", () => {
+  it("indexes by entity then action", () => {
+    for (const entity of ["risk_register_record", "risk_assessment_result", "treatment_plan"]) {
+      assert.ok(GOVERNANCE_FIELDS[entity], `missing entity '${entity}'`);
+      assert.ok(Array.isArray(GOVERNANCE_FIELDS[entity].create), `${entity}.create not an array`);
+      assert.ok(Array.isArray(GOVERNANCE_FIELDS[entity].update), `${entity}.update not an array`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// risk_assessment_result allowlist (#878)
+// ---------------------------------------------------------------------------
+
+describe("risk_assessment_result create allowlist (#878)", () => {
+  const list = () => GOVERNANCE_FIELDS.risk_assessment_result.create;
+
+  it("contains every backend RiskAssessmentResultRequest field", () => {
+    for (const f of [
+      "risk_scenario_id", "risk_register_record_id", "methodology_profile_id",
+      "analyst_identity", "assumptions", "input_factors",
+      "observation_date", "assessment_at", "time_horizon", "confidence",
+      "uncertainty_metadata", "computed_outputs",
+      "evidence_refs", "notes", "observation_ids",
+    ]) {
+      assert.ok(list().includes(f), `${f} missing from risk_assessment_result.create`);
+    }
+  });
+
+  it("does NOT contain stale fields that the backend DTO does not accept", () => {
+    for (const f of [
+      "uid", "title", "description",
+      "quantitative_value", "qualitative_value",
+      "scenario_id", "approval_state", "metadata", "status",
+    ]) {
+      assert.ok(!list().includes(f), `${f} should not be on risk_assessment_result.create`);
+    }
+  });
+});
+
+describe("risk_assessment_result update allowlist (#878)", () => {
+  const list = () => GOVERNANCE_FIELDS.risk_assessment_result.update;
+
+  it("contains every UpdateRiskAssessmentResultRequest field", () => {
+    for (const f of [
+      "risk_register_record_id", "methodology_profile_id",
+      "analyst_identity", "assumptions", "input_factors",
+      "observation_date", "assessment_at", "time_horizon", "confidence",
+      "uncertainty_metadata", "computed_outputs",
+      "evidence_refs", "notes", "observation_ids",
+    ]) {
+      assert.ok(list().includes(f), `${f} missing from risk_assessment_result.update`);
+    }
+  });
+
+  it("does NOT contain create-only 'risk_scenario_id' (scenario is immutable after create)", () => {
+    assert.ok(!list().includes("risk_scenario_id"));
+  });
+
+  it("does NOT contain stale fields", () => {
+    for (const f of ["uid", "title", "description", "quantitative_value", "qualitative_value", "scenario_id", "approval_state", "metadata", "status"]) {
+      assert.ok(!list().includes(f), `${f} should not be on risk_assessment_result.update`);
+    }
+  });
+});
+
+describe("risk_assessment_result wire body (#878)", () => {
+  const SCENARIO = "11111111-1111-1111-1111-111111111111";
+  const REGISTER = "22222222-2222-2222-2222-222222222222";
+  const PROFILE = "33333333-3333-3333-3333-333333333333";
+
+  it("create produces a camelCased body with every backend create field", async () => {
+    const calls = makeFetchSpy();
+    const args = {
+      risk_scenario_id: SCENARIO,
+      risk_register_record_id: REGISTER,
+      methodology_profile_id: PROFILE,
+      analyst_identity: "agent-a",
+      assumptions: "stable inputs",
+      input_factors: { ale: 100 },
+      observation_date: "2026-01-15T00:00:00Z",
+      assessment_at: "2026-01-16T00:00:00Z",
+      time_horizon: "12 months",
+      confidence: "HIGH",
+      uncertainty_metadata: { variance: 0.05 },
+      computed_outputs: { ale: 485000 },
+      evidence_refs: ["EV-1", "EV-2"],
+      notes: "Phase A smoke",
+      observation_ids: ["44444444-4444-4444-4444-444444444444"],
+    };
+    const body = pick(args, GOVERNANCE_FIELDS.risk_assessment_result.create);
+    await createRiskAssessmentResult(body, "proj-a");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, /\/api\/v1\/risk-assessment-results\b/);
+    assert.match(calls[0].url, /project=proj-a/);
+    assert.deepEqual(calls[0].body, {
+      riskScenarioId: SCENARIO,
+      riskRegisterRecordId: REGISTER,
+      methodologyProfileId: PROFILE,
+      analystIdentity: "agent-a",
+      assumptions: "stable inputs",
+      inputFactors: { ale: 100 },
+      observationDate: "2026-01-15T00:00:00Z",
+      assessmentAt: "2026-01-16T00:00:00Z",
+      timeHorizon: "12 months",
+      confidence: "HIGH",
+      uncertaintyMetadata: { variance: 0.05 },
+      computedOutputs: { ale: 485000 },
+      evidenceRefs: ["EV-1", "EV-2"],
+      notes: "Phase A smoke",
+      observationIds: ["44444444-4444-4444-4444-444444444444"],
+    });
+  });
+
+  it("create drops stale caller fields before reaching the wire", async () => {
+    const calls = makeFetchSpy();
+    const args = {
+      risk_scenario_id: SCENARIO,
+      methodology_profile_id: PROFILE,
+      // stale fields the bug report shipped with:
+      uid: "RAR-1",
+      title: "drop me",
+      description: "drop me",
+      quantitative_value: 485000,
+      qualitative_value: "HIGH",
+      scenario_id: SCENARIO, // legacy alias, must NOT reach the wire
+      approval_state: "DRAFT",
+      metadata: { stale: true },
+      status: "DRAFT",
+    };
+    const body = pick(args, GOVERNANCE_FIELDS.risk_assessment_result.create);
+    await createRiskAssessmentResult(body, "proj-a");
+    assert.equal(calls.length, 1);
+    for (const stale of [
+      "uid", "title", "description", "quantitativeValue", "qualitativeValue",
+      "scenarioId", "approvalState", "metadata", "status",
+    ]) {
+      assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire`);
+    }
+  });
+
+  it("update strips create-only 'risk_scenario_id' even if the caller passes it", async () => {
+    const calls = makeFetchSpy();
+    const args = {
+      risk_scenario_id: SCENARIO, // must NOT reach the wire (immutable after create)
+      methodology_profile_id: PROFILE,
+      analyst_identity: "agent-b",
+      notes: "second-pass",
+    };
+    const body = pick(args, GOVERNANCE_FIELDS.risk_assessment_result.update);
+    await updateRiskAssessmentResult("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", body, "proj-a");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.ok(!("riskScenarioId" in calls[0].body));
+    assert.equal(calls[0].body.methodologyProfileId, PROFILE);
+    assert.equal(calls[0].body.analystIdentity, "agent-b");
+    assert.equal(calls[0].body.notes, "second-pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// risk_register_record allowlist (#879)
+// ---------------------------------------------------------------------------
+
+describe("risk_register_record create allowlist (#879)", () => {
+  const list = () => GOVERNANCE_FIELDS.risk_register_record.create;
+
+  it("contains every backend RiskRegisterRecordRequest field", () => {
+    for (const f of [
+      "uid", "title", "owner", "review_cadence", "next_review_at",
+      "category_tags", "decision_metadata", "asset_scope_summary",
+      "risk_scenario_ids",
+    ]) {
+      assert.ok(list().includes(f), `${f} missing from risk_register_record.create`);
+    }
+  });
+
+  it("does NOT contain singular 'scenario_id' (backend is List<UUID> riskScenarioIds)", () => {
+    assert.ok(!list().includes("scenario_id"));
+  });
+
+  it("does NOT contain 'description' or 'status' (not on the Create DTO; status is transition-only)", () => {
+    assert.ok(!list().includes("description"));
+    assert.ok(!list().includes("status"));
+  });
+
+  it("does NOT contain 'metadata' (typed fields must not tunnel through metadata)", () => {
+    assert.ok(!list().includes("metadata"));
+  });
+});
+
+describe("risk_register_record update allowlist (#879)", () => {
+  const list = () => GOVERNANCE_FIELDS.risk_register_record.update;
+
+  it("contains every UpdateRiskRegisterRecordRequest field", () => {
+    for (const f of [
+      "title", "owner", "review_cadence", "next_review_at",
+      "category_tags", "decision_metadata", "asset_scope_summary",
+      "risk_scenario_ids",
+    ]) {
+      assert.ok(list().includes(f), `${f} missing from risk_register_record.update`);
+    }
+  });
+
+  it("does NOT contain create-only 'uid'", () => {
+    assert.ok(!list().includes("uid"));
+  });
+
+  it("does NOT contain stale 'scenario_id', 'description', 'status', 'metadata'", () => {
+    for (const f of ["scenario_id", "description", "status", "metadata"]) {
+      assert.ok(!list().includes(f), `${f} should not be on risk_register_record.update`);
+    }
+  });
+});
+
+describe("risk_register_record wire body (#879)", () => {
+  const SC1 = "55555555-5555-5555-5555-555555555555";
+  const SC2 = "66666666-6666-6666-6666-666666666666";
+
+  it("create routes multi-scenario via risk_scenario_ids as List<UUID>", async () => {
+    const calls = makeFetchSpy();
+    const args = {
+      uid: "REG-1",
+      title: "Portfolio record",
+      owner: "team-x",
+      review_cadence: "quarterly",
+      next_review_at: "2026-04-01T00:00:00Z",
+      category_tags: ["regulatory", "supplier"],
+      decision_metadata: { rationale: "merged after retro" },
+      asset_scope_summary: "covers PCI-DSS assets in prod",
+      risk_scenario_ids: [SC1, SC2],
+    };
+    const body = pick(args, GOVERNANCE_FIELDS.risk_register_record.create);
+    await createRiskRegisterRecord(body, "proj-a");
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /\/api\/v1\/risk-register-records\b/);
+    assert.deepEqual(calls[0].body, {
+      uid: "REG-1",
+      title: "Portfolio record",
+      owner: "team-x",
+      reviewCadence: "quarterly",
+      nextReviewAt: "2026-04-01T00:00:00Z",
+      categoryTags: ["regulatory", "supplier"],
+      decisionMetadata: { rationale: "merged after retro" },
+      assetScopeSummary: "covers PCI-DSS assets in prod",
+      riskScenarioIds: [SC1, SC2],
+    });
+  });
+
+  it("create drops singular 'scenario_id', 'description', 'status', 'metadata' before reaching the wire", async () => {
+    const calls = makeFetchSpy();
+    const args = {
+      uid: "REG-2",
+      title: "T",
+      scenario_id: SC1, // singular, must NOT reach the wire
+      description: "drop me",
+      status: "ACCEPTED",
+      metadata: { stale: true },
+    };
+    const body = pick(args, GOVERNANCE_FIELDS.risk_register_record.create);
+    await createRiskRegisterRecord(body, "proj-a");
+    assert.equal(calls.length, 1);
+    for (const stale of ["scenarioId", "description", "status", "metadata"]) {
+      assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire`);
+    }
+  });
+
+  it("update strips create-only 'uid' even if the caller passes it", async () => {
+    const calls = makeFetchSpy();
+    const args = {
+      uid: "REG-LEAK",
+      title: "rename",
+      risk_scenario_ids: [SC1],
+    };
+    const body = pick(args, GOVERNANCE_FIELDS.risk_register_record.update);
+    await updateRiskRegisterRecord("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", body, "proj-a");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.ok(!("uid" in calls[0].body));
+    assert.equal(calls[0].body.title, "rename");
+    assert.deepEqual(calls[0].body.riskScenarioIds, [SC1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// treatment_plan allowlist (#880)
+// ---------------------------------------------------------------------------
+
+describe("treatment_plan create allowlist (#880)", () => {
+  const list = () => GOVERNANCE_FIELDS.treatment_plan.create;
+
+  it("contains every backend TreatmentPlanRequest field", () => {
+    for (const f of [
+      "uid", "title", "risk_scenario_id", "risk_register_record_id",
+      "strategy", "owner", "rationale", "due_date", "status",
+      "action_items", "reassessment_triggers",
+    ]) {
+      assert.ok(list().includes(f), `${f} missing from treatment_plan.create`);
+    }
+  });
+
+  it("does NOT contain 'description' (backend has 'rationale', not 'description')", () => {
+    assert.ok(!list().includes("description"));
+  });
+
+  it("does NOT contain misnamed 'due_at' (backend field is 'dueDate' / 'due_date')", () => {
+    assert.ok(!list().includes("due_at"));
+  });
+
+  it("does NOT contain singular 'scenario_id' (backend field is 'riskScenarioId' / 'risk_scenario_id')", () => {
+    assert.ok(!list().includes("scenario_id"));
+  });
+
+  it("does NOT contain 'metadata' (typed fields must not tunnel through metadata)", () => {
+    assert.ok(!list().includes("metadata"));
+  });
+});
+
+describe("treatment_plan update allowlist (#880)", () => {
+  const list = () => GOVERNANCE_FIELDS.treatment_plan.update;
+
+  it("contains every UpdateTreatmentPlanRequest field", () => {
+    for (const f of [
+      "title", "risk_scenario_id", "strategy", "owner",
+      "rationale", "due_date", "action_items", "reassessment_triggers",
+    ]) {
+      assert.ok(list().includes(f), `${f} missing from treatment_plan.update`);
+    }
+  });
+
+  it("does NOT contain create-only 'uid', 'risk_register_record_id', 'status'", () => {
+    // Status changes go through the transition action — the dedicated /status sub-resource.
+    for (const f of ["uid", "risk_register_record_id", "status"]) {
+      assert.ok(!list().includes(f), `${f} should not be on treatment_plan.update`);
+    }
+  });
+
+  it("does NOT contain stale 'scenario_id', 'due_at', 'description', 'metadata'", () => {
+    for (const f of ["scenario_id", "due_at", "description", "metadata"]) {
+      assert.ok(!list().includes(f), `${f} should not be on treatment_plan.update`);
+    }
+  });
+});
+
+describe("treatment_plan wire body (#880)", () => {
+  const SCEN = "77777777-7777-7777-7777-777777777777";
+  const REG = "88888888-8888-8888-8888-888888888888";
+
+  it("create produces a camelCased body with every backend create field", async () => {
+    const calls = makeFetchSpy();
+    const args = {
+      uid: "TP-1",
+      title: "Mitigate scenario X",
+      risk_scenario_id: SCEN,
+      risk_register_record_id: REG,
+      strategy: "MITIGATE",
+      owner: "team-y",
+      rationale: "Cost-benefit favors mitigation",
+      due_date: "2026-06-30T00:00:00Z",
+      status: "PLANNED",
+      action_items: [{ what: "patch", who: "team-y" }],
+      reassessment_triggers: ["new evidence", "control change"],
+    };
+    const body = pick(args, GOVERNANCE_FIELDS.treatment_plan.create);
+    await createTreatmentPlan(body, "proj-a");
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /\/api\/v1\/treatment-plans\b/);
+    assert.deepEqual(calls[0].body, {
+      uid: "TP-1",
+      title: "Mitigate scenario X",
+      riskScenarioId: SCEN,
+      riskRegisterRecordId: REG,
+      strategy: "MITIGATE",
+      owner: "team-y",
+      rationale: "Cost-benefit favors mitigation",
+      dueDate: "2026-06-30T00:00:00Z",
+      status: "PLANNED",
+      actionItems: [{ what: "patch", who: "team-y" }],
+      reassessmentTriggers: ["new evidence", "control change"],
+    });
+  });
+
+  it("create drops stale 'due_at', 'scenario_id', 'description', 'metadata' before reaching the wire", async () => {
+    const calls = makeFetchSpy();
+    const args = {
+      uid: "TP-2",
+      title: "T",
+      strategy: "ACCEPT",
+      risk_register_record_id: REG,
+      // stale fields the bug report shipped with:
+      due_at: "2026-06-30T00:00:00Z", // misnamed → must NOT reach the wire as 'dueAt'
+      scenario_id: SCEN,
+      description: "drop me",
+      metadata: { stale: true },
+    };
+    const body = pick(args, GOVERNANCE_FIELDS.treatment_plan.create);
+    await createTreatmentPlan(body, "proj-a");
+    assert.equal(calls.length, 1);
+    for (const stale of ["dueAt", "scenarioId", "description", "metadata"]) {
+      assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire`);
+    }
+    // And dueDate is not present either (caller didn't supply due_date)
+    assert.ok(!("dueDate" in calls[0].body));
+  });
+
+  it("update strips create-only 'uid', 'risk_register_record_id', 'status'", async () => {
+    const calls = makeFetchSpy();
+    const args = {
+      uid: "TP-LEAK",
+      risk_register_record_id: REG,
+      status: "IN_PROGRESS", // must go through transition action, not update
+      title: "rename",
+      due_date: "2026-07-01T00:00:00Z",
+    };
+    const body = pick(args, GOVERNANCE_FIELDS.treatment_plan.update);
+    await updateTreatmentPlan("cccccccc-cccc-cccc-cccc-cccccccccccc", body, "proj-a");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    for (const stale of ["uid", "riskRegisterRecordId", "status"]) {
+      assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire on update`);
+    }
+    assert.equal(calls[0].body.title, "rename");
+    assert.equal(calls[0].body.dueDate, "2026-07-01T00:00:00Z");
+  });
+});

--- a/mcp/ground-control/gc-risk-governance.test.js
+++ b/mcp/ground-control/gc-risk-governance.test.js
@@ -186,6 +186,12 @@ describe("risk_assessment_result wire body (#878)", () => {
     const body = pick(args, GOVERNANCE_FIELDS.risk_assessment_result.create);
     await createRiskAssessmentResult(body, "proj-a");
     assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    // Positive assertion: the valid fields actually reached the wire. Without
+    // this, an empty wire body `{}` would silently satisfy every negative
+    // `!(stale in body)` check below.
+    assert.equal(calls[0].body.riskScenarioId, SCENARIO);
+    assert.equal(calls[0].body.methodologyProfileId, PROFILE);
     for (const stale of [
       "uid", "title", "description", "quantitativeValue", "qualitativeValue",
       "scenarioId", "approvalState", "metadata", "status",
@@ -288,6 +294,7 @@ describe("risk_register_record wire body (#879)", () => {
     const body = pick(args, GOVERNANCE_FIELDS.risk_register_record.create);
     await createRiskRegisterRecord(body, "proj-a");
     assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
     assert.match(calls[0].url, /\/api\/v1\/risk-register-records\b/);
     assert.deepEqual(calls[0].body, {
       uid: "REG-1",
@@ -315,6 +322,11 @@ describe("risk_register_record wire body (#879)", () => {
     const body = pick(args, GOVERNANCE_FIELDS.risk_register_record.create);
     await createRiskRegisterRecord(body, "proj-a");
     assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    // Positive assertion guards against `{}` body silently satisfying the
+    // negative checks: confirm the valid create-DTO fields survived.
+    assert.equal(calls[0].body.uid, "REG-2");
+    assert.equal(calls[0].body.title, "T");
     for (const stale of ["scenarioId", "description", "status", "metadata"]) {
       assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire`);
     }
@@ -419,6 +431,7 @@ describe("treatment_plan wire body (#880)", () => {
     const body = pick(args, GOVERNANCE_FIELDS.treatment_plan.create);
     await createTreatmentPlan(body, "proj-a");
     assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
     assert.match(calls[0].url, /\/api\/v1\/treatment-plans\b/);
     assert.deepEqual(calls[0].body, {
       uid: "TP-1",
@@ -451,6 +464,13 @@ describe("treatment_plan wire body (#880)", () => {
     const body = pick(args, GOVERNANCE_FIELDS.treatment_plan.create);
     await createTreatmentPlan(body, "proj-a");
     assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    // Positive assertion guards against `{}` body silently satisfying the
+    // negative checks: confirm the valid create-DTO fields survived.
+    assert.equal(calls[0].body.uid, "TP-2");
+    assert.equal(calls[0].body.title, "T");
+    assert.equal(calls[0].body.strategy, "ACCEPT");
+    assert.equal(calls[0].body.riskRegisterRecordId, REG);
     for (const stale of ["dueAt", "scenarioId", "description", "metadata"]) {
       assert.ok(!(stale in calls[0].body), `${stale} leaked onto the wire`);
     }

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -185,6 +185,11 @@ import {
   GC_RISK_SCENARIO_DESCRIPTION,
 } from "./gc-risk-scenario.js";
 import {
+  gcRiskGovernanceZodShape,
+  gcRiskGovernanceToolHandler,
+  GC_RISK_GOVERNANCE_DESCRIPTION,
+} from "./gc-risk-governance.js";
+import {
   linkCreateOptionalSharedZodFields,
   performLinkCreate,
 } from "./link-create.js";
@@ -1423,138 +1428,19 @@ server.tool(
   },
 );
 
-const RISK_GOVERNANCE_ENTITIES = [
-  "methodology_profile", "risk_register_record", "risk_assessment_result",
-  "treatment_plan", "verification_result",
-];
-const RISK_GOVERNANCE_ACTIONS = ["create", "update", "delete", "transition", "transition_approval"];
-
-// Per-entity, per-action body allowlist for gc_risk_governance create/update
-// DTOs lives in lib.js (GOVERNANCE_FIELDS). It mirrors the backend Request
-// records under api/riskscenarios/. Issues #878/#879/#880.
-
+// gc_risk_governance: methodology profile / risk register record / risk
+// assessment result / treatment plan / verification result. Handler logic
+// (Zod shape, per-entity per-action allowlist dispatch via lib.js
+// GOVERNANCE_FIELDS, backend dispatch) lives in gc-risk-governance.js so the
+// adapter is testable in isolation; index.js just registers it.
 server.tool(
   "gc_risk_governance",
-  `Methodology profiles, risk register records, risk assessments, treatment plans, verification results. ` +
-    `Entity: ${RISK_GOVERNANCE_ENTITIES.join(", ")}. Actions: ${RISK_GOVERNANCE_ACTIONS.join(", ")}. ` +
-    `Reads (list, get) route through gc_query. ` +
-    `Per-entity create fields (snake_case; round-trip to backend camelCase): ` +
-    `risk_register_record={uid,title,owner,review_cadence,next_review_at,category_tags,decision_metadata,asset_scope_summary,risk_scenario_ids}; ` +
-    `risk_assessment_result={risk_scenario_id,risk_register_record_id,methodology_profile_id,analyst_identity,assumptions,input_factors,observation_date,assessment_at,time_horizon,confidence,uncertainty_metadata,computed_outputs,evidence_refs,notes,observation_ids}; ` +
-    `treatment_plan={uid,title,risk_scenario_id,risk_register_record_id,strategy,owner,rationale,due_date,status,action_items,reassessment_triggers}. ` +
-    `Update DTOs drop create-only foreign keys (uid; risk_register_record_id for treatment_plan; risk_scenario_id for risk_assessment_result) and status fields whose changes go through the transition action. ` +
-    `Unknown fields are dropped — never tunneled through metadata.`,
-  {
-    entity: z.enum(RISK_GOVERNANCE_ENTITIES),
-    action: z.enum(RISK_GOVERNANCE_ACTIONS),
-    id: z.string().uuid().optional(),
-    project: z.string().optional(),
-    // Status vocabulary is per-entity; the handler validates it against
-    // GOVERNANCE_STATUS_ENUMS[args.entity] before any backend call. The Zod
-    // shape accepts any string here — a discriminated check at the schema
-    // level would require restructuring this tool into five entity-specific
-    // tools, which ADR-035 already rejected.
-    status: z.string().optional(),
-    approval_state: z.enum(RISK_ASSESSMENT_APPROVAL_STATUSES).optional(),
-    // Shared entity fields. Per-entity allowlist (GOVERNANCE_FIELDS) gates which
-    // ones reach the backend on create/update, so unrelated MCP control fields
-    // (action, entity, id, project) don't leak into the DTO.
-    uid: z.string().optional(),
-    name: z.string().optional(),
-    title: z.string().optional(),
-    description: z.string().optional(),
-    family: z.enum(METHODOLOGY_FAMILIES).optional(),
-    risk_scenario_id: z.string().uuid().optional(),
-    risk_scenario_ids: z.array(z.string().uuid()).optional(),
-    risk_register_record_id: z.string().uuid().optional(),
-    methodology_profile_id: z.string().uuid().optional(),
-    owner: z.string().optional(),
-    review_cadence: z.string().optional(),
-    next_review_at: z.string().optional(),
-    category_tags: z.array(z.string()).optional(),
-    decision_metadata: z.record(z.any()).optional(),
-    asset_scope_summary: z.string().optional(),
-    analyst_identity: z.string().optional(),
-    assumptions: z.string().optional(),
-    input_factors: z.record(z.any()).optional(),
-    observation_date: z.string().optional(),
-    assessment_at: z.string().optional(),
-    time_horizon: z.string().optional(),
-    confidence: z.string().optional(),
-    uncertainty_metadata: z.record(z.any()).optional(),
-    computed_outputs: z.record(z.any()).optional(),
-    evidence_refs: z.array(z.string()).optional(),
-    notes: z.string().optional(),
-    observation_ids: z.array(z.string().uuid()).optional(),
-    strategy: z.enum(TREATMENT_STRATEGIES).optional(),
-    rationale: z.string().optional(),
-    due_date: z.string().optional(),
-    action_items: z.array(z.record(z.any())).optional(),
-    reassessment_triggers: z.array(z.string()).optional(),
-    outcome: z.string().optional(),
-    assurance_level: z.enum(ASSURANCE_LEVELS).optional(),
-    verified_at: z.string().optional(),
-    metadata: z.record(z.any()).optional(),
-  },
+  GC_RISK_GOVERNANCE_DESCRIPTION,
+  gcRiskGovernanceZodShape,
   async (args) => {
     try {
-      // Per-entity status discriminated check (issue #881). status uses a
-      // different enum per entity; reject before the backend is touched so
-      // the wrong-status-for-entity case surfaces at the MCP boundary with
-      // the actual valid values rather than a backend 422.
-      validateGovernanceStatus(args.entity, args.status);
-      // Per-action allowlist: create and update DTOs differ across entities
-      // (Update DTOs drop uid, create-only foreign keys, and status). Status
-      // changes flow through the dedicated transition/transition_approval
-      // actions, never through the create/update body. Issues #878/#879/#880.
-      const fieldsForAction = GOVERNANCE_FIELDS[args.entity]?.[args.action] ?? [];
-      const data = pick(args, fieldsForAction);
-      switch (args.entity) {
-        case "methodology_profile": {
-          switch (args.action) {
-            case "create": return ok(JSON.stringify(await createMethodologyProfile(data, args.project), null, 2));
-            case "update": reqArg(args, "id", "update"); return ok(JSON.stringify(await updateMethodologyProfile(args.id, data, args.project), null, 2));
-            case "delete": reqArg(args, "id", "delete"); await deleteMethodologyProfile(args.id, args.project); return ok("Deleted");
-            default: return err(new Error(`Action '${args.action}' not valid for methodology_profile`));
-          }
-        }
-        case "risk_register_record": {
-          switch (args.action) {
-            case "create": return ok(JSON.stringify(await createRiskRegisterRecord(data, args.project), null, 2));
-            case "update": reqArg(args, "id", "update"); return ok(JSON.stringify(await updateRiskRegisterRecord(args.id, data, args.project), null, 2));
-            case "delete": reqArg(args, "id", "delete"); await deleteRiskRegisterRecord(args.id, args.project); return ok("Deleted");
-            case "transition": reqArg(args, "id", "transition"); reqArg(args, "status", "transition"); return ok(JSON.stringify(await transitionRiskRegisterRecordStatus(args.id, args.status, args.project), null, 2));
-            default: return err(new Error(`Action '${args.action}' not valid for risk_register_record`));
-          }
-        }
-        case "risk_assessment_result": {
-          switch (args.action) {
-            case "create": return ok(JSON.stringify(await createRiskAssessmentResult(data, args.project), null, 2));
-            case "update": reqArg(args, "id", "update"); return ok(JSON.stringify(await updateRiskAssessmentResult(args.id, data, args.project), null, 2));
-            case "delete": reqArg(args, "id", "delete"); await deleteRiskAssessmentResult(args.id, args.project); return ok("Deleted");
-            case "transition_approval": reqArg(args, "id", "transition_approval"); reqArg(args, "approval_state", "transition_approval"); return ok(JSON.stringify(await transitionRiskAssessmentApprovalState(args.id, args.approval_state, args.project), null, 2));
-            default: return err(new Error(`Action '${args.action}' not valid for risk_assessment_result`));
-          }
-        }
-        case "treatment_plan": {
-          switch (args.action) {
-            case "create": return ok(JSON.stringify(await createTreatmentPlan(data, args.project), null, 2));
-            case "update": reqArg(args, "id", "update"); return ok(JSON.stringify(await updateTreatmentPlan(args.id, data, args.project), null, 2));
-            case "delete": reqArg(args, "id", "delete"); await deleteTreatmentPlan(args.id, args.project); return ok("Deleted");
-            case "transition": reqArg(args, "id", "transition"); reqArg(args, "status", "transition"); return ok(JSON.stringify(await transitionTreatmentPlanStatus(args.id, args.status, args.project), null, 2));
-            default: return err(new Error(`Action '${args.action}' not valid for treatment_plan`));
-          }
-        }
-        case "verification_result": {
-          switch (args.action) {
-            case "create": return ok(JSON.stringify(await createVerificationResult(data, args.project), null, 2));
-            case "update": reqArg(args, "id", "update"); return ok(JSON.stringify(await updateVerificationResult(args.id, data, args.project), null, 2));
-            case "delete": reqArg(args, "id", "delete"); await deleteVerificationResult(args.id, args.project); return ok("Deleted");
-            default: return err(new Error(`Action '${args.action}' not valid for verification_result`));
-          }
-        }
-        default: return err(new Error(`Unknown entity: ${args.entity}`));
-      }
+      const result = await gcRiskGovernanceToolHandler(args);
+      return ok(result === null ? "Deleted" : JSON.stringify(result, null, 2));
     } catch (e) { return err(e); }
   },
 );

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -163,6 +163,7 @@ import {
   TRUST_POLICY_FIELDS, TRUST_POLICY_RULE_OPERATORS,
   pick, reqArg,
   validateGovernanceStatus,
+  GOVERNANCE_FIELDS,
 } from "./lib.js";
 import {
   executeGcQuery,
@@ -1428,20 +1429,21 @@ const RISK_GOVERNANCE_ENTITIES = [
 ];
 const RISK_GOVERNANCE_ACTIONS = ["create", "update", "delete", "transition", "transition_approval"];
 
-// Per-entity field allowlists for gc_risk_governance create/update DTOs.
-const GOVERNANCE_FIELDS = {
-  methodology_profile: ["name", "description", "family", "status", "metadata"],
-  risk_register_record: ["uid", "title", "description", "scenario_id", "owner", "status", "review_cadence", "next_review_at", "metadata"],
-  risk_assessment_result: ["uid", "title", "description", "scenario_id", "approval_state", "quantitative_value", "qualitative_value", "metadata"],
-  treatment_plan: ["uid", "title", "description", "scenario_id", "risk_register_record_id", "status", "strategy", "owner", "due_at", "metadata"],
-  verification_result: ["uid", "title", "description", "outcome", "status", "assurance_level", "verified_at", "metadata"],
-};
+// Per-entity, per-action body allowlist for gc_risk_governance create/update
+// DTOs lives in lib.js (GOVERNANCE_FIELDS). It mirrors the backend Request
+// records under api/riskscenarios/. Issues #878/#879/#880.
 
 server.tool(
   "gc_risk_governance",
   `Methodology profiles, risk register records, risk assessments, treatment plans, verification results. ` +
     `Entity: ${RISK_GOVERNANCE_ENTITIES.join(", ")}. Actions: ${RISK_GOVERNANCE_ACTIONS.join(", ")}. ` +
-    `Reads (list, get) route through gc_query. Entity-specific fields are validated against the per-entity allowlist; unknown fields are dropped (NOT forwarded to the backend).`,
+    `Reads (list, get) route through gc_query. ` +
+    `Per-entity create fields (snake_case; round-trip to backend camelCase): ` +
+    `risk_register_record={uid,title,owner,review_cadence,next_review_at,category_tags,decision_metadata,asset_scope_summary,risk_scenario_ids}; ` +
+    `risk_assessment_result={risk_scenario_id,risk_register_record_id,methodology_profile_id,analyst_identity,assumptions,input_factors,observation_date,assessment_at,time_horizon,confidence,uncertainty_metadata,computed_outputs,evidence_refs,notes,observation_ids}; ` +
+    `treatment_plan={uid,title,risk_scenario_id,risk_register_record_id,strategy,owner,rationale,due_date,status,action_items,reassessment_triggers}. ` +
+    `Update DTOs drop create-only foreign keys (uid; risk_register_record_id for treatment_plan; risk_scenario_id for risk_assessment_result) and status fields whose changes go through the transition action. ` +
+    `Unknown fields are dropped — never tunneled through metadata.`,
   {
     entity: z.enum(RISK_GOVERNANCE_ENTITIES),
     action: z.enum(RISK_GOVERNANCE_ACTIONS),
@@ -1462,15 +1464,33 @@ server.tool(
     title: z.string().optional(),
     description: z.string().optional(),
     family: z.enum(METHODOLOGY_FAMILIES).optional(),
-    scenario_id: z.string().uuid().optional(),
+    risk_scenario_id: z.string().uuid().optional(),
+    risk_scenario_ids: z.array(z.string().uuid()).optional(),
     risk_register_record_id: z.string().uuid().optional(),
+    methodology_profile_id: z.string().uuid().optional(),
     owner: z.string().optional(),
     review_cadence: z.string().optional(),
     next_review_at: z.string().optional(),
-    quantitative_value: z.number().optional(),
-    qualitative_value: z.string().optional(),
+    category_tags: z.array(z.string()).optional(),
+    decision_metadata: z.record(z.any()).optional(),
+    asset_scope_summary: z.string().optional(),
+    analyst_identity: z.string().optional(),
+    assumptions: z.string().optional(),
+    input_factors: z.record(z.any()).optional(),
+    observation_date: z.string().optional(),
+    assessment_at: z.string().optional(),
+    time_horizon: z.string().optional(),
+    confidence: z.string().optional(),
+    uncertainty_metadata: z.record(z.any()).optional(),
+    computed_outputs: z.record(z.any()).optional(),
+    evidence_refs: z.array(z.string()).optional(),
+    notes: z.string().optional(),
+    observation_ids: z.array(z.string().uuid()).optional(),
     strategy: z.enum(TREATMENT_STRATEGIES).optional(),
-    due_at: z.string().optional(),
+    rationale: z.string().optional(),
+    due_date: z.string().optional(),
+    action_items: z.array(z.record(z.any())).optional(),
+    reassessment_triggers: z.array(z.string()).optional(),
     outcome: z.string().optional(),
     assurance_level: z.enum(ASSURANCE_LEVELS).optional(),
     verified_at: z.string().optional(),
@@ -1483,7 +1503,12 @@ server.tool(
       // the wrong-status-for-entity case surfaces at the MCP boundary with
       // the actual valid values rather than a backend 422.
       validateGovernanceStatus(args.entity, args.status);
-      const data = pick(args, GOVERNANCE_FIELDS[args.entity] ?? []);
+      // Per-action allowlist: create and update DTOs differ across entities
+      // (Update DTOs drop uid, create-only foreign keys, and status). Status
+      // changes flow through the dedicated transition/transition_approval
+      // actions, never through the create/update body. Issues #878/#879/#880.
+      const fieldsForAction = GOVERNANCE_FIELDS[args.entity]?.[args.action] ?? [];
+      const data = pick(args, fieldsForAction);
       switch (args.entity) {
         case "methodology_profile": {
           switch (args.action) {

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -8482,6 +8482,70 @@ export const GOVERNANCE_STATUS_ENUMS = {
   verification_result: VERIFICATION_STATUSES,
 };
 
+// gc_risk_governance per-entity, per-action body allowlist. Mirrors the
+// backend Request records under
+// backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/.
+// Create and update DTOs differ — Update DTOs drop create-only foreign keys
+// (uid, riskRegisterRecordId for treatment plans, riskScenarioId for
+// assessment results) and exclude status fields whose changes go through a
+// dedicated transition endpoint. Snake_case field names round-trip through
+// the shared TO_CAMEL map in this file. Issues #878/#879/#880.
+export const GOVERNANCE_FIELDS = {
+  methodology_profile: {
+    create: ["name", "description", "family", "status", "metadata"],
+    update: ["name", "description", "family", "status", "metadata"],
+  },
+  risk_register_record: {
+    create: [
+      "uid", "title", "owner", "review_cadence", "next_review_at",
+      "category_tags", "decision_metadata", "asset_scope_summary",
+      "risk_scenario_ids",
+    ],
+    update: [
+      "title", "owner", "review_cadence", "next_review_at",
+      "category_tags", "decision_metadata", "asset_scope_summary",
+      "risk_scenario_ids",
+    ],
+  },
+  risk_assessment_result: {
+    create: [
+      "risk_scenario_id", "risk_register_record_id", "methodology_profile_id",
+      "analyst_identity", "assumptions", "input_factors",
+      "observation_date", "assessment_at", "time_horizon", "confidence",
+      "uncertainty_metadata", "computed_outputs",
+      "evidence_refs", "notes", "observation_ids",
+    ],
+    update: [
+      "risk_register_record_id", "methodology_profile_id",
+      "analyst_identity", "assumptions", "input_factors",
+      "observation_date", "assessment_at", "time_horizon", "confidence",
+      "uncertainty_metadata", "computed_outputs",
+      "evidence_refs", "notes", "observation_ids",
+    ],
+  },
+  treatment_plan: {
+    create: [
+      "uid", "title", "risk_scenario_id", "risk_register_record_id",
+      "strategy", "owner", "rationale", "due_date", "status",
+      "action_items", "reassessment_triggers",
+    ],
+    update: [
+      "title", "risk_scenario_id", "strategy", "owner",
+      "rationale", "due_date", "action_items", "reassessment_triggers",
+    ],
+  },
+  verification_result: {
+    create: [
+      "uid", "title", "description", "outcome", "status",
+      "assurance_level", "verified_at", "metadata",
+    ],
+    update: [
+      "title", "description", "outcome", "status",
+      "assurance_level", "verified_at", "metadata",
+    ],
+  },
+};
+
 /**
  * Validate a gc_risk_governance `status` argument against the per-entity
  * vocabulary. Throws on mismatch with a message naming the entity and the

--- a/mcp/ground-control/package.json
+++ b/mcp/ground-control/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node --test lib.test.js gc-query.test.js gc-threat-model.test.js gc-risk-scenario.test.js link-create.test.js",
+    "test": "node --test lib.test.js gc-query.test.js gc-threat-model.test.js gc-risk-scenario.test.js gc-risk-governance.test.js link-create.test.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },


### PR DESCRIPTION
## Summary

Aligns `gc_risk_governance` per-entity create/update body allowlists with the backend `RiskAssessmentResultRequest` / `RiskRegisterRecordRequest` / `TreatmentPlanRequest` records (and their Update DTO siblings). All three issues are the same shape of bug at the same boundary — misnamed fields, missing typed columns, stale fields the backend silently drops — so they ship as one PR. No backend changes; the fix lives entirely at the MCP adapter boundary (ADR-035 consolidated tool surface).

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #878
Closes #879
Closes #880

## ADR Impact

- ADR-035

## Changes

- Split `GOVERNANCE_FIELDS` into per-action (`create` / `update`) sub-lists in `mcp/ground-control/lib.js` so Update DTOs that lack `uid`, `riskRegisterRecordId`, `riskScenarioId`, or `status` stop receiving them silently.
- Replace `scenario_id` with explicit `risk_scenario_id` (singular, for assessment results + treatment plans) and `risk_scenario_ids` (array of UUIDs, for register records) — matches the backend `riskScenarioId(s)` field names and reuses the existing `TO_CAMEL` mappings.
- Add the typed governance fields the backend DTOs accept but the MCP was hiding: `methodology_profile_id`, `analyst_identity`, `assumptions`, `input_factors`, `observation_date`, `assessment_at`, `time_horizon`, `confidence`, `uncertainty_metadata`, `computed_outputs`, `evidence_refs`, `notes`, `observation_ids` (assessment); `category_tags`, `decision_metadata`, `asset_scope_summary` (register); `rationale`, `due_date`, `action_items`, `reassessment_triggers` (treatment).
- Drop fields the backend Create DTOs do not declare: `uid`, `title`, `description`, `quantitative_value`, `qualitative_value`, `approval_state` (assessment); `description`, `status` (register — register Create DTO has no status; transitions go through the dedicated `/status` sub-resource); `description`, `due_at` (treatment).
- Update the registered tool description so the per-entity create field set is discoverable at MCP catalog time (mirrors `GC_RISK_SCENARIO_DESCRIPTION` in `gc-risk-scenario.js`).
- Add adapter-level tests at `mcp/ground-control/gc-risk-governance.test.js` modeled on `gc-risk-scenario.test.js`: assert allowlist contents per entity per action, and assert the camelCased wire body produced through `pick` + the lib.js create/update functions. Wires the new file into `npm test` in `package.json`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

30 new adapter-level tests in `mcp/ground-control/gc-risk-governance.test.js`. `npm test` in `mcp/ground-control/` goes from 576 → 606 tests, all passing. `make check` and `make policy` both green locally.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #878 ← mcp/ground-control/lib.js GOVERNANCE_FIELDS.risk_assessment_result, #879 ← mcp/ground-control/lib.js GOVERNANCE_FIELDS.risk_register_record, #880 ← mcp/ground-control/lib.js GOVERNANCE_FIELDS.treatment_plan
- TESTS: #878 ← mcp/ground-control/gc-risk-governance.test.js (risk_assessment_result suites), #879 ← mcp/ground-control/gc-risk-governance.test.js (risk_register_record suites), #880 ← mcp/ground-control/gc-risk-governance.test.js (treatment_plan suites)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/878.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
