### PR TITLE
fix(assets): clear 47 SonarCloud findings on GC-M011 work

### DIFF
--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/model/OperationalAsset.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/model/OperationalAsset.java
@@ -66,14 +66,19 @@ public class OperationalAsset extends BaseEntity {
     @Column(name = "scope_designation", length = 20)
     private AssetScope scopeDesignation;
 
-    // GC-M011: narrower classification under AssetType. Free-form,
-    // project-defined; a registered AssetSubtypeSchema may formalize the
-    // (project, assetType, subtype) contract.
+    /**
+     * GC-M011 narrower classification under {@link AssetType}. Free-form,
+     * project-defined; a registered {@code AssetSubtypeSchema} may formalize
+     * the {@code (project, assetType, subtype)} contract.
+     */
     @Column(length = 100)
     private String subtype;
 
-    // GC-M011: subtype-specific metadata bag. Bounded by AssetSubtypeValidator;
-    // schema-validated when a matching ACTIVE AssetSubtypeSchema exists.
+    /**
+     * GC-M011 subtype-specific metadata bag. Bounded by
+     * {@code AssetSubtypeValidator}; schema-validated when a matching ACTIVE
+     * {@code AssetSubtypeSchema} exists.
+     */
     @Convert(converter = JacksonTextCollectionConverters.StringObjectMapConverter.class)
     @Column(columnDefinition = "TEXT")
     private Map<String, Object> metadata;

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/repository/OperationalAssetRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/repository/OperationalAssetRepository.java
@@ -39,6 +39,7 @@ public interface OperationalAssetRepository extends JpaRepository<OperationalAss
      * match the free-form string shape; subtype is case-sensitive because the
      * subtype catalog (AssetSubtypeSchema) keys off the exact string.
      */
+    @SuppressWarnings("java:S107") // JPA @Query requires each filter as an explicit @Param binding.
     @Query(
             """
             SELECT a FROM OperationalAsset a

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java
@@ -36,6 +36,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AssetService {
 
+    // Constants for repeated detail-map / field-name literals (Sonar S1192).
+    private static final String FIELD_SUBTYPE = "subtype";
+    private static final String DETAIL_REASON = "reason";
+    private static final String DETAIL_FIELD = "field";
+    private static final String DETAIL_LIMIT = "limit";
+
     private final OperationalAssetRepository assetRepository;
     private final AssetRelationRepository relationRepository;
     private final AssetLinkRepository linkRepository;
@@ -77,7 +83,7 @@ public class AssetService {
         bounded("name", command.name(), OperationalAssetBounds.NAME);
         bounded("owner", command.owner(), OperationalAssetBounds.OWNER);
         bounded("steward", command.steward(), OperationalAssetBounds.STEWARD);
-        bounded("subtype", command.subtype(), OperationalAssetBounds.SUBTYPE);
+        bounded(FIELD_SUBTYPE, command.subtype(), OperationalAssetBounds.SUBTYPE);
 
         var project = projectRepository
                 .findById(command.projectId())
@@ -143,7 +149,7 @@ public class AssetService {
             throw new DomainValidationException(
                     "Asset " + field + " exceeds maximum length of " + max + " characters",
                     "asset_field_invalid",
-                    Map.of("reason", "field_too_long", "field", field, "limit", max));
+                    Map.of(DETAIL_REASON, "field_too_long", DETAIL_FIELD, field, DETAIL_LIMIT, max));
         }
     }
 
@@ -185,6 +191,7 @@ public class AssetService {
         return assetRepository.findByProjectIdAndArchivedAtIsNull(projectId);
     }
 
+    @SuppressWarnings("java:S107") // JPA @Query needs each @Param explicit; reflected on the public method
     @Transactional(readOnly = true)
     public List<OperationalAsset> listByProjectAndFilters(
             UUID projectId,
@@ -199,6 +206,11 @@ public class AssetService {
                 projectId, assetType, owner, steward, environment, criticality, scopeDesignation, subtype);
     }
 
+    /**
+     * @deprecated GC-M011 added the {@code subtype} filter facet. Callers
+     *     should adopt the 8-arg overload so the subtype query parameter is
+     *     honored. Retained for source compatibility with pre-GC-M011 callers.
+     */
     @Deprecated(forRemoval = false)
     @Transactional(readOnly = true)
     public List<OperationalAsset> listByProjectAndFilters(
@@ -209,7 +221,11 @@ public class AssetService {
             com.keplerops.groundcontrol.domain.assets.state.AssetEnvironment environment,
             com.keplerops.groundcontrol.domain.assets.state.AssetCriticality criticality,
             com.keplerops.groundcontrol.domain.assets.state.AssetScope scopeDesignation) {
-        return listByProjectAndFilters(
+        // Call the repository directly rather than self-invoking the new
+        // overload via `this.` — the @Transactional proxy would be bypassed
+        // and Sonar S6809 flags the pattern. The repository call is itself
+        // already covered by the class-level @Transactional.
+        return assetRepository.findByProjectIdAndArchivedAtIsNullAndFilters(
                 projectId, assetType, owner, steward, environment, criticality, scopeDesignation, null);
     }
 
@@ -768,7 +784,7 @@ public class AssetService {
     }
 
     public AssetSubtypeSchema updateSubtypeSchema(UUID projectId, UUID id, UpdateAssetSubtypeSchemaCommand command) {
-        var schema = getSubtypeSchema(projectId, id);
+        var schema = loadSubtypeSchema(projectId, id);
         boolean active = schema.getStatus() == AssetSubtypeSchemaStatus.ACTIVE;
         // ACTIVE rows MUST keep an enforceable schema body. Reject
         // clearSchemaBody on ACTIVE rows so callers cannot null out the
@@ -788,7 +804,7 @@ public class AssetService {
     }
 
     public AssetSubtypeSchema deprecateSubtypeSchema(UUID projectId, UUID id) {
-        var schema = getSubtypeSchema(projectId, id);
+        var schema = loadSubtypeSchema(projectId, id);
         if (schema.getStatus() != AssetSubtypeSchemaStatus.DEPRECATED) {
             schema.deprecate();
             subtypeSchemaRepository.save(schema);
@@ -798,6 +814,16 @@ public class AssetService {
 
     @Transactional(readOnly = true)
     public AssetSubtypeSchema getSubtypeSchema(UUID projectId, UUID id) {
+        return loadSubtypeSchema(projectId, id);
+    }
+
+    /**
+     * Internal lookup shared with the {@code update*} / {@code deprecate*}
+     * paths. Bypassing the {@code public getSubtypeSchema} method avoids the
+     * Sonar S6809 self-invocation pattern (calling a {@code @Transactional}
+     * method via {@code this} skips the proxy).
+     */
+    private AssetSubtypeSchema loadSubtypeSchema(UUID projectId, UUID id) {
         return subtypeSchemaRepository
                 .findByIdAndProjectId(id, projectId)
                 .orElseThrow(() -> new NotFoundException("Asset subtype schema not found: " + id));

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/validation/AssetSubtypeValidator.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/validation/AssetSubtypeValidator.java
@@ -4,9 +4,11 @@ import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -27,6 +29,47 @@ public class AssetSubtypeValidator {
 
     private static final String ERROR_CODE = "asset_metadata_invalid";
 
+    // Detail-map keys (Sonar S1192).
+    private static final String K_REASON = "reason";
+    private static final String K_LIMIT = "limit";
+    private static final String K_ACTUAL = "actual";
+    private static final String K_FIELD = "field";
+    private static final String K_KEYWORD = "keyword";
+    private static final String K_ACTUAL_TYPE = "actualType";
+    private static final String K_EXPECTED_TYPE = "expectedType";
+    private static final String K_MINIMUM = "minimum";
+    private static final String K_MAXIMUM = "maximum";
+
+    // Detail-map reason values (Sonar S1192).
+    private static final String R_INVALID_SCHEMA_SHAPE = "invalid_schema_shape";
+    private static final String R_SCHEMA_BODY_REQUIRED = "schema_body_required";
+
+    // Schema-language keywords.
+    private static final String KW_FIELDS = "fields";
+    private static final String KW_ALLOW_ADDITIONAL = "allowAdditional";
+    private static final String KW_REQUIRED = "required";
+    private static final String KW_MAX_LENGTH = "maxLength";
+    private static final String KW_MINIMUM = "minimum";
+    private static final String KW_MAXIMUM = "maximum";
+    private static final String KW_VALUES = "values";
+    private static final String KW_TYPE = "type";
+
+    // Message-construction fragments.
+    private static final String SCHEMA_FIELD_PREFIX = "Subtype schema field '";
+    private static final String ASSET_FIELD_PREFIX = "Asset metadata field '";
+    private static final String EXCEEDS = "' exceeds ";
+    private static final String CHARACTERS = " characters";
+    private static final String ROOT_PATH = "<root>";
+
+    private static final Set<String> ROOT_KEYWORDS = Set.of(KW_FIELDS, KW_ALLOW_ADDITIONAL);
+
+    private static final Map<FieldType, Set<String>> FIELD_KEYWORDS_BY_TYPE = Map.of(
+            FieldType.STRING, Set.of(KW_TYPE, KW_REQUIRED, KW_MAX_LENGTH),
+            FieldType.INTEGER, Set.of(KW_TYPE, KW_REQUIRED, KW_MINIMUM, KW_MAXIMUM),
+            FieldType.NUMBER, Set.of(KW_TYPE, KW_REQUIRED, KW_MINIMUM, KW_MAXIMUM),
+            FieldType.BOOLEAN, Set.of(KW_TYPE, KW_REQUIRED),
+            FieldType.ENUM, Set.of(KW_TYPE, KW_REQUIRED, KW_VALUES));
+
     public void validateMetadataBounds(Map<String, Object> metadata) {
         if (metadata == null || metadata.isEmpty()) {
             return;
@@ -34,17 +77,17 @@ public class AssetSubtypeValidator {
         if (metadata.size() > MAX_METADATA_KEYS) {
             throw fail(
                     "Asset metadata exceeds maximum of " + MAX_METADATA_KEYS + " keys",
-                    detail("reason", "too_many_keys", "limit", MAX_METADATA_KEYS, "actual", metadata.size()));
+                    detail(K_REASON, "too_many_keys", K_LIMIT, MAX_METADATA_KEYS, K_ACTUAL, metadata.size()));
         }
         for (Map.Entry<String, Object> entry : metadata.entrySet()) {
             String key = entry.getKey();
             if (key == null || key.isBlank()) {
-                throw fail("Asset metadata key must not be blank", detail("reason", "blank_key"));
+                throw fail("Asset metadata key must not be blank", detail(K_REASON, "blank_key"));
             }
             if (key.length() > MAX_KEY_LENGTH) {
                 throw fail(
-                        "Asset metadata key '" + truncate(key) + "' exceeds " + MAX_KEY_LENGTH + " characters",
-                        detail("reason", "key_too_long", "field", truncate(key), "limit", MAX_KEY_LENGTH));
+                        "Asset metadata key '" + truncate(key) + EXCEEDS + MAX_KEY_LENGTH + CHARACTERS,
+                        detail(K_REASON, "key_too_long", K_FIELD, truncate(key), K_LIMIT, MAX_KEY_LENGTH));
             }
             validateScalarValue(key, entry.getValue());
         }
@@ -56,33 +99,44 @@ public class AssetSubtypeValidator {
             return;
         }
         Map<String, Object> fields = readFieldsMap(schemaBody);
-        boolean allowAdditional = readBooleanKeyword(schemaBody, "allowAdditional", "<root>", false);
+        boolean allowAdditional = readBooleanKeyword(schemaBody, KW_ALLOW_ADDITIONAL, ROOT_PATH, false);
 
         Map<String, Object> effective = metadata == null ? Map.of() : metadata;
-        for (Map.Entry<String, Object> e : effective.entrySet()) {
-            if (!fields.containsKey(e.getKey()) && !allowAdditional) {
-                throw fail(
-                        "Asset metadata key '" + e.getKey() + "' is not declared by the subtype schema",
-                        detail("reason", "unknown_field", "field", e.getKey()));
-            }
-        }
+        rejectUndeclaredMetadataKeys(effective, fields, allowAdditional);
         for (Map.Entry<String, Object> fieldEntry : fields.entrySet()) {
-            String name = fieldEntry.getKey();
-            Map<String, Object> def = castStringObjectMap("fields." + name, fieldEntry.getValue());
-            FieldType type = parseFieldType(name, def.get("type"));
-            boolean required = readBooleanKeyword(def, "required", name, false);
-            boolean present = effective.containsKey(name);
-            Object value = effective.get(name);
-            if (!present || value == null) {
-                if (required) {
-                    throw fail(
-                            "Required asset metadata field '" + name + "' is missing",
-                            detail("reason", "required_field_missing", "field", name, "expectedType", type.name()));
-                }
-                continue;
-            }
-            validateTyped(name, value, type, def);
+            validateMetadataAgainstField(fieldEntry, effective);
         }
+    }
+
+    private void rejectUndeclaredMetadataKeys(
+            Map<String, Object> metadata, Map<String, Object> fields, boolean allowAdditional) {
+        if (allowAdditional) {
+            return;
+        }
+        for (String key : metadata.keySet()) {
+            if (!fields.containsKey(key)) {
+                throw fail(
+                        "Asset metadata key '" + key + "' is not declared by the subtype schema",
+                        detail(K_REASON, "unknown_field", K_FIELD, key));
+            }
+        }
+    }
+
+    private void validateMetadataAgainstField(Map.Entry<String, Object> fieldEntry, Map<String, Object> metadata) {
+        String name = fieldEntry.getKey();
+        Map<String, Object> def = castStringObjectMap(KW_FIELDS + "." + name, fieldEntry.getValue());
+        FieldType type = parseFieldType(name, def.get(KW_TYPE));
+        boolean required = readBooleanKeyword(def, KW_REQUIRED, name, false);
+        Object value = metadata.get(name);
+        if (!metadata.containsKey(name) || value == null) {
+            if (required) {
+                throw fail(
+                        "Required asset metadata field '" + name + "' is missing",
+                        detail(K_REASON, "required_field_missing", K_FIELD, name, K_EXPECTED_TYPE, type.name()));
+            }
+            return;
+        }
+        validateTyped(name, value, type, def);
     }
 
     /**
@@ -98,194 +152,197 @@ public class AssetSubtypeValidator {
         if (schemaBody == null) {
             if (requireFields) {
                 throw fail(
-                        "Subtype schema body is required", detail("reason", "schema_body_required", "field", "<root>"));
+                        "Subtype schema body is required",
+                        detail(K_REASON, R_SCHEMA_BODY_REQUIRED, K_FIELD, ROOT_PATH));
             }
             return;
         }
-        rejectUnknownKeywords("<root>", schemaBody, ROOT_KEYWORDS);
-        Object rawFields = schemaBody.get("fields");
+        rejectUnknownKeywords(ROOT_PATH, schemaBody, ROOT_KEYWORDS);
+        Map<String, Object> fields = readRequiredFields(schemaBody, requireFields);
+        readBooleanKeyword(schemaBody, KW_ALLOW_ADDITIONAL, ROOT_PATH, false);
+        int requiredCount = walkAndValidateSchemaFields(fields);
+        rejectImpossibleRequiredCount(requiredCount);
+    }
+
+    private Map<String, Object> readRequiredFields(Map<String, Object> schemaBody, boolean requireFields) {
+        Object rawFields = schemaBody.get(KW_FIELDS);
         if (requireFields && rawFields == null) {
             throw fail(
                     "Subtype schema body must declare a 'fields' object",
-                    detail("reason", "schema_body_required", "field", "fields"));
+                    detail(K_REASON, R_SCHEMA_BODY_REQUIRED, K_FIELD, KW_FIELDS));
         }
         Map<String, Object> fields = readFieldsMap(schemaBody);
         if (requireFields && fields.isEmpty()) {
             throw fail(
                     "Subtype schema 'fields' object must declare at least one field",
-                    detail("reason", "schema_body_required", "field", "fields"));
+                    detail(K_REASON, R_SCHEMA_BODY_REQUIRED, K_FIELD, KW_FIELDS));
         }
-        readBooleanKeyword(schemaBody, "allowAdditional", "<root>", false);
-        // Cap required-field count at the universal metadata-key limit; a
-        // schema that demands more required fields than any payload can
-        // legally carry is unsatisfiable by construction.
+        return fields;
+    }
+
+    private int walkAndValidateSchemaFields(Map<String, Object> fields) {
         int requiredCount = 0;
         for (Map.Entry<String, Object> fieldEntry : fields.entrySet()) {
-            String name = fieldEntry.getKey();
-            // Field names are persisted as metadata keys; enforce the same
-            // bounds the metadata validator applies so a schema cannot
-            // declare a field that no metadata payload could legally carry.
-            if (name == null || name.isBlank()) {
-                throw fail(
-                        "Subtype schema field name must not be blank",
-                        detail("reason", "invalid_schema_shape", "field", "fields"));
-            }
-            if (name.length() > MAX_KEY_LENGTH) {
-                throw fail(
-                        "Subtype schema field name '" + name + "' exceeds " + MAX_KEY_LENGTH + " characters",
-                        detail("reason", "invalid_schema_shape", "field", name, "limit", MAX_KEY_LENGTH));
-            }
-            Map<String, Object> def = castStringObjectMap("fields." + name, fieldEntry.getValue());
-            FieldType type = parseFieldType(name, def.get("type"));
-            rejectUnknownKeywords(name, def, FIELD_KEYWORDS_BY_TYPE.get(type));
-            boolean required = readBooleanKeyword(def, "required", name, false);
-            if (required) {
+            if (validateSchemaField(fieldEntry)) {
                 requiredCount++;
             }
-            switch (type) {
-                case STRING -> {
-                    Integer maxLength = readIntBound(def, "maxLength", name);
-                    // STRING values are also bounded by the universal
-                    // MAX_STRING_VALUE_LENGTH; a maxLength larger than that
-                    // can never reject a real overrun before bounds do, so
-                    // it is functionally dead but allowed.
-                    if (maxLength != null && maxLength > MAX_STRING_VALUE_LENGTH) {
-                        throw fail(
-                                "Subtype schema field '" + name + "' has maxLength " + maxLength
-                                        + " exceeding universal limit " + MAX_STRING_VALUE_LENGTH,
-                                detail(
-                                        "reason",
-                                        "invalid_schema_shape",
-                                        "field",
-                                        name,
-                                        "keyword",
-                                        "maxLength",
-                                        "limit",
-                                        MAX_STRING_VALUE_LENGTH));
-                    }
-                }
-                case INTEGER -> validateIntegerBounds(name, def);
-                case NUMBER -> {
-                    java.math.BigDecimal min = readNumberKeyword(def, "minimum", name);
-                    java.math.BigDecimal max = readNumberKeyword(def, "maximum", name);
-                    if (min != null && max != null && min.compareTo(max) > 0) {
-                        throw unsatisfiableRange(name, min, max);
-                    }
-                }
-                case ENUM -> {
-                    List<String> values = readEnumValues(def, name);
-                    for (String v : values) {
-                        if (v.length() > MAX_STRING_VALUE_LENGTH) {
-                            throw fail(
-                                    "Subtype schema field '" + name + "' ENUM value exceeds universal limit "
-                                            + MAX_STRING_VALUE_LENGTH,
-                                    detail(
-                                            "reason",
-                                            "invalid_schema_shape",
-                                            "field",
-                                            name,
-                                            "keyword",
-                                            "values",
-                                            "limit",
-                                            MAX_STRING_VALUE_LENGTH));
-                        }
-                    }
-                }
-                case BOOLEAN -> {
-                    /* no bounds */
-                }
-                default -> throw new IllegalStateException("Unhandled field type: " + type);
+        }
+        return requiredCount;
+    }
+
+    /** Returns true if the field is required, so the caller can tally. */
+    private boolean validateSchemaField(Map.Entry<String, Object> fieldEntry) {
+        String name = fieldEntry.getKey();
+        validateSchemaFieldName(name);
+        Map<String, Object> def = castStringObjectMap(KW_FIELDS + "." + name, fieldEntry.getValue());
+        FieldType type = parseFieldType(name, def.get(KW_TYPE));
+        rejectUnknownKeywords(name, def, FIELD_KEYWORDS_BY_TYPE.get(type));
+        boolean required = readBooleanKeyword(def, KW_REQUIRED, name, false);
+        validateFieldTypeBounds(name, def, type);
+        return required;
+    }
+
+    private void validateSchemaFieldName(String name) {
+        if (name == null || name.isBlank()) {
+            throw fail(
+                    "Subtype schema field name must not be blank",
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, KW_FIELDS));
+        }
+        if (name.length() > MAX_KEY_LENGTH) {
+            throw fail(
+                    "Subtype schema field name '" + name + EXCEEDS + MAX_KEY_LENGTH + CHARACTERS,
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, name, K_LIMIT, MAX_KEY_LENGTH));
+        }
+    }
+
+    private void validateFieldTypeBounds(String name, Map<String, Object> def, FieldType type) {
+        switch (type) {
+            case STRING -> validateStringFieldBounds(name, def);
+            case INTEGER -> validateIntegerBounds(name, def);
+            case NUMBER -> validateNumericRange(name, def);
+            case ENUM -> validateEnumBounds(name, def);
+            case BOOLEAN -> {
+                // No bounds for BOOLEAN.
+            }
+            default -> throw new IllegalStateException("Unhandled field type: " + type);
+        }
+    }
+
+    private void validateStringFieldBounds(String name, Map<String, Object> def) {
+        Integer maxLength = readIntBound(def, KW_MAX_LENGTH, name);
+        // STRING values are also bounded by the universal MAX_STRING_VALUE_LENGTH;
+        // a maxLength larger than that can never reject a real overrun, so reject
+        // it as foot-gun-prone schema authoring.
+        if (maxLength != null && maxLength > MAX_STRING_VALUE_LENGTH) {
+            throw fail(
+                    SCHEMA_FIELD_PREFIX + name + "' has maxLength " + maxLength + " exceeding universal limit "
+                            + MAX_STRING_VALUE_LENGTH,
+                    detail(
+                            K_REASON, R_INVALID_SCHEMA_SHAPE,
+                            K_FIELD, name,
+                            K_KEYWORD, KW_MAX_LENGTH,
+                            K_LIMIT, MAX_STRING_VALUE_LENGTH));
+        }
+    }
+
+    private void validateNumericRange(String name, Map<String, Object> def) {
+        BigDecimal min = readNumberKeyword(def, KW_MINIMUM, name);
+        BigDecimal max = readNumberKeyword(def, KW_MAXIMUM, name);
+        if (min != null && max != null && min.compareTo(max) > 0) {
+            throw unsatisfiableRange(name, min, max);
+        }
+    }
+
+    private void validateEnumBounds(String name, Map<String, Object> def) {
+        for (String v : readEnumValues(def, name)) {
+            if (v.length() > MAX_STRING_VALUE_LENGTH) {
+                throw fail(
+                        SCHEMA_FIELD_PREFIX + name + "' ENUM value exceeds universal limit " + MAX_STRING_VALUE_LENGTH,
+                        detail(
+                                K_REASON, R_INVALID_SCHEMA_SHAPE,
+                                K_FIELD, name,
+                                K_KEYWORD, KW_VALUES,
+                                K_LIMIT, MAX_STRING_VALUE_LENGTH));
             }
         }
+    }
+
+    private void rejectImpossibleRequiredCount(int requiredCount) {
         if (requiredCount > MAX_METADATA_KEYS) {
             throw fail(
                     "Subtype schema declares " + requiredCount + " required fields, exceeding the universal "
                             + "metadata-key limit of " + MAX_METADATA_KEYS,
                     detail(
-                            "reason",
-                            "invalid_schema_shape",
-                            "field",
-                            "fields",
-                            "limit",
-                            MAX_METADATA_KEYS,
-                            "actual",
-                            requiredCount));
+                            K_REASON, R_INVALID_SCHEMA_SHAPE,
+                            K_FIELD, KW_FIELDS,
+                            K_LIMIT, MAX_METADATA_KEYS,
+                            K_ACTUAL, requiredCount));
         }
     }
 
     private void validateIntegerBounds(String name, Map<String, Object> def) {
-        java.math.BigDecimal min = readNumberKeyword(def, "minimum", name);
-        java.math.BigDecimal max = readNumberKeyword(def, "maximum", name);
-        // INTEGER min/max must themselves be whole numbers — fractional
-        // bounds are nonsensical for an integer field and a pair like
-        // (0.1, 0.2) is unsatisfiable while passing a naive min<=max check.
+        BigDecimal min = readNumberKeyword(def, KW_MINIMUM, name);
+        BigDecimal max = readNumberKeyword(def, KW_MAXIMUM, name);
+        // INTEGER min/max must themselves be whole numbers — fractional bounds
+        // are nonsensical for an integer field and a pair like (0.1, 0.2) is
+        // unsatisfiable while passing a naive min<=max check.
         if (min != null && hasFractionalPart(min)) {
             throw fail(
                     "Subtype schema INTEGER field '" + name + "' has fractional minimum",
-                    detail("reason", "invalid_schema_shape", "field", name, "keyword", "minimum"));
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, name, K_KEYWORD, KW_MINIMUM));
         }
         if (max != null && hasFractionalPart(max)) {
             throw fail(
                     "Subtype schema INTEGER field '" + name + "' has fractional maximum",
-                    detail("reason", "invalid_schema_shape", "field", name, "keyword", "maximum"));
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, name, K_KEYWORD, KW_MAXIMUM));
         }
         if (min != null && max != null && min.compareTo(max) > 0) {
             throw unsatisfiableRange(name, min, max);
         }
     }
 
-    private DomainValidationException unsatisfiableRange(
-            String name, java.math.BigDecimal min, java.math.BigDecimal max) {
+    private DomainValidationException unsatisfiableRange(String name, BigDecimal min, BigDecimal max) {
         return fail(
-                "Subtype schema field '" + name + "' has minimum > maximum (unsatisfiable)",
+                SCHEMA_FIELD_PREFIX + name + "' has minimum > maximum (unsatisfiable)",
                 detail(
-                        "reason",
-                        "invalid_schema_shape",
-                        "field",
+                        K_REASON,
+                        R_INVALID_SCHEMA_SHAPE,
+                        K_FIELD,
                         name,
-                        "minimum",
+                        K_MINIMUM,
                         min.toPlainString(),
-                        "maximum",
+                        K_MAXIMUM,
                         max.toPlainString()));
     }
 
-    private static boolean hasFractionalPart(java.math.BigDecimal value) {
+    private static boolean hasFractionalPart(BigDecimal value) {
         return value.scale() > 0 && value.stripTrailingZeros().scale() > 0;
     }
 
-    private void rejectUnknownKeywords(String fieldName, Map<String, Object> map, java.util.Set<String> allowed) {
+    private void rejectUnknownKeywords(String fieldName, Map<String, Object> map, Set<String> allowed) {
         if (allowed == null) {
             return;
         }
         for (String key : map.keySet()) {
             if (!allowed.contains(key)) {
                 throw fail(
-                        "Subtype schema field '" + fieldName + "' has unsupported keyword '" + key + "'",
-                        detail("reason", "invalid_schema_shape", "field", fieldName, "keyword", key));
+                        SCHEMA_FIELD_PREFIX + fieldName + "' has unsupported keyword '" + key + "'",
+                        detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_KEYWORD, key));
             }
         }
     }
 
-    private static final java.util.Set<String> ROOT_KEYWORDS = java.util.Set.of("fields", "allowAdditional");
-
-    private static final Map<FieldType, java.util.Set<String>> FIELD_KEYWORDS_BY_TYPE = Map.of(
-            FieldType.STRING, java.util.Set.of("type", "required", "maxLength"),
-            FieldType.INTEGER, java.util.Set.of("type", "required", "minimum", "maximum"),
-            FieldType.NUMBER, java.util.Set.of("type", "required", "minimum", "maximum"),
-            FieldType.BOOLEAN, java.util.Set.of("type", "required"),
-            FieldType.ENUM, java.util.Set.of("type", "required", "values"));
-
     private Map<String, Object> readFieldsMap(Map<String, Object> schemaBody) {
-        Object rawFields = schemaBody.get("fields");
+        Object rawFields = schemaBody.get(KW_FIELDS);
         if (rawFields == null) {
             return Map.of();
         }
         if (!(rawFields instanceof Map<?, ?>)) {
             throw fail(
                     "Subtype schema 'fields' must be an object",
-                    detail("reason", "invalid_schema_shape", "field", "fields"));
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, KW_FIELDS));
         }
-        return castStringObjectMap("fields", rawFields);
+        return castStringObjectMap(KW_FIELDS, rawFields);
     }
 
     private void validateScalarValue(String key, Object value) {
@@ -295,8 +352,8 @@ public class AssetSubtypeValidator {
         if (value instanceof String s) {
             if (s.length() > MAX_STRING_VALUE_LENGTH) {
                 throw fail(
-                        "Asset metadata value for '" + key + "' exceeds " + MAX_STRING_VALUE_LENGTH + " characters",
-                        detail("reason", "string_value_too_long", "field", key, "limit", MAX_STRING_VALUE_LENGTH));
+                        "Asset metadata value for '" + key + EXCEEDS + MAX_STRING_VALUE_LENGTH + CHARACTERS,
+                        detail(K_REASON, "string_value_too_long", K_FIELD, key, K_LIMIT, MAX_STRING_VALUE_LENGTH));
             }
             return;
         }
@@ -306,11 +363,11 @@ public class AssetSubtypeValidator {
         throw fail(
                 "Asset metadata value for '" + key + "' must be a string, number, boolean, or null",
                 detail(
-                        "reason",
+                        K_REASON,
                         "unsupported_value_type",
-                        "field",
+                        K_FIELD,
                         key,
-                        "actualType",
+                        K_ACTUAL_TYPE,
                         value.getClass().getSimpleName()));
     }
 
@@ -329,11 +386,11 @@ public class AssetSubtypeValidator {
         if (!(value instanceof String s)) {
             throw typeMismatch(name, value, FieldType.STRING);
         }
-        Integer maxLength = readIntBound(def, "maxLength", name);
+        Integer maxLength = readIntBound(def, KW_MAX_LENGTH, name);
         if (maxLength != null && s.length() > maxLength) {
             throw fail(
-                    "Asset metadata field '" + name + "' exceeds maxLength " + maxLength,
-                    detail("reason", "string_too_long", "field", name, "limit", maxLength));
+                    ASSET_FIELD_PREFIX + name + "' exceeds maxLength " + maxLength,
+                    detail(K_REASON, "string_too_long", K_FIELD, name, K_LIMIT, maxLength));
         }
     }
 
@@ -344,44 +401,43 @@ public class AssetSubtypeValidator {
         Object raw = def.get(key);
         // Distinguish "key absent" (default) from "key present with null value"
         // (malformed — reject). Without this guard a schema with `required: null`
-        // or `allowAdditional: null` silently weakens its own contract
-        // (codex cycle-5 finding 1).
-        if (raw == null || !(raw instanceof Boolean b)) {
+        // or `allowAdditional: null` silently weakens its own contract.
+        if (!(raw instanceof Boolean b)) {
             throw fail(
-                    "Subtype schema field '" + fieldName + "' has non-boolean '" + key + "'",
-                    detail("reason", "invalid_schema_shape", "field", fieldName, "keyword", key));
+                    SCHEMA_FIELD_PREFIX + fieldName + "' has non-boolean '" + key + "'",
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_KEYWORD, key));
         }
         return b;
     }
 
-    private java.math.BigDecimal readNumberKeyword(Map<String, Object> def, String key, String fieldName) {
+    private BigDecimal readNumberKeyword(Map<String, Object> def, String key, String fieldName) {
         if (!def.containsKey(key)) {
             return null;
         }
         Object raw = def.get(key);
         // Boolean is not a subclass of Number — pattern check alone excludes it.
         // Present-null is rejected (see readBooleanKeyword rationale).
-        if (raw == null || !(raw instanceof Number n)) {
+        if (!(raw instanceof Number n)) {
             throw fail(
-                    "Subtype schema field '" + fieldName + "' has non-numeric '" + key + "'",
-                    detail("reason", "invalid_schema_shape", "field", fieldName, "keyword", key));
+                    SCHEMA_FIELD_PREFIX + fieldName + "' has non-numeric '" + key + "'",
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_KEYWORD, key));
         }
         return toBigDecimal(n);
     }
 
     private List<String> readEnumValues(Map<String, Object> def, String fieldName) {
-        Object raw = def.get("values");
+        Object raw = def.get(KW_VALUES);
         if (!(raw instanceof List<?> list) || list.isEmpty()) {
             throw fail(
                     "Subtype schema ENUM field '" + fieldName + "' must declare a non-empty 'values' array",
-                    detail("reason", "invalid_schema_shape", "field", fieldName, "keyword", "values"));
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_KEYWORD, KW_VALUES));
         }
-        List<String> out = new java.util.ArrayList<>();
+        List<String> out = new ArrayList<>();
         for (Object item : list) {
             if (!(item instanceof String s)) {
                 throw fail(
                         "Subtype schema ENUM field '" + fieldName + "' 'values' must be strings",
-                        detail("reason", "invalid_schema_shape", "field", fieldName, "keyword", "values"));
+                        detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_KEYWORD, KW_VALUES));
             }
             out.add(s);
         }
@@ -421,38 +477,38 @@ public class AssetSubtypeValidator {
         }
         if (!allowed.contains(s)) {
             throw fail(
-                    "Asset metadata field '" + name + "' must be one of the allowed enum values",
-                    detail("reason", "enum_value_not_allowed", "field", name, "actual", s));
+                    ASSET_FIELD_PREFIX + name + "' must be one of the allowed enum values",
+                    detail(K_REASON, "enum_value_not_allowed", K_FIELD, name, K_ACTUAL, s));
         }
     }
 
     private void checkRange(String name, BigDecimal value, Map<String, Object> def) {
-        BigDecimal min = readNumberKeyword(def, "minimum", name);
+        BigDecimal min = readNumberKeyword(def, KW_MINIMUM, name);
         if (min != null && value.compareTo(min) < 0) {
             throw fail(
-                    "Asset metadata field '" + name + "' is below minimum",
-                    detail("reason", "below_minimum", "field", name, "minimum", min.toPlainString()));
+                    ASSET_FIELD_PREFIX + name + "' is below minimum",
+                    detail(K_REASON, "below_minimum", K_FIELD, name, K_MINIMUM, min.toPlainString()));
         }
-        BigDecimal max = readNumberKeyword(def, "maximum", name);
+        BigDecimal max = readNumberKeyword(def, KW_MAXIMUM, name);
         if (max != null && value.compareTo(max) > 0) {
             throw fail(
-                    "Asset metadata field '" + name + "' is above maximum",
-                    detail("reason", "above_maximum", "field", name, "maximum", max.toPlainString()));
+                    ASSET_FIELD_PREFIX + name + "' is above maximum",
+                    detail(K_REASON, "above_maximum", K_FIELD, name, K_MAXIMUM, max.toPlainString()));
         }
     }
 
     private FieldType parseFieldType(String fieldName, Object raw) {
         if (!(raw instanceof String s)) {
             throw fail(
-                    "Subtype schema field '" + fieldName + "' must declare a string 'type'",
-                    detail("reason", "invalid_schema_shape", "field", fieldName));
+                    SCHEMA_FIELD_PREFIX + fieldName + "' must declare a string 'type'",
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName));
         }
         try {
             return FieldType.valueOf(s);
         } catch (IllegalArgumentException ex) {
             throw fail(
-                    "Subtype schema field '" + fieldName + "' has unsupported type '" + s + "'",
-                    detail("reason", "invalid_schema_shape", "field", fieldName, "actualType", s));
+                    SCHEMA_FIELD_PREFIX + fieldName + "' has unsupported type '" + s + "'",
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_ACTUAL_TYPE, s));
         }
     }
 
@@ -463,44 +519,51 @@ public class AssetSubtypeValidator {
         Object raw = def.get(key);
         // Boolean is not a subclass of Number — pattern check alone excludes it.
         // Present-null is rejected (see readBooleanKeyword rationale).
-        if (raw == null || !(raw instanceof Number n)) {
+        if (!(raw instanceof Number n)) {
             throw fail(
-                    "Subtype schema field '" + fieldName + "' has non-numeric '" + key + "'",
-                    detail("reason", "invalid_schema_shape", "field", fieldName, "keyword", key));
+                    SCHEMA_FIELD_PREFIX + fieldName + "' has non-numeric '" + key + "'",
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_KEYWORD, key));
         }
         BigDecimal value = toBigDecimal(n);
         if (value.scale() > 0 && value.stripTrailingZeros().scale() > 0) {
             throw fail(
-                    "Subtype schema field '" + fieldName + "' '" + key + "' must be an integer",
-                    detail("reason", "invalid_schema_shape", "field", fieldName, "keyword", key));
+                    SCHEMA_FIELD_PREFIX + fieldName + "' '" + key + "' must be an integer",
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_KEYWORD, key));
         }
         try {
             int as = value.intValueExact();
             if (as < 0) {
                 throw fail(
-                        "Subtype schema field '" + fieldName + "' '" + key + "' must be non-negative",
-                        detail("reason", "invalid_schema_shape", "field", fieldName, "keyword", key));
+                        SCHEMA_FIELD_PREFIX + fieldName + "' '" + key + "' must be non-negative",
+                        detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_KEYWORD, key));
             }
             return as;
         } catch (ArithmeticException ex) {
             throw fail(
-                    "Subtype schema field '" + fieldName + "' '" + key + "' is out of integer range",
-                    detail("reason", "invalid_schema_shape", "field", fieldName, "keyword", key));
+                    SCHEMA_FIELD_PREFIX + fieldName + "' '" + key + "' is out of integer range",
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, fieldName, K_KEYWORD, key));
         }
     }
 
     private DomainValidationException typeMismatch(String name, Object value, FieldType expected) {
         return fail(
-                "Asset metadata field '" + name + "' expected type " + expected,
+                ASSET_FIELD_PREFIX + name + "' expected type " + expected,
                 detail(
-                        "reason",
+                        K_REASON,
                         "type_mismatch",
-                        "field",
+                        K_FIELD,
                         name,
-                        "expectedType",
+                        K_EXPECTED_TYPE,
                         expected.name(),
-                        "actualType",
-                        value == null ? "null" : value.getClass().getSimpleName()));
+                        K_ACTUAL_TYPE,
+                        classNameOrNull(value)));
+    }
+
+    private static String classNameOrNull(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        return value.getClass().getSimpleName();
     }
 
     private DomainValidationException fail(String message, Map<String, Serializable> detail) {
@@ -528,7 +591,7 @@ public class AssetSubtypeValidator {
             throw new DomainValidationException(
                     "Subtype schema '" + path + "' must be an object",
                     ERROR_CODE,
-                    detail("reason", "invalid_schema_shape", "field", path));
+                    detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, path));
         }
         Map<String, Object> out = new LinkedHashMap<>();
         for (Map.Entry<?, ?> e : map.entrySet()) {
@@ -536,7 +599,7 @@ public class AssetSubtypeValidator {
                 throw new DomainValidationException(
                         "Subtype schema '" + path + "' keys must be strings",
                         ERROR_CODE,
-                        detail("reason", "invalid_schema_shape", "field", path));
+                        detail(K_REASON, R_INVALID_SCHEMA_SHAPE, K_FIELD, path));
             }
             out.put(key, e.getValue());
         }
@@ -547,10 +610,19 @@ public class AssetSubtypeValidator {
         Map<String, Serializable> out = new LinkedHashMap<>();
         for (int i = 0; i + 1 < pairs.length; i += 2) {
             String key = (String) pairs[i];
-            Object value = pairs[i + 1];
-            out.put(key, value instanceof Serializable s ? s : value == null ? null : value.toString());
+            out.put(key, asSerializable(pairs[i + 1]));
         }
         return out;
+    }
+
+    private static Serializable asSerializable(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Serializable s) {
+            return s;
+        }
+        return value.toString();
     }
 
     private static String truncate(String s) {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetGraphProjectionContributorTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetGraphProjectionContributorTest.java
@@ -17,6 +17,7 @@ import com.keplerops.groundcontrol.domain.assets.state.AssetLinkType;
 import com.keplerops.groundcontrol.domain.assets.state.AssetRelationType;
 import com.keplerops.groundcontrol.domain.assets.state.AssetType;
 import com.keplerops.groundcontrol.domain.assets.state.ObservationCategory;
+import com.keplerops.groundcontrol.domain.graph.model.GraphEdge;
 import com.keplerops.groundcontrol.domain.graph.model.GraphEntityType;
 import com.keplerops.groundcontrol.domain.graph.model.GraphIds;
 import com.keplerops.groundcontrol.domain.graph.service.AssetGraphProjectionContributor;
@@ -108,7 +109,7 @@ class AssetGraphProjectionContributorTest {
         assertThat(edges)
                 .filteredOn(edge -> edge.edgeType().equals("ASSOCIATED"))
                 .singleElement()
-                .extracting(edge -> edge.targetId())
+                .extracting(GraphEdge::targetId)
                 .isEqualTo(GraphIds.nodeId(GraphEntityType.RISK_SCENARIO, internalLink.getTargetEntityId()));
     }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetServiceTest.java
@@ -1990,8 +1990,9 @@ class AssetServiceTest {
                     .thenReturn(Optional.of(schema));
 
             var command = new UpdateAssetSubtypeSchemaCommand(null, null, false, /* clearSchemaBody */ true);
+            var schemaId = schema.getId();
 
-            assertThatThrownBy(() -> assetService.updateSubtypeSchema(projectId, schema.getId(), command))
+            assertThatThrownBy(() -> assetService.updateSubtypeSchema(projectId, schemaId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getErrorCode())
                     .isEqualTo("asset_subtype_schema_active_body_required");

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetSubtypeValidatorTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetSubtypeValidatorTest.java
@@ -175,18 +175,21 @@ class AssetSubtypeValidatorTest {
         void integerRangeEnforced() {
             Map<String, Object> fields = Map.of("count", Map.of("type", "INTEGER", "minimum", 0, "maximum", 10));
             Map<String, Object> schema = Map.of("fields", fields);
+            Map<String, Object> belowMin = Map.of("count", -1);
+            Map<String, Object> aboveMax = Map.of("count", 11);
+            Map<String, Object> within = Map.of("count", 5);
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("count", -1), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(belowMin, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("below_minimum");
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("count", 11), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(aboveMax, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("above_maximum");
 
-            assertThatCode(() -> validator.validateAgainstSchema(Map.of("count", 5), schema))
+            assertThatCode(() -> validator.validateAgainstSchema(within, schema))
                     .doesNotThrowAnyException();
         }
 
@@ -194,8 +197,9 @@ class AssetSubtypeValidatorTest {
         void integerRejectsFractionalValue() {
             Map<String, Object> fields = Map.of("count", Map.of("type", "INTEGER"));
             Map<String, Object> schema = Map.of("fields", fields);
+            Map<String, Object> metadata = Map.of("count", 3.14d);
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("count", 3.14d), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(metadata, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("type_mismatch");
@@ -217,11 +221,13 @@ class AssetSubtypeValidatorTest {
             Map<String, Object> fields =
                     Map.of("tier", Map.of("type", "ENUM", "values", List.of("BRONZE", "SILVER", "GOLD")));
             Map<String, Object> schema = Map.of("fields", fields);
+            Map<String, Object> allowed = Map.of("tier", "SILVER");
+            Map<String, Object> disallowed = Map.of("tier", "platinum");
 
-            assertThatCode(() -> validator.validateAgainstSchema(Map.of("tier", "SILVER"), schema))
+            assertThatCode(() -> validator.validateAgainstSchema(allowed, schema))
                     .doesNotThrowAnyException();
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("tier", "platinum"), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(disallowed, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("enum_value_not_allowed");
@@ -231,11 +237,12 @@ class AssetSubtypeValidatorTest {
         void booleanType() {
             Map<String, Object> fields = Map.of("encrypted", Map.of("type", "BOOLEAN", "required", Boolean.TRUE));
             Map<String, Object> schema = Map.of("fields", fields);
+            Map<String, Object> bool = Map.of("encrypted", Boolean.TRUE);
+            Map<String, Object> string = Map.of("encrypted", "yes");
 
-            assertThatCode(() -> validator.validateAgainstSchema(Map.of("encrypted", Boolean.TRUE), schema))
-                    .doesNotThrowAnyException();
+            assertThatCode(() -> validator.validateAgainstSchema(bool, schema)).doesNotThrowAnyException();
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("encrypted", "yes"), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(string, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("type_mismatch");
@@ -244,8 +251,9 @@ class AssetSubtypeValidatorTest {
         @Test
         void invalidSchemaShapeRejectedWithStableCode() {
             Map<String, Object> schema = Map.of("fields", "not-a-map");
+            Map<String, Object> metadata = Map.of("k", "v");
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("k", "v"), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(metadata, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("invalid_schema_shape");
@@ -272,8 +280,9 @@ class AssetSubtypeValidatorTest {
             Map<String, Object> schema = new LinkedHashMap<>();
             schema.put("fields", Map.of());
             schema.put("allowAdditional", "yes");
+            Map<String, Object> metadata = Map.of();
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of(), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(metadata, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("invalid_schema_shape");
@@ -283,8 +292,9 @@ class AssetSubtypeValidatorTest {
         void rejectsNonBooleanRequired() {
             Map<String, Object> fields = Map.of("name", Map.of("type", "STRING", "required", "yes"));
             Map<String, Object> schema = Map.of("fields", fields);
+            Map<String, Object> metadata = Map.of("name", "x");
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("name", "x"), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(metadata, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("invalid_schema_shape");
@@ -294,8 +304,9 @@ class AssetSubtypeValidatorTest {
         void rejectsNonNumericMinimum() {
             Map<String, Object> fields = Map.of("count", Map.of("type", "INTEGER", "minimum", "zero"));
             Map<String, Object> schema = Map.of("fields", fields);
+            Map<String, Object> metadata = Map.of("count", 1);
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("count", 1), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(metadata, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("invalid_schema_shape");
@@ -305,8 +316,9 @@ class AssetSubtypeValidatorTest {
         void rejectsNegativeMaxLength() {
             Map<String, Object> fields = Map.of("name", Map.of("type", "STRING", "maxLength", -1));
             Map<String, Object> schema = Map.of("fields", fields);
+            Map<String, Object> metadata = Map.of("name", "x");
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("name", "x"), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(metadata, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("invalid_schema_shape");
@@ -316,8 +328,9 @@ class AssetSubtypeValidatorTest {
         void rejectsNonStringEnumValues() {
             Map<String, Object> fields = Map.of("tier", Map.of("type", "ENUM", "values", List.of("OK", 42)));
             Map<String, Object> schema = Map.of("fields", fields);
+            Map<String, Object> metadata = Map.of("tier", "OK");
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("tier", "OK"), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(metadata, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("invalid_schema_shape");
@@ -327,8 +340,9 @@ class AssetSubtypeValidatorTest {
         void rejectsEmptyEnumValues() {
             Map<String, Object> fields = Map.of("tier", Map.of("type", "ENUM", "values", List.of()));
             Map<String, Object> schema = Map.of("fields", fields);
+            Map<String, Object> metadata = Map.of("tier", "x");
 
-            assertThatThrownBy(() -> validator.validateAgainstSchema(Map.of("tier", "x"), schema))
+            assertThatThrownBy(() -> validator.validateAgainstSchema(metadata, schema))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("invalid_schema_shape");
@@ -477,58 +491,46 @@ class AssetSubtypeValidatorTest {
                     .isEqualTo("invalid_schema_shape");
         }
 
-        @Test
-        void rejectsPresentNullRequired() {
-            // Codex cycle-5 finding 1: a present-null keyword must NOT be
-            // silently treated as absent — that would let a malformed schema
-            // weaken its own contract.
-            Map<String, Object> def = new LinkedHashMap<>();
-            def.put("type", "STRING");
-            def.put("required", null);
-            Map<String, Object> body = Map.of("fields", Map.of("name", def));
-
+        /**
+         * Codex cycle-5 finding 1: a present-null keyword must NOT be silently
+         * treated as absent — that would let a malformed schema weaken its
+         * own contract. Parameterized to cover all four keyword categories
+         * (per Sonar S5976; was four separate tests).
+         */
+        @org.junit.jupiter.params.ParameterizedTest(name = "present-null {0} rejected")
+        @org.junit.jupiter.params.provider.MethodSource("presentNullKeywords")
+        void rejectsPresentNullKeyword(String keyword, Map<String, Object> body) {
             assertThatThrownBy(() -> validator.validateSchemaBody(body, true))
                     .isInstanceOf(DomainValidationException.class)
                     .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
                     .isEqualTo("invalid_schema_shape");
         }
 
-        @Test
-        void rejectsPresentNullAllowAdditional() {
-            Map<String, Object> body = new LinkedHashMap<>();
-            body.put("fields", Map.of("name", Map.of("type", "STRING")));
-            body.put("allowAdditional", null);
+        static java.util.stream.Stream<org.junit.jupiter.params.provider.Arguments> presentNullKeywords() {
+            Map<String, Object> requiredNull = new LinkedHashMap<>();
+            requiredNull.put("type", "STRING");
+            requiredNull.put("required", null);
 
-            assertThatThrownBy(() -> validator.validateSchemaBody(body, true))
-                    .isInstanceOf(DomainValidationException.class)
-                    .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
-                    .isEqualTo("invalid_schema_shape");
-        }
+            Map<String, Object> allowAdditionalNull = new LinkedHashMap<>();
+            allowAdditionalNull.put("fields", Map.of("name", Map.of("type", "STRING")));
+            allowAdditionalNull.put("allowAdditional", null);
 
-        @Test
-        void rejectsPresentNullMaxLength() {
-            Map<String, Object> def = new LinkedHashMap<>();
-            def.put("type", "STRING");
-            def.put("maxLength", null);
-            Map<String, Object> body = Map.of("fields", Map.of("name", def));
+            Map<String, Object> maxLengthNull = new LinkedHashMap<>();
+            maxLengthNull.put("type", "STRING");
+            maxLengthNull.put("maxLength", null);
 
-            assertThatThrownBy(() -> validator.validateSchemaBody(body, true))
-                    .isInstanceOf(DomainValidationException.class)
-                    .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
-                    .isEqualTo("invalid_schema_shape");
-        }
+            Map<String, Object> minimumNull = new LinkedHashMap<>();
+            minimumNull.put("type", "INTEGER");
+            minimumNull.put("minimum", null);
 
-        @Test
-        void rejectsPresentNullMinimum() {
-            Map<String, Object> def = new LinkedHashMap<>();
-            def.put("type", "INTEGER");
-            def.put("minimum", null);
-            Map<String, Object> body = Map.of("fields", Map.of("count", def));
-
-            assertThatThrownBy(() -> validator.validateSchemaBody(body, true))
-                    .isInstanceOf(DomainValidationException.class)
-                    .extracting(e -> ((DomainValidationException) e).getDetail().get("reason"))
-                    .isEqualTo("invalid_schema_shape");
+            return java.util.stream.Stream.of(
+                    org.junit.jupiter.params.provider.Arguments.of(
+                            "required", Map.of("fields", Map.of("name", requiredNull))),
+                    org.junit.jupiter.params.provider.Arguments.of("allowAdditional", allowAdditionalNull),
+                    org.junit.jupiter.params.provider.Arguments.of(
+                            "maxLength", Map.of("fields", Map.of("name", maxLengthNull))),
+                    org.junit.jupiter.params.provider.Arguments.of(
+                            "minimum", Map.of("fields", Map.of("count", minimumNull))));
         }
 
         @Test

--- a/changelog.d/+gc-m011-sonar-cleanup.changed.md
+++ b/changelog.d/+gc-m011-sonar-cleanup.changed.md
@@ -1,0 +1,1 @@
+### Changed - Internal refactor of GC-M011 asset subtype/metadata code to clear SonarCloud findings: extract repeated string constants, split AssetSubtypeValidator.validateSchemaBody into smaller helpers, replace deprecated AssetService self-invocations with private helpers, suppress S107 on JPA query repository signatures, parameterize present-null schema-keyword tests.


### PR DESCRIPTION
## Summary

Source-only SonarCloud cleanup of the GC-M011 asset subtype/metadata code that landed in PR #917. No behavior changes — every edit targets a Sonar rule (S1192 string-literal duplication, S3776/S6541 cognitive complexity / brain method, S6809 transactional self-invocation, S107 parameter count, S5778 multi-throwing-call lambdas, S5976 parameterize related tests, S125 commented-out code, S1123 missing @deprecated tag, S3358 nested ternary, S1612 lambda → method reference).

## Requirement UIDs

- `GC-M011`

## Related Issues

Closes #722

## ADR Impact

- No ADR required

## Changes

- AssetSubtypeValidator: extract detail-map / keyword / message-prefix string constants (S1192, 22 issues); split validateSchemaBody into helpers (validateSchemaField, validateFieldTypeBounds, validateStringFieldBounds, validateNumericRange, validateEnumBounds, rejectImpossibleRequiredCount) to drop cognitive complexity below 15 and brain-method LOC below 64 (S3776, S6541); replace the nested ternary in detail() with an asSerializable helper (S3358).
- AssetService: extract FIELD_SUBTYPE / DETAIL_REASON / DETAIL_FIELD / DETAIL_LIMIT constants (S1192); inline the deprecated listByProjectAndFilters overload's call so it hits the repository directly without bypassing the @Transactional proxy (S6809); add private loadSubtypeSchema helper used by updateSubtypeSchema and deprecateSubtypeSchema to remove the remaining two S6809 self-invocations; add the @deprecated Javadoc tag on the 7-arg overload (S1123); suppress S107 on the 8-arg public method with rationale.
- OperationalAssetRepository: suppress S107 on the 8-arg JPQL filter method with rationale — Spring Data @Query requires each filter as an explicit @Param binding.
- OperationalAsset: convert subtype/metadata field comments to Javadoc so Sonar S125's commented-out-code heuristic stops firing.
- AssetGraphProjectionContributorTest: replace `edge -> edge.targetId()` lambda with `GraphEdge::targetId` (S1612).
- AssetSubtypeValidatorTest: hoist Map.of(...) literals out of assertThatThrownBy lambdas so each lambda has at most one potentially-throwing call (S5778, 12 issues); collapse four rejectsPresentNull* tests into a single parameterized rejectsPresentNullKeyword(keyword, body) (S5976).
- AssetServiceTest: hoist schema.getId() out of an assertThatThrownBy lambda (S5778).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local gates green: `make check`, `make policy`, `pre-commit run --all-files`, MCP `npm test`. SonarCloud should drop from 47 → 0 on this PR.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GC-M011 ← (no new IMPLEMENTS targets; this PR is an internal refactor of code already linked in PR #917)
- TESTS: GC-M011 ← (no new TESTS targets; existing tests refactored for Sonar compliance, coverage unchanged)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/+gc-m011-sonar-cleanup.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed