### PR TITLE
security: add step-based test case format for TC-002

### DIFF
--- a/architecture/adrs/041-test-case-step-format.md
+++ b/architecture/adrs/041-test-case-step-format.md
@@ -1,0 +1,221 @@
+# ADR-041: Step-based test case format
+
+- Status: Accepted
+- Date: 2026-05-16
+- Driver: TC-002 (issue #670)
+
+## Context
+
+TC-002 introduces the step-based test case format on top of the TestCase aggregate
+defined in ADR-040. The requirement statement is:
+
+> The system shall support a step-based test case format where each test case contains
+> an ordered sequence of steps, each with: step number, action description, expected
+> result, and actual result fields. Steps shall support rich text and inline images.
+
+ADR-040 deferred test steps to TC-002. This ADR records the design decisions for the
+child step aggregate, the rich-text representation, the inline-image strategy, the
+cascade behaviour on parent deletion, and the API surface.
+
+## Decision
+
+Introduce a `TestCaseStep` aggregate inside the existing `testcases` domain package at
+`backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/`. The step is a
+child of a single `TestCase` and inherits its project-scoping through that parent.
+
+### Identity and ordering
+
+- **UUID primary key** via `BaseEntity`. `stepNumber` is a value, not the identity.
+  This is the explicit guard called out in the architecture preflight: making
+  `stepNumber` the PK would break re-ordering and forbid stable references from any
+  future per-step execution layer.
+- **Positive integer `stepNumber`** with a database `CHECK (step_number > 0)` and a
+  service-layer `existsByTestCaseIdAndStepNumber` pre-check that returns HTTP 409 on
+  duplicate.
+- **Per-test-case uniqueness** via the unique constraint
+  `(test_case_id, step_number)`. Gaps after deletion are permitted; clients renumber
+  manually when they care about contiguity.
+- **List ordering** by `stepNumber` ascending in `findByTestCaseIdOrderByStepNumberAsc`;
+  the controller never returns steps unsorted.
+
+A bulk-reorder endpoint is intentionally **not** added. Frontend reorder, when it
+ships, can swap two step numbers with one intermediate PUT (`step 1 → 99`,
+`step 2 → 1`, `step 99 → 2`); this is awkward but does not justify a parallel
+collection-replace API in the TC-002 scope. A future requirement may add bulk
+reorder if it becomes load-bearing.
+
+### Step fields
+
+- `action` — `TEXT NOT NULL`, max 10000 chars at the DTO. What the operator does.
+- `expectedResult` — `TEXT NOT NULL`, max 10000 chars at the DTO. What should happen.
+- `actualResult` — `TEXT NULL`, max 10000 chars at the DTO. What actually happened on
+  the latest authored pass. Nullable because a freshly-authored step has no observed
+  outcome yet.
+
+The 10000-character bound is a constrained-untrusted-content footprint trade-off: large
+enough for real prose with several embedded Markdown image references, small enough
+that a single test case's list response stays bounded even with many steps.
+
+### Rich text
+
+Rich-text fields use **CommonMark Markdown** by convention, the same precedent set by
+ADR-040 §Rich text for the parent's `description` / `preconditions` /
+`postconditions`. The backend stores the Markdown source verbatim as TEXT; it does
+not render HTML, does not sanitize, and does not parse the Markdown server-side. When
+a shared sanitised renderer lands (preflight forward-compat note), these fields are
+forward-compatible.
+
+The preflight explicitly warned against introducing `dangerouslySetInnerHTML` or an
+equivalent unsafe HTML sink. This ADR upholds that: the rich-text path is text in →
+text out. Frontend renderers are responsible for choosing a safe Markdown library
+when UI work ships.
+
+### Inline images
+
+The requirement says "Steps shall support rich text and inline images". The chosen
+seam is the **CommonMark image syntax** `![alt](url)` embedded in the same TEXT
+field. The backend carries these strings verbatim — it does not validate the URL,
+does not fetch the bytes, and does not host image binaries.
+
+This is the smallest design that satisfies the clause while staying inside every
+preflight non-goal:
+
+- No image-binary upload API.
+- No image-processing pipeline.
+- No remote URL fetcher (an SSRF surface).
+- No antivirus or content scanner.
+- No filesystem temp paths.
+- No OCR.
+
+Image binary storage and upload — when a downstream requirement demands them — plug in
+as a separate `Asset`-style aggregate that exposes `https://<host>/api/v1/assets/<id>`
+URLs the Markdown reference can target. The text representation does not change.
+
+### Aggregate boundary
+
+`TestCaseStep` references `TestCase` via `@ManyToOne(fetch = LAZY)` only. There is
+**no** `@OneToMany` back-collection on `TestCase`. Rationale:
+
+- Avoids the N+1 fetch / `LazyInitializationException` surprises a bidirectional
+  mapping brings when test cases are serialised from a controller.
+- Steps are loaded through `TestCaseStepRepository.findByTestCaseIdOrderByStepNumberAsc`
+  with an explicit project-scope check, which is the same pattern used by other
+  unidirectional child collections in the domain.
+- Keeps the TC-001 parent aggregate unchanged.
+
+### Cascade on parent deletion
+
+Deleting a `TestCase` must remove its steps. Two implementations were considered:
+
+1. **DB-level `ON DELETE CASCADE`** on the `test_case_step.test_case_id` FK. Simple,
+   self-contained at the schema layer.
+2. **Service-level cascade** — `TestCaseService.delete()` first calls
+   `TestCaseStepService.deleteAllByTestCase(...)` and only then deletes the parent.
+
+Choice: **option 2**. Envers records each `TestCaseStep` delete in the
+`test_case_step_audit` table only when the delete flows through Hibernate. A
+DB-level CASCADE bypasses Envers and silently loses the per-step audit trail. Audit
+fidelity is the load-bearing constraint; the extra few lines in the service are
+worth it.
+
+The behavior is pinned by a `Mockito.inOrder` assertion in `TestCaseServiceTest` so a
+future refactor that flipped the call order (or replaced the service-level cascade
+with a DB CASCADE) would fail the test rather than silently regress audit coverage.
+
+### Audit
+
+`TestCaseStep` is `@Audited` (Envers). Because the only `@ManyToOne` is to
+`TestCase`, which is itself `@Audited`, no `@NotAudited` is needed. The Flyway pair
+`V073__create_test_case_step.sql` + `V074__create_test_case_step_audit.sql` lands
+the main and audit tables together. `test_case_step_audit` is added to
+`AuditRetentionJob.AUDIT_TABLES` so retention sweeps cover it.
+
+### API surface
+
+```
+POST   /api/v1/test-cases/{testCaseId}/steps?project=…            → 201
+GET    /api/v1/test-cases/{testCaseId}/steps?project=…            → 200 (list, ordered)
+GET    /api/v1/test-cases/{testCaseId}/steps/{stepId}?project=…   → 200
+PUT    /api/v1/test-cases/{testCaseId}/steps/{stepId}?project=…   → 200
+DELETE /api/v1/test-cases/{testCaseId}/steps/{stepId}?project=…   → 204
+```
+
+The service validates that the `testCaseId` resolves to a row inside the resolved
+project. A step request targeting a test case that is not in the resolved project
+returns HTTP 404 — the cross-project-leakage shape called out in the preflight is
+covered by `crossTestCaseStepAccessRejected` in the integration test.
+
+### MCP surface
+
+The `controller-parity` policy check (`tools/policy/checks.py::run_controller_contracts`)
+requires every new controller to land alongside `docs/API.md`,
+`mcp/ground-control/lib.js`, and `mcp/ground-control/index.js` updates. TC-002
+satisfies this by extending the existing `gc_test_case` consolidated tool with three
+new actions:
+
+- `step-create`
+- `step-update`
+- `step-delete`
+
+Read paths (step-list, step-get) route through `gc_query` against the
+`TestCaseStep` entity, the same pattern TC-001 established. Snake-case → camelCase
+mapping is covered by the `TO_CAMEL` table entries for `step_number`,
+`expected_result`, `actual_result`, and `clear_actual_result`, with an adapter test
+in `test-case-tools.test.js` so a missing entry surfaces immediately (the failure
+mode that drove TC-001 codex cycle 1).
+
+The discriminator collision between the MCP tool's existing `action` argument and
+the step's `action` field is resolved by exposing the step content as `step_action`
+on the MCP surface; the handler maps it to `action` before posting to the backend.
+
+### Frontend mirror
+
+`frontend/src/types/api.ts` ships `TestCaseStepResponse`, `TestCaseStepRequest`, and
+`UpdateTestCaseStepRequest` interfaces alongside the existing TC-001 enum mirrors.
+No new enums are introduced in TC-002 (steps have no status or type vocabulary), so
+ADR-034's enum-mirror requirement does not produce additional rows.
+
+## Consequences
+
+- TC-002 fully implements the step-based format clause-by-clause with no shortcuts.
+- Future per-step execution tracking (next likely TC requirement) plugs into a
+  separate execution-layer aggregate that references step UUIDs. The authored step's
+  `actualResult` field is preserved for the "what was observed when the step was
+  last authored" use case; runtime/historical observations belong in the future
+  execution layer.
+- Image hosting can be added later behind a separate `Asset` aggregate without
+  changing the step format. The Markdown URL stays the seam.
+- Pre-existing TC-001 service code gains one cascade call and one corresponding unit
+  test. Blast radius is local to the `testcases` package.
+
+## Alternatives considered
+
+1. **Store steps as JSON in `TestCase.customFields`.** Rejected — preflight explicit
+   non-goal. JSON-in-text loses per-step audit, per-field validation, and the
+   `(test_case_id, step_number)` uniqueness invariant.
+2. **`@OneToMany` collection on `TestCase`.** Rejected — would have required loading
+   every step every time a test case is serialised, or carrying a lazy-init hazard
+   that bidirectional collections regularly trigger in Spring serialisation.
+3. **DB-level `ON DELETE CASCADE` for parent deletion.** Rejected — bypasses Envers
+   and silently loses per-step audit revisions.
+4. **HTML rich text with a server-side sanitiser.** Rejected — introduces an HTML
+   sink the codebase doesn't currently need, and the sanitiser is a non-trivial
+   security surface that the preflight pushed to a future shared-renderer
+   requirement. Markdown stays the smaller surface.
+5. **Inline image binaries as base64 in the step body.** Rejected — preflight
+   non-goal. Inflates every list/detail response, makes audit diffs unreadable,
+   and conflicts with the bounded-untrusted-content footprint goal.
+6. **Bulk reorder endpoint.** Rejected for TC-002 — the requirement statement does
+   not mandate it, and the unique constraint plus three sequential PUTs implement
+   any reorder. A future frontend-driven requirement can revisit.
+
+## Out of scope
+
+- Image binary upload / hosting / antivirus / processing pipeline.
+- Per-step execution results, pass/fail tracking across runs, environments, or
+  testers.
+- Bulk reorder primitive.
+- A React UI for step authoring.
+- Cross-test-case step references or step reuse.
+- Graph projection for steps (inherits from TestCase, which is not graph-visible
+  per ADR-040).

--- a/architecture/notes/test-case-step-format-preflight.md
+++ b/architecture/notes/test-case-step-format-preflight.md
@@ -1,0 +1,155 @@
+# Test Case Step Format Preflight
+
+Issue: #670
+Requirement: TC-002
+
+TC-002 introduces a step-based test case format. This note records the
+architecture guardrails for the implementation that follows. It is not an
+implementation plan.
+
+## Boundary
+
+Step-based test cases are structured test-design artifacts. They must remain
+separate from:
+
+- `Requirement`, which owns requirement identity, statement, rationale,
+  lifecycle, priority, wave, custom fields, and requirement relations.
+- `TraceabilityLink`, which links requirements to external artifacts and must
+  not become an embedded test-case schema.
+- `VerificationResult`, which records verification outcomes and evidence after
+  evaluation. It is not the authored test procedure.
+- `Document`, `Section`, and `SectionContent`, which own document organization
+  and text blocks, not executable test-case structure.
+
+Do not store ordered steps as markdown conventions inside
+`Requirement.statement`, as ad hoc JSON in `Requirement.customFields`, as
+`VerificationResult.evidence`, or as `TEXT_BLOCK` section content. A step-based
+test case needs one canonical domain contract with ordered steps, per-step
+fields, ownership, validation, audit behavior, and project scoping.
+
+## Incumbents To Reuse
+
+- **Domain shape:** follow the existing domain package pattern:
+  `model`, `repository`, `service`, command records, state enums only when the
+  state has real domain semantics.
+- **Requirement association:** use `RequirementRepository.findByIdAndProjectId`
+  or the same same-project validation pattern already used by
+  `VerificationResultService`; do not rely on globally unique requirement UIDs.
+- **Project scope:** route API calls through `ProjectService.resolveProjectId`
+  or `requireProjectId` as the adjacent controllers do. Every test case and
+  step query must be project-scoped.
+- **Persistence:** use Flyway migrations as the schema authority, UUID primary
+  keys via `BaseEntity`, explicit indexes for project and parent lookups, and
+  service-owned writes through Spring Data repositories.
+- **Audit:** if authored test cases and steps are business records, annotate
+  them with Envers and add matching `_audit` migrations. Add `@NotAudited` on
+  `@ManyToOne` references to non-audited entities such as `Project`.
+- **Validation:** keep DTO shape validation in request records with
+  `jakarta.validation`, and semantic validation in services. Existing examples:
+  `RequirementRequest`, `SectionContentService.validateContentType`, and
+  project mismatch checks in `VerificationResultService`.
+- **Errors:** throw the existing exception hierarchy (`NotFoundException`,
+  `ConflictException`, `DomainValidationException`) so
+  `GlobalExceptionHandler` emits the shared `ErrorResponse` envelope.
+- **Logging and audit identity:** use SLF4J lifecycle logs sparingly and rely on
+  `RequestLoggingFilter`, `ActorFilter`, MDC, and Envers for request/actor
+  context. Do not log rich text bodies, image payloads, bearer tokens, or raw
+  multipart metadata.
+- **Graph:** if test cases become graph-visible, add a `GraphEntityType`,
+  `GraphIds` usage, and a `GraphProjectionContributor`; do not add feature-local
+  graph endpoints or AGE write paths.
+- **Frontend contract:** mirror backend DTOs in `frontend/src/types/api.ts` and
+  keep hooks near `use-requirements.ts` style. If new enums are exposed, extend
+  ADR-034's enum contract inventory and frontend constants instead of adding
+  component-local literal lists.
+- **API documentation:** update `docs/API.md` only for public endpoint contract
+  changes. Do not document internal persistence tables as API.
+- **Policy and workflow:** source or test changes require the repo's normal
+  changelog fragment rule. Database migrations must update the hardcoded
+  migration lists named in `.gc/plan-rules.md`. Completion must run
+  `make policy`.
+
+## Security Layers In Scope
+
+- **Spring Security path matrix:** new endpoints under `/api/v1/**` are
+  authenticated by ADR-026 through `ApiSecurityConfig`. Do not mount test-case
+  APIs outside that namespace or add controller-local authorization.
+- **Request parser and Bean Validation:** JSON requests pass through Jackson and
+  `@Valid`. Step number, action description, expected result, actual result,
+  ordering, attachment references, and rich-text format must be shape-checked at
+  the DTO boundary and semantically checked in the service before persistence.
+- **Rich text rendering:** rich text is untrusted user content. The backend must
+  preserve a constrained representation rather than trusting arbitrary HTML; any
+  HTML export or browser rendering must escape or sanitize through one
+  canonical renderer. Do not introduce `dangerouslySetInnerHTML` without an
+  explicit sanitizer and tests.
+- **Inline images:** image bytes or references are untrusted content. Enforce
+  allowed media types, size limits, ownership, and same-project access before
+  storage or rendering. Do not accept remote image URLs as implicit fetch
+  instructions from the backend.
+- **Multipart or upload handling:** if image upload is introduced, reuse
+  Spring's existing multipart handling and `GlobalExceptionHandler` missing-part
+  responses. Avoid passing filenames, content, tokens, or paths through process
+  argv, shell commands, logs, or error bodies.
+- **Error envelope:** validation and parser failures must use stable
+  `ErrorResponse` bodies and must not reflect raw rich text, filenames, image
+  bytes, stack traces, filesystem paths, or sanitizer internals.
+- **Configuration:** if storage limits or allowed MIME types become configurable,
+  use `@ConfigurationProperties` with startup validation. Do not read ad hoc
+  environment variables in services or controllers.
+- **OS/runtime exposure:** the design should not require shell-outs, external
+  image fetches, temporary files in predictable paths, or executable content.
+  Any unavoidable filesystem storage needs explicit path confinement and
+  retention/backup implications before implementation.
+
+## Extensibility
+
+The next likely changes are importing test cases from external tools,
+per-step execution status, attachments beyond inline images, and test-case
+reuse across requirements. The seam belongs in the authored test-case model:
+step content should carry a constrained rich-text representation plus
+attachment references, not inline binary blobs or parser-specific HTML. Step
+ordering should be explicit and re-orderable without rewriting the whole test
+case.
+
+If execution tracking is added later, model it as an execution/result layer that
+references the authored test case and step identities. Do not mutate the
+authored step's `actualResult` into the only execution record if multiple runs,
+actors, environments, or timestamps are expected.
+
+## Gotchas and Anti-Patterns
+
+- Do not conflate authored test cases with verification results. Test cases are
+  planned procedures; verification results are observed outcomes/evidence.
+- Do not represent steps as a newline parser over `statement` or markdown list
+  syntax. That loses ordering invariants, per-field validation, and per-step
+  auditability.
+- Do not create duplicate validation, exception, logging, or auth layers for
+  test cases. Extend the existing Spring/Bean Validation/service/error stack.
+- Do not make `stepNumber` the database identity. Use stable UUID identity plus
+  a unique per-test-case order/number constraint so reordering and future
+  references remain possible.
+- Do not allow gaps, duplicates, negative numbers, or cross-test-case step
+  ownership unless the service has an explicit rule and test coverage for it.
+- Do not embed base64 image data in every list/detail response by default.
+  Return references and metadata; fetch bytes through an explicit, authorized
+  path if the implementation adds binary storage.
+- Do not add broad nullable columns for every vendor field. Vendor import
+  metadata belongs in a constrained metadata field only after first-class
+  identity, ordering, content, and attachment semantics are modeled.
+- Do not let frontend-only validation become the enforcement layer. Backend
+  DTOs and services remain authoritative.
+
+## Non-Goals
+
+- No new workflow engine, state machine library, or generic content-management
+  abstraction for TC-002.
+- No change to requirement lifecycle states or traceability link semantics.
+- No external test-management integration, importer, or vendor-specific schema
+  unless covered by a separate requirement.
+- No image processing pipeline, OCR, remote URL fetcher, or antivirus subsystem
+  as part of the base step-format requirement.
+- No replacement of the existing document model, ReqIF export, or
+  `SectionContent` grammar.
+- No new authentication scheme, exception hierarchy, policy runner, or
+  frontend validation framework.

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseStepController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseStepController.java
@@ -1,0 +1,92 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseStepCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseStepService;
+import com.keplerops.groundcontrol.domain.testcases.service.UpdateTestCaseStepCommand;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/test-cases/{testCaseId}/steps")
+public class TestCaseStepController {
+
+    private final TestCaseStepService stepService;
+    private final ProjectService projectService;
+
+    public TestCaseStepController(TestCaseStepService stepService, ProjectService projectService) {
+        this.stepService = stepService;
+        this.projectService = projectService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TestCaseStepResponse create(
+            @PathVariable UUID testCaseId,
+            @Valid @RequestBody TestCaseStepRequest request,
+            @RequestParam(required = false) String project) {
+        var projectId = projectService.resolveProjectId(project);
+        return TestCaseStepResponse.from(stepService.create(new CreateTestCaseStepCommand(
+                projectId,
+                testCaseId,
+                request.stepNumber(),
+                request.action(),
+                request.expectedResult(),
+                request.actualResult())));
+    }
+
+    @GetMapping
+    public List<TestCaseStepResponse> list(
+            @PathVariable UUID testCaseId, @RequestParam(required = false) String project) {
+        var projectId = projectService.resolveProjectId(project);
+        return stepService.listByTestCase(projectId, testCaseId).stream()
+                .map(TestCaseStepResponse::from)
+                .toList();
+    }
+
+    @GetMapping("/{stepId}")
+    public TestCaseStepResponse getById(
+            @PathVariable UUID testCaseId, @PathVariable UUID stepId, @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        return TestCaseStepResponse.from(stepService.getById(projectId, testCaseId, stepId));
+    }
+
+    @PutMapping("/{stepId}")
+    public TestCaseStepResponse update(
+            @PathVariable UUID testCaseId,
+            @PathVariable UUID stepId,
+            @Valid @RequestBody UpdateTestCaseStepRequest request,
+            @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        return TestCaseStepResponse.from(stepService.update(
+                projectId,
+                testCaseId,
+                stepId,
+                new UpdateTestCaseStepCommand(
+                        request.stepNumber(),
+                        request.action(),
+                        request.expectedResult(),
+                        request.actualResult(),
+                        Boolean.TRUE.equals(request.clearActualResult()))));
+    }
+
+    @DeleteMapping("/{stepId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(
+            @PathVariable UUID testCaseId, @PathVariable UUID stepId, @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        stepService.delete(projectId, testCaseId, stepId);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseStepRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseStepRequest.java
@@ -1,0 +1,18 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Create request for a step. Rich-text fields are bounded at 10,000 characters
+ * each (extends ADR-040 §Rich text to TC-002 steps): generous enough for real
+ * prose with embedded Markdown image references, finite enough to constrain
+ * untrusted-content footprint and response size. See ADR-041.
+ */
+public record TestCaseStepRequest(
+        @NotNull @Positive Integer stepNumber,
+        @NotBlank @Size(max = 10000) String action,
+        @NotBlank @Size(max = 10000) String expectedResult,
+        @Size(max = 10000) String actualResult) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseStepResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseStepResponse.java
@@ -1,0 +1,28 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseStep;
+import java.time.Instant;
+import java.util.UUID;
+
+public record TestCaseStepResponse(
+        UUID id,
+        UUID testCaseId,
+        int stepNumber,
+        String action,
+        String expectedResult,
+        String actualResult,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public static TestCaseStepResponse from(TestCaseStep step) {
+        return new TestCaseStepResponse(
+                step.getId(),
+                step.getTestCase().getId(),
+                step.getStepNumber(),
+                step.getAction(),
+                step.getExpectedResult(),
+                step.getActualResult(),
+                step.getCreatedAt(),
+                step.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/UpdateTestCaseStepRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/UpdateTestCaseStepRequest.java
@@ -1,0 +1,19 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Partial-update DTO for a test case step. Same convention as
+ * {@link UpdateTestCaseRequest}: {@code null} means "no change"; the
+ * {@code clearActualResult} flag means "set to null". {@code action} and
+ * {@code expectedResult} are non-nullable on the entity, so they cannot be
+ * cleared — passing {@code null} leaves them untouched, passing a blank value
+ * is rejected by the entity-level validation.
+ */
+public record UpdateTestCaseStepRequest(
+        @Positive Integer stepNumber,
+        @Size(max = 10000) String action,
+        @Size(max = 10000) String expectedResult,
+        @Size(max = 10000) String actualResult,
+        Boolean clearActualResult) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/model/TestCaseStep.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/model/TestCaseStep.java
@@ -1,0 +1,107 @@
+package com.keplerops.groundcontrol.domain.testcases.model;
+
+import com.keplerops.groundcontrol.domain.BaseEntity;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.Map;
+import org.hibernate.envers.Audited;
+
+@Entity
+@Audited
+@Table(name = "test_case_step", uniqueConstraints = @UniqueConstraint(columnNames = {"test_case_id", "step_number"}))
+public class TestCaseStep extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "test_case_id", nullable = false)
+    private TestCase testCase;
+
+    @Column(name = "step_number", nullable = false)
+    private int stepNumber;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String action;
+
+    @Column(name = "expected_result", nullable = false, columnDefinition = "TEXT")
+    private String expectedResult;
+
+    @Column(name = "actual_result", columnDefinition = "TEXT")
+    private String actualResult;
+
+    protected TestCaseStep() {
+        // JPA
+    }
+
+    public TestCaseStep(TestCase testCase, int stepNumber, String action, String expectedResult) {
+        if (testCase == null) {
+            throw new DomainValidationException("Test case must not be null", "invalid_test_case_step", Map.of());
+        }
+        if (stepNumber <= 0) {
+            throw new DomainValidationException(
+                    "Step number must be positive",
+                    "invalid_test_case_step",
+                    Map.of("stepNumber", String.valueOf(stepNumber)));
+        }
+        requireNonBlank(action, "Action");
+        requireNonBlank(expectedResult, "Expected result");
+        this.testCase = testCase;
+        this.stepNumber = stepNumber;
+        this.action = action;
+        this.expectedResult = expectedResult;
+    }
+
+    public TestCase getTestCase() {
+        return testCase;
+    }
+
+    public int getStepNumber() {
+        return stepNumber;
+    }
+
+    public void setStepNumber(int stepNumber) {
+        if (stepNumber <= 0) {
+            throw new DomainValidationException(
+                    "Step number must be positive",
+                    "invalid_test_case_step",
+                    Map.of("stepNumber", String.valueOf(stepNumber)));
+        }
+        this.stepNumber = stepNumber;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        requireNonBlank(action, "Action");
+        this.action = action;
+    }
+
+    public String getExpectedResult() {
+        return expectedResult;
+    }
+
+    public void setExpectedResult(String expectedResult) {
+        requireNonBlank(expectedResult, "Expected result");
+        this.expectedResult = expectedResult;
+    }
+
+    public String getActualResult() {
+        return actualResult;
+    }
+
+    public void setActualResult(String actualResult) {
+        this.actualResult = actualResult;
+    }
+
+    private static void requireNonBlank(String value, String fieldLabel) {
+        if (value == null || value.isBlank()) {
+            throw new DomainValidationException(fieldLabel + " must not be blank", "invalid_test_case_step", Map.of());
+        }
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/repository/TestCaseStepRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/repository/TestCaseStepRepository.java
@@ -1,0 +1,18 @@
+package com.keplerops.groundcontrol.domain.testcases.repository;
+
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseStep;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TestCaseStepRepository extends JpaRepository<TestCaseStep, UUID> {
+
+    List<TestCaseStep> findByTestCaseIdOrderByStepNumberAsc(UUID testCaseId);
+
+    Optional<TestCaseStep> findByIdAndTestCaseId(UUID id, UUID testCaseId);
+
+    boolean existsByTestCaseIdAndStepNumber(UUID testCaseId, int stepNumber);
+
+    long deleteAllByTestCaseId(UUID testCaseId);
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/CreateTestCaseStepCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/CreateTestCaseStepCommand.java
@@ -1,0 +1,6 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import java.util.UUID;
+
+public record CreateTestCaseStepCommand(
+        UUID projectId, UUID testCaseId, int stepNumber, String action, String expectedResult, String actualResult) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseService.java
@@ -21,10 +21,15 @@ public class TestCaseService {
 
     private final TestCaseRepository testCaseRepository;
     private final ProjectService projectService;
+    private final TestCaseStepService testCaseStepService;
 
-    public TestCaseService(TestCaseRepository testCaseRepository, ProjectService projectService) {
+    public TestCaseService(
+            TestCaseRepository testCaseRepository,
+            ProjectService projectService,
+            TestCaseStepService testCaseStepService) {
         this.testCaseRepository = testCaseRepository;
         this.projectService = projectService;
+        this.testCaseStepService = testCaseStepService;
     }
 
     public TestCase create(CreateTestCaseCommand command) {
@@ -110,6 +115,7 @@ public class TestCaseService {
 
     public void delete(UUID projectId, UUID id) {
         var testCase = findOrThrow(projectId, id);
+        testCaseStepService.deleteAllByTestCase(id);
         testCaseRepository.delete(testCase);
         log.info("test_case_deleted: uid={} id={}", testCase.getUid(), id);
     }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseStepService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseStepService.java
@@ -1,0 +1,114 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseStep;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseRepository;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseStepRepository;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class TestCaseStepService {
+
+    private static final Logger log = LoggerFactory.getLogger(TestCaseStepService.class);
+
+    private final TestCaseStepRepository stepRepository;
+    private final TestCaseRepository testCaseRepository;
+
+    public TestCaseStepService(TestCaseStepRepository stepRepository, TestCaseRepository testCaseRepository) {
+        this.stepRepository = stepRepository;
+        this.testCaseRepository = testCaseRepository;
+    }
+
+    public TestCaseStep create(CreateTestCaseStepCommand command) {
+        var testCase = testCaseRepository
+                .findByIdAndProjectId(command.testCaseId(), command.projectId())
+                .orElseThrow(() -> new NotFoundException("Test case not found: " + command.testCaseId()));
+        if (stepRepository.existsByTestCaseIdAndStepNumber(testCase.getId(), command.stepNumber())) {
+            throw new ConflictException(
+                    "Step number " + command.stepNumber() + " already exists in test case " + testCase.getUid());
+        }
+        var step = new TestCaseStep(testCase, command.stepNumber(), command.action(), command.expectedResult());
+        step.setActualResult(command.actualResult());
+        step = stepRepository.save(step);
+        log.info(
+                "test_case_step_created: test_case={} step_number={} id={}",
+                testCase.getUid(),
+                step.getStepNumber(),
+                step.getId());
+        return step;
+    }
+
+    public TestCaseStep update(UUID projectId, UUID testCaseId, UUID stepId, UpdateTestCaseStepCommand command) {
+        var step = findStepOrThrow(projectId, testCaseId, stepId);
+        if (command.stepNumber() != null && command.stepNumber() != step.getStepNumber()) {
+            if (stepRepository.existsByTestCaseIdAndStepNumber(testCaseId, command.stepNumber())) {
+                throw new ConflictException(
+                        "Step number " + command.stepNumber() + " already exists in this test case");
+            }
+            step.setStepNumber(command.stepNumber());
+        }
+        if (command.action() != null) {
+            step.setAction(command.action());
+        }
+        if (command.expectedResult() != null) {
+            step.setExpectedResult(command.expectedResult());
+        }
+        if (command.clearActualResult()) {
+            step.setActualResult(null);
+        } else if (command.actualResult() != null) {
+            step.setActualResult(command.actualResult());
+        }
+        step = stepRepository.save(step);
+        log.info(
+                "test_case_step_updated: id={} test_case={} step_number={}",
+                step.getId(),
+                testCaseId,
+                step.getStepNumber());
+        return step;
+    }
+
+    @Transactional(readOnly = true)
+    public TestCaseStep getById(UUID projectId, UUID testCaseId, UUID stepId) {
+        return findStepOrThrow(projectId, testCaseId, stepId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TestCaseStep> listByTestCase(UUID projectId, UUID testCaseId) {
+        requireTestCaseInProject(projectId, testCaseId);
+        return stepRepository.findByTestCaseIdOrderByStepNumberAsc(testCaseId);
+    }
+
+    public void delete(UUID projectId, UUID testCaseId, UUID stepId) {
+        var step = findStepOrThrow(projectId, testCaseId, stepId);
+        stepRepository.delete(step);
+        log.info("test_case_step_deleted: id={} test_case={}", stepId, testCaseId);
+    }
+
+    public long deleteAllByTestCase(UUID testCaseId) {
+        long deleted = stepRepository.deleteAllByTestCaseId(testCaseId);
+        if (deleted > 0) {
+            log.info("test_case_steps_deleted: test_case={} count={}", testCaseId, deleted);
+        }
+        return deleted;
+    }
+
+    private TestCaseStep findStepOrThrow(UUID projectId, UUID testCaseId, UUID stepId) {
+        requireTestCaseInProject(projectId, testCaseId);
+        return stepRepository
+                .findByIdAndTestCaseId(stepId, testCaseId)
+                .orElseThrow(() -> new NotFoundException("Test case step not found: " + stepId));
+    }
+
+    private void requireTestCaseInProject(UUID projectId, UUID testCaseId) {
+        if (!testCaseRepository.existsByIdAndProjectId(testCaseId, projectId)) {
+            throw new NotFoundException("Test case not found: " + testCaseId);
+        }
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/UpdateTestCaseStepCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/UpdateTestCaseStepCommand.java
@@ -1,0 +1,4 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+public record UpdateTestCaseStepCommand(
+        Integer stepNumber, String action, String expectedResult, String actualResult, boolean clearActualResult) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/compliance/AuditRetentionJob.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/compliance/AuditRetentionJob.java
@@ -43,7 +43,8 @@ public class AuditRetentionJob {
             "treatment_plan_audit",
             "control_test_audit",
             "control_effectiveness_assessment_audit",
-            "test_case_audit");
+            "test_case_audit",
+            "test_case_step_audit");
 
     private final AuditRetentionProperties properties;
     private final EntityManager entityManager;

--- a/backend/src/main/resources/db/migration/V073__create_test_case_step.sql
+++ b/backend/src/main/resources/db/migration/V073__create_test_case_step.sql
@@ -1,0 +1,15 @@
+CREATE TABLE test_case_step (
+    id                UUID PRIMARY KEY,
+    test_case_id      UUID         NOT NULL REFERENCES test_case(id),
+    step_number       INTEGER      NOT NULL,
+    action            TEXT         NOT NULL,
+    expected_result   TEXT         NOT NULL,
+    actual_result     TEXT,
+    created_at        TIMESTAMPTZ  NOT NULL,
+    updated_at        TIMESTAMPTZ  NOT NULL,
+    CONSTRAINT uq_test_case_step_number UNIQUE (test_case_id, step_number),
+    CONSTRAINT ck_test_case_step_number_positive CHECK (step_number > 0)
+);
+
+CREATE INDEX idx_test_case_step_test_case ON test_case_step (test_case_id);
+CREATE INDEX idx_test_case_step_order ON test_case_step (test_case_id, step_number);

--- a/backend/src/main/resources/db/migration/V074__create_test_case_step_audit.sql
+++ b/backend/src/main/resources/db/migration/V074__create_test_case_step_audit.sql
@@ -1,0 +1,16 @@
+CREATE TABLE test_case_step_audit (
+    id                UUID         NOT NULL,
+    rev               INTEGER      NOT NULL REFERENCES revinfo(rev),
+    revtype           SMALLINT     NOT NULL,
+    test_case_id      UUID,
+    step_number       INTEGER,
+    action            TEXT,
+    expected_result   TEXT,
+    actual_result     TEXT,
+    -- BaseEntity timestamps are @Audited (no @NotAudited override), so Envers
+    -- writes them on every revision. Omitting these columns would silently
+    -- fail audit inserts at flush time. Matches the V058/V061/V066 pattern.
+    created_at        TIMESTAMPTZ,
+    updated_at        TIMESTAMPTZ,
+    PRIMARY KEY (id, rev)
+);

--- a/backend/src/main/resources/db/migration/V075__add_test_case_audit_timestamp_columns.sql
+++ b/backend/src/main/resources/db/migration/V075__add_test_case_audit_timestamp_columns.sql
@@ -1,0 +1,10 @@
+-- V072 (TC-001) created `test_case_audit` without the inherited BaseEntity
+-- timestamp columns. `TestCase` extends BaseEntity with no @NotAudited
+-- override on `createdAt` / `updatedAt`, so Envers should be writing them on
+-- every revision — the missing columns make those INSERTs silently drop the
+-- values (or fail at flush, depending on dialect). Forward-fix: add the
+-- columns nullable so prior rows back-fill cleanly. Pattern matches V058 /
+-- V061 / V066 audit tables. See codex pre-push review on issue #670.
+ALTER TABLE test_case_audit
+    ADD COLUMN created_at TIMESTAMPTZ,
+    ADD COLUMN updated_at TIMESTAMPTZ;

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
@@ -49,7 +49,7 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         "027", "028", "029", "030", "031", "032", "033", "034", "035", "036", "037", "038", "039",
                         "040", "041", "042", "043", "044", "045", "046", "047", "048", "049", "050", "051", "052",
                         "053", "054", "055", "056", "057", "058", "059", "060", "061", "062", "063", "064", "065",
-                        "066", "067", "068", "069", "070", "071", "072");
+                        "066", "067", "068", "069", "070", "071", "072", "073", "074", "075");
     }
 
     @Test
@@ -296,6 +296,55 @@ class MigrationSmokeTest extends BaseIntegrationTest {
         entityManager
                 .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_audit'"
                         + " AND column_name = 'priority'")
+                .getSingleResult();
+        // V073-V074 test_case_step + audit (TC-002 / ADR-041). Same rationale
+        // as the test_case_audit probes above — ddl-auto: validate doesn't see
+        // the audit shadow tables, so verify the structural shape by
+        // information_schema for the columns that would silently regress.
+        entityManager.createNativeQuery("SELECT 1 FROM test_case_step LIMIT 1").getResultList();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM test_case_step_audit LIMIT 1")
+                .getResultList();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_step_audit'"
+                        + " AND column_name = 'step_number'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_step_audit'"
+                        + " AND column_name = 'action'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_step_audit'"
+                        + " AND column_name = 'expected_result'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_step_audit'"
+                        + " AND column_name = 'actual_result'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_step'"
+                        + " AND column_name = 'step_number' AND is_nullable = 'NO'")
+                .getSingleResult();
+        // BaseEntity timestamps are @Audited, so every _audit table for an
+        // entity that extends BaseEntity MUST carry created_at / updated_at
+        // columns. The TC-001 V072 omission is fixed by V075; pin the
+        // post-V075 shape on both audit tables so a future drift surfaces
+        // here rather than as a flush-time Envers failure in production.
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_audit'"
+                        + " AND column_name = 'created_at'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_audit'"
+                        + " AND column_name = 'updated_at'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_step_audit'"
+                        + " AND column_name = 'created_at'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_step_audit'"
+                        + " AND column_name = 'updated_at'")
                 .getSingleResult();
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -470,6 +470,9 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
                         "069", // V069: operational_asset ownership/criticality/scope (GC-M012)
                         "070", // V070: operational_asset_audit parity for GC-M012
                         "071", // V071: test_case (TC-001 / ADR-040)
-                        "072"); // V072: test_case_audit
+                        "072", // V072: test_case_audit
+                        "073", // V073: test_case_step (TC-002 / ADR-041)
+                        "074", // V074: test_case_step_audit
+                        "075"); // V075: forward-fix V072 missing timestamp columns on test_case_audit
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseStepControllerIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseStepControllerIntegrationTest.java
@@ -1,0 +1,167 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureMockMvc
+@Transactional
+class TestCaseStepControllerIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static Map<String, Object> testCaseRequest(String uid) {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("uid", uid);
+        request.put("title", "Login flow validation");
+        request.put("type", "MANUAL");
+        request.put("priority", "HIGH");
+        return request;
+    }
+
+    private static Map<String, Object> stepRequest(int stepNumber, String action, String expected) {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("stepNumber", stepNumber);
+        request.put("action", action);
+        request.put("expectedResult", expected);
+        return request;
+    }
+
+    private String createTestCase(String uid) throws Exception {
+        var result = mockMvc.perform(post("/api/v1/test-cases")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testCaseRequest(uid))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper
+                .readTree(result.getResponse().getContentAsString())
+                .get("id")
+                .asText();
+    }
+
+    private String createStep(String testCaseId, Map<String, Object> body) throws Exception {
+        var result = mockMvc.perform(post("/api/v1/test-cases/{tc}/steps", testCaseId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper
+                .readTree(result.getResponse().getContentAsString())
+                .get("id")
+                .asText();
+    }
+
+    @Test
+    void create_list_update_delete_roundTrip() throws Exception {
+        var testCaseId = createTestCase("TC-STEP-001");
+
+        // Create three steps out of order to verify list sorts by stepNumber
+        createStep(testCaseId, stepRequest(2, "Click Login", "Form submits"));
+        createStep(testCaseId, stepRequest(1, "Open login page", "Page renders"));
+        var step3Id = createStep(testCaseId, stepRequest(3, "Verify dashboard", "Dashboard visible"));
+
+        // List returns steps ordered by stepNumber ascending
+        mockMvc.perform(get("/api/v1/test-cases/{tc}/steps", testCaseId).param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(3)))
+                .andExpect(jsonPath("$[0].stepNumber", is(1)))
+                .andExpect(jsonPath("$[1].stepNumber", is(2)))
+                .andExpect(jsonPath("$[2].stepNumber", is(3)))
+                .andExpect(jsonPath("$[0].action", is("Open login page")));
+
+        // Duplicate stepNumber rejected with 409
+        mockMvc.perform(post("/api/v1/test-cases/{tc}/steps", testCaseId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(stepRequest(1, "duplicate", "shouldn't happen"))))
+                .andExpect(status().isConflict());
+
+        // Get by id
+        mockMvc.perform(get("/api/v1/test-cases/{tc}/steps/{s}", testCaseId, step3Id)
+                        .param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stepNumber", is(3)));
+
+        // Update — change actualResult + action (rich text with image reference)
+        Map<String, Object> updateBody = new LinkedHashMap<>();
+        updateBody.put("action", "## Verify dashboard\n\n![dash](https://example.com/dash.png)");
+        updateBody.put("actualResult", "observed dashboard rendered");
+        mockMvc.perform(put("/api/v1/test-cases/{tc}/steps/{s}", testCaseId, step3Id)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateBody)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.action", is("## Verify dashboard\n\n![dash](https://example.com/dash.png)")))
+                .andExpect(jsonPath("$.actualResult", is("observed dashboard rendered")));
+
+        // Clear actualResult via the dedicated flag
+        Map<String, Object> clearBody = new LinkedHashMap<>();
+        clearBody.put("clearActualResult", true);
+        mockMvc.perform(put("/api/v1/test-cases/{tc}/steps/{s}", testCaseId, step3Id)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(clearBody)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.actualResult", is(nullValue())));
+
+        // Update step number — must remain unique per test case
+        Map<String, Object> renumber = new LinkedHashMap<>();
+        renumber.put("stepNumber", 1);
+        mockMvc.perform(put("/api/v1/test-cases/{tc}/steps/{s}", testCaseId, step3Id)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(renumber)))
+                .andExpect(status().isConflict());
+
+        // Delete one step
+        mockMvc.perform(delete("/api/v1/test-cases/{tc}/steps/{s}", testCaseId, step3Id)
+                        .param("project", "ground-control"))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/test-cases/{tc}/steps", testCaseId).param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)));
+
+        // Deleting the parent test case cascade-deletes its remaining steps
+        mockMvc.perform(delete("/api/v1/test-cases/{tc}", testCaseId).param("project", "ground-control"))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/v1/test-cases/{tc}", testCaseId).param("project", "ground-control"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void crossTestCaseStepAccessRejected() throws Exception {
+        var testCaseA = createTestCase("TC-STEP-A");
+        var testCaseB = createTestCase("TC-STEP-B");
+        var stepInAId = createStep(testCaseA, stepRequest(1, "act", "exp"));
+
+        // Reading step A through test case B's path must 404 — service enforces
+        // step belongs to the test case in the URL path.
+        mockMvc.perform(get("/api/v1/test-cases/{tc}/steps/{s}", testCaseB, stepInAId)
+                        .param("project", "ground-control"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseStepServiceIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseStepServiceIntegrationTest.java
@@ -1,0 +1,153 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.repository.ProjectRepository;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseStep;
+import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseStepCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseService;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseStepService;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseType;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.UUID;
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.envers.RevisionType;
+import org.hibernate.envers.query.AuditEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Exercises the Envers commit/flush path for TestCaseStep. The controller
+ * integration test is @Transactional with implicit rollback, which means the
+ * MockMvc work never flushes through Envers — a missing audit column or a
+ * misordered cascade would not surface there. This test uses the established
+ * `TestTransaction.flagForCommit()` pattern (see RequirementServiceIntegrationTest)
+ * so every step boundary commits real rows, including audit rows. ADR-041 makes
+ * the service-level cascade with preserved per-step audit revisions
+ * load-bearing; this test pins it.
+ */
+@Transactional
+class TestCaseStepServiceIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private TestCaseService testCaseService;
+
+    @Autowired
+    private TestCaseStepService stepService;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+        project = projectRepository.findByIdentifier("ground-control").orElseThrow();
+    }
+
+    @Test
+    void enversCapturesStepCreateAndCascadeDeleteRevisions() {
+        // 1. Create the parent test case and one step in committed transactions
+        //    so Envers flushes audit revisions to test_case_step_audit.
+        var testCase = testCaseService.create(new CreateTestCaseCommand(
+                project.getId(),
+                "TC-ENVERS-001",
+                "Envers cascade roundtrip",
+                TestCaseType.MANUAL,
+                TestCasePriority.MEDIUM,
+                null,
+                null,
+                null,
+                null));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        TestTransaction.start();
+        var step = stepService.create(new CreateTestCaseStepCommand(
+                project.getId(), testCase.getId(), 1, "Open the login page", "Page renders the email field", null));
+        UUID stepId = step.getId();
+        UUID testCaseId = testCase.getId();
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // 2. Verify the audit table received the step's create revision. This
+        //    is the load-bearing assertion that would have failed if V074 was
+        //    missing the BaseEntity timestamp columns — Envers would have
+        //    refused the audit insert at flush time. Use the same
+        //    forRevisionsOfEntity(includeRevType=true) shape as the DEL check
+        //    below so both ends are explicit RevisionType assertions; a
+        //    weaker isNotEmpty() check could pass on a stale phantom row.
+        TestTransaction.start();
+        var afterCreateReader = AuditReaderFactory.get(entityManager);
+        @SuppressWarnings("unchecked")
+        List<Object[]> afterCreateRevisions = (List<Object[]>) afterCreateReader
+                .createQuery()
+                .forRevisionsOfEntity(TestCaseStep.class, false, true)
+                .add(AuditEntity.id().eq(stepId))
+                .getResultList();
+        var afterCreateRevTypes =
+                afterCreateRevisions.stream().map(row -> (RevisionType) row[2]).toList();
+        assertThat(afterCreateRevTypes)
+                .as("expected an ADD audit row immediately after step creation")
+                .contains(RevisionType.ADD);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // 3. Delete the parent test case. The service-level cascade in
+        //    TestCaseService.delete() routes through Hibernate (NOT a DB
+        //    ON DELETE CASCADE), so Envers writes a DELETE revision for each
+        //    step before the parent row goes away.
+        TestTransaction.start();
+        testCaseService.delete(project.getId(), testCaseId);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // 4. Verify the audit DELETE revision exists for the step. This is the
+        //    audit-preservation guarantee ADR-041 §Cascade on parent deletion
+        //    pins. Use forRevisionsOfEntity with `includeRevType=true` so each
+        //    row carries the explicit RevisionType — a stronger assertion than
+        //    "find returns null at the latest revision", which could pass for a
+        //    soft-delete snapshot too.
+        TestTransaction.start();
+        var reader = AuditReaderFactory.get(entityManager);
+        @SuppressWarnings("unchecked")
+        List<Object[]> stepRevisions = (List<Object[]>) reader.createQuery()
+                .forRevisionsOfEntity(TestCaseStep.class, false, true)
+                .add(AuditEntity.id().eq(stepId))
+                .getResultList();
+        assertThat(stepRevisions)
+                .as("expected ADD plus DEL audit rows for the cascaded step delete")
+                .hasSizeGreaterThanOrEqualTo(2);
+        var stepRevTypes =
+                stepRevisions.stream().map(row -> (RevisionType) row[2]).toList();
+        assertThat(stepRevTypes)
+                .as("step audit history must contain a DEL revtype after cascade delete")
+                .contains(RevisionType.DEL);
+
+        // 5. Same guarantee for the parent test case — the audit chain on the
+        //    parent must include the DELETE revision so retention sweeps can
+        //    find the parent and child revisions together.
+        @SuppressWarnings("unchecked")
+        List<Object[]> parentRevisions = (List<Object[]>) reader.createQuery()
+                .forRevisionsOfEntity(TestCase.class, false, true)
+                .add(AuditEntity.id().eq(testCaseId))
+                .getResultList();
+        assertThat(parentRevisions).hasSizeGreaterThanOrEqualTo(2);
+        var parentRevTypes =
+                parentRevisions.stream().map(row -> (RevisionType) row[2]).toList();
+        assertThat(parentRevTypes)
+                .as("test case audit history must contain a DEL revtype after delete")
+                .contains(RevisionType.DEL);
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseStepControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseStepControllerTest.java
@@ -1,0 +1,280 @@
+package com.keplerops.groundcontrol.unit.api;
+
+import static com.keplerops.groundcontrol.TestUtil.setField;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keplerops.groundcontrol.api.testcases.TestCaseStepController;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseStep;
+import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseStepCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseStepService;
+import com.keplerops.groundcontrol.domain.testcases.service.UpdateTestCaseStepCommand;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseType;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(TestCaseStepController.class)
+class TestCaseStepControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TestCaseStepService stepService;
+
+    @MockitoBean
+    private ProjectService projectService;
+
+    private static final UUID PROJECT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID TEST_CASE_ID = UUID.fromString("00000000-0000-0000-0000-000000000700");
+    private static final UUID STEP_ID = UUID.fromString("00000000-0000-0000-0000-000000000800");
+    private static final Instant NOW = Instant.parse("2026-05-16T05:00:00Z");
+
+    private TestCaseStep makeStep(int number, String actual) {
+        var project = new Project("ground-control", "Ground Control");
+        setField(project, "id", PROJECT_ID);
+        var testCase = new TestCase(project, "TC-001", "Login flow", TestCaseType.MANUAL, TestCasePriority.HIGH);
+        setField(testCase, "id", TEST_CASE_ID);
+        var step = new TestCaseStep(testCase, number, "Open login page", "Page renders");
+        step.setActualResult(actual);
+        setField(step, "id", STEP_ID);
+        setField(step, "createdAt", NOW);
+        setField(step, "updatedAt", NOW);
+        return step;
+    }
+
+    @Test
+    void createReturns201() throws Exception {
+        when(projectService.resolveProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(stepService.create(any())).thenReturn(makeStep(1, null));
+
+        mockMvc.perform(
+                        post("/api/v1/test-cases/{tcId}/steps", TEST_CASE_ID)
+                                .param("project", "ground-control")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {
+                                  "stepNumber": 1,
+                                  "action": "Open login page",
+                                  "expectedResult": "Page renders"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", is(STEP_ID.toString())))
+                .andExpect(jsonPath("$.testCaseId", is(TEST_CASE_ID.toString())))
+                .andExpect(jsonPath("$.stepNumber", is(1)))
+                .andExpect(jsonPath("$.action", is("Open login page")))
+                .andExpect(jsonPath("$.expectedResult", is("Page renders")))
+                .andExpect(jsonPath("$.actualResult", is(nullValue())));
+    }
+
+    @Test
+    void createAcceptsRichTextWithMarkdownImage() throws Exception {
+        when(projectService.resolveProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(stepService.create(any())).thenReturn(makeStep(1, null));
+        var captor = ArgumentCaptor.forClass(CreateTestCaseStepCommand.class);
+
+        var richAction = "## Open page\n\n![login](https://example.com/login.png)";
+        var richExpected = "Page renders **completely**";
+        mockMvc.perform(
+                        post("/api/v1/test-cases/{tcId}/steps", TEST_CASE_ID)
+                                .param("project", "ground-control")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {
+                                  "stepNumber": 1,
+                                  "action": "## Open page\\n\\n![login](https://example.com/login.png)",
+                                  "expectedResult": "Page renders **completely**"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        // Pin the controller's command assembly: rich-text fields must reach
+        // the service exactly as the request body shaped them. Without the
+        // captor a regression that mapped `action` to `expectedResult` (or
+        // truncated the markdown) would still match `any()` and the test
+        // would pass silently.
+        verify(stepService).create(captor.capture());
+        var cmd = captor.getValue();
+        org.assertj.core.api.Assertions.assertThat(cmd.action()).isEqualTo(richAction);
+        org.assertj.core.api.Assertions.assertThat(cmd.expectedResult()).isEqualTo(richExpected);
+        org.assertj.core.api.Assertions.assertThat(cmd.stepNumber()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(cmd.testCaseId()).isEqualTo(TEST_CASE_ID);
+    }
+
+    static Stream<Arguments> invalidCreateBodies() {
+        return Stream.of(
+                Arguments.of(
+                        "missing-step-number",
+                        """
+                        {"action": "act", "expectedResult": "exp"}
+                        """),
+                Arguments.of(
+                        "zero-step-number",
+                        """
+                        {"stepNumber": 0, "action": "act", "expectedResult": "exp"}
+                        """),
+                Arguments.of(
+                        "negative-step-number",
+                        """
+                        {"stepNumber": -1, "action": "act", "expectedResult": "exp"}
+                        """),
+                Arguments.of(
+                        "blank-action",
+                        """
+                        {"stepNumber": 1, "action": "", "expectedResult": "exp"}
+                        """),
+                Arguments.of(
+                        "missing-action",
+                        """
+                        {"stepNumber": 1, "expectedResult": "exp"}
+                        """),
+                Arguments.of(
+                        "blank-expected-result",
+                        """
+                        {"stepNumber": 1, "action": "act", "expectedResult": ""}
+                        """),
+                Arguments.of(
+                        "missing-expected-result",
+                        """
+                        {"stepNumber": 1, "action": "act"}
+                        """));
+    }
+
+    @ParameterizedTest(name = "create rejects {0} with 422")
+    @MethodSource("invalidCreateBodies")
+    void createRejectsInvalidBody(String label, String body) throws Exception {
+        when(projectService.resolveProjectId("ground-control")).thenReturn(PROJECT_ID);
+
+        mockMvc.perform(post("/api/v1/test-cases/{tcId}/steps", TEST_CASE_ID)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void createRejectsOversizeAction() throws Exception {
+        when(projectService.resolveProjectId("ground-control")).thenReturn(PROJECT_ID);
+        var oversize = "a".repeat(10_001);
+        var body = "{\"stepNumber\": 1, \"action\": \"" + oversize + "\", \"expectedResult\": \"exp\"}";
+
+        mockMvc.perform(post("/api/v1/test-cases/{tcId}/steps", TEST_CASE_ID)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void listReturnsStepsInOrder() throws Exception {
+        when(projectService.resolveProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(stepService.listByTestCase(PROJECT_ID, TEST_CASE_ID))
+                .thenReturn(List.of(makeStep(1, null), makeStep(2, "observed")));
+
+        mockMvc.perform(get("/api/v1/test-cases/{tcId}/steps", TEST_CASE_ID).param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].stepNumber", is(1)))
+                .andExpect(jsonPath("$[1].stepNumber", is(2)))
+                .andExpect(jsonPath("$[1].actualResult", is("observed")));
+    }
+
+    @Test
+    void getByIdReturnsStep() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(stepService.getById(PROJECT_ID, TEST_CASE_ID, STEP_ID)).thenReturn(makeStep(1, null));
+
+        mockMvc.perform(get("/api/v1/test-cases/{tcId}/steps/{sId}", TEST_CASE_ID, STEP_ID)
+                        .param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(STEP_ID.toString())));
+    }
+
+    @Test
+    void updateReturnsUpdatedStep() throws Exception {
+        var step = makeStep(3, null);
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(stepService.update(eq(PROJECT_ID), eq(TEST_CASE_ID), eq(STEP_ID), any()))
+                .thenReturn(step);
+        var captor = ArgumentCaptor.forClass(UpdateTestCaseStepCommand.class);
+
+        mockMvc.perform(
+                        put("/api/v1/test-cases/{tcId}/steps/{sId}", TEST_CASE_ID, STEP_ID)
+                                .param("project", "ground-control")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {"stepNumber": 3, "action": "Open page", "clearActualResult": true}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stepNumber", is(3)));
+
+        // Capture the command and assert the controller forwarded every field
+        // from the request body. clearActualResult is the riskier one — a
+        // controller that hardcoded it to false would still satisfy any() and
+        // the wipe would never happen.
+        verify(stepService).update(eq(PROJECT_ID), eq(TEST_CASE_ID), eq(STEP_ID), captor.capture());
+        var cmd = captor.getValue();
+        org.assertj.core.api.Assertions.assertThat(cmd.stepNumber()).isEqualTo(3);
+        org.assertj.core.api.Assertions.assertThat(cmd.action()).isEqualTo("Open page");
+        org.assertj.core.api.Assertions.assertThat(cmd.clearActualResult()).isTrue();
+    }
+
+    @Test
+    void updateRejectsNonPositiveStepNumber() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+
+        mockMvc.perform(
+                        put("/api/v1/test-cases/{tcId}/steps/{sId}", TEST_CASE_ID, STEP_ID)
+                                .param("project", "ground-control")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {"stepNumber": 0}
+                                """))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void deleteReturns204() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+
+        mockMvc.perform(delete("/api/v1/test-cases/{tcId}/steps/{sId}", TEST_CASE_ID, STEP_ID)
+                        .param("project", "ground-control"))
+                .andExpect(status().isNoContent());
+
+        verify(stepService).delete(PROJECT_ID, TEST_CASE_ID, STEP_ID);
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseServiceTest.java
@@ -16,6 +16,7 @@ import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
 import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseRepository;
 import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseCommand;
 import com.keplerops.groundcontrol.domain.testcases.service.TestCaseService;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseStepService;
 import com.keplerops.groundcontrol.domain.testcases.service.UpdateTestCaseCommand;
 import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
 import com.keplerops.groundcontrol.domain.testcases.state.TestCaseStatus;
@@ -39,6 +40,9 @@ class TestCaseServiceTest {
 
     @Mock
     private ProjectService projectService;
+
+    @Mock
+    private TestCaseStepService testCaseStepService;
 
     @InjectMocks
     private TestCaseService testCaseService;
@@ -305,6 +309,23 @@ class TestCaseServiceTest {
             testCaseService.delete(projectId, existing.getId());
 
             verify(testCaseRepository).delete(existing);
+        }
+
+        @Test
+        void cascadesToDeleteSteps() {
+            // Steps must be deleted via the step service (so Envers records each
+            // step delete) BEFORE the test case row goes away. A future change
+            // that replaced this with a DB-level CASCADE would silently lose
+            // the per-step audit trail, so the test pins the order of calls.
+            var existing = makeTestCase();
+            var id = existing.getId();
+            when(testCaseRepository.findByIdAndProjectId(id, projectId)).thenReturn(Optional.of(existing));
+
+            testCaseService.delete(projectId, id);
+
+            var order = org.mockito.Mockito.inOrder(testCaseStepService, testCaseRepository);
+            order.verify(testCaseStepService).deleteAllByTestCase(id);
+            order.verify(testCaseRepository).delete(existing);
         }
 
         @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseStepServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseStepServiceTest.java
@@ -170,8 +170,9 @@ class TestCaseStepServiceTest {
             when(stepRepository.existsByTestCaseIdAndStepNumber(testCaseId, 5)).thenReturn(true);
 
             var command = new UpdateTestCaseStepCommand(5, null, null, null, false);
+            UUID stepId = step.getId();
 
-            assertThatThrownBy(() -> stepService.update(projectId, testCaseId, step.getId(), command))
+            assertThatThrownBy(() -> stepService.update(projectId, testCaseId, stepId, command))
                     .isInstanceOf(ConflictException.class)
                     .hasMessageContaining("Step number 5");
         }
@@ -226,8 +227,9 @@ class TestCaseStepServiceTest {
                     .thenReturn(false);
 
             var command = new UpdateTestCaseStepCommand(null, "act", null, null, false);
+            UUID randomStepId = UUID.randomUUID();
 
-            assertThatThrownBy(() -> stepService.update(projectId, testCaseId, UUID.randomUUID(), command))
+            assertThatThrownBy(() -> stepService.update(projectId, testCaseId, randomStepId, command))
                     .isInstanceOf(NotFoundException.class);
         }
 
@@ -265,8 +267,9 @@ class TestCaseStepServiceTest {
         void getByIdRejectsCrossProjectAccess() {
             when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
                     .thenReturn(false);
+            UUID randomStepId = UUID.randomUUID();
 
-            assertThatThrownBy(() -> stepService.getById(projectId, testCaseId, UUID.randomUUID()))
+            assertThatThrownBy(() -> stepService.getById(projectId, testCaseId, randomStepId))
                     .isInstanceOf(NotFoundException.class);
         }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseStepServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseStepServiceTest.java
@@ -1,0 +1,315 @@
+package com.keplerops.groundcontrol.unit.domain;
+
+import static com.keplerops.groundcontrol.TestUtil.setField;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseStep;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseRepository;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseStepRepository;
+import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseStepCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseStepService;
+import com.keplerops.groundcontrol.domain.testcases.service.UpdateTestCaseStepCommand;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseType;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TestCaseStepServiceTest {
+
+    @Mock
+    private TestCaseStepRepository stepRepository;
+
+    @Mock
+    private TestCaseRepository testCaseRepository;
+
+    @InjectMocks
+    private TestCaseStepService stepService;
+
+    private Project project;
+    private TestCase testCase;
+    private UUID projectId;
+    private UUID testCaseId;
+
+    @BeforeEach
+    void setUp() {
+        project = new Project("ground-control", "Ground Control");
+        projectId = UUID.randomUUID();
+        setField(project, "id", projectId);
+        testCase = new TestCase(project, "TC-001", "Login flow", TestCaseType.MANUAL, TestCasePriority.HIGH);
+        testCaseId = UUID.randomUUID();
+        setField(testCase, "id", testCaseId);
+    }
+
+    private TestCaseStep makeStep(int stepNumber) {
+        var step = new TestCaseStep(testCase, stepNumber, "Open page", "Page renders");
+        setField(step, "id", UUID.randomUUID());
+        return step;
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void createsStep() {
+            when(testCaseRepository.findByIdAndProjectId(testCaseId, projectId)).thenReturn(Optional.of(testCase));
+            when(stepRepository.existsByTestCaseIdAndStepNumber(testCaseId, 1)).thenReturn(false);
+            when(stepRepository.save(any(TestCaseStep.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new CreateTestCaseStepCommand(projectId, testCaseId, 1, "act", "exp", null);
+            var result = stepService.create(command);
+
+            assertThat(result.getStepNumber()).isEqualTo(1);
+            assertThat(result.getAction()).isEqualTo("act");
+            assertThat(result.getExpectedResult()).isEqualTo("exp");
+            assertThat(result.getActualResult()).isNull();
+            assertThat(result.getTestCase()).isSameAs(testCase);
+        }
+
+        @Test
+        void createsStepWithActualResult() {
+            when(testCaseRepository.findByIdAndProjectId(testCaseId, projectId)).thenReturn(Optional.of(testCase));
+            when(stepRepository.existsByTestCaseIdAndStepNumber(testCaseId, 2)).thenReturn(false);
+            when(stepRepository.save(any(TestCaseStep.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new CreateTestCaseStepCommand(projectId, testCaseId, 2, "act", "exp", "observed");
+            var result = stepService.create(command);
+
+            assertThat(result.getActualResult()).isEqualTo("observed");
+        }
+
+        @Test
+        void rejectsCreateWhenTestCaseNotInProject() {
+            when(testCaseRepository.findByIdAndProjectId(testCaseId, projectId)).thenReturn(Optional.empty());
+
+            var command = new CreateTestCaseStepCommand(projectId, testCaseId, 1, "act", "exp", null);
+
+            assertThatThrownBy(() -> stepService.create(command))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessageContaining(testCaseId.toString());
+        }
+
+        @Test
+        void rejectsDuplicateStepNumber() {
+            when(testCaseRepository.findByIdAndProjectId(testCaseId, projectId)).thenReturn(Optional.of(testCase));
+            when(stepRepository.existsByTestCaseIdAndStepNumber(testCaseId, 1)).thenReturn(true);
+
+            var command = new CreateTestCaseStepCommand(projectId, testCaseId, 1, "act", "exp", null);
+
+            assertThatThrownBy(() -> stepService.create(command))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("Step number 1");
+        }
+
+        @Test
+        void rejectsNonPositiveStepNumber() {
+            when(testCaseRepository.findByIdAndProjectId(testCaseId, projectId)).thenReturn(Optional.of(testCase));
+
+            var command = new CreateTestCaseStepCommand(projectId, testCaseId, 0, "act", "exp", null);
+
+            assertThatThrownBy(() -> stepService.create(command)).isInstanceOf(DomainValidationException.class);
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void updatesActionAndExpectedResult() {
+            var step = makeStep(1);
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            when(stepRepository.findByIdAndTestCaseId(step.getId(), testCaseId)).thenReturn(Optional.of(step));
+            when(stepRepository.save(any(TestCaseStep.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new UpdateTestCaseStepCommand(null, "new action", "new expected", null, false);
+            var result = stepService.update(projectId, testCaseId, step.getId(), command);
+
+            assertThat(result.getAction()).isEqualTo("new action");
+            assertThat(result.getExpectedResult()).isEqualTo("new expected");
+        }
+
+        @Test
+        void updatesStepNumberWhenUnique() {
+            var step = makeStep(1);
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            when(stepRepository.findByIdAndTestCaseId(step.getId(), testCaseId)).thenReturn(Optional.of(step));
+            when(stepRepository.existsByTestCaseIdAndStepNumber(testCaseId, 5)).thenReturn(false);
+            when(stepRepository.save(any(TestCaseStep.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new UpdateTestCaseStepCommand(5, null, null, null, false);
+            var result = stepService.update(projectId, testCaseId, step.getId(), command);
+
+            assertThat(result.getStepNumber()).isEqualTo(5);
+        }
+
+        @Test
+        void rejectsDuplicateStepNumberOnUpdate() {
+            var step = makeStep(1);
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            when(stepRepository.findByIdAndTestCaseId(step.getId(), testCaseId)).thenReturn(Optional.of(step));
+            when(stepRepository.existsByTestCaseIdAndStepNumber(testCaseId, 5)).thenReturn(true);
+
+            var command = new UpdateTestCaseStepCommand(5, null, null, null, false);
+
+            assertThatThrownBy(() -> stepService.update(projectId, testCaseId, step.getId(), command))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("Step number 5");
+        }
+
+        @Test
+        void allowsKeepingSameStepNumber() {
+            var step = makeStep(3);
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            when(stepRepository.findByIdAndTestCaseId(step.getId(), testCaseId)).thenReturn(Optional.of(step));
+            when(stepRepository.save(any(TestCaseStep.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new UpdateTestCaseStepCommand(3, "tweak", null, null, false);
+            var result = stepService.update(projectId, testCaseId, step.getId(), command);
+
+            assertThat(result.getStepNumber()).isEqualTo(3);
+            assertThat(result.getAction()).isEqualTo("tweak");
+        }
+
+        @Test
+        void clearsActualResultWhenFlagSet() {
+            var step = makeStep(1);
+            step.setActualResult("previously observed");
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            when(stepRepository.findByIdAndTestCaseId(step.getId(), testCaseId)).thenReturn(Optional.of(step));
+            when(stepRepository.save(any(TestCaseStep.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new UpdateTestCaseStepCommand(null, null, null, null, true);
+            var result = stepService.update(projectId, testCaseId, step.getId(), command);
+
+            assertThat(result.getActualResult()).isNull();
+        }
+
+        @Test
+        void setsActualResultWhenProvided() {
+            var step = makeStep(1);
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            when(stepRepository.findByIdAndTestCaseId(step.getId(), testCaseId)).thenReturn(Optional.of(step));
+            when(stepRepository.save(any(TestCaseStep.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new UpdateTestCaseStepCommand(null, null, null, "observed", false);
+            var result = stepService.update(projectId, testCaseId, step.getId(), command);
+
+            assertThat(result.getActualResult()).isEqualTo("observed");
+        }
+
+        @Test
+        void rejectsUpdateWhenTestCaseNotInProject() {
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(false);
+
+            var command = new UpdateTestCaseStepCommand(null, "act", null, null, false);
+
+            assertThatThrownBy(() -> stepService.update(projectId, testCaseId, UUID.randomUUID(), command))
+                    .isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        void rejectsUpdateWhenStepNotInTestCase() {
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            var stepId = UUID.randomUUID();
+            when(stepRepository.findByIdAndTestCaseId(stepId, testCaseId)).thenReturn(Optional.empty());
+
+            var command = new UpdateTestCaseStepCommand(null, "act", null, null, false);
+
+            assertThatThrownBy(() -> stepService.update(projectId, testCaseId, stepId, command))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessageContaining(stepId.toString());
+        }
+    }
+
+    @Nested
+    class GetAndList {
+
+        @Test
+        void getByIdReturnsStep() {
+            var step = makeStep(1);
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            when(stepRepository.findByIdAndTestCaseId(step.getId(), testCaseId)).thenReturn(Optional.of(step));
+
+            var result = stepService.getById(projectId, testCaseId, step.getId());
+
+            assertThat(result).isSameAs(step);
+        }
+
+        @Test
+        void getByIdRejectsCrossProjectAccess() {
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> stepService.getById(projectId, testCaseId, UUID.randomUUID()))
+                    .isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        void listByTestCaseReturnsOrderedSteps() {
+            var step1 = makeStep(1);
+            var step2 = makeStep(2);
+            var step3 = makeStep(3);
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            when(stepRepository.findByTestCaseIdOrderByStepNumberAsc(testCaseId))
+                    .thenReturn(List.of(step1, step2, step3));
+
+            var result = stepService.listByTestCase(projectId, testCaseId);
+
+            assertThat(result).extracting(TestCaseStep::getStepNumber).containsExactly(1, 2, 3);
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void deletesStep() {
+            var step = makeStep(1);
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            when(stepRepository.findByIdAndTestCaseId(step.getId(), testCaseId)).thenReturn(Optional.of(step));
+
+            stepService.delete(projectId, testCaseId, step.getId());
+
+            verify(stepRepository).delete(step);
+        }
+
+        @Test
+        void rejectsDeleteWhenStepNotInTestCase() {
+            when(testCaseRepository.existsByIdAndProjectId(testCaseId, projectId))
+                    .thenReturn(true);
+            var stepId = UUID.randomUUID();
+            when(stepRepository.findByIdAndTestCaseId(stepId, testCaseId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> stepService.delete(projectId, testCaseId, stepId))
+                    .isInstanceOf(NotFoundException.class);
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseStepTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseStepTest.java
@@ -1,0 +1,120 @@
+package com.keplerops.groundcontrol.unit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseStep;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseType;
+import org.junit.jupiter.api.Test;
+
+class TestCaseStepTest {
+
+    private static TestCase testCase() {
+        var project = new Project("ground-control", "Ground Control");
+        return new TestCase(project, "TC-001", "Login flow", TestCaseType.MANUAL, TestCasePriority.HIGH);
+    }
+
+    @Test
+    void constructorInitialisesRequiredFields() {
+        var step = new TestCaseStep(testCase(), 1, "Open the login page", "Page renders with email field");
+        assertThat(step.getStepNumber()).isEqualTo(1);
+        assertThat(step.getAction()).isEqualTo("Open the login page");
+        assertThat(step.getExpectedResult()).isEqualTo("Page renders with email field");
+        assertThat(step.getActualResult()).isNull();
+    }
+
+    @Test
+    void constructorRejectsNullTestCase() {
+        assertThatThrownBy(() -> new TestCaseStep(null, 1, "act", "exp"))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Test case");
+    }
+
+    @Test
+    void constructorRejectsNonPositiveStepNumber() {
+        var tc = testCase();
+        assertThatThrownBy(() -> new TestCaseStep(tc, 0, "act", "exp"))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Step number");
+        assertThatThrownBy(() -> new TestCaseStep(tc, -1, "act", "exp"))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Step number");
+    }
+
+    @Test
+    void constructorRejectsBlankAction() {
+        var tc = testCase();
+        assertThatThrownBy(() -> new TestCaseStep(tc, 1, "", "exp"))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Action");
+        assertThatThrownBy(() -> new TestCaseStep(tc, 1, "   ", "exp"))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Action");
+        assertThatThrownBy(() -> new TestCaseStep(tc, 1, null, "exp"))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Action");
+    }
+
+    @Test
+    void constructorRejectsBlankExpectedResult() {
+        var tc = testCase();
+        assertThatThrownBy(() -> new TestCaseStep(tc, 1, "act", ""))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Expected result");
+        assertThatThrownBy(() -> new TestCaseStep(tc, 1, "act", null))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Expected result");
+    }
+
+    @Test
+    void setStepNumberRejectsNonPositive() {
+        var step = new TestCaseStep(testCase(), 1, "act", "exp");
+        assertThatThrownBy(() -> step.setStepNumber(0)).isInstanceOf(DomainValidationException.class);
+        assertThatThrownBy(() -> step.setStepNumber(-3)).isInstanceOf(DomainValidationException.class);
+    }
+
+    @Test
+    void setStepNumberUpdatesValue() {
+        var step = new TestCaseStep(testCase(), 1, "act", "exp");
+        step.setStepNumber(5);
+        assertThat(step.getStepNumber()).isEqualTo(5);
+    }
+
+    @Test
+    void setActionRejectsBlank() {
+        var step = new TestCaseStep(testCase(), 1, "act", "exp");
+        assertThatThrownBy(() -> step.setAction("")).isInstanceOf(DomainValidationException.class);
+        assertThatThrownBy(() -> step.setAction("   ")).isInstanceOf(DomainValidationException.class);
+        assertThatThrownBy(() -> step.setAction(null)).isInstanceOf(DomainValidationException.class);
+    }
+
+    @Test
+    void setExpectedResultRejectsBlank() {
+        var step = new TestCaseStep(testCase(), 1, "act", "exp");
+        assertThatThrownBy(() -> step.setExpectedResult("")).isInstanceOf(DomainValidationException.class);
+        assertThatThrownBy(() -> step.setExpectedResult(null)).isInstanceOf(DomainValidationException.class);
+    }
+
+    @Test
+    void setActualResultAcceptsNullAndBlank() {
+        var step = new TestCaseStep(testCase(), 1, "act", "exp");
+        step.setActualResult("Observed: redirected to /dashboard");
+        assertThat(step.getActualResult()).isEqualTo("Observed: redirected to /dashboard");
+        step.setActualResult(null);
+        assertThat(step.getActualResult()).isNull();
+        step.setActualResult("");
+        assertThat(step.getActualResult()).isEmpty();
+    }
+
+    @Test
+    void setActionPreservesRichTextMarkdown() {
+        var step = new TestCaseStep(testCase(), 1, "act", "exp");
+        var richText = "## Step 1\n\nClick the **Login** button.\n\n![screenshot](https://example.com/login.png)";
+        step.setAction(richText);
+        assertThat(step.getAction()).isEqualTo(richText);
+    }
+}

--- a/changelog.d/670.added.md
+++ b/changelog.d/670.added.md
@@ -1,0 +1,16 @@
+### Added
+
+- **TC-002 — step-based test case format.** A `TestCaseStep` aggregate (UUID id,
+  positive `stepNumber` unique per test case, `action` / `expectedResult` /
+  `actualResult` rich-text fields capped at 10,000 chars) anchors ordered step
+  authoring under each `TestCase`. CRUD endpoints at
+  `/api/v1/test-cases/{testCaseId}/steps`, list returns steps ordered by
+  `stepNumber` ascending, duplicate step numbers return HTTP 409, project-scoped via
+  the parent test case. Rich-text fields use CommonMark Markdown by convention,
+  inline images via `![alt](url)` references with no backend-side image
+  hosting/fetching/sanitisation (deferred to a future asset-hosting aggregate).
+  Parent-deletion cascades through the service so Envers records each step's
+  delete revision; DB-level CASCADE intentionally avoided. Flyway pair V073/V074
+  ships the main and audit tables together; `AuditRetentionJob.AUDIT_TABLES`
+  picks up `test_case_step_audit`. MCP `gc_test_case` tool extends with
+  `step-create | step-update | step-delete` actions. See ADR-041.

--- a/changelog.d/670.fixed.md
+++ b/changelog.d/670.fixed.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Refactored `assertThatThrownBy` lambdas in `TestCaseStepServiceTest` to pull
+  the throwing-method's argument expressions out of the lambda body, so each
+  lambda has exactly one invocation that can throw. Clears three MAJOR
+  SonarCloud code smells without changing test semantics.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1005,6 +1005,35 @@ layer with HTTP 422.
 Rich-text fields (`description`, `preconditions`, `postconditions`) are stored as plain text
 and rendered as Markdown by clients; no HTML sanitizer is wired through this surface.
 
+### Test Case Steps (TC-002 / ADR-041)
+
+| Method | Path | Body | Status | Purpose |
+|--------|------|------|--------|---------|
+| POST | `/test-cases/{testCaseId}/steps` | TestCaseStepRequest | 201 | Create a step in a test case |
+| GET | `/test-cases/{testCaseId}/steps` | — | 200 | List steps ordered by `stepNumber` ascending |
+| GET | `/test-cases/{testCaseId}/steps/{stepId}` | — | 200 | Get one step |
+| PUT | `/test-cases/{testCaseId}/steps/{stepId}` | UpdateTestCaseStepRequest | 200 | Update step fields (null = no change) |
+| DELETE | `/test-cases/{testCaseId}/steps/{stepId}` | — | 204 | Delete a step |
+
+Steps are an ordered child collection of a test case. Each step carries a `stepNumber` (unique
+within its test case, positive), an `action` (what to do), an `expectedResult` (what should
+happen), and an optional `actualResult` (what actually happened on the latest authored pass).
+Rich-text fields use the same CommonMark Markdown convention as the parent test case;
+inline images use the `![alt](url)` syntax with no backend-side fetching, sanitisation, or
+binary storage (see ADR-041 §Rich text and inline images).
+
+**TestCaseStepRequest fields:** `stepNumber` (required positive `Integer`), `action` (required,
+max 10000), `expectedResult` (required, max 10000), `actualResult` (optional, max 10000).
+
+**UpdateTestCaseStepRequest fields:** `stepNumber`, `action`, `expectedResult`, `actualResult`
+— all optional with null-means-no-change — plus `clearActualResult: true` to wipe the
+`actualResult` to null (same partial-update convention as `UpdateTestCaseRequest`).
+
+Duplicate `stepNumber` within a test case returns HTTP 409. Non-positive `stepNumber` and
+oversize rich-text fields return HTTP 422. A step request against a test case that is not in
+the resolved project returns HTTP 404. Deleting the parent test case cascade-deletes its
+steps service-side so Envers captures each step's delete revision.
+
 ## Request / Response Format
 
 JSON. Error responses use a nested envelope:

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -116,6 +116,35 @@ export const TEST_CASE_PRIORITIES: TestCasePriority[] = [
   "MEDIUM",
   "LOW",
 ];
+
+// TC-002 / ADR-041 — step-based test case format. Rich-text fields hold
+// CommonMark Markdown by convention (inline images via `![alt](url)`).
+// Mirrors backend TestCaseStepResponse / TestCaseStepRequest field-for-field.
+export interface TestCaseStepResponse {
+  id: string;
+  testCaseId: string;
+  stepNumber: number;
+  action: string;
+  expectedResult: string;
+  actualResult: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TestCaseStepRequest {
+  stepNumber: number;
+  action: string;
+  expectedResult: string;
+  actualResult?: string | null;
+}
+
+export interface UpdateTestCaseStepRequest {
+  stepNumber?: number;
+  action?: string;
+  expectedResult?: string;
+  actualResult?: string | null;
+  clearActualResult?: boolean;
+}
 export type GraphEntityType =
   | "REQUIREMENT"
   | "OPERATIONAL_ASSET"

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -144,6 +144,8 @@ import {
   // ---- test cases (TC-001 / ADR-040) ----
   createTestCase, updateTestCase, deleteTestCase, transitionTestCaseStatus,
   TEST_CASE_STATUSES, TEST_CASE_TYPES, TEST_CASE_PRIORITIES,
+  // ---- test case steps (TC-002 / ADR-041) ----
+  createTestCaseStep, updateTestCaseStep, deleteTestCaseStep,
   // ---- enums ----
   STATUSES, REQUIREMENT_TYPES, PRIORITIES, RELATION_TYPES,
   ARTIFACT_TYPES, LINK_TYPES, CHANGE_CATEGORIES, CONFIDENCE_LEVELS,
@@ -1468,14 +1470,19 @@ server.tool(
   },
 );
 
-// gc_test_case: TC-001 / ADR-040. Reusable test-definition aggregate at
-// /api/v1/test-cases. Reads (list, get, get-by-uid) route through gc_query.
-const TEST_CASE_ACTIONS = ["create", "update", "delete", "transition"];
+// gc_test_case: TC-001 / ADR-040 + TC-002 / ADR-041. Reusable test-definition
+// aggregate at /api/v1/test-cases and its ordered child step aggregate at
+// /api/v1/test-cases/{id}/steps. Reads (list, get, get-by-uid, step-list,
+// step-get) route through gc_query.
+const TEST_CASE_ACTIONS = [
+  "create", "update", "delete", "transition",
+  "step-create", "step-update", "step-delete",
+];
 
 server.tool(
   "gc_test_case",
-  `Test case operations (TC-001 / ADR-040). Actions: ${TEST_CASE_ACTIONS.join(", ")}. ` +
-    `Reads (list, get, get-by-uid) route through gc_query.`,
+  `Test case operations (TC-001 / ADR-040 + TC-002 / ADR-041). Actions: ${TEST_CASE_ACTIONS.join(", ")}. ` +
+    `Reads (list, get, get-by-uid, step-list, step-get) route through gc_query.`,
   {
     action: z.enum(TEST_CASE_ACTIONS),
     id: z.string().uuid().optional(),
@@ -1496,6 +1503,17 @@ server.tool(
     clear_preconditions: z.boolean().optional(),
     clear_postconditions: z.boolean().optional(),
     clear_estimated_duration: z.boolean().optional(),
+    // TC-002 step actions. test_case_id is the parent test case; step_id is the
+    // step itself (step-update / step-delete). step_number is the per-test-case
+    // ordering value. action / expected_result / actual_result are the step's
+    // rich-text fields (CommonMark Markdown by convention per ADR-041).
+    test_case_id: z.string().uuid().optional(),
+    step_id: z.string().uuid().optional(),
+    step_number: z.number().int().positive().optional(),
+    step_action: z.string().optional(),
+    expected_result: z.string().optional(),
+    actual_result: z.string().nullable().optional(),
+    clear_actual_result: z.boolean().optional(),
   },
   async (args) => {
     try {
@@ -1505,6 +1523,19 @@ server.tool(
         "clear_description", "clear_preconditions", "clear_postconditions",
         "clear_estimated_duration",
       ];
+      const STEP_FIELDS = [
+        "step_number", "expected_result", "actual_result", "clear_actual_result",
+      ];
+      // Map step_action → action so the MCP arg shape (which uses step_action
+      // to avoid clashing with the existing action discriminator) lines up with
+      // the backend's TestCaseStepRequest.action / .expectedResult / .actualResult.
+      const stepBody = (extra) => {
+        const body = pick(args, STEP_FIELDS);
+        if (extra && extra.includeAction && args.step_action !== undefined) {
+          body.action = args.step_action;
+        }
+        return body;
+      };
       switch (args.action) {
         case "create": {
           reqArg(args, "uid", "create");
@@ -1534,6 +1565,37 @@ server.tool(
             null,
             2,
           ));
+        }
+        case "step-create": {
+          reqArg(args, "test_case_id", "step-create");
+          reqArg(args, "step_number", "step-create");
+          reqArg(args, "step_action", "step-create");
+          reqArg(args, "expected_result", "step-create");
+          return ok(JSON.stringify(
+            await createTestCaseStep(args.test_case_id, stepBody({ includeAction: true }), args.project),
+            null,
+            2,
+          ));
+        }
+        case "step-update": {
+          reqArg(args, "test_case_id", "step-update");
+          reqArg(args, "step_id", "step-update");
+          return ok(JSON.stringify(
+            await updateTestCaseStep(
+              args.test_case_id,
+              args.step_id,
+              stepBody({ includeAction: true }),
+              args.project,
+            ),
+            null,
+            2,
+          ));
+        }
+        case "step-delete": {
+          reqArg(args, "test_case_id", "step-delete");
+          reqArg(args, "step_id", "step-delete");
+          await deleteTestCaseStep(args.test_case_id, args.step_id, args.project);
+          return ok("Deleted");
         }
         default: return err(new Error(`Unknown action: ${args.action}`));
       }

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -524,6 +524,13 @@ const TO_CAMEL = {
   clear_preconditions: "clearPreconditions",
   clear_postconditions: "clearPostconditions",
   clear_estimated_duration: "clearEstimatedDuration",
+  // TC-002 / ADR-041 — TestCaseStepRequest / UpdateTestCaseStepRequest fields.
+  // Same rationale as the TC-001 entries above: omitting these would let
+  // `gc_test_case` step actions forward snake-case names that Jackson drops.
+  step_number: "stepNumber",
+  expected_result: "expectedResult",
+  actual_result: "actualResult",
+  clear_actual_result: "clearActualResult",
   // GC-V001 finding adapter — backend FindingRequest / UpdateFindingRequest
   // use these camelCase field names. Mapping is needed so `gc_finding` reaches
   // backend Bean Validation with the right field names (issue #279).
@@ -7510,6 +7517,32 @@ export async function transitionTestCaseStatus(id, status, project) {
     body: { status },
     params: { project },
   });
+}
+
+// TC-002 / ADR-041 — step-based test case format. Reads (list, get) route
+// through gc_query against the TestCaseStep entity.
+
+export async function createTestCaseStep(testCaseId, data, project) {
+  return request("POST", `/api/v1/test-cases/${encodeURIComponent(testCaseId)}/steps`, {
+    body: data,
+    params: { project },
+  });
+}
+
+export async function updateTestCaseStep(testCaseId, stepId, data, project) {
+  return request(
+    "PUT",
+    `/api/v1/test-cases/${encodeURIComponent(testCaseId)}/steps/${encodeURIComponent(stepId)}`,
+    { body: data, params: { project } },
+  );
+}
+
+export async function deleteTestCaseStep(testCaseId, stepId, project) {
+  await request(
+    "DELETE",
+    `/api/v1/test-cases/${encodeURIComponent(testCaseId)}/steps/${encodeURIComponent(stepId)}`,
+    { params: { project } },
+  );
 }
 
 export async function createControl(data, project) {

--- a/mcp/ground-control/test-case-tools.test.js
+++ b/mcp/ground-control/test-case-tools.test.js
@@ -18,16 +18,20 @@ import {
   TEST_CASE_STATUSES,
   TEST_CASE_TYPES,
   createTestCase,
+  createTestCaseStep,
   deleteTestCase,
+  deleteTestCaseStep,
   getTestCase,
   getTestCaseByUid,
   listTestCases,
   transitionTestCaseStatus,
   updateTestCase,
+  updateTestCaseStep,
 } from "./lib.js";
 
 const BASE_URL = "http://gc-test:8000";
 const TEST_CASE_ID = "11111111-1111-1111-1111-111111111111";
+const STEP_ID = "22222222-2222-2222-2222-222222222222";
 
 let fetchCalls;
 let originalFetch;
@@ -197,6 +201,97 @@ describe("transitionTestCaseStatus (gc_test_case action=transition)", () => {
   });
 });
 
+describe("createTestCaseStep (gc_test_case action=step-create)", () => {
+  it("POSTs /api/v1/test-cases/{tc}/steps with camelCase body (TC-002)", async () => {
+    setNextResponse({
+      body: {
+        id: STEP_ID,
+        testCaseId: TEST_CASE_ID,
+        stepNumber: 1,
+        action: "Open login page",
+        expectedResult: "Page renders",
+      },
+    });
+
+    const result = await createTestCaseStep(
+      TEST_CASE_ID,
+      {
+        step_number: 1,
+        action: "Open login page",
+        expected_result: "Page renders",
+        actual_result: null,
+      },
+      "ground-control",
+    );
+
+    assert.equal(fetchCalls.length, 1);
+    const { url, opts } = fetchCalls[0];
+    const parsed = new URL(url);
+    assert.equal(opts.method, "POST");
+    assert.equal(parsed.pathname, `/api/v1/test-cases/${TEST_CASE_ID}/steps`);
+    assert.equal(parsed.searchParams.get("project"), "ground-control");
+    // Critical: snake → camel mapping must reach Spring's TestCaseStepRequest.
+    // A missing TO_CAMEL entry would have Jackson silently drop the field —
+    // same failure mode as TC-001 codex cycle 1.
+    assert.deepEqual(JSON.parse(opts.body), {
+      stepNumber: 1,
+      action: "Open login page",
+      expectedResult: "Page renders",
+      actualResult: null,
+    });
+    assert.equal(result.id, STEP_ID);
+  });
+});
+
+describe("updateTestCaseStep (gc_test_case action=step-update)", () => {
+  it("PUTs /api/v1/test-cases/{tc}/steps/{s} with clear_actual_result mapped to camelCase", async () => {
+    setNextResponse({ body: { id: STEP_ID, stepNumber: 1, actualResult: null } });
+
+    const result = await updateTestCaseStep(
+      TEST_CASE_ID,
+      STEP_ID,
+      {
+        step_number: 2,
+        action: "## Updated\n![img](https://example.com/x.png)",
+        expected_result: "Updated result",
+        clear_actual_result: true,
+      },
+      "ground-control",
+    );
+
+    const { url, opts } = fetchCalls[0];
+    const parsed = new URL(url);
+    assert.equal(opts.method, "PUT");
+    assert.equal(parsed.pathname, `/api/v1/test-cases/${TEST_CASE_ID}/steps/${STEP_ID}`);
+    // Match every other write-test in this file: assert the `project` query
+    // param is forwarded. A regression that dropped `params: { project }` from
+    // updateTestCaseStep's request() call would route the update to whichever
+    // project the server defaults to instead of the caller's intended one.
+    assert.equal(parsed.searchParams.get("project"), "ground-control");
+    assert.deepEqual(JSON.parse(opts.body), {
+      stepNumber: 2,
+      action: "## Updated\n![img](https://example.com/x.png)",
+      expectedResult: "Updated result",
+      clearActualResult: true,
+    });
+    assert.equal(result.id, STEP_ID);
+  });
+});
+
+describe("deleteTestCaseStep (gc_test_case action=step-delete)", () => {
+  it("DELETEs /api/v1/test-cases/{tc}/steps/{s}", async () => {
+    setNextResponse({ ok: true, status: 204, body: null });
+
+    await deleteTestCaseStep(TEST_CASE_ID, STEP_ID, "ground-control");
+
+    const { url, opts } = fetchCalls[0];
+    const parsed = new URL(url);
+    assert.equal(opts.method, "DELETE");
+    assert.equal(parsed.pathname, `/api/v1/test-cases/${TEST_CASE_ID}/steps/${STEP_ID}`);
+    assert.equal(parsed.searchParams.get("project"), "ground-control");
+  });
+});
+
 describe("Read paths (gc_query routing)", () => {
   it("listTestCases GETs /api/v1/test-cases with project param and returns the array", async () => {
     setNextResponse({ body: [{ id: TEST_CASE_ID, uid: "TC-001" }] });
@@ -256,6 +351,29 @@ describe("Error envelope propagation", () => {
         && e.status === 422
         && e.code === "validation_failed"
         && e.detail?.field === "estimatedDurationSeconds",
+    );
+  });
+
+  it("createTestCaseStep surfaces a 409 duplicate_step_number envelope", async () => {
+    setNextResponse({
+      ok: false,
+      status: 409,
+      body: {
+        error: {
+          code: "conflict",
+          message: "Step number 1 already exists in test case TC-001",
+        },
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        createTestCaseStep(
+          TEST_CASE_ID,
+          { step_number: 1, action: "act", expected_result: "exp" },
+          "ground-control",
+        ),
+      (e) => e instanceof RequestError && e.status === 409,
     );
   });
 


### PR DESCRIPTION
## Summary

Introduces TC-002 — the step-based test case format. A new `TestCaseStep` aggregate hangs ordered, project-scoped steps off the TC-001 `TestCase`: positive `stepNumber` (unique per test case), `action` / `expectedResult` rich-text fields (required) plus an optional `actualResult`, each bounded to 10,000 chars and stored as CommonMark Markdown by convention. Inline images are carried verbatim as Markdown `![alt](url)` references; the backend does no image hosting, fetching, sanitisation, or processing — image binary storage is out of scope for TC-002 (see ADR-041 §Non-goals; a future asset-hosting requirement covers it). Parent-deletion cascades through the service layer so Envers records each step's DELETE revision (DB-level CASCADE was rejected because it would silently bypass audit). The PR also forward-fixes a TC-001 schema gap: V072's `test_case_audit` table was missing the inherited `created_at` / `updated_at` columns that Envers writes for every revision; new V075 adds them, and MigrationSmokeTest probes both audit tables for both columns.

## Requirement UIDs

- `TC-002`

## Related Issues

Closes #670

## ADR Impact

- ADR-041

## Changes

- New `TestCaseStep` entity / repository / service in the `testcases` domain package, with `@Audited` Envers tracking and a service-level `deleteAllByTestCase` cascade path
- New `/api/v1/test-cases/{testCaseId}/steps` REST surface (POST / GET / GET-by-id / PUT / DELETE) project-scoped through `ProjectService.resolveProjectId`, DTO-bounded rich-text fields at 10k chars, with a `clearActualResult` partial-update flag mirroring the TC-001 convention
- Flyway pair V073 (`test_case_step`) + V074 (`test_case_step_audit`) — main table has `(test_case_id, step_number)` unique constraint and `step_number > 0` check; audit table includes the BaseEntity timestamp columns Envers writes
- Forward migration V075 to add the missing `created_at` / `updated_at` columns on TC-001's `test_case_audit`; MigrationSmokeTest probes both audit tables for both columns
- `TestCaseService.delete()` now cascades through `TestCaseStepService.deleteAllByTestCase(...)` before deleting the parent, preserving per-step Envers audit revisions; behaviour pinned by an in-order Mockito assertion AND a committed-transaction integration test that asserts the actual DEL revtype on both step and parent
- `AuditRetentionJob.AUDIT_TABLES` extended with `test_case_step_audit`
- MCP `gc_test_case` tool extended with `step-create | step-update | step-delete` actions (reads via `gc_query`); snake/camel mappings for `step_number`, `expected_result`, `actual_result`, `clear_actual_result`, plus a `step_action`/`action` discriminator-rename so the MCP arg shape doesn't collide with the existing action enum
- `docs/API.md` section for the step endpoints; ADR-041 documents the boundary, rich-text + image strategy, cascade rationale, and explicit non-goals; `frontend/src/types/api.ts` ships the response/request type mirrors
- Test coverage: TestCaseStepTest (entity), TestCaseStepServiceTest (service unit, Mockito), TestCaseStepControllerTest (@WebMvcTest with ArgumentCaptors on rich-text + clearActualResult command assembly), TestCaseStepControllerIntegrationTest (HTTP roundtrip + cross-test-case access rejection), TestCaseStepServiceIntegrationTest (committed transactions + Envers ADD/DEL revtype assertions), MCP test-case-tools.test.js extensions
- **Migration reminder:** update version lists in `MigrationSmokeTest.java` and `RequirementsE2EIntegrationTest.java` (per `.gc/plan-rules.md`).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Both pre-push review cycles (architecture review + test-quality review) ran clean after fix-in-turn; decision records posted on issue #670. Full `make check` (gradle check + spotless + spotbugs + checkstyle + jacoco + ArchUnit) plus the targeted integration tests for the new endpoints all pass locally.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: TC-002 ← backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/model/TestCaseStep.java, TC-002 ← backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseStepController.java, TC-002 ← backend/src/main/resources/db/migration/V073__create_test_case_step.sql, TC-002 ← architecture/adrs/041-test-case-step-format.md
- TESTS: TC-002 ← backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseStepTest.java, TC-002 ← backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseStepServiceTest.java, TC-002 ← backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseStepControllerTest.java, TC-002 ← backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseStepControllerIntegrationTest.java, TC-002 ← backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseStepServiceIntegrationTest.java

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/670.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed