### PR TITLE
docs: harden conversation surface against external interaction

### DIFF
--- a/architecture/adrs/053-conversation-surface-hardening.md
+++ b/architecture/adrs/053-conversation-surface-hardening.md
@@ -1,0 +1,39 @@
+# ADR-036: Conversation Surface Hardening
+
+## Status
+
+accepted
+
+## Date
+
+2026-05-17
+
+## Context
+
+The repository's issue, pull-request, and discussion surfaces accept
+unstructured text from arbitrary authors. That text is consumed both by
+human maintainers and by agent-assisted workflows that read historical
+threads as context when responding to current tasks. Unrestricted
+authorship on these surfaces is a path for external input to influence
+those downstream consumers.
+
+The non-functional security requirement is that input on these surfaces
+originates only from vetted authors. The mechanism, scope, and lifetime
+of that restriction are operational concerns and are deliberately not
+recorded in this ADR or in the tracking issue.
+
+## Decision
+
+Issue, pull-request, and discussion authorship on this repository is
+restricted to vetted authors. Past content authored outside the vetted
+set is reviewed and curated where appropriate.
+
+## Consequences
+
+- External authors cannot open or comment on issues, pull requests, or
+  discussions on this repository without prior vetting.
+- Maintainers and approved contributors are unaffected.
+- Existing historical content is preserved except where curation
+  required its removal.
+- Operational details of the mechanism live outside the repository and
+  are not subject to ADR change-control.


### PR DESCRIPTION
## Summary

Adds ADR-053 documenting the policy that the repository's issue, pull-request, and discussion surfaces accept input only from vetted authors. Mechanism, scope, and lifetime are operational details outside ADR change-control and are deliberately not recorded here. SEC-001 (`Vetted-Author-Only Conversation Surface`) is the corresponding requirement.

## Requirement UIDs

- `SEC-001`

## Related Issues

Closes #915

## ADR Impact

- ADR-053 (added)

## Changes

- New ADR: `architecture/adrs/053-conversation-surface-hardening.md`. Renumbered from the originally-drafted ADR-036 to resolve a number collision with `036-per-step-routing-tool-surfaces-telemetry.md` that landed on `dev` after this branch was cut.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SEC-001 ← architecture/adrs/053-conversation-surface-hardening.md
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed