### PR TITLE
feat(testcases): hierarchical folder organization for test cases (TC-005)

### DIFF
--- a/architecture/adrs/043-test-case-hierarchical-organization.md
+++ b/architecture/adrs/043-test-case-hierarchical-organization.md
@@ -1,0 +1,192 @@
+# ADR-043: Test Case Hierarchical Organization
+
+## Status
+
+Accepted — 2026-05-17.
+
+## Context
+
+TC-005 (Wave 1, MUST) requires the system to support hierarchical
+folder/section organisation for test cases, with unlimited nesting,
+drag-and-drop reordering, move/copy between folders, and tree-based
+repository browsing.
+
+The existing test-case aggregates (`TestCase`, `TestCaseStep`,
+`TestCaseGherkin` from ADR-040/041/042) are flat: every test case sits
+directly under a project, with no notion of grouping. The
+`domain/documents/section` package already implements a tree for
+document content, but its semantics (document-scoped, no audit, no
+cycle protection) do not match test repository organisation.
+
+## Decision
+
+Introduce a dedicated `TestCaseFolder` aggregate inside the existing
+`domain/testcases` boundary. The folder is project-scoped, self-
+referencing (`parent` nullable), `@Audited`, and ordered within its
+container via `sort_order`. The `TestCase` aggregate gains
+`parentFolderId` (nullable; null ⇒ project root) and `sort_order`.
+
+### Boundary and naming
+
+- The aggregate is **not** a reuse of `documents.Section`. Test
+  organisation and document structure are unrelated concerns and
+  conflating them would couple two ordering models, leak document
+  semantics into test management, and force every audit/compliance
+  invariant for one to apply to the other.
+- The vocabulary is `TestCaseFolder`. Test steps, runs, results,
+  defects, suites, automation, and traceability remain separate
+  surfaces.
+
+### Sibling sort spaces
+
+Folders and test cases use **independent** `sort_order` axes within
+each container. The tree renders folders first (sorted by their
+`sort_order`), then test cases (sorted by their `sort_order`). This
+matches best-of-breed UX (folders sit above leaves in file explorers
+and test repositories) and keeps reorder queries simple — each
+operation rewrites at most N rows in one container of one entity type.
+
+A unified ordering across heterogeneous entities was considered and
+rejected: it would require either a synthetic key on each entity that
+includes its kind, or a discriminator column on a shared `position`
+table. Both add structural complexity for marginal UX gain.
+
+### Sibling-title uniqueness
+
+Folder titles must be unique within their container. PostgreSQL treats
+NULL parents as distinct under a plain `UNIQUE`, so two partial unique
+indexes back the invariant:
+
+- `uq_test_case_folder_title_root` covers `(project_id, title)` where
+  `parent_id IS NULL`.
+- `uq_test_case_folder_title_under_parent` covers
+  `(project_id, parent_id, title)` where `parent_id IS NOT NULL`.
+
+Test-case sibling uniqueness already exists via `(project_id, uid)`
+on `TestCase`; no additional index is needed for placement.
+
+### Move semantics
+
+`TestCaseFolderService.move` and `TestCaseService.move` change
+placement only:
+
+- The moved aggregate retains its identity (`id`, `uid` for test
+  cases, audit history). The Envers revision records the new parent
+  and sort order.
+- Cross-project moves are rejected because `findByIdAndProjectId` is
+  used for every lookup; the target folder must belong to the same
+  project.
+- Folder moves additionally reject moving a folder under itself or
+  any descendant (cycle protection by ancestor walk with a defensive
+  depth cap of 10_000).
+- Same-container moves are a no-op when `sortOrder` is null (no
+  rebalancing); explicit sort positions are honoured.
+
+### Copy semantics
+
+`TestCaseService.copy` creates a new `TestCase` with a
+caller-supplied `newUid`, copies every immutable definition field
+(title, description, preconditions, postconditions, priority, type,
+format, estimatedDurationSeconds), resets status to `DRAFT`, and
+clones authored children through their owning services
+(`TestCaseStepService.copyStepsToTestCase`,
+`TestCaseGherkinService.copyGherkinToTestCase`). The source test case
+is unchanged.
+
+Copy placement uses the **same convention as move**: `parentFolderId`
+is the explicit target — a UUID names the folder, `null` (or omitted)
+means the project root. The earlier "null preserves the source's
+folder" semantic was rejected because it conflated JSON omission and
+explicit null, leaving the project root unreachable for a copy from a
+folder. Callers that want to clone in place pass the source's
+`parentFolderId` explicitly.
+
+A copy without a `newUid` is rejected. Auto-generating UIDs would
+either leak naming conventions into the domain or force callers to
+clean up afterwards; explicit naming keeps the contract obvious.
+
+`actualResult` is **not** copied for step children — it is run-time
+evidence (ADR-041), not part of the test-case definition.
+
+### Folder deletion
+
+Folder deletion is **rejected** when the folder still contains child
+folders or test cases. Callers must move or delete the contents first.
+Silent cascade was rejected because:
+
+- It would skip the per-child Envers audit revision that explicit
+  service calls produce.
+- It would surprise users by destroying authored test definitions on
+  a single DELETE.
+
+### Tree read
+
+`GET /api/v1/test-cases/tree` returns a deterministic nested tree.
+The service issues one batch SELECT per entity kind and assembles
+the tree in memory (group-by-parent, sort by `sort_order`); there
+are no recursive repository calls. Adapted from
+`SectionService.getTree` but kept in the test-case domain.
+
+### API surface
+
+All routes stay under `/api/v1/test-cases/**` so the existing auth
+allow-list, IP guard, and actor-filter chain apply unchanged:
+
+- `POST/GET/PUT/DELETE /api/v1/test-cases/folders[/...]`
+- `PUT /api/v1/test-cases/folders/{id}/move`
+- `PUT /api/v1/test-cases/folders/reorder`
+- `PUT /api/v1/test-cases/{id}/move`
+- `POST /api/v1/test-cases/{id}/copy`
+- `PUT /api/v1/test-cases/reorder`
+- `GET /api/v1/test-cases/tree`
+
+### Persistence
+
+Four migrations (V084–V087) introduce the folder table, its audit
+shadow, and the placement columns on `test_case` / `test_case_audit`.
+`AUDIT_TABLES` in `AuditRetentionJob` is updated to include the
+folder audit table. `MigrationSmokeTest` covers the new versions and
+probes for the new tables/columns/indexes.
+
+### MCP and frontend parity
+
+- `gc_test_case` gains folder/move/copy/reorder actions.
+- `gc_query` allowlist covers `/api/v1/test-cases/folders` and
+  `/api/v1/test-cases/tree` reads.
+- `frontend/src/types/api.ts` mirrors the new request/response shapes
+  and the tree-node discriminated union.
+- `docs/API.md` documents the new endpoints.
+
+## Consequences
+
+- Drag-and-drop reordering becomes a single-container `PUT /reorder`
+  call; the backend renumbers `sort_order` to 0..N-1 atomically and
+  rejects partial reorder lists.
+- Move/copy/delete are audit-visible operations; Envers records every
+  state change at the row level for compliance.
+- The tree read scales to "unlimited nesting" while staying O(n) in
+  the number of folders + test cases.
+- Future "archived" filters and root-folder selection plug into the
+  tree read as additional query parameters without folder-schema
+  changes.
+
+## Alternatives considered
+
+- **Reuse `documents.Section`.** Rejected: coupling unrelated domains.
+- **Embed folder path in the test-case UID.** Rejected: UIDs would
+  drift under move; foreign-key denormalisation; existing UIDs would
+  need rewriting.
+- **Cascade-delete folder contents.** Rejected: skips per-child audit;
+  surprising blast radius.
+- **Unified sort_order across folders + test cases.** Rejected: extra
+  structural complexity for marginal UX gain.
+- **Auto-generate copy UIDs.** Rejected: leaks naming conventions into
+  the domain.
+
+## Related
+
+- TC-005 — Hierarchical Test Case Organization (Wave 1)
+- ADR-040 Test Case Domain
+- ADR-041 Test Case Step Format
+- ADR-042 Test Case BDD/Gherkin Format
+- `architecture/notes/test-case-hierarchy-preflight.md`

--- a/architecture/notes/test-case-hierarchy-preflight.md
+++ b/architecture/notes/test-case-hierarchy-preflight.md
@@ -1,0 +1,140 @@
+# Test Case Hierarchy Preflight
+
+Issue: #672
+Requirement: TC-005
+
+This note records architecture guardrails for hierarchical test-case
+organization. It is not an implementation plan.
+
+## Boundary
+
+TC-005 organizes existing `TestCase` definitions from ADR-040. It does not
+create a second test-case aggregate and it does not replace document sections.
+
+Use the vocabulary `TestCaseFolder` for repository organization unless a future
+product decision deliberately exposes another display label. `Section` already
+means document structure under `domain/documents`; reusing that entity or its
+API for test repositories would couple two unrelated ordering models and leak
+document export semantics into test management.
+
+The hierarchy owns only repository placement and browse order:
+
+- folders with project scope, title, optional description, parent folder, and
+  sibling order;
+- test-case placement under either a folder or the project root, with sibling
+  order;
+- tree reads that return folders and test-case leaf nodes in deterministic order.
+
+Test steps, Gherkin source, execution runs, results, defects, suites,
+automation binding, and traceability links remain separate surfaces.
+
+## Incumbents To Reuse
+
+- **Test-case domain:** extend `domain/testcases/{model,repository,service}` and
+  `api/testcases`; do not create `domain/testrepositories` unless a broader
+  repository aggregate appears.
+- **Tree precedent:** reuse the data-shaping pattern from
+  `SectionService.getTree` and `DocumentReadingOrderService` (batch load,
+  group by parent, return nested DTOs), but keep the implementation in the
+  test-case domain and add cycle/project-scope checks missing from the older
+  document section path.
+- **Project scope:** resolve the project through `ProjectService` and require
+  every folder and test-case lookup to include `projectId`. Moving or copying
+  between folders is inside one project only; cross-project copy is a separate
+  requirement because UID, audit, traceability, and authorization semantics all
+  change.
+- **Validation and errors:** use request-record Bean Validation for shape
+  checks, service validation for parent ownership, cycle prevention, duplicate
+  sibling names, and move/copy semantics, and the existing
+  `DomainValidationException`, `ConflictException`, and `NotFoundException`
+  hierarchy so `GlobalExceptionHandler` emits `ErrorResponse`.
+- **Persistence:** use Flyway migrations, UUID identities via `BaseEntity`,
+  explicit indexes for `(project_id, parent_id, sort_order)`, project-root
+  lookups, and test-case listing by folder. If a new folder entity is audited,
+  add the matching `_audit` migration, `MigrationSmokeTest` coverage, and
+  `AuditRetentionJob.AUDIT_TABLES`.
+- **Audit and deletion:** route folder deletion and descendant/test-case
+  placement changes through services/Hibernate so Envers sees the mutations.
+  Do not rely on DB cascades for audited business records.
+- **API/MCP/frontend parity:** controller changes must update `docs/API.md`,
+  `mcp/ground-control/lib.js`, `mcp/ground-control/index.js`, and a matching
+  `@WebMvcTest`. Extend the existing `gc_test_case` tool for write actions and
+  keep pure tree/list reads reachable through the `/api/v1/test-cases`
+  `gc_query` allowlist. Mirror DTOs in `frontend/src/types/api.ts`; add enum
+  mirrors only if new API-visible enums are introduced.
+
+## Cross-Cutting Layers
+
+- **Auth:** routes stay under `/api/v1/test-cases/**` so bearer traffic passes
+  `IpAllowlistFilter`, `BearerTokenAuthFilter`, `ApiPathMatrix`, and
+  `ActorFilter`; browser traffic passes the ADR-037 session/CSRF chain and the
+  same path matrix. Do not add endpoint-local auth, caller-supplied actor
+  fields, or routes outside the shared matrix.
+- **Parser/validation:** Jackson and Bean Validation own UUID/body/enum shape.
+  Services must reject a folder parent from another project, a test case from
+  another project, a folder moved under itself or any descendant, negative
+  ordering values, and duplicate sibling folder names.
+- **Error envelope:** ownership mismatches should use the existing 404
+  concealment pattern where revealing the real parent would leak data. Error
+  details may name fields and expected constraints; they must not echo rich
+  text, Gherkin source, request bodies, auth headers, or stack traces.
+- **Config/OS exposure:** TC-005 needs no new secrets, env vars, network
+  clients, subprocesses, temp files, or process argv. If future import/export
+  limits become configurable, bind them through validated
+  `@ConfigurationProperties`; do not read ad hoc environment variables from
+  controllers or services.
+- **Logging:** use SLF4J lifecycle events with low-cardinality fields such as
+  project identifier, folder id, test-case id/uid, action, and target parent id.
+  Do not log full descriptions, step bodies, Gherkin source, request payloads,
+  tokens, or authorization headers.
+- **Policy:** application-source changes need a changelog fragment per
+  `.gc/plan-rules.md`; migrations must update the hardcoded migration smoke
+  lists; completion must run `make policy`.
+
+## Extensibility
+
+The reusable seam is a project-scoped repository item placement model:
+`parentFolderId` plus container-local `sortOrder`, with root represented as
+`parentFolderId = null`. Keep folder ordering and test-case ordering
+container-scoped so drag-and-drop can update one folder/root without rewriting
+the whole repository.
+
+Move semantics should preserve the moved test case's identity and audit history.
+Copy semantics should create a new `TestCase` definition with a new UUID and a
+project-unique UID, then copy authored children through their owning services
+(`TestCaseStepService`, `TestCaseGherkinService`) so future child formats can
+join by adding one copy collaborator instead of modifying unrelated controllers.
+
+Tree reads should be parameterized for obvious future variation: include or
+exclude archived/deprecated test cases, optionally choose a root folder, and
+leave room for search/filter inputs without changing the folder schema.
+
+## Gotchas And Anti-Patterns
+
+- Do not reuse `documents.Section` or `SectionContent` for test-case folders.
+- Do not encode hierarchy in UID prefixes, titles, paths, custom fields, or
+  traceability links.
+- Do not allow cross-project folder moves/copies as an accidental side effect
+  of accepting arbitrary source and destination IDs.
+- Do not make drag-and-drop update only frontend state; persisted sibling order
+  must be deterministic and stable across clients.
+- Do not use recursive service calls without cycle protection for an
+  "unlimited nesting" tree; malformed data must not cause infinite recursion.
+- Do not add duplicate exception hierarchies, validation frameworks, auth
+  filters, audit writers, graph writers, MCP serializers, or frontend API
+  clients.
+- Do not make folder deletion silently delete test cases unless the API contract
+  states that destructive cascade explicitly. Prefer explicit move/delete
+  behavior with audit-visible service operations.
+
+## Non-Goals
+
+- No implementation of TC-005 in this preflight.
+- No test execution, run/result, defect, suite, automation-runner, or evidence
+  model.
+- No cross-project copy/migration workflow.
+- No replacement of ADR-040 `TestCase`, ADR-041 `TestCaseStep`, ADR-042
+  `TestCaseGherkin`, document sections, requirements, traceability links,
+  graph projection, or control-test records.
+- No new security scheme, sanitizer stack, workflow engine, generic CMS, or
+  repository-wide graph projection for test cases.

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/CopyTestCaseRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/CopyTestCaseRequest.java
@@ -1,0 +1,9 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record CopyTestCaseRequest(
+        @NotBlank @Size(max = 50) String newUid, UUID parentFolderId, @PositiveOrZero Integer sortOrder) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/MoveTestCaseFolderRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/MoveTestCaseFolderRequest.java
@@ -1,0 +1,6 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.UUID;
+
+public record MoveTestCaseFolderRequest(UUID parentFolderId, @PositiveOrZero Integer sortOrder) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/MoveTestCaseRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/MoveTestCaseRequest.java
@@ -1,0 +1,6 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import java.util.UUID;
+
+public record MoveTestCaseRequest(UUID parentFolderId, @PositiveOrZero Integer sortOrder) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/ReorderTestCaseFoldersRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/ReorderTestCaseFoldersRequest.java
@@ -1,0 +1,7 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+public record ReorderTestCaseFoldersRequest(UUID parentFolderId, @NotNull List<UUID> orderedFolderIds) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/ReorderTestCasesRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/ReorderTestCasesRequest.java
@@ -1,0 +1,7 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+
+public record ReorderTestCasesRequest(UUID parentFolderId, @NotNull List<UUID> orderedTestCaseIds) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseController.java
@@ -1,7 +1,10 @@
 package com.keplerops.groundcontrol.api.testcases;
 
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.testcases.service.CopyTestCaseCommand;
 import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.MoveTestCaseCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.ReorderTestCasesCommand;
 import com.keplerops.groundcontrol.domain.testcases.service.TestCaseService;
 import com.keplerops.groundcontrol.domain.testcases.service.UpdateTestCaseCommand;
 import jakarta.validation.Valid;
@@ -46,7 +49,9 @@ public class TestCaseController {
                 request.description(),
                 request.preconditions(),
                 request.postconditions(),
-                request.estimatedDurationSeconds())));
+                request.estimatedDurationSeconds(),
+                request.parentFolderId(),
+                request.sortOrder())));
     }
 
     @GetMapping
@@ -106,5 +111,37 @@ public class TestCaseController {
             @RequestParam(required = false) String project) {
         var projectId = projectService.requireProjectId(project);
         return TestCaseResponse.from(testCaseService.transitionStatus(projectId, id, request.status()));
+    }
+
+    @PutMapping("/{id}/move")
+    public TestCaseResponse move(
+            @PathVariable UUID id,
+            @Valid @RequestBody MoveTestCaseRequest request,
+            @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        return TestCaseResponse.from(testCaseService.move(
+                projectId, id, new MoveTestCaseCommand(request.parentFolderId(), request.sortOrder())));
+    }
+
+    @PostMapping("/{id}/copy")
+    @ResponseStatus(HttpStatus.CREATED)
+    public TestCaseResponse copy(
+            @PathVariable UUID id,
+            @Valid @RequestBody CopyTestCaseRequest request,
+            @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        return TestCaseResponse.from(testCaseService.copy(
+                projectId,
+                id,
+                new CopyTestCaseCommand(request.newUid(), request.parentFolderId(), request.sortOrder())));
+    }
+
+    @PutMapping("/reorder")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void reorder(
+            @Valid @RequestBody ReorderTestCasesRequest request, @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        testCaseService.reorder(
+                projectId, new ReorderTestCasesCommand(request.parentFolderId(), request.orderedTestCaseIds()));
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseFolderController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseFolderController.java
@@ -1,0 +1,101 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseFolderCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.MoveTestCaseFolderCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.ReorderTestCaseFoldersCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseFolderService;
+import com.keplerops.groundcontrol.domain.testcases.service.UpdateTestCaseFolderCommand;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * TC-005 / ADR-043 — REST surface for the test-case folder aggregate. Paths
+ * stay under {@code /api/v1/test-cases/**} so existing auth, IP allow-list,
+ * and actor-filter chains apply unchanged.
+ */
+@RestController
+@RequestMapping("/api/v1/test-cases/folders")
+public class TestCaseFolderController {
+
+    private final TestCaseFolderService folderService;
+    private final ProjectService projectService;
+
+    public TestCaseFolderController(TestCaseFolderService folderService, ProjectService projectService) {
+        this.folderService = folderService;
+        this.projectService = projectService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TestCaseFolderResponse create(
+            @Valid @RequestBody TestCaseFolderRequest request, @RequestParam(required = false) String project) {
+        var projectId = projectService.resolveProjectId(project);
+        var command = new CreateTestCaseFolderCommand(
+                projectId, request.parentFolderId(), request.title(), request.description(), request.sortOrder());
+        return TestCaseFolderResponse.from(folderService.create(command));
+    }
+
+    @GetMapping
+    public List<TestCaseFolderResponse> list(@RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        return folderService.listByProject(projectId).stream()
+                .map(TestCaseFolderResponse::from)
+                .toList();
+    }
+
+    @GetMapping("/{id}")
+    public TestCaseFolderResponse getById(@PathVariable UUID id, @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        return TestCaseFolderResponse.from(folderService.getById(projectId, id));
+    }
+
+    @PutMapping("/{id}")
+    public TestCaseFolderResponse update(
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateTestCaseFolderRequest request,
+            @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        var command = new UpdateTestCaseFolderCommand(
+                request.title(), request.description(), Boolean.TRUE.equals(request.clearDescription()));
+        return TestCaseFolderResponse.from(folderService.update(projectId, id, command));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id, @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        folderService.delete(projectId, id);
+    }
+
+    @PutMapping("/{id}/move")
+    public TestCaseFolderResponse move(
+            @PathVariable UUID id,
+            @Valid @RequestBody MoveTestCaseFolderRequest request,
+            @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        var command = new MoveTestCaseFolderCommand(request.parentFolderId(), request.sortOrder());
+        return TestCaseFolderResponse.from(folderService.move(projectId, id, command));
+    }
+
+    @PutMapping("/reorder")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void reorder(
+            @Valid @RequestBody ReorderTestCaseFoldersRequest request, @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        folderService.reorder(
+                projectId, new ReorderTestCaseFoldersCommand(request.parentFolderId(), request.orderedFolderIds()));
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseFolderRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseFolderRequest.java
@@ -1,0 +1,12 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record TestCaseFolderRequest(
+        UUID parentFolderId,
+        @NotBlank @Size(max = 200) String title,
+        String description,
+        @PositiveOrZero Integer sortOrder) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseFolderResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseFolderResponse.java
@@ -1,0 +1,28 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
+import java.time.Instant;
+import java.util.UUID;
+
+public record TestCaseFolderResponse(
+        UUID id,
+        String projectIdentifier,
+        UUID parentFolderId,
+        String title,
+        String description,
+        int sortOrder,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public static TestCaseFolderResponse from(TestCaseFolder folder) {
+        return new TestCaseFolderResponse(
+                folder.getId(),
+                folder.getProject().getIdentifier(),
+                folder.getParent() != null ? folder.getParent().getId() : null,
+                folder.getTitle(),
+                folder.getDescription(),
+                folder.getSortOrder(),
+                folder.getCreatedAt(),
+                folder.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
+import java.util.UUID;
 
 public record TestCaseRequest(
         @NotBlank @Size(max = 50) String uid,
@@ -20,4 +21,9 @@ public record TestCaseRequest(
         String description,
         String preconditions,
         String postconditions,
-        @PositiveOrZero Long estimatedDurationSeconds) {}
+        @PositiveOrZero Long estimatedDurationSeconds,
+        // TC-005 / ADR-043 — Hierarchical placement. Both optional: null
+        // parentFolderId means project root; null sortOrder asks the service
+        // to append (max+1 in container).
+        UUID parentFolderId,
+        @PositiveOrZero Integer sortOrder) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseResponse.java
@@ -21,6 +21,8 @@ public record TestCaseResponse(
         TestCaseType type,
         TestCaseFormat format,
         Long estimatedDurationSeconds,
+        UUID parentFolderId,
+        int sortOrder,
         Instant createdAt,
         Instant updatedAt) {
 
@@ -38,6 +40,8 @@ public record TestCaseResponse(
                 testCase.getType(),
                 testCase.getFormat(),
                 testCase.getEstimatedDurationSeconds(),
+                testCase.getParentFolder() != null ? testCase.getParentFolder().getId() : null,
+                testCase.getSortOrder(),
                 testCase.getCreatedAt(),
                 testCase.getUpdatedAt());
     }

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseTreeController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseTreeController.java
@@ -1,0 +1,35 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseFolderService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * TC-005 / ADR-043 — Tree read for hierarchical test repository browsing.
+ * Returns a deterministic nested representation of folders and the test
+ * cases placed inside them, sorted by container-local {@code sortOrder}.
+ */
+@RestController
+@RequestMapping("/api/v1/test-cases/tree")
+public class TestCaseTreeController {
+
+    private final TestCaseFolderService folderService;
+    private final ProjectService projectService;
+
+    public TestCaseTreeController(TestCaseFolderService folderService, ProjectService projectService) {
+        this.folderService = folderService;
+        this.projectService = projectService;
+    }
+
+    @GetMapping
+    public List<TestCaseTreeNodeResponse> getTree(@RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        return folderService.getTree(projectId).stream()
+                .map(TestCaseTreeNodeResponse::from)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseTreeNodeResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseTreeNodeResponse.java
@@ -1,0 +1,42 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseTreeNode;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseFormat;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseStatus;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseType;
+import java.util.List;
+import java.util.UUID;
+
+public record TestCaseTreeNodeResponse(
+        String kind,
+        UUID id,
+        UUID parentFolderId,
+        String title,
+        String description,
+        int sortOrder,
+        TestCaseLeaf testCase,
+        List<TestCaseTreeNodeResponse> children) {
+
+    public static TestCaseTreeNodeResponse from(TestCaseTreeNode node) {
+        return new TestCaseTreeNodeResponse(
+                node.kind().name(),
+                node.id(),
+                node.parentFolderId(),
+                node.title(),
+                node.description(),
+                node.sortOrder(),
+                node.testCase() == null
+                        ? null
+                        : new TestCaseLeaf(
+                                node.testCase().uid(),
+                                node.testCase().status(),
+                                node.testCase().type(),
+                                node.testCase().priority(),
+                                node.testCase().format()),
+                node.children().stream().map(TestCaseTreeNodeResponse::from).toList());
+    }
+
+    public record TestCaseLeaf(
+            String uid, TestCaseStatus status, TestCaseType type, TestCasePriority priority, TestCaseFormat format) {}
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/UpdateTestCaseFolderRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/testcases/UpdateTestCaseFolderRequest.java
@@ -1,0 +1,6 @@
+package com.keplerops.groundcontrol.api.testcases;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateTestCaseFolderRequest(
+        @Size(max = 200) String title, String description, Boolean clearDescription) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/documents/service/SectionService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/documents/service/SectionService.java
@@ -5,7 +5,11 @@ import com.keplerops.groundcontrol.domain.documents.repository.DocumentRepositor
 import com.keplerops.groundcontrol.domain.documents.repository.SectionRepository;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +109,13 @@ public class SectionService {
             }
         }
 
-        return roots.stream().map(r -> buildNode(r, childrenByParentId)).toList();
+        // Iterative bottom-up assembly: a recursive descent on a deeply
+        // nested section tree would risk StackOverflowError. Materialise
+        // nodes in descending-depth order so each parent finds its
+        // children's SectionTreeNode instances already built (codex
+        // cycle-1 class finding category — same shape as
+        // TestCaseFolderService.getTree).
+        return buildIterativeForest(all, roots, childrenByParentId);
     }
 
     public void delete(UUID id) {
@@ -115,17 +125,76 @@ public class SectionService {
         log.info("section_deleted: id={} title={}", section.getId(), section.getTitle());
     }
 
-    private SectionTreeNode buildNode(Section section, Map<UUID, List<Section>> childrenByParentId) {
-        var children = childrenByParentId.getOrDefault(section.getId(), List.of());
-        return new SectionTreeNode(
-                section.getId(),
-                section.getParent() != null ? section.getParent().getId() : null,
-                section.getTitle(),
-                section.getDescription(),
-                section.getSortOrder(),
-                section.getCreatedAt(),
-                section.getUpdatedAt(),
-                children.stream().map(c -> buildNode(c, childrenByParentId)).toList());
+    /**
+     * Iterative O(n) section tree assembly (codex cycle-2 finding).
+     * Walks the children map from each root via an explicit stack to
+     * produce a post-order visit list, then materialises SectionTreeNode
+     * instances in that order so each parent finds its children's nodes
+     * already built. Each section is touched twice (push + pop); no
+     * per-node parent walk is performed, so a linear chain stays linear
+     * rather than quadratic.
+     */
+    private List<SectionTreeNode> buildIterativeForest(
+            List<Section> all, List<Section> roots, Map<UUID, List<Section>> childrenByParentId) {
+        List<Section> postOrder = new ArrayList<>(all.size());
+        HashSet<UUID> visited = new HashSet<>();
+        Deque<SectionStackFrame> stack = new ArrayDeque<>();
+        for (Section root : roots) {
+            stack.push(new SectionStackFrame(root));
+            while (!stack.isEmpty()) {
+                SectionStackFrame frame = stack.peek();
+                if (frame.expanded) {
+                    stack.pop();
+                    postOrder.add(frame.section);
+                    continue;
+                }
+                if (!visited.add(frame.section.getId())) {
+                    stack.pop();
+                    continue;
+                }
+                frame.expanded = true;
+                List<Section> children = childrenByParentId.getOrDefault(frame.section.getId(), List.of());
+                for (int i = children.size() - 1; i >= 0; i--) {
+                    stack.push(new SectionStackFrame(children.get(i)));
+                }
+            }
+        }
+
+        Map<UUID, SectionTreeNode> nodesById = new HashMap<>();
+        for (Section section : postOrder) {
+            var childSections = childrenByParentId.getOrDefault(section.getId(), List.of());
+            List<SectionTreeNode> children = new ArrayList<>(childSections.size());
+            for (Section child : childSections) {
+                children.add(nodesById.get(child.getId()));
+            }
+            nodesById.put(
+                    section.getId(),
+                    new SectionTreeNode(
+                            section.getId(),
+                            section.getParent() != null ? section.getParent().getId() : null,
+                            section.getTitle(),
+                            section.getDescription(),
+                            section.getSortOrder(),
+                            section.getCreatedAt(),
+                            section.getUpdatedAt(),
+                            children));
+        }
+
+        List<SectionTreeNode> result = new ArrayList<>(roots.size());
+        for (Section root : roots) {
+            result.add(nodesById.get(root.getId()));
+        }
+        return result;
+    }
+
+    /** Stack frame used by the iterative post-order traversal in {@link #buildIterativeForest}. */
+    private static final class SectionStackFrame {
+        final Section section;
+        boolean expanded;
+
+        SectionStackFrame(Section section) {
+            this.section = section;
+        }
     }
 
     private void checkTitleUniqueness(UUID documentId, UUID parentId, String title) {

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/documents/service/SectionService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/documents/service/SectionService.java
@@ -136,55 +136,70 @@ public class SectionService {
      */
     private List<SectionTreeNode> buildIterativeForest(
             List<Section> all, List<Section> roots, Map<UUID, List<Section>> childrenByParentId) {
+        List<Section> postOrder = collectPostOrder(all, roots, childrenByParentId);
+        Map<UUID, SectionTreeNode> nodesById = new HashMap<>();
+        for (Section section : postOrder) {
+            nodesById.put(section.getId(), materialiseNode(section, childrenByParentId, nodesById));
+        }
+        List<SectionTreeNode> result = new ArrayList<>(roots.size());
+        for (Section root : roots) {
+            result.add(nodesById.get(root.getId()));
+        }
+        return result;
+    }
+
+    private List<Section> collectPostOrder(
+            List<Section> all, List<Section> roots, Map<UUID, List<Section>> childrenByParentId) {
         List<Section> postOrder = new ArrayList<>(all.size());
         HashSet<UUID> visited = new HashSet<>();
         Deque<SectionStackFrame> stack = new ArrayDeque<>();
         for (Section root : roots) {
             stack.push(new SectionStackFrame(root));
             while (!stack.isEmpty()) {
-                SectionStackFrame frame = stack.peek();
-                if (frame.expanded) {
-                    stack.pop();
-                    postOrder.add(frame.section);
-                    continue;
-                }
-                if (!visited.add(frame.section.getId())) {
-                    stack.pop();
-                    continue;
-                }
-                frame.expanded = true;
-                List<Section> children = childrenByParentId.getOrDefault(frame.section.getId(), List.of());
-                for (int i = children.size() - 1; i >= 0; i--) {
-                    stack.push(new SectionStackFrame(children.get(i)));
-                }
+                visitNext(stack, postOrder, visited, childrenByParentId);
             }
         }
+        return postOrder;
+    }
 
-        Map<UUID, SectionTreeNode> nodesById = new HashMap<>();
-        for (Section section : postOrder) {
-            var childSections = childrenByParentId.getOrDefault(section.getId(), List.of());
-            List<SectionTreeNode> children = new ArrayList<>(childSections.size());
-            for (Section child : childSections) {
-                children.add(nodesById.get(child.getId()));
-            }
-            nodesById.put(
-                    section.getId(),
-                    new SectionTreeNode(
-                            section.getId(),
-                            section.getParent() != null ? section.getParent().getId() : null,
-                            section.getTitle(),
-                            section.getDescription(),
-                            section.getSortOrder(),
-                            section.getCreatedAt(),
-                            section.getUpdatedAt(),
-                            children));
+    private void visitNext(
+            Deque<SectionStackFrame> stack,
+            List<Section> postOrder,
+            HashSet<UUID> visited,
+            Map<UUID, List<Section>> childrenByParentId) {
+        SectionStackFrame frame = stack.peek();
+        if (frame.expanded) {
+            stack.pop();
+            postOrder.add(frame.section);
+            return;
         }
+        if (!visited.add(frame.section.getId())) {
+            stack.pop();
+            return;
+        }
+        frame.expanded = true;
+        List<Section> children = childrenByParentId.getOrDefault(frame.section.getId(), List.of());
+        for (int i = children.size() - 1; i >= 0; i--) {
+            stack.push(new SectionStackFrame(children.get(i)));
+        }
+    }
 
-        List<SectionTreeNode> result = new ArrayList<>(roots.size());
-        for (Section root : roots) {
-            result.add(nodesById.get(root.getId()));
+    private SectionTreeNode materialiseNode(
+            Section section, Map<UUID, List<Section>> childrenByParentId, Map<UUID, SectionTreeNode> nodesById) {
+        var childSections = childrenByParentId.getOrDefault(section.getId(), List.of());
+        List<SectionTreeNode> children = new ArrayList<>(childSections.size());
+        for (Section child : childSections) {
+            children.add(nodesById.get(child.getId()));
         }
-        return result;
+        return new SectionTreeNode(
+                section.getId(),
+                section.getParent() != null ? section.getParent().getId() : null,
+                section.getTitle(),
+                section.getDescription(),
+                section.getSortOrder(),
+                section.getCreatedAt(),
+                section.getUpdatedAt(),
+                children);
     }
 
     /** Stack frame used by the iterative post-order traversal in {@link #buildIterativeForest}. */

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/model/TestCase.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/model/TestCase.java
@@ -19,6 +19,7 @@ import jakarta.persistence.UniqueConstraint;
 import java.util.Map;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
+import org.hibernate.envers.RelationTargetAuditMode;
 
 @Entity
 @Audited
@@ -70,6 +71,20 @@ public class TestCase extends BaseEntity {
 
     @Column(name = "estimated_duration_seconds")
     private Long estimatedDurationSeconds;
+
+    /**
+     * TC-005 / ADR-043 — Hierarchical placement. {@code null} parent means
+     * the test case sits at the project root. Sibling order within the
+     * container is provided by {@link #sortOrder}; reorder operations
+     * update only the affected container.
+     */
+    @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_folder_id")
+    private TestCaseFolder parentFolder;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
 
     protected TestCase() {
         // JPA
@@ -205,5 +220,24 @@ public class TestCase extends BaseEntity {
                     "Estimated duration must be non-negative", "invalid_test_case", Map.of());
         }
         this.estimatedDurationSeconds = estimatedDurationSeconds;
+    }
+
+    public TestCaseFolder getParentFolder() {
+        return parentFolder;
+    }
+
+    public void setParentFolder(TestCaseFolder parentFolder) {
+        this.parentFolder = parentFolder;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(int sortOrder) {
+        if (sortOrder < 0) {
+            throw new DomainValidationException("Sort order must be non-negative", "invalid_test_case", Map.of());
+        }
+        this.sortOrder = sortOrder;
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/model/TestCaseFolder.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/model/TestCaseFolder.java
@@ -1,0 +1,118 @@
+package com.keplerops.groundcontrol.domain.testcases.model;
+
+import com.keplerops.groundcontrol.domain.BaseEntity;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.Map;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.NotAudited;
+import org.hibernate.envers.RelationTargetAuditMode;
+
+/**
+ * TC-005 / ADR-043 — Test repository organisation aggregate.
+ *
+ * <p>Folders are project-scoped and self-referencing; {@code parent == null}
+ * means the folder sits at the project root. Sibling ordering is
+ * container-local via {@link #sortOrder}, and sibling-title uniqueness is
+ * enforced by partial unique indexes at the database (see V080).
+ */
+@Entity
+@Audited
+@Table(name = "test_case_folder")
+public class TestCaseFolder extends BaseEntity {
+
+    @NotAudited
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private TestCaseFolder parent;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    protected TestCaseFolder() {
+        // JPA
+    }
+
+    public TestCaseFolder(Project project, TestCaseFolder parent, String title, String description, int sortOrder) {
+        if (project == null) {
+            throw new DomainValidationException("Project must not be null", "invalid_test_case_folder", Map.of());
+        }
+        if (title == null || title.isBlank()) {
+            throw new DomainValidationException("Title must not be blank", "invalid_test_case_folder", Map.of());
+        }
+        if (sortOrder < 0) {
+            throw new DomainValidationException(
+                    "Sort order must be non-negative", "invalid_test_case_folder", Map.of());
+        }
+        this.project = project;
+        this.parent = parent;
+        this.title = title;
+        this.description = description;
+        this.sortOrder = sortOrder;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public TestCaseFolder getParent() {
+        return parent;
+    }
+
+    public void setParent(TestCaseFolder parent) {
+        this.parent = parent;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new DomainValidationException("Title must not be blank", "invalid_test_case_folder", Map.of());
+        }
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(int sortOrder) {
+        if (sortOrder < 0) {
+            throw new DomainValidationException(
+                    "Sort order must be non-negative", "invalid_test_case_folder", Map.of());
+        }
+        this.sortOrder = sortOrder;
+    }
+
+    @Override
+    public String toString() {
+        return title;
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/repository/TestCaseFolderRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/repository/TestCaseFolderRepository.java
@@ -1,0 +1,41 @@
+package com.keplerops.groundcontrol.domain.testcases.repository;
+
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface TestCaseFolderRepository extends JpaRepository<TestCaseFolder, UUID> {
+
+    Optional<TestCaseFolder> findByIdAndProjectId(UUID id, UUID projectId);
+
+    @Query("SELECT f FROM TestCaseFolder f WHERE f.project.id = :projectId "
+            + "ORDER BY f.sortOrder, f.createdAt, f.id")
+    List<TestCaseFolder> findByProjectIdOrderBySortOrder(@Param("projectId") UUID projectId);
+
+    // TC-005 / ADR-043 — Tie-breakers (createdAt, id) keep sibling order
+    // deterministic when two folders share a sort_order.
+    @Query("SELECT f FROM TestCaseFolder f WHERE f.project.id = :projectId "
+            + "AND f.parent.id = :parentId ORDER BY f.sortOrder, f.createdAt, f.id")
+    List<TestCaseFolder> findByProjectIdAndParentIdOrderBySortOrder(
+            @Param("projectId") UUID projectId, @Param("parentId") UUID parentId);
+
+    @Query("SELECT f FROM TestCaseFolder f WHERE f.project.id = :projectId "
+            + "AND f.parent IS NULL ORDER BY f.sortOrder, f.createdAt, f.id")
+    List<TestCaseFolder> findRootByProjectIdOrderBySortOrder(@Param("projectId") UUID projectId);
+
+    @Query("SELECT COUNT(f) > 0 FROM TestCaseFolder f WHERE f.project.id = :projectId "
+            + "AND f.parent.id = :parentId AND f.title = :title")
+    boolean existsByProjectIdAndParentIdAndTitle(
+            @Param("projectId") UUID projectId, @Param("parentId") UUID parentId, @Param("title") String title);
+
+    @Query("SELECT COUNT(f) > 0 FROM TestCaseFolder f WHERE f.project.id = :projectId "
+            + "AND f.parent IS NULL AND f.title = :title")
+    boolean existsRootByProjectIdAndTitle(@Param("projectId") UUID projectId, @Param("title") String title);
+
+    @Query("SELECT COUNT(f) FROM TestCaseFolder f WHERE f.parent.id = :parentId")
+    long countByParentId(@Param("parentId") UUID parentId);
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/repository/TestCaseRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/repository/TestCaseRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TestCaseRepository extends JpaRepository<TestCase, UUID> {
 
@@ -17,4 +19,23 @@ public interface TestCaseRepository extends JpaRepository<TestCase, UUID> {
     Optional<TestCase> findByProjectIdAndUid(UUID projectId, String uid);
 
     List<TestCase> findByProjectIdOrderByCreatedAtDesc(UUID projectId);
+
+    // TC-005 / ADR-043 — Tie-breakers (createdAt, id) make the order
+    // deterministic even when two siblings share a sort_order (e.g.
+    // pre-V082 backfilled rows after a manual sort_order update, or
+    // future write paths that accept caller-supplied sort_order).
+    @Query("SELECT t FROM TestCase t WHERE t.project.id = :projectId "
+            + "AND t.parentFolder.id = :folderId ORDER BY t.sortOrder, t.createdAt, t.id")
+    List<TestCase> findByProjectIdAndParentFolderIdOrderBySortOrder(
+            @Param("projectId") UUID projectId, @Param("folderId") UUID folderId);
+
+    @Query("SELECT t FROM TestCase t WHERE t.project.id = :projectId "
+            + "AND t.parentFolder IS NULL ORDER BY t.sortOrder, t.createdAt, t.id")
+    List<TestCase> findRootByProjectIdOrderBySortOrder(@Param("projectId") UUID projectId);
+
+    @Query("SELECT t FROM TestCase t WHERE t.project.id = :projectId " + "ORDER BY t.sortOrder, t.createdAt, t.id")
+    List<TestCase> findAllByProjectIdOrderBySortOrder(@Param("projectId") UUID projectId);
+
+    @Query("SELECT COUNT(t) FROM TestCase t WHERE t.parentFolder.id = :folderId")
+    long countByParentFolderId(@Param("folderId") UUID folderId);
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/CopyTestCaseCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/CopyTestCaseCommand.java
@@ -1,0 +1,5 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import java.util.UUID;
+
+public record CopyTestCaseCommand(String newUid, UUID parentFolderId, Integer sortOrder) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/CreateTestCaseCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/CreateTestCaseCommand.java
@@ -15,4 +15,34 @@ public record CreateTestCaseCommand(
         String description,
         String preconditions,
         String postconditions,
-        Long estimatedDurationSeconds) {}
+        Long estimatedDurationSeconds,
+        UUID parentFolderId,
+        Integer sortOrder) {
+
+    /** Backwards-compatible constructor for callers that do not yet specify placement. */
+    public CreateTestCaseCommand(
+            UUID projectId,
+            String uid,
+            String title,
+            TestCaseType type,
+            TestCasePriority priority,
+            TestCaseFormat format,
+            String description,
+            String preconditions,
+            String postconditions,
+            Long estimatedDurationSeconds) {
+        this(
+                projectId,
+                uid,
+                title,
+                type,
+                priority,
+                format,
+                description,
+                preconditions,
+                postconditions,
+                estimatedDurationSeconds,
+                null,
+                null);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/CreateTestCaseFolderCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/CreateTestCaseFolderCommand.java
@@ -1,0 +1,6 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import java.util.UUID;
+
+public record CreateTestCaseFolderCommand(
+        UUID projectId, UUID parentFolderId, String title, String description, Integer sortOrder) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/MoveTestCaseCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/MoveTestCaseCommand.java
@@ -1,0 +1,5 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import java.util.UUID;
+
+public record MoveTestCaseCommand(UUID parentFolderId, Integer sortOrder) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/MoveTestCaseFolderCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/MoveTestCaseFolderCommand.java
@@ -1,0 +1,5 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import java.util.UUID;
+
+public record MoveTestCaseFolderCommand(UUID parentFolderId, Integer sortOrder) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/ReorderTestCaseFoldersCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/ReorderTestCaseFoldersCommand.java
@@ -1,0 +1,6 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ReorderTestCaseFoldersCommand(UUID parentFolderId, List<UUID> orderedFolderIds) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/ReorderTestCasesCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/ReorderTestCasesCommand.java
@@ -1,0 +1,6 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ReorderTestCasesCommand(UUID parentFolderId, List<UUID> orderedTestCaseIds) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/SiblingOrderingHelper.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/SiblingOrderingHelper.java
@@ -1,0 +1,61 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * TC-005 / ADR-043 — Shared sibling reorder algorithm.
+ *
+ * <p>Lives in the testcases service package because both
+ * {@link TestCaseFolderService} (folder reorder) and
+ * {@link TestCaseService} (test-case reorder) need the same semantics:
+ * verify the requested list matches the container's current siblings
+ * exactly, then renumber {@code sort_order} = 0..N-1 in the supplied
+ * order. Keeping the algorithm here lets each aggregate's service own
+ * its own placement writes while sharing the validation contract.
+ */
+final class SiblingOrderingHelper {
+
+    private SiblingOrderingHelper() {}
+
+    /**
+     * Rejects partial / mismatched lists with {@link ConflictException}
+     * and duplicates / nulls with {@link DomainValidationException}, then
+     * calls {@code setOrder} on each sibling with its new 0..N-1
+     * position. The caller is responsible for the in-project containment
+     * guard on the parent container; this helper only sees siblings.
+     */
+    static <T> void applyOrdering(
+            String entityLabel,
+            List<UUID> orderedIds,
+            List<T> currentSiblings,
+            Function<T, UUID> idOf,
+            BiConsumer<T, Integer> setOrder) {
+        if (orderedIds == null) {
+            throw new DomainValidationException(
+                    "Ordered " + entityLabel + " id list is required", "invalid_reorder", Map.of());
+        }
+        if (orderedIds.size() != orderedIds.stream().distinct().count()) {
+            throw new DomainValidationException(
+                    "Ordered " + entityLabel + " id list contains duplicates", "invalid_reorder", Map.of());
+        }
+        var byId = new LinkedHashMap<UUID, T>();
+        for (T item : currentSiblings) {
+            byId.put(idOf.apply(item), item);
+        }
+        if (!byId.keySet().equals(new HashSet<>(orderedIds))) {
+            throw new ConflictException("Reorder list must contain exactly the current siblings");
+        }
+        for (int index = 0; index < orderedIds.size(); index++) {
+            T item = byId.get(orderedIds.get(index));
+            setOrder.accept(item, index);
+        }
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/SiblingOrderingHelper.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/SiblingOrderingHelper.java
@@ -7,8 +7,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.ObjIntConsumer;
 
 /**
  * TC-005 / ADR-043 — Shared sibling reorder algorithm.
@@ -37,7 +37,7 @@ final class SiblingOrderingHelper {
             List<UUID> orderedIds,
             List<T> currentSiblings,
             Function<T, UUID> idOf,
-            BiConsumer<T, Integer> setOrder) {
+            ObjIntConsumer<T> setOrder) {
         if (orderedIds == null) {
             throw new DomainValidationException(
                     "Ordered " + entityLabel + " id list is required", "invalid_reorder", Map.of());

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseFolderService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseFolderService.java
@@ -175,9 +175,8 @@ public class TestCaseFolderService {
 
     @Transactional(readOnly = true)
     public List<TestCaseTreeNode> getTree(UUID projectId) {
-        // Single-batch fetch per entity type so the tree assembly is O(n)
-        // without recursive repository calls. SectionService.getTree shape;
-        // adapted for two entity kinds.
+        // One batch fetch per entity type keeps the assembly O(n) and
+        // avoids per-folder repository round-trips.
         var folders = folderRepository.findByProjectIdOrderBySortOrder(projectId);
         var testCases = testCaseRepository.findAllByProjectIdOrderBySortOrder(projectId);
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseFolderService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseFolderService.java
@@ -116,13 +116,11 @@ public class TestCaseFolderService {
         }
         folder.setParent(newParent);
         // Same-container moves with an omitted sortOrder preserve the
-        // folder's current placement so idempotent move calls do not
-        // rebalance siblings or produce audit revisions. Explicit
-        // sortOrder uses insertion semantics — siblings shift to make
-        // room (codex cycle-2 finding).
-        if (sameContainer && command.sortOrder() == null) {
-            // No-op on sort_order; keep current value.
-        } else {
+        // folder's current placement (idempotent move = no rebalance, no
+        // audit revision). Explicit sortOrder uses insertion semantics —
+        // target siblings shift to make room.
+        boolean preserveCurrentSortOrder = sameContainer && command.sortOrder() == null;
+        if (!preserveCurrentSortOrder) {
             folder.setSortOrder(placeFolderInContainer(projectId, newParentId, folder.getId(), command.sortOrder()));
         }
         folder = folderRepository.save(folder);
@@ -253,47 +251,70 @@ public class TestCaseFolderService {
             List<TestCaseFolder> rootFolders,
             Map<UUID, List<TestCaseFolder>> childFoldersByParent,
             Map<UUID, List<TestCase>> testCasesByParent) {
+        List<TestCaseFolder> postOrder = collectPostOrder(rootFolders, childFoldersByParent);
+        Map<UUID, TestCaseTreeNode> folderNodesById = new HashMap<>();
+        for (TestCaseFolder folder : postOrder) {
+            folderNodesById.put(
+                    folder.getId(),
+                    materialiseFolderNode(folder, childFoldersByParent, testCasesByParent, folderNodesById));
+        }
+        return folderNodesById;
+    }
+
+    private List<TestCaseFolder> collectPostOrder(
+            List<TestCaseFolder> rootFolders, Map<UUID, List<TestCaseFolder>> childFoldersByParent) {
         List<TestCaseFolder> postOrder = new ArrayList<>();
         HashSet<UUID> visited = new HashSet<>();
         Deque<StackFrame> stack = new ArrayDeque<>();
         for (TestCaseFolder root : rootFolders) {
             stack.push(new StackFrame(root));
             while (!stack.isEmpty()) {
-                StackFrame frame = stack.peek();
-                if (frame.expanded) {
-                    stack.pop();
-                    postOrder.add(frame.folder);
-                    continue;
-                }
-                if (!visited.add(frame.folder.getId())) {
-                    // Already visited (shouldn't happen with a valid
-                    // tree, but defend against malformed graphs).
-                    stack.pop();
-                    continue;
-                }
-                frame.expanded = true;
-                List<TestCaseFolder> children = childFoldersByParent.getOrDefault(frame.folder.getId(), List.of());
-                // Push in reverse so left-to-right child order pops first.
-                for (int i = children.size() - 1; i >= 0; i--) {
-                    stack.push(new StackFrame(children.get(i)));
-                }
+                visitNext(stack, postOrder, visited, childFoldersByParent);
             }
         }
+        return postOrder;
+    }
 
-        Map<UUID, TestCaseTreeNode> folderNodesById = new HashMap<>();
-        for (TestCaseFolder folder : postOrder) {
-            List<TestCaseFolder> childFolders = childFoldersByParent.getOrDefault(folder.getId(), List.of());
-            List<TestCase> childTestCases = testCasesByParent.getOrDefault(folder.getId(), List.of());
-            List<TestCaseTreeNode> children = new ArrayList<>(childFolders.size() + childTestCases.size());
-            for (TestCaseFolder child : childFolders) {
-                children.add(folderNodesById.get(child.getId()));
-            }
-            for (TestCase testCase : childTestCases) {
-                children.add(TestCaseTreeNode.testCase(testCase));
-            }
-            folderNodesById.put(folder.getId(), TestCaseTreeNode.folder(folder, children));
+    private void visitNext(
+            Deque<StackFrame> stack,
+            List<TestCaseFolder> postOrder,
+            HashSet<UUID> visited,
+            Map<UUID, List<TestCaseFolder>> childFoldersByParent) {
+        StackFrame frame = stack.peek();
+        if (frame.expanded) {
+            stack.pop();
+            postOrder.add(frame.folder);
+            return;
         }
-        return folderNodesById;
+        if (!visited.add(frame.folder.getId())) {
+            // Already-visited node — only possible on a malformed graph
+            // that slipped past cycle protection. Drop the duplicate frame.
+            stack.pop();
+            return;
+        }
+        frame.expanded = true;
+        List<TestCaseFolder> children = childFoldersByParent.getOrDefault(frame.folder.getId(), List.of());
+        // Push in reverse so left-to-right child order pops first.
+        for (int i = children.size() - 1; i >= 0; i--) {
+            stack.push(new StackFrame(children.get(i)));
+        }
+    }
+
+    private TestCaseTreeNode materialiseFolderNode(
+            TestCaseFolder folder,
+            Map<UUID, List<TestCaseFolder>> childFoldersByParent,
+            Map<UUID, List<TestCase>> testCasesByParent,
+            Map<UUID, TestCaseTreeNode> folderNodesById) {
+        List<TestCaseFolder> childFolders = childFoldersByParent.getOrDefault(folder.getId(), List.of());
+        List<TestCase> childTestCases = testCasesByParent.getOrDefault(folder.getId(), List.of());
+        List<TestCaseTreeNode> children = new ArrayList<>(childFolders.size() + childTestCases.size());
+        for (TestCaseFolder child : childFolders) {
+            children.add(folderNodesById.get(child.getId()));
+        }
+        for (TestCase testCase : childTestCases) {
+            children.add(TestCaseTreeNode.testCase(testCase));
+        }
+        return TestCaseTreeNode.folder(folder, children);
     }
 
     /** Stack frame used by the iterative post-order traversal in {@link #buildFolderNodesIteratively}. */

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseFolderService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseFolderService.java
@@ -1,0 +1,406 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseFolderRepository;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseRepository;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * TC-005 / ADR-043 — Hierarchical organisation for test cases.
+ *
+ * <p>Folders are project-scoped, self-referencing, container-locally ordered
+ * via {@code sort_order}, and uniquely titled per container. Move/reorder
+ * operations stay inside one project; cycle protection rejects moving a
+ * folder under itself or any of its descendants.
+ */
+@Service
+@Transactional
+public class TestCaseFolderService {
+
+    private static final Logger log = LoggerFactory.getLogger(TestCaseFolderService.class);
+
+    /**
+     * Defensive ceiling on hierarchy depth during cycle checks. The product
+     * statement says "unlimited nesting"; in practice anything past a few
+     * thousand is malformed data and walking the whole chain would lock the
+     * thread. The cap is well above any plausible real tree depth.
+     */
+    private static final int MAX_DEPTH = 10_000;
+
+    private final TestCaseFolderRepository folderRepository;
+    private final TestCaseRepository testCaseRepository;
+    private final ProjectService projectService;
+
+    public TestCaseFolderService(
+            TestCaseFolderRepository folderRepository,
+            TestCaseRepository testCaseRepository,
+            ProjectService projectService) {
+        this.folderRepository = folderRepository;
+        this.testCaseRepository = testCaseRepository;
+        this.projectService = projectService;
+    }
+
+    public TestCaseFolder create(CreateTestCaseFolderCommand command) {
+        var project = projectService.getById(command.projectId());
+        TestCaseFolder parent = null;
+        if (command.parentFolderId() != null) {
+            parent = requireFolderInProject(project.getId(), command.parentFolderId());
+        }
+        UUID parentId = parent != null ? parent.getId() : null;
+        requireUniqueTitleInContainer(project.getId(), parentId, command.title());
+        // Insertion semantics: shift target siblings before assigning the
+        // new folder's sort_order (codex cycle-2 finding).
+        int sortOrder = placeFolderInContainer(project.getId(), parentId, null, command.sortOrder());
+        var folder = new TestCaseFolder(project, parent, command.title(), command.description(), sortOrder);
+        folder = folderRepository.save(folder);
+        log.info(
+                "test_case_folder_created: project={} parent={} id={} title={}",
+                project.getIdentifier(),
+                parentId,
+                folder.getId(),
+                folder.getTitle());
+        return folder;
+    }
+
+    public TestCaseFolder update(UUID projectId, UUID id, UpdateTestCaseFolderCommand command) {
+        var folder = requireFolderInProject(projectId, id);
+        if (command.title() != null && !command.title().equals(folder.getTitle())) {
+            requireUniqueTitleInContainer(
+                    projectId, folder.getParent() != null ? folder.getParent().getId() : null, command.title());
+            folder.setTitle(command.title());
+        }
+        if (command.clearDescription()) {
+            folder.setDescription(null);
+        } else if (command.description() != null) {
+            folder.setDescription(command.description());
+        }
+        folder = folderRepository.save(folder);
+        log.info("test_case_folder_updated: id={} title={}", folder.getId(), folder.getTitle());
+        return folder;
+    }
+
+    public TestCaseFolder move(UUID projectId, UUID folderId, MoveTestCaseFolderCommand command) {
+        var folder = requireFolderInProject(projectId, folderId);
+        TestCaseFolder newParent = null;
+        if (command.parentFolderId() != null) {
+            newParent = requireFolderInProject(projectId, command.parentFolderId());
+        }
+        if (newParent != null && wouldCreateCycle(folder, newParent)) {
+            throw new ConflictException(
+                    "Cannot move folder " + folder.getId() + " under itself or one of its descendants");
+        }
+        UUID currentParentId = folder.getParent() != null ? folder.getParent().getId() : null;
+        UUID newParentId = newParent != null ? newParent.getId() : null;
+        boolean sameContainer = Objects.equals(currentParentId, newParentId);
+        if (!sameContainer) {
+            requireTitleAvailableInContainer(projectId, newParentId, folder.getTitle(), folder.getId());
+        }
+        folder.setParent(newParent);
+        // Same-container moves with an omitted sortOrder preserve the
+        // folder's current placement so idempotent move calls do not
+        // rebalance siblings or produce audit revisions. Explicit
+        // sortOrder uses insertion semantics — siblings shift to make
+        // room (codex cycle-2 finding).
+        if (sameContainer && command.sortOrder() == null) {
+            // No-op on sort_order; keep current value.
+        } else {
+            folder.setSortOrder(placeFolderInContainer(projectId, newParentId, folder.getId(), command.sortOrder()));
+        }
+        folder = folderRepository.save(folder);
+        log.info(
+                "test_case_folder_moved: id={} new_parent={} sort_order={}",
+                folder.getId(),
+                newParentId,
+                folder.getSortOrder());
+        return folder;
+    }
+
+    public void reorder(UUID projectId, ReorderTestCaseFoldersCommand command) {
+        if (command.parentFolderId() != null
+                && folderRepository
+                        .findByIdAndProjectId(command.parentFolderId(), projectId)
+                        .isEmpty()) {
+            // Containment guard: a missing or cross-project parent must
+            // surface as 404 rather than be silently no-op'd by an empty
+            // sibling set (codex cycle-1 finding, parity with
+            // TestCaseService.reorder).
+            throw new NotFoundException("Test case folder not found: " + command.parentFolderId());
+        }
+        var siblings = command.parentFolderId() == null
+                ? folderRepository.findRootByProjectIdOrderBySortOrder(projectId)
+                : folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, command.parentFolderId());
+        applyFolderOrdering(command.orderedFolderIds(), siblings);
+    }
+
+    public void delete(UUID projectId, UUID id) {
+        var folder = requireFolderInProject(projectId, id);
+        if (folderRepository.countByParentId(id) > 0) {
+            throw new ConflictException(
+                    "Folder " + folder.getTitle() + " still contains subfolders; move or delete them first");
+        }
+        if (testCaseRepository.countByParentFolderId(id) > 0) {
+            throw new ConflictException(
+                    "Folder " + folder.getTitle() + " still contains test cases; move or delete them first");
+        }
+        folderRepository.delete(folder);
+        log.info("test_case_folder_deleted: id={} title={}", folder.getId(), folder.getTitle());
+    }
+
+    @Transactional(readOnly = true)
+    public TestCaseFolder getById(UUID projectId, UUID id) {
+        return requireFolderInProject(projectId, id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TestCaseFolder> listByProject(UUID projectId) {
+        return folderRepository.findByProjectIdOrderBySortOrder(projectId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TestCaseTreeNode> getTree(UUID projectId) {
+        // Single-batch fetch per entity type so the tree assembly is O(n)
+        // without recursive repository calls. SectionService.getTree shape;
+        // adapted for two entity kinds.
+        var folders = folderRepository.findByProjectIdOrderBySortOrder(projectId);
+        var testCases = testCaseRepository.findAllByProjectIdOrderBySortOrder(projectId);
+
+        Map<UUID, List<TestCaseFolder>> childFoldersByParent = new LinkedHashMap<>();
+        List<TestCaseFolder> rootFolders = new ArrayList<>();
+        for (TestCaseFolder folder : folders) {
+            if (folder.getParent() == null) {
+                rootFolders.add(folder);
+            } else {
+                childFoldersByParent
+                        .computeIfAbsent(folder.getParent().getId(), k -> new ArrayList<>())
+                        .add(folder);
+            }
+        }
+
+        Map<UUID, List<TestCase>> testCasesByParent = new LinkedHashMap<>();
+        List<TestCase> rootTestCases = new ArrayList<>();
+        for (TestCase testCase : testCases) {
+            if (testCase.getParentFolder() == null) {
+                rootTestCases.add(testCase);
+            } else {
+                testCasesByParent
+                        .computeIfAbsent(testCase.getParentFolder().getId(), k -> new ArrayList<>())
+                        .add(testCase);
+            }
+        }
+
+        // Tie-breakers (sortOrder, createdAt, id) keep the order
+        // deterministic when two siblings share a sort_order — codex
+        // cycle-1 class finding. Applied to roots and to every container.
+        Comparator<TestCaseFolder> folderOrder = Comparator.comparingInt(TestCaseFolder::getSortOrder)
+                .thenComparing(TestCaseFolder::getCreatedAt)
+                .thenComparing(TestCaseFolder::getId);
+        Comparator<TestCase> testCaseOrder = Comparator.comparingInt(TestCase::getSortOrder)
+                .thenComparing(TestCase::getCreatedAt)
+                .thenComparing(TestCase::getId);
+        rootFolders.sort(folderOrder);
+        rootTestCases.sort(testCaseOrder);
+        childFoldersByParent.values().forEach(list -> list.sort(folderOrder));
+        testCasesByParent.values().forEach(list -> list.sort(testCaseOrder));
+
+        Map<UUID, TestCaseTreeNode> folderNodesById =
+                buildFolderNodesIteratively(rootFolders, childFoldersByParent, testCasesByParent);
+
+        List<TestCaseTreeNode> roots = new ArrayList<>();
+        for (TestCaseFolder folder : rootFolders) {
+            roots.add(folderNodesById.get(folder.getId()));
+        }
+        for (TestCase testCase : rootTestCases) {
+            roots.add(TestCaseTreeNode.testCase(testCase));
+        }
+        return roots;
+    }
+
+    /**
+     * Iterative O(n) tree assembly (codex cycle-1 + cycle-2 findings).
+     * Walks the already-grouped children map from each root with an
+     * explicit stack to produce a post-order visit list, then builds
+     * TestCaseTreeNode instances in that order so each parent finds its
+     * children's nodes already constructed. Each folder is touched
+     * exactly twice (push + pop) and no per-node parent walk is
+     * performed, so a 5000-deep linear tree stays linear rather than
+     * quadratic.
+     *
+     * <p>Recursive descent is intentionally avoided so a valid deep tree
+     * does not blow the JVM stack (TC-005 promises unlimited nesting).
+     * The {@code visited} set defends against malformed graphs that
+     * slipped past cycle protection.
+     */
+    private Map<UUID, TestCaseTreeNode> buildFolderNodesIteratively(
+            List<TestCaseFolder> rootFolders,
+            Map<UUID, List<TestCaseFolder>> childFoldersByParent,
+            Map<UUID, List<TestCase>> testCasesByParent) {
+        List<TestCaseFolder> postOrder = new ArrayList<>();
+        HashSet<UUID> visited = new HashSet<>();
+        Deque<StackFrame> stack = new ArrayDeque<>();
+        for (TestCaseFolder root : rootFolders) {
+            stack.push(new StackFrame(root));
+            while (!stack.isEmpty()) {
+                StackFrame frame = stack.peek();
+                if (frame.expanded) {
+                    stack.pop();
+                    postOrder.add(frame.folder);
+                    continue;
+                }
+                if (!visited.add(frame.folder.getId())) {
+                    // Already visited (shouldn't happen with a valid
+                    // tree, but defend against malformed graphs).
+                    stack.pop();
+                    continue;
+                }
+                frame.expanded = true;
+                List<TestCaseFolder> children = childFoldersByParent.getOrDefault(frame.folder.getId(), List.of());
+                // Push in reverse so left-to-right child order pops first.
+                for (int i = children.size() - 1; i >= 0; i--) {
+                    stack.push(new StackFrame(children.get(i)));
+                }
+            }
+        }
+
+        Map<UUID, TestCaseTreeNode> folderNodesById = new HashMap<>();
+        for (TestCaseFolder folder : postOrder) {
+            List<TestCaseFolder> childFolders = childFoldersByParent.getOrDefault(folder.getId(), List.of());
+            List<TestCase> childTestCases = testCasesByParent.getOrDefault(folder.getId(), List.of());
+            List<TestCaseTreeNode> children = new ArrayList<>(childFolders.size() + childTestCases.size());
+            for (TestCaseFolder child : childFolders) {
+                children.add(folderNodesById.get(child.getId()));
+            }
+            for (TestCase testCase : childTestCases) {
+                children.add(TestCaseTreeNode.testCase(testCase));
+            }
+            folderNodesById.put(folder.getId(), TestCaseTreeNode.folder(folder, children));
+        }
+        return folderNodesById;
+    }
+
+    /** Stack frame used by the iterative post-order traversal in {@link #buildFolderNodesIteratively}. */
+    private static final class StackFrame {
+        final TestCaseFolder folder;
+        boolean expanded;
+
+        StackFrame(TestCaseFolder folder) {
+            this.folder = folder;
+        }
+    }
+
+    private TestCaseFolder requireFolderInProject(UUID projectId, UUID folderId) {
+        return folderRepository
+                .findByIdAndProjectId(folderId, projectId)
+                .orElseThrow(() -> new NotFoundException("Test case folder not found: " + folderId));
+    }
+
+    private void requireUniqueTitleInContainer(UUID projectId, UUID parentId, String title) {
+        boolean exists = parentId == null
+                ? folderRepository.existsRootByProjectIdAndTitle(projectId, title)
+                : folderRepository.existsByProjectIdAndParentIdAndTitle(projectId, parentId, title);
+        if (exists) {
+            throw new ConflictException("A folder titled '" + title + "' already exists at this level");
+        }
+    }
+
+    private void requireTitleAvailableInContainer(UUID projectId, UUID parentId, String title, UUID excludedId) {
+        if (!titleAvailable(projectId, parentId, title, excludedId)) {
+            throw new ConflictException("A folder titled '" + title + "' already exists at the target location");
+        }
+    }
+
+    private boolean titleAvailable(UUID projectId, UUID parentId, String title, UUID excludedId) {
+        var siblings = parentId == null
+                ? folderRepository.findRootByProjectIdOrderBySortOrder(projectId)
+                : folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, parentId);
+        return siblings.stream()
+                .noneMatch(f -> !f.getId().equals(excludedId) && f.getTitle().equals(title));
+    }
+
+    /**
+     * Insertion semantics for an explicit sort order (codex cycle-2
+     * finding): the caller hands us a target container and a desired
+     * position; the helper renumbers the target container atomically so
+     * the placing folder lands at the requested position and existing
+     * siblings shift up by 1. Null {@code requested} appends. Source
+     * container (on a cross-container move) is left with a gap; the
+     * (sortOrder, createdAt, id) tie-breaker keeps it deterministic and
+     * the reorder API can normalize.
+     */
+    private int placeFolderInContainer(UUID projectId, UUID parentId, UUID placingId, Integer requested) {
+        if (requested != null && requested < 0) {
+            throw new DomainValidationException(
+                    "Sort order must be non-negative", "invalid_test_case_folder", Map.of());
+        }
+        List<TestCaseFolder> others = (parentId == null
+                        ? folderRepository.findRootByProjectIdOrderBySortOrder(projectId)
+                        : folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, parentId))
+                .stream()
+                        .filter(f -> placingId == null || !placingId.equals(f.getId()))
+                        .toList();
+        int pos = requested == null ? others.size() : Math.min(requested, others.size());
+        for (int i = 0; i < others.size(); i++) {
+            int newOrder = i < pos ? i : i + 1;
+            TestCaseFolder sibling = others.get(i);
+            if (sibling.getSortOrder() != newOrder) {
+                sibling.setSortOrder(newOrder);
+                folderRepository.save(sibling);
+            }
+        }
+        return pos;
+    }
+
+    private boolean wouldCreateCycle(TestCaseFolder folder, TestCaseFolder proposedParent) {
+        if (folder.getId() == null || proposedParent == null) {
+            return false;
+        }
+        TestCaseFolder cursor = proposedParent;
+        var visited = new HashSet<UUID>();
+        for (int depth = 0; depth < MAX_DEPTH && cursor != null; depth++) {
+            if (cursor.getId().equals(folder.getId())) {
+                return true;
+            }
+            if (!visited.add(cursor.getId())) {
+                // Already-malformed data; bail out conservatively.
+                return true;
+            }
+            cursor = cursor.getParent();
+        }
+        // If we exited because of the depth cap, treat as cycle so the user
+        // fixes the tree rather than silently allowing more breadth.
+        return cursor != null;
+    }
+
+    /**
+     * Reorder helper used by {@link #reorder}. Containment for the parent
+     * folder is checked above; this helper just verifies the requested
+     * list matches the current sibling set exactly and renumbers
+     * sort_order = 0..N-1 via {@link SiblingOrderingHelper}.
+     */
+    private void applyFolderOrdering(List<UUID> orderedIds, List<TestCaseFolder> siblings) {
+        SiblingOrderingHelper.applyOrdering(
+                "test_case_folder", orderedIds, siblings, TestCaseFolder::getId, (folder, newOrder) -> {
+                    folder.setSortOrder(newOrder);
+                    folderRepository.save(folder);
+                });
+        log.info("test_case_folder_container_reordered: count={}", orderedIds.size());
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseGherkinService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseGherkinService.java
@@ -97,6 +97,26 @@ public class TestCaseGherkinService {
         return deleted;
     }
 
+    /**
+     * TC-005 / ADR-043 — Clone the source's Gherkin source onto {@code target}.
+     * Returns 1 when a Gherkin row was cloned, 0 when the source had no
+     * Gherkin content or the target is not in GHERKIN format. Goes through
+     * Hibernate so Envers captures the insert on the target.
+     */
+    public int copyGherkinToTestCase(UUID sourceTestCaseId, TestCase target) {
+        if (target.getFormat() != TestCaseFormat.GHERKIN) {
+            return 0;
+        }
+        var sourceGherkin = gherkinRepository.findByTestCaseId(sourceTestCaseId).orElse(null);
+        if (sourceGherkin == null) {
+            return 0;
+        }
+        var clone = gherkinRepository.save(new TestCaseGherkin(target, sourceGherkin.getSource()));
+        log.info(
+                "test_case_gherkin_copied: source={} target={} id={}", sourceTestCaseId, target.getId(), clone.getId());
+        return 1;
+    }
+
     private TestCaseGherkin findOrThrow(TestCase testCase) {
         return gherkinRepository
                 .findByTestCaseId(testCase.getId())

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TestCaseService {
 
     private static final Logger log = LoggerFactory.getLogger(TestCaseService.class);
+    private static final String FOLDER_NOT_FOUND_PREFIX = "Test case folder not found: ";
 
     private final TestCaseRepository testCaseRepository;
     private final TestCaseFolderRepository folderRepository;
@@ -50,8 +51,7 @@ public class TestCaseService {
         if (command.parentFolderId() != null) {
             parentFolder = folderRepository
                     .findByIdAndProjectId(command.parentFolderId(), project.getId())
-                    .orElseThrow(
-                            () -> new NotFoundException("Test case folder not found: " + command.parentFolderId()));
+                    .orElseThrow(() -> new NotFoundException(FOLDER_NOT_FOUND_PREFIX + command.parentFolderId()));
         }
         var format = command.format() != null ? command.format() : TestCaseFormat.STEP_BASED;
         var testCase =
@@ -163,8 +163,7 @@ public class TestCaseService {
         if (command.parentFolderId() != null) {
             targetFolder = folderRepository
                     .findByIdAndProjectId(command.parentFolderId(), projectId)
-                    .orElseThrow(
-                            () -> new NotFoundException("Test case folder not found: " + command.parentFolderId()));
+                    .orElseThrow(() -> new NotFoundException(FOLDER_NOT_FOUND_PREFIX + command.parentFolderId()));
         }
         UUID currentParentId =
                 testCase.getParentFolder() != null ? testCase.getParentFolder().getId() : null;
@@ -215,8 +214,7 @@ public class TestCaseService {
         if (command.parentFolderId() != null) {
             targetFolder = folderRepository
                     .findByIdAndProjectId(command.parentFolderId(), projectId)
-                    .orElseThrow(
-                            () -> new NotFoundException("Test case folder not found: " + command.parentFolderId()));
+                    .orElseThrow(() -> new NotFoundException(FOLDER_NOT_FOUND_PREFIX + command.parentFolderId()));
         }
         var copy = new TestCase(
                 source.getProject(),
@@ -263,7 +261,7 @@ public class TestCaseService {
             // Containment guard before touching siblings: a missing or
             // cross-project target must surface as 404 rather than being
             // silently no-op'd by an empty current-sibling set.
-            throw new NotFoundException("Test case folder not found: " + command.parentFolderId());
+            throw new NotFoundException(FOLDER_NOT_FOUND_PREFIX + command.parentFolderId());
         }
         var siblings = command.parentFolderId() == null
                 ? testCaseRepository.findRootByProjectIdOrderBySortOrder(projectId)

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseService.java
@@ -4,6 +4,8 @@ import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseFolderRepository;
 import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseRepository;
 import com.keplerops.groundcontrol.domain.testcases.state.TestCaseFormat;
 import com.keplerops.groundcontrol.domain.testcases.state.TestCaseStatus;
@@ -21,16 +23,19 @@ public class TestCaseService {
     private static final Logger log = LoggerFactory.getLogger(TestCaseService.class);
 
     private final TestCaseRepository testCaseRepository;
+    private final TestCaseFolderRepository folderRepository;
     private final ProjectService projectService;
     private final TestCaseStepService testCaseStepService;
     private final TestCaseGherkinService testCaseGherkinService;
 
     public TestCaseService(
             TestCaseRepository testCaseRepository,
+            TestCaseFolderRepository folderRepository,
             ProjectService projectService,
             TestCaseStepService testCaseStepService,
             TestCaseGherkinService testCaseGherkinService) {
         this.testCaseRepository = testCaseRepository;
+        this.folderRepository = folderRepository;
         this.projectService = projectService;
         this.testCaseStepService = testCaseStepService;
         this.testCaseGherkinService = testCaseGherkinService;
@@ -41,6 +46,13 @@ public class TestCaseService {
         if (testCaseRepository.existsByProjectIdAndUid(project.getId(), command.uid())) {
             throw new ConflictException("Test case with UID " + command.uid() + " already exists in this project");
         }
+        TestCaseFolder parentFolder = null;
+        if (command.parentFolderId() != null) {
+            parentFolder = folderRepository
+                    .findByIdAndProjectId(command.parentFolderId(), project.getId())
+                    .orElseThrow(
+                            () -> new NotFoundException("Test case folder not found: " + command.parentFolderId()));
+        }
         var format = command.format() != null ? command.format() : TestCaseFormat.STEP_BASED;
         var testCase =
                 new TestCase(project, command.uid(), command.title(), command.type(), command.priority(), format);
@@ -48,11 +60,20 @@ public class TestCaseService {
         testCase.setPreconditions(command.preconditions());
         testCase.setPostconditions(command.postconditions());
         testCase.setEstimatedDurationSeconds(command.estimatedDurationSeconds());
+        testCase.setParentFolder(parentFolder);
+        // Insertion semantics (codex cycle-2 finding): shift target
+        // siblings before assigning sort_order so an explicit position is
+        // honoured. placingId is null because the entity is not yet
+        // persisted.
+        UUID parentIdForPlacement = parentFolder != null ? parentFolder.getId() : null;
+        testCase.setSortOrder(
+                placeTestCaseInContainer(project.getId(), parentIdForPlacement, null, command.sortOrder()));
         testCase = testCaseRepository.save(testCase);
         log.info(
-                "test_case_created: uid={} project={} type={} format={} priority={}",
+                "test_case_created: uid={} project={} parent_folder={} type={} format={} priority={}",
                 testCase.getUid(),
                 project.getIdentifier(),
+                parentFolder != null ? parentFolder.getId() : null,
                 testCase.getType(),
                 testCase.getFormat(),
                 testCase.getPriority());
@@ -128,6 +149,168 @@ public class TestCaseService {
         testCaseGherkinService.cascadeDeleteByTestCase(id);
         testCaseRepository.delete(testCase);
         log.info("test_case_deleted: uid={} id={}", testCase.getUid(), id);
+    }
+
+    /**
+     * TC-005 / ADR-043 — Move a test case to another folder (or to the
+     * project root). Project scope is enforced via {@code findByIdAndProjectId}
+     * on both the test case and the target folder, so cross-project moves
+     * are rejected.
+     */
+    public TestCase move(UUID projectId, UUID id, MoveTestCaseCommand command) {
+        var testCase = findOrThrow(projectId, id);
+        TestCaseFolder targetFolder = null;
+        if (command.parentFolderId() != null) {
+            targetFolder = folderRepository
+                    .findByIdAndProjectId(command.parentFolderId(), projectId)
+                    .orElseThrow(
+                            () -> new NotFoundException("Test case folder not found: " + command.parentFolderId()));
+        }
+        UUID currentParentId =
+                testCase.getParentFolder() != null ? testCase.getParentFolder().getId() : null;
+        UUID newParentId = targetFolder != null ? targetFolder.getId() : null;
+        boolean sameContainer = java.util.Objects.equals(currentParentId, newParentId);
+        testCase.setParentFolder(targetFolder);
+        // Same-container moves with omitted sortOrder preserve placement
+        // (parity with TestCaseFolderService.move; codex cycle-1 finding).
+        // Explicit sortOrder uses insertion semantics — target siblings
+        // shift to make room (codex cycle-2 finding).
+        if (!sameContainer || command.sortOrder() != null) {
+            testCase.setSortOrder(
+                    placeTestCaseInContainer(projectId, newParentId, testCase.getId(), command.sortOrder()));
+        }
+        testCase = testCaseRepository.save(testCase);
+        log.info(
+                "test_case_moved: uid={} id={} parent_folder={} sort_order={}",
+                testCase.getUid(),
+                testCase.getId(),
+                targetFolder != null ? targetFolder.getId() : null,
+                testCase.getSortOrder());
+        return testCase;
+    }
+
+    /**
+     * TC-005 / ADR-043 — Copy a test case to a (possibly different) container.
+     * The copy is a new aggregate root with a caller-supplied UID, status
+     * reset to DRAFT, and freshly cloned authored children. The source test
+     * case is unchanged.
+     */
+    public TestCase copy(UUID projectId, UUID sourceId, CopyTestCaseCommand command) {
+        var source = findOrThrow(projectId, sourceId);
+        if (command.newUid() == null || command.newUid().isBlank()) {
+            throw new ConflictException("Copy requires a new UID");
+        }
+        if (testCaseRepository.existsByProjectIdAndUid(projectId, command.newUid())) {
+            throw new ConflictException("Test case with UID " + command.newUid() + " already exists in this project");
+        }
+        // Copy placement follows the same semantics as move (codex
+        // cycle-1 finding): explicit null parentFolderId means the
+        // project root; a UUID means that folder. The previous "preserve
+        // source's folder when null" semantic conflated JSON omission
+        // and explicit null, leaving the project root unreachable from a
+        // test originally in a folder. Callers that want to keep the
+        // copy in the source's folder must pass the source's
+        // parentFolderId explicitly.
+        TestCaseFolder targetFolder = null;
+        if (command.parentFolderId() != null) {
+            targetFolder = folderRepository
+                    .findByIdAndProjectId(command.parentFolderId(), projectId)
+                    .orElseThrow(
+                            () -> new NotFoundException("Test case folder not found: " + command.parentFolderId()));
+        }
+        var copy = new TestCase(
+                source.getProject(),
+                command.newUid(),
+                source.getTitle(),
+                source.getType(),
+                source.getPriority(),
+                source.getFormat());
+        copy.setDescription(source.getDescription());
+        copy.setPreconditions(source.getPreconditions());
+        copy.setPostconditions(source.getPostconditions());
+        copy.setEstimatedDurationSeconds(source.getEstimatedDurationSeconds());
+        copy.setParentFolder(targetFolder);
+        // Persist first so the placement helper sees the copy in the
+        // sibling query result and can exclude it correctly.
+        copy = testCaseRepository.save(copy);
+        UUID copyParentId = targetFolder != null ? targetFolder.getId() : null;
+        copy.setSortOrder(placeTestCaseInContainer(projectId, copyParentId, copy.getId(), command.sortOrder()));
+        copy = testCaseRepository.save(copy);
+        // Status is implicitly DRAFT via the entity default — a copy is
+        // unreviewed even when the source was APPROVED.
+        testCaseStepService.copyStepsToTestCase(sourceId, copy);
+        testCaseGherkinService.copyGherkinToTestCase(sourceId, copy);
+        log.info(
+                "test_case_copied: source_uid={} source_id={} new_uid={} new_id={} parent_folder={}",
+                source.getUid(),
+                source.getId(),
+                copy.getUid(),
+                copy.getId(),
+                targetFolder != null ? targetFolder.getId() : null);
+        return copy;
+    }
+
+    /**
+     * TC-005 / ADR-043 — Bulk reorder of test cases within one container.
+     * Delegates to {@link TestCaseFolderService#reorderTestCases} so the
+     * applyOrdering algorithm has one home.
+     */
+    public void reorder(UUID projectId, ReorderTestCasesCommand command) {
+        if (command.parentFolderId() != null
+                && folderRepository
+                        .findByIdAndProjectId(command.parentFolderId(), projectId)
+                        .isEmpty()) {
+            // Containment guard before touching siblings: a missing or
+            // cross-project target must surface as 404 rather than being
+            // silently no-op'd by an empty current-sibling set.
+            throw new NotFoundException("Test case folder not found: " + command.parentFolderId());
+        }
+        var siblings = command.parentFolderId() == null
+                ? testCaseRepository.findRootByProjectIdOrderBySortOrder(projectId)
+                : testCaseRepository.findByProjectIdAndParentFolderIdOrderBySortOrder(
+                        projectId, command.parentFolderId());
+        SiblingOrderingHelper.applyOrdering(
+                "test_case", command.orderedTestCaseIds(), siblings, TestCase::getId, (testCase, newOrder) -> {
+                    testCase.setSortOrder(newOrder);
+                    testCaseRepository.save(testCase);
+                });
+        log.info(
+                "test_case_container_reordered: project={} parent_folder={} count={}",
+                projectId,
+                command.parentFolderId(),
+                command.orderedTestCaseIds().size());
+    }
+
+    /**
+     * Insertion semantics for an explicit sort order (codex cycle-2
+     * finding): renumbers the target container so the placing test
+     * case lands at the requested position. Null {@code requested}
+     * appends. The {@code placingId} is excluded from the sibling list
+     * so same-container moves don't double-count the moved row; pass
+     * {@code null} for create/copy where the entity is not yet in the
+     * sibling query result.
+     */
+    private int placeTestCaseInContainer(UUID projectId, UUID parentFolderId, UUID placingId, Integer requested) {
+        if (requested != null && requested < 0) {
+            throw new ConflictException("Sort order must be non-negative");
+        }
+        List<TestCase> others = (parentFolderId == null
+                        ? testCaseRepository.findRootByProjectIdOrderBySortOrder(projectId)
+                        : testCaseRepository.findByProjectIdAndParentFolderIdOrderBySortOrder(
+                                projectId, parentFolderId))
+                .stream()
+                        .filter(t -> placingId == null || !placingId.equals(t.getId()))
+                        .toList();
+        int pos = requested == null ? others.size() : Math.min(requested, others.size());
+        for (int i = 0; i < others.size(); i++) {
+            int newOrder = i < pos ? i : i + 1;
+            TestCase sibling = others.get(i);
+            if (sibling.getSortOrder() != newOrder) {
+                sibling.setSortOrder(newOrder);
+                testCaseRepository.save(sibling);
+            }
+        }
+        return pos;
     }
 
     private TestCase findOrThrow(UUID projectId, UUID id) {

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseStepService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseStepService.java
@@ -2,6 +2,7 @@ package com.keplerops.groundcontrol.domain.testcases.service;
 
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
 import com.keplerops.groundcontrol.domain.testcases.model.TestCaseStep;
 import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseRepository;
 import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseStepRepository;
@@ -102,6 +103,34 @@ public class TestCaseStepService {
             log.info("test_case_steps_deleted: test_case={} count={}", testCaseId, deleted);
         }
         return deleted;
+    }
+
+    /**
+     * TC-005 / ADR-043 — Clone every step from {@code sourceTestCaseId} onto
+     * {@code target}. Used by {@link TestCaseService#copy} so a STEP_BASED
+     * copy carries its authored children. The clones go through Hibernate so
+     * Envers captures them as inserts on the target. Returns the number of
+     * cloned rows.
+     */
+    public int copyStepsToTestCase(UUID sourceTestCaseId, TestCase target) {
+        if (target.getFormat() != TestCaseFormat.STEP_BASED) {
+            return 0;
+        }
+        var sourceSteps = stepRepository.findByTestCaseIdOrderByStepNumberAsc(sourceTestCaseId);
+        int count = 0;
+        for (TestCaseStep source : sourceSteps) {
+            var clone =
+                    new TestCaseStep(target, source.getStepNumber(), source.getAction(), source.getExpectedResult());
+            // Actual result is run-time evidence (ADR-041); copying a definition
+            // should leave the new test case's actual result blank.
+            clone.setActualResult(null);
+            stepRepository.save(clone);
+            count++;
+        }
+        if (count > 0) {
+            log.info("test_case_steps_copied: source={} target={} count={}", sourceTestCaseId, target.getId(), count);
+        }
+        return count;
     }
 
     private TestCaseStep findStepOrThrow(UUID projectId, UUID testCaseId, UUID stepId) {

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseTreeNode.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseTreeNode.java
@@ -1,0 +1,64 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseFormat;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseStatus;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseType;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * TC-005 / ADR-043 — Tree node for hierarchical test repository browsing.
+ *
+ * <p>A node is either a folder or a test case (discriminated by {@link #kind()}).
+ * Folder nodes carry nested {@code children}; test-case nodes are leaves and
+ * carry the test-case payload via {@link #testCase()}.
+ */
+public record TestCaseTreeNode(
+        Kind kind,
+        UUID id,
+        UUID parentFolderId,
+        String title,
+        String description,
+        int sortOrder,
+        TestCaseLeaf testCase,
+        List<TestCaseTreeNode> children) {
+
+    public enum Kind {
+        FOLDER,
+        TEST_CASE
+    }
+
+    public static TestCaseTreeNode folder(TestCaseFolder folder, List<TestCaseTreeNode> children) {
+        return new TestCaseTreeNode(
+                Kind.FOLDER,
+                folder.getId(),
+                folder.getParent() != null ? folder.getParent().getId() : null,
+                folder.getTitle(),
+                folder.getDescription(),
+                folder.getSortOrder(),
+                null,
+                List.copyOf(children));
+    }
+
+    public static TestCaseTreeNode testCase(TestCase testCase) {
+        return new TestCaseTreeNode(
+                Kind.TEST_CASE,
+                testCase.getId(),
+                testCase.getParentFolder() != null ? testCase.getParentFolder().getId() : null,
+                testCase.getTitle(),
+                testCase.getDescription(),
+                testCase.getSortOrder(),
+                TestCaseLeaf.from(testCase),
+                List.of());
+    }
+
+    public record TestCaseLeaf(
+            String uid, TestCaseStatus status, TestCaseType type, TestCasePriority priority, TestCaseFormat format) {
+        public static TestCaseLeaf from(TestCase t) {
+            return new TestCaseLeaf(t.getUid(), t.getStatus(), t.getType(), t.getPriority(), t.getFormat());
+        }
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/UpdateTestCaseFolderCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/UpdateTestCaseFolderCommand.java
@@ -1,0 +1,3 @@
+package com.keplerops.groundcontrol.domain.testcases.service;
+
+public record UpdateTestCaseFolderCommand(String title, String description, boolean clearDescription) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/compliance/AuditRetentionJob.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/compliance/AuditRetentionJob.java
@@ -46,7 +46,8 @@ public class AuditRetentionJob {
             "test_case_audit",
             "test_case_step_audit",
             "test_case_gherkin_audit",
-            "asset_subtype_schema_audit");
+            "asset_subtype_schema_audit",
+            "test_case_folder_audit");
 
     private final AuditRetentionProperties properties;
     private final EntityManager entityManager;

--- a/backend/src/main/resources/db/migration/V084__create_test_case_folder.sql
+++ b/backend/src/main/resources/db/migration/V084__create_test_case_folder.sql
@@ -1,0 +1,35 @@
+-- TC-005 / ADR-043 — Hierarchical Test Case Organization.
+--
+-- TestCaseFolder is the test-repository organisation aggregate. It is
+-- project-scoped and self-referencing; a folder with parent_id IS NULL
+-- sits at the project root. Sibling ordering is container-local: the
+-- (project_id, parent_id, sort_order) index keeps drag-and-drop reorder
+-- queries cheap without touching siblings outside the container.
+--
+-- Sibling-title uniqueness is enforced by two partial unique indexes
+-- because PostgreSQL treats NULL parents as distinct under a plain
+-- UNIQUE constraint: one index covers the project-root case (parent IS
+-- NULL), and one covers non-root containers.
+CREATE TABLE test_case_folder (
+    id           UUID PRIMARY KEY,
+    project_id   UUID         NOT NULL REFERENCES project(id),
+    parent_id    UUID         REFERENCES test_case_folder(id),
+    title        VARCHAR(200) NOT NULL,
+    description  TEXT,
+    sort_order   INTEGER      NOT NULL DEFAULT 0,
+    created_at   TIMESTAMPTZ  NOT NULL,
+    updated_at   TIMESTAMPTZ  NOT NULL
+);
+
+CREATE INDEX idx_test_case_folder_project ON test_case_folder (project_id);
+CREATE INDEX idx_test_case_folder_parent ON test_case_folder (parent_id);
+CREATE INDEX idx_test_case_folder_container
+    ON test_case_folder (project_id, parent_id, sort_order);
+
+CREATE UNIQUE INDEX uq_test_case_folder_title_root
+    ON test_case_folder (project_id, title)
+    WHERE parent_id IS NULL;
+
+CREATE UNIQUE INDEX uq_test_case_folder_title_under_parent
+    ON test_case_folder (project_id, parent_id, title)
+    WHERE parent_id IS NOT NULL;

--- a/backend/src/main/resources/db/migration/V085__create_test_case_folder_audit.sql
+++ b/backend/src/main/resources/db/migration/V085__create_test_case_folder_audit.sql
@@ -1,0 +1,18 @@
+-- TC-005 / ADR-043 — Envers audit shadow for test_case_folder.
+--
+-- Project FK is intentionally absent (@NotAudited on TestCaseFolder.project);
+-- parent_id is audited so move/rebalance operations are reconstructable.
+-- BaseEntity timestamps are mirrored so AuditRetentionJob.purgeOldAuditRecords
+-- can age out folder revisions alongside the other test-case audit tables.
+CREATE TABLE test_case_folder_audit (
+    id           UUID         NOT NULL,
+    rev          INTEGER      NOT NULL REFERENCES revinfo(rev),
+    revtype      SMALLINT     NOT NULL,
+    parent_id    UUID,
+    title        VARCHAR(200),
+    description  TEXT,
+    sort_order   INTEGER,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    PRIMARY KEY (id, rev)
+);

--- a/backend/src/main/resources/db/migration/V086__add_test_case_parent_folder_and_sort_order.sql
+++ b/backend/src/main/resources/db/migration/V086__add_test_case_parent_folder_and_sort_order.sql
@@ -1,0 +1,33 @@
+-- TC-005 / ADR-043 — Hierarchical placement for existing test_case rows.
+--
+-- parent_folder_id IS NULL means the test case sits at the project root.
+-- The NOT NULL DEFAULT 0 on sort_order makes the ALTER TABLE safe; the
+-- explicit back-fill below replaces the default with a dense per-container
+-- ranking so existing rows have deterministic ordering immediately, not
+-- a wall of ties at 0. New writes set sort_order explicitly via
+-- TestCaseService (max+1 of the target container when the caller omits a
+-- value).
+ALTER TABLE test_case
+    ADD COLUMN parent_folder_id UUID REFERENCES test_case_folder(id),
+    ADD COLUMN sort_order       INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_test_case_parent_folder ON test_case (parent_folder_id);
+CREATE INDEX idx_test_case_container
+    ON test_case (project_id, parent_folder_id, sort_order);
+
+-- Back-fill: assign sort_order = row_number per (project_id, parent_folder_id)
+-- - 1, ordered deterministically by (created_at, id). Without this every
+-- pre-V086 row would sit at sort_order = 0 and tree/reorder reads would
+-- have to fall back to a tie-breaker for every container in the system.
+WITH numbered AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY project_id, parent_folder_id
+               ORDER BY created_at, id
+           ) - 1 AS new_sort_order
+    FROM test_case
+)
+UPDATE test_case t
+SET sort_order = numbered.new_sort_order
+FROM numbered
+WHERE t.id = numbered.id;

--- a/backend/src/main/resources/db/migration/V087__add_test_case_audit_parent_folder_and_sort_order.sql
+++ b/backend/src/main/resources/db/migration/V087__add_test_case_audit_parent_folder_and_sort_order.sql
@@ -1,0 +1,6 @@
+-- TC-005 / ADR-043 — Envers audit parity for test_case placement columns.
+-- Audit columns are nullable per Envers convention (revisions before the
+-- new field existed carry NULL).
+ALTER TABLE test_case_audit
+    ADD COLUMN parent_folder_id UUID,
+    ADD COLUMN sort_order       INTEGER;

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
@@ -50,7 +50,7 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         "040", "041", "042", "043", "044", "045", "046", "047", "048", "049", "050", "051", "052",
                         "053", "054", "055", "056", "057", "058", "059", "060", "061", "062", "063", "064", "065",
                         "066", "067", "068", "069", "070", "071", "072", "073", "074", "075", "076", "077", "078",
-                        "079", "080", "081", "082", "083");
+                        "079", "080", "081", "082", "083", "084", "085", "086", "087");
     }
 
     @Test
@@ -394,7 +394,7 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         + " WHERE table_name = 'test_case_gherkin'"
                         + " AND constraint_name = 'uq_test_case_gherkin_test_case'")
                 .getSingleResult();
-        // V080 / V081 GC-M011 subtype + metadata column-existence probes.
+        // GC-M011 V080 / V081 subtype + metadata column-existence probes.
         org.assertj.core.api.Assertions.assertThatCode(() -> entityManager
                         .createNativeQuery("SELECT subtype, metadata FROM operational_asset LIMIT 1")
                         .getResultList())
@@ -403,7 +403,7 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         .createNativeQuery("SELECT subtype, metadata FROM operational_asset_audit LIMIT 1")
                         .getResultList())
                 .doesNotThrowAnyException();
-        // V082 / V083 asset_subtype_schema + audit table presence.
+        // GC-M011 V082 / V083 asset_subtype_schema + audit table presence.
         entityManager
                 .createNativeQuery("SELECT 1 FROM asset_subtype_schema LIMIT 1")
                 .getResultList();
@@ -429,6 +429,74 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                 .createNativeQuery(
                         "SELECT 1 FROM information_schema.columns WHERE table_name = 'asset_subtype_schema_audit'"
                                 + " AND column_name = 'updated_at'")
+                .getSingleResult();
+        // V084-V087 test_case_folder + audit + test_case placement columns
+        // (TC-005 / ADR-043). Same column-existence probe rationale as the
+        // older audit-table assertions: ddl-auto: validate doesn't see audit
+        // shadow tables, and ALTER TABLE silent regressions on the parent
+        // would otherwise pass.
+        entityManager
+                .createNativeQuery("SELECT 1 FROM test_case_folder LIMIT 1")
+                .getResultList();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM test_case_folder_audit LIMIT 1")
+                .getResultList();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_folder'"
+                        + " AND column_name = 'parent_id'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_folder'"
+                        + " AND column_name = 'sort_order' AND is_nullable = 'NO'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery(
+                        "SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_folder_audit'"
+                                + " AND column_name = 'parent_id'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery(
+                        "SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_folder_audit'"
+                                + " AND column_name = 'sort_order'")
+                .getSingleResult();
+        // BaseEntity timestamps on the test_case_folder_audit shadow — required by
+        // AuditRetentionJob.purgeOldAuditRecords to age out folder revisions.
+        entityManager
+                .createNativeQuery(
+                        "SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_folder_audit'"
+                                + " AND column_name = 'created_at'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery(
+                        "SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_folder_audit'"
+                                + " AND column_name = 'updated_at'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case'"
+                        + " AND column_name = 'parent_folder_id'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case'"
+                        + " AND column_name = 'sort_order' AND is_nullable = 'NO'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_audit'"
+                        + " AND column_name = 'parent_folder_id'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns WHERE table_name = 'test_case_audit'"
+                        + " AND column_name = 'sort_order'")
+                .getSingleResult();
+        // Partial unique indexes on (project_id, title) WHERE parent IS NULL
+        // and (project_id, parent_id, title) WHERE parent IS NOT NULL back
+        // the sibling-title uniqueness invariant.
+        entityManager
+                .createNativeQuery("SELECT 1 FROM pg_indexes WHERE tablename = 'test_case_folder'"
+                        + " AND indexname = 'uq_test_case_folder_title_root'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM pg_indexes WHERE tablename = 'test_case_folder'"
+                        + " AND indexname = 'uq_test_case_folder_title_under_parent'")
                 .getSingleResult();
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -481,6 +481,10 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
                         "080", // V080: operational_asset subtype + metadata (GC-M011)
                         "081", // V081: operational_asset_audit parity for GC-M011
                         "082", // V082: asset_subtype_schema (GC-M011 registry)
-                        "083"); // V083: asset_subtype_schema_audit
+                        "083", // V083: asset_subtype_schema_audit
+                        "084", // V084: create test_case_folder (TC-005 / ADR-043)
+                        "085", // V085: create test_case_folder_audit
+                        "086", // V086: add test_case.parent_folder_id + sort_order
+                        "087"); // V087: add test_case_audit.parent_folder_id + sort_order
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseControllerIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package com.keplerops.groundcontrol.integration;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -129,5 +130,92 @@ class TestCaseControllerIntegrationTest extends BaseIntegrationTest {
         // Subsequent GET returns 404
         mockMvc.perform(get("/api/v1/test-cases/{id}", testCaseId).param("project", "ground-control"))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void move_copy_reorder_roundTrip() throws Exception {
+        // Create a folder to place the test case into.
+        Map<String, Object> folderReq = new LinkedHashMap<>();
+        folderReq.put("title", "Hierarchy bucket");
+        var folderResult = mockMvc.perform(post("/api/v1/test-cases/folders")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(folderReq)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        String folderId = objectMapper
+                .readTree(folderResult.getResponse().getContentAsString())
+                .get("id")
+                .asText();
+
+        // Create source test case at the root.
+        var srcResult = mockMvc.perform(post("/api/v1/test-cases")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest("TC-MV-001"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        String srcId = objectMapper
+                .readTree(srcResult.getResponse().getContentAsString())
+                .get("id")
+                .asText();
+
+        // Move into folder.
+        Map<String, Object> moveBody = new LinkedHashMap<>();
+        moveBody.put("parentFolderId", folderId);
+        mockMvc.perform(put("/api/v1/test-cases/{id}/move", srcId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(moveBody)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.parentFolderId", is(folderId)));
+
+        // Copy into the same folder under a new UID. Per the move/copy
+        // parity convention, callers pass the desired parentFolderId
+        // explicitly; null or omitted means project root.
+        Map<String, Object> copyBody = new LinkedHashMap<>();
+        copyBody.put("newUid", "TC-MV-001-COPY");
+        copyBody.put("parentFolderId", folderId);
+        mockMvc.perform(post("/api/v1/test-cases/{id}/copy", srcId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(copyBody)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.uid", is("TC-MV-001-COPY")))
+                .andExpect(jsonPath("$.status", is("DRAFT")))
+                .andExpect(jsonPath("$.parentFolderId", is(folderId)));
+
+        // Copy to root by passing parentFolderId = null explicitly.
+        Map<String, Object> copyToRootBody = new LinkedHashMap<>();
+        copyToRootBody.put("newUid", "TC-MV-001-ROOT");
+        copyToRootBody.put("parentFolderId", null);
+        mockMvc.perform(post("/api/v1/test-cases/{id}/copy", srcId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(copyToRootBody)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.parentFolderId", is(nullValue())));
+
+        // Copy with the existing source UID is rejected.
+        Map<String, Object> dupBody = new LinkedHashMap<>();
+        dupBody.put("newUid", "TC-MV-001");
+        mockMvc.perform(post("/api/v1/test-cases/{id}/copy", srcId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dupBody)))
+                .andExpect(status().isConflict());
+
+        // Move back to root — assert parentFolderId actually nulled out
+        // (test-quality cycle 2): a regression where 200 OK comes back
+        // but the test case stays in its folder is otherwise invisible
+        // because this is the last step.
+        Map<String, Object> rootMove = new LinkedHashMap<>();
+        rootMove.put("parentFolderId", null);
+        mockMvc.perform(put("/api/v1/test-cases/{id}/move", srcId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(rootMove)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.parentFolderId", is(nullValue())));
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseFolderControllerIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseFolderControllerIntegrationTest.java
@@ -1,0 +1,224 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@AutoConfigureMockMvc
+@Transactional
+class TestCaseFolderControllerIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static Map<String, Object> folderRequest(String title) {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("title", title);
+        request.put("description", "set of regression tests");
+        return request;
+    }
+
+    private String createRootFolder(String title) throws Exception {
+        var result = mockMvc.perform(post("/api/v1/test-cases/folders")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(folderRequest(title))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title", is(title)))
+                .andReturn();
+        return objectMapper
+                .readTree(result.getResponse().getContentAsString())
+                .get("id")
+                .asText();
+    }
+
+    @Test
+    void create_list_update_move_reorder_delete_roundTrip() throws Exception {
+        String folderId = createRootFolder("Smoke");
+        String anotherRoot = createRootFolder("Regression");
+
+        // Duplicate sibling title rejected
+        mockMvc.perform(post("/api/v1/test-cases/folders")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(folderRequest("Smoke"))))
+                .andExpect(status().isConflict());
+
+        // List
+        mockMvc.perform(get("/api/v1/test-cases/folders").param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)));
+
+        // Get by id
+        mockMvc.perform(get("/api/v1/test-cases/folders/{id}", folderId).param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title", is("Smoke")));
+
+        // Update title
+        Map<String, Object> update = new LinkedHashMap<>();
+        update.put("title", "Smoke (renamed)");
+        mockMvc.perform(put("/api/v1/test-cases/folders/{id}", folderId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(update)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title", is("Smoke (renamed)")));
+
+        // Move under sibling
+        Map<String, Object> move = new LinkedHashMap<>();
+        move.put("parentFolderId", anotherRoot);
+        mockMvc.perform(put("/api/v1/test-cases/folders/{id}/move", folderId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(move)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.parentFolderId", is(anotherRoot)));
+
+        // Move under self is rejected (cycle)
+        Map<String, Object> selfMove = new LinkedHashMap<>();
+        selfMove.put("parentFolderId", folderId);
+        mockMvc.perform(put("/api/v1/test-cases/folders/{id}/move", folderId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(selfMove)))
+                .andExpect(status().isConflict());
+
+        // Delete non-empty parent rejected (has the moved child)
+        mockMvc.perform(delete("/api/v1/test-cases/folders/{id}", anotherRoot).param("project", "ground-control"))
+                .andExpect(status().isConflict());
+
+        // Move back to root then delete (now empty)
+        Map<String, Object> backToRoot = new LinkedHashMap<>();
+        backToRoot.put("parentFolderId", null);
+        mockMvc.perform(put("/api/v1/test-cases/folders/{id}/move", folderId)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(backToRoot)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/v1/test-cases/folders/{id}", anotherRoot).param("project", "ground-control"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void reorderRenumbersSiblings() throws Exception {
+        String a = createRootFolder("A");
+        String b = createRootFolder("B");
+        String c = createRootFolder("C");
+
+        Map<String, Object> reorder = new LinkedHashMap<>();
+        reorder.put("parentFolderId", null);
+        reorder.put("orderedFolderIds", List.of(c, a, b));
+
+        mockMvc.perform(put("/api/v1/test-cases/folders/reorder")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reorder)))
+                .andExpect(status().isNoContent());
+
+        var listResult = mockMvc.perform(get("/api/v1/test-cases/folders").param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andReturn();
+        // Folders come back ordered by sort_order; verify the renumbering took.
+        var json = objectMapper.readTree(listResult.getResponse().getContentAsString());
+        // Find each folder by id and confirm its sortOrder.
+        int sortA = -1;
+        int sortB = -1;
+        int sortC = -1;
+        for (var node : json) {
+            String id = node.get("id").asText();
+            int order = node.get("sortOrder").asInt();
+            if (id.equals(a)) {
+                sortA = order;
+            } else if (id.equals(b)) {
+                sortB = order;
+            } else if (id.equals(c)) {
+                sortC = order;
+            }
+        }
+        org.assertj.core.api.Assertions.assertThat(sortC).isZero();
+        org.assertj.core.api.Assertions.assertThat(sortA).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(sortB).isEqualTo(2);
+    }
+
+    @Test
+    void deletionRequiresEmptyFolder() throws Exception {
+        String folderId = createRootFolder("BucketA");
+
+        // Place a test case inside, then attempt deletion.
+        Map<String, Object> testCase = new LinkedHashMap<>();
+        testCase.put("uid", "TC-FOLD-001");
+        testCase.put("title", "inside folder");
+        testCase.put("type", "MANUAL");
+        testCase.put("priority", "LOW");
+        testCase.put("parentFolderId", folderId);
+        mockMvc.perform(post("/api/v1/test-cases")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(testCase)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.parentFolderId", is(folderId)));
+
+        mockMvc.perform(delete("/api/v1/test-cases/folders/{id}", folderId).param("project", "ground-control"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void treeIncludesFoldersAndTestCases() throws Exception {
+        String root = createRootFolder("Top");
+
+        Map<String, Object> child = new LinkedHashMap<>();
+        child.put("parentFolderId", root);
+        child.put("title", "Nested");
+        mockMvc.perform(post("/api/v1/test-cases/folders")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(child)))
+                .andExpect(status().isCreated());
+
+        Map<String, Object> tc = new LinkedHashMap<>();
+        tc.put("uid", "TC-TREE-001");
+        tc.put("title", "leaf");
+        tc.put("type", "MANUAL");
+        tc.put("priority", "LOW");
+        tc.put("parentFolderId", root);
+        mockMvc.perform(post("/api/v1/test-cases")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tc)))
+                .andExpect(status().isCreated());
+
+        // Folder-first-then-test-case ordering (ADR-043) is the contract;
+        // assert child kind + title at each position so a regression
+        // mixing kinds or inverting the order is caught here, not just
+        // by count (test-quality cycle 1).
+        mockMvc.perform(get("/api/v1/test-cases/tree").param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].kind", is("FOLDER")))
+                .andExpect(jsonPath("$[0].title", is("Top")))
+                .andExpect(jsonPath("$[0].children", hasSize(2)))
+                .andExpect(jsonPath("$[0].children[0].kind", is("FOLDER")))
+                .andExpect(jsonPath("$[0].children[0].title", is("Nested")))
+                .andExpect(jsonPath("$[0].children[1].kind", is("TEST_CASE")))
+                .andExpect(jsonPath("$[0].children[1].title", is("leaf")));
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseFolderControllerIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseFolderControllerIntegrationTest.java
@@ -207,10 +207,8 @@ class TestCaseFolderControllerIntegrationTest extends BaseIntegrationTest {
                         .content(objectMapper.writeValueAsString(tc)))
                 .andExpect(status().isCreated());
 
-        // Folder-first-then-test-case ordering (ADR-043) is the contract;
-        // assert child kind + title at each position so a regression
-        // mixing kinds or inverting the order is caught here, not just
-        // by count (test-quality cycle 1).
+        // Assert child kind and title at each position so any inversion of
+        // the documented folders-before-test-cases ordering fails the test.
         mockMvc.perform(get("/api/v1/test-cases/tree").param("project", "ground-control"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].kind", is("FOLDER")))

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseControllerTest.java
@@ -20,7 +20,10 @@ import com.keplerops.groundcontrol.api.testcases.TestCaseRequest;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.service.CopyTestCaseCommand;
 import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.MoveTestCaseCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.ReorderTestCasesCommand;
 import com.keplerops.groundcontrol.domain.testcases.service.TestCaseService;
 import com.keplerops.groundcontrol.domain.testcases.state.TestCaseFormat;
 import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
@@ -34,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -291,6 +295,8 @@ class TestCaseControllerTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null);
         assertThat(request.format()).isEqualTo(TestCaseFormat.GHERKIN);
     }
@@ -308,5 +314,73 @@ class TestCaseControllerTest {
                                 {"status":"NOT_A_STATUS"}
                                 """))
                 .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void moveDelegatesToService() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(testCaseService.move(eq(PROJECT_ID), eq(TEST_CASE_ID), any(MoveTestCaseCommand.class)))
+                .thenReturn(makeTestCase());
+
+        UUID folderId = UUID.randomUUID();
+        mockMvc.perform(put("/api/v1/test-cases/{id}/move", TEST_CASE_ID)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"parentFolderId\":\"" + folderId + "\",\"sortOrder\":3}"))
+                .andExpect(status().isOk());
+        // Capture so a body-binding regression dropping parentFolderId or
+        // sortOrder is caught at unit level (test-quality cycle 1).
+        ArgumentCaptor<MoveTestCaseCommand> captor = ArgumentCaptor.forClass(MoveTestCaseCommand.class);
+        verify(testCaseService).move(eq(PROJECT_ID), eq(TEST_CASE_ID), captor.capture());
+        assertThat(captor.getValue().parentFolderId()).isEqualTo(folderId);
+        assertThat(captor.getValue().sortOrder()).isEqualTo(3);
+    }
+
+    @Test
+    void copyDelegatesToServiceAndReturns201() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(testCaseService.copy(eq(PROJECT_ID), eq(TEST_CASE_ID), any(CopyTestCaseCommand.class)))
+                .thenReturn(makeTestCase());
+
+        mockMvc.perform(post("/api/v1/test-cases/{id}/copy", TEST_CASE_ID)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"newUid\":\"TC-002\"}"))
+                .andExpect(status().isCreated());
+        // Capture: a regression failing to bind newUid would produce a
+        // blank-UID copy at runtime (test-quality cycle 1).
+        ArgumentCaptor<CopyTestCaseCommand> captor = ArgumentCaptor.forClass(CopyTestCaseCommand.class);
+        verify(testCaseService).copy(eq(PROJECT_ID), eq(TEST_CASE_ID), captor.capture());
+        assertThat(captor.getValue().newUid()).isEqualTo("TC-002");
+    }
+
+    @Test
+    void copyReturns422WhenNewUidBlank() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+
+        mockMvc.perform(post("/api/v1/test-cases/{id}/copy", TEST_CASE_ID)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"newUid\":\"\"}"))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void reorderDelegatesToService() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+
+        mockMvc.perform(put("/api/v1/test-cases/reorder")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"parentFolderId\":null,\"orderedTestCaseIds\":[\"" + a + "\",\"" + b + "\"]}"))
+                .andExpect(status().isNoContent());
+        // Capture: a wrong DTO field name for orderedTestCaseIds would
+        // silently no-op the reorder (test-quality cycle 1).
+        ArgumentCaptor<ReorderTestCasesCommand> captor = ArgumentCaptor.forClass(ReorderTestCasesCommand.class);
+        verify(testCaseService).reorder(eq(PROJECT_ID), captor.capture());
+        assertThat(captor.getValue().parentFolderId()).isNull();
+        assertThat(captor.getValue().orderedTestCaseIds()).containsExactly(a, b);
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseFolderControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseFolderControllerTest.java
@@ -1,0 +1,188 @@
+package com.keplerops.groundcontrol.unit.api;
+
+import static com.keplerops.groundcontrol.TestUtil.setField;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keplerops.groundcontrol.api.testcases.TestCaseFolderController;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
+import com.keplerops.groundcontrol.domain.testcases.service.MoveTestCaseFolderCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.ReorderTestCaseFoldersCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseFolderService;
+import com.keplerops.groundcontrol.domain.testcases.service.UpdateTestCaseFolderCommand;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(TestCaseFolderController.class)
+class TestCaseFolderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TestCaseFolderService folderService;
+
+    @MockitoBean
+    private ProjectService projectService;
+
+    private static final UUID PROJECT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID FOLDER_ID = UUID.fromString("00000000-0000-0000-0000-000000000900");
+    private static final Instant NOW = Instant.parse("2026-05-17T12:00:00Z");
+
+    private TestCaseFolder makeFolder() {
+        var project = new Project("ground-control", "Ground Control");
+        setField(project, "id", PROJECT_ID);
+        var folder = new TestCaseFolder(project, null, "Smoke tests", "set of smoke tests", 0);
+        setField(folder, "id", FOLDER_ID);
+        setField(folder, "createdAt", NOW);
+        setField(folder, "updatedAt", NOW);
+        return folder;
+    }
+
+    @Test
+    void createReturns201() throws Exception {
+        when(projectService.resolveProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(folderService.create(any())).thenReturn(makeFolder());
+
+        mockMvc.perform(
+                        post("/api/v1/test-cases/folders")
+                                .param("project", "ground-control")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {
+                                  "title": "Smoke tests",
+                                  "description": "set of smoke tests"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id", notNullValue()))
+                .andExpect(jsonPath("$.title", is("Smoke tests")));
+    }
+
+    @Test
+    void createReturns422WhenTitleBlank() throws Exception {
+        when(projectService.resolveProjectId("ground-control")).thenReturn(PROJECT_ID);
+
+        mockMvc.perform(post("/api/v1/test-cases/folders")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"\"}"))
+                .andExpect(status().isUnprocessableEntity());
+        verifyNoInteractions(folderService);
+    }
+
+    @Test
+    void listReturnsFolders() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(folderService.listByProject(PROJECT_ID)).thenReturn(List.of(makeFolder()));
+
+        mockMvc.perform(get("/api/v1/test-cases/folders").param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].title", is("Smoke tests")));
+    }
+
+    @Test
+    void getByIdReturnsFolder() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(folderService.getById(PROJECT_ID, FOLDER_ID)).thenReturn(makeFolder());
+
+        mockMvc.perform(get("/api/v1/test-cases/folders/{id}", FOLDER_ID).param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title", is("Smoke tests")));
+    }
+
+    @Test
+    void updateAcceptsBodyAndReturnsUpdatedFolder() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(folderService.update(eq(PROJECT_ID), eq(FOLDER_ID), any())).thenReturn(makeFolder());
+
+        mockMvc.perform(put("/api/v1/test-cases/folders/{id}", FOLDER_ID)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"Renamed\"}"))
+                .andExpect(status().isOk());
+        // Capture the command so a regression in body binding (wrong field
+        // name, null-coalesced title) is caught at the unit level instead
+        // of silently passing through with any().
+        ArgumentCaptor<UpdateTestCaseFolderCommand> captor = ArgumentCaptor.forClass(UpdateTestCaseFolderCommand.class);
+        verify(folderService).update(eq(PROJECT_ID), eq(FOLDER_ID), captor.capture());
+        assertThat(captor.getValue().title()).isEqualTo("Renamed");
+    }
+
+    @Test
+    void deleteReturns204() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+
+        mockMvc.perform(delete("/api/v1/test-cases/folders/{id}", FOLDER_ID).param("project", "ground-control"))
+                .andExpect(status().isNoContent());
+        verify(folderService).delete(PROJECT_ID, FOLDER_ID);
+    }
+
+    @Test
+    void moveAcceptsParentBody() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(folderService.move(eq(PROJECT_ID), eq(FOLDER_ID), any(MoveTestCaseFolderCommand.class)))
+                .thenReturn(makeFolder());
+
+        UUID newParent = UUID.randomUUID();
+        mockMvc.perform(put("/api/v1/test-cases/folders/{id}/move", FOLDER_ID)
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"parentFolderId\":\"" + newParent + "\",\"sortOrder\":2}"))
+                .andExpect(status().isOk());
+        // Capture so a body-binding regression that drops parentFolderId or
+        // sortOrder is caught at the unit level (test-quality cycle 1).
+        ArgumentCaptor<MoveTestCaseFolderCommand> captor = ArgumentCaptor.forClass(MoveTestCaseFolderCommand.class);
+        verify(folderService).move(eq(PROJECT_ID), eq(FOLDER_ID), captor.capture());
+        assertThat(captor.getValue().parentFolderId()).isEqualTo(newParent);
+        assertThat(captor.getValue().sortOrder()).isEqualTo(2);
+    }
+
+    @Test
+    void reorderAcceptsOrderedIds() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        UUID a = UUID.randomUUID();
+        UUID b = UUID.randomUUID();
+
+        mockMvc.perform(put("/api/v1/test-cases/folders/reorder")
+                        .param("project", "ground-control")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"parentFolderId\":null,\"orderedFolderIds\":[\"" + a + "\",\"" + b + "\"]}"))
+                .andExpect(status().isNoContent());
+        // Capture: a wrong DTO field name would deserialize orderedFolderIds
+        // to an empty list and silently no-op the reorder; the previous
+        // any()-based verify wouldn't catch that (test-quality cycle 1).
+        ArgumentCaptor<ReorderTestCaseFoldersCommand> captor =
+                ArgumentCaptor.forClass(ReorderTestCaseFoldersCommand.class);
+        verify(folderService).reorder(eq(PROJECT_ID), captor.capture());
+        assertThat(captor.getValue().parentFolderId()).isNull();
+        assertThat(captor.getValue().orderedFolderIds()).containsExactly(a, b);
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseTreeControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseTreeControllerTest.java
@@ -1,0 +1,62 @@
+package com.keplerops.groundcontrol.unit.api;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.keplerops.groundcontrol.api.testcases.TestCaseTreeController;
+import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseFolderService;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseTreeNode;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(TestCaseTreeController.class)
+class TestCaseTreeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TestCaseFolderService folderService;
+
+    @MockitoBean
+    private ProjectService projectService;
+
+    private static final UUID PROJECT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    @Test
+    void getTreeReturnsNestedNodes() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        var folderId = UUID.randomUUID();
+        var node =
+                new TestCaseTreeNode(TestCaseTreeNode.Kind.FOLDER, folderId, null, "Suite", null, 0, null, List.of());
+        when(folderService.getTree(PROJECT_ID)).thenReturn(List.of(node));
+
+        mockMvc.perform(get("/api/v1/test-cases/tree").param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].kind", is("FOLDER")))
+                .andExpect(jsonPath("$[0].title", is("Suite")));
+    }
+
+    @Test
+    void getTreeReturnsEmptyArrayWhenNothingExists() throws Exception {
+        when(projectService.requireProjectId("ground-control")).thenReturn(PROJECT_ID);
+        when(folderService.getTree(PROJECT_ID)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/test-cases/tree").param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseFolderServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseFolderServiceTest.java
@@ -1,0 +1,541 @@
+package com.keplerops.groundcontrol.unit.domain;
+
+import static com.keplerops.groundcontrol.TestUtil.setField;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseFolderRepository;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseRepository;
+import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseFolderCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.MoveTestCaseFolderCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.ReorderTestCaseFoldersCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseFolderService;
+import com.keplerops.groundcontrol.domain.testcases.service.TestCaseTreeNode;
+import com.keplerops.groundcontrol.domain.testcases.service.UpdateTestCaseFolderCommand;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
+import com.keplerops.groundcontrol.domain.testcases.state.TestCaseType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TestCaseFolderServiceTest {
+
+    @Mock
+    private TestCaseFolderRepository folderRepository;
+
+    @Mock
+    private TestCaseRepository testCaseRepository;
+
+    @Mock
+    private ProjectService projectService;
+
+    @InjectMocks
+    private TestCaseFolderService folderService;
+
+    private Project project;
+    private UUID projectId;
+
+    @BeforeEach
+    void setUp() {
+        project = new Project("ground-control", "Ground Control");
+        projectId = UUID.randomUUID();
+        setField(project, "id", projectId);
+    }
+
+    private TestCaseFolder folder(String title, TestCaseFolder parent, int sortOrder) {
+        var folder = new TestCaseFolder(project, parent, title, null, sortOrder);
+        setField(folder, "id", UUID.randomUUID());
+        // createdAt populated so the (sortOrder, createdAt, id) tie-breaker
+        // comparator in TestCaseFolderService.getTree has a non-null value
+        // to compare; without it the in-memory sort would NPE on tied rows.
+        setField(folder, "createdAt", java.time.Instant.now());
+        return folder;
+    }
+
+    private TestCase testCase(String uid, TestCaseFolder parent, int sortOrder) {
+        var testCase = new TestCase(project, uid, "title", TestCaseType.MANUAL, TestCasePriority.LOW);
+        testCase.setParentFolder(parent);
+        testCase.setSortOrder(sortOrder);
+        setField(testCase, "id", UUID.randomUUID());
+        setField(testCase, "createdAt", java.time.Instant.now());
+        return testCase;
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void createsRootFolder() {
+            when(projectService.getById(projectId)).thenReturn(project);
+            when(folderRepository.existsRootByProjectIdAndTitle(projectId, "Smoke"))
+                    .thenReturn(false);
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = folderService.create(new CreateTestCaseFolderCommand(projectId, null, "Smoke", "desc", null));
+
+            assertThat(result.getTitle()).isEqualTo("Smoke");
+            assertThat(result.getParent()).isNull();
+            // Root container empty (default mock) → first folder appends at pos=0.
+            assertThat(result.getSortOrder()).isZero();
+        }
+
+        @Test
+        void createsChildFolderAppendsAtEndOfContainer() {
+            var parent = folder("Suite", null, 0);
+            var existingA = folder("A", parent, 0);
+            var existingB = folder("B", parent, 1);
+            var existingC = folder("C", parent, 2);
+            when(projectService.getById(projectId)).thenReturn(project);
+            when(folderRepository.findByIdAndProjectId(parent.getId(), projectId))
+                    .thenReturn(Optional.of(parent));
+            when(folderRepository.existsByProjectIdAndParentIdAndTitle(projectId, parent.getId(), "Login"))
+                    .thenReturn(false);
+            when(folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, parent.getId()))
+                    .thenReturn(List.of(existingA, existingB, existingC));
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = folderService.create(
+                    new CreateTestCaseFolderCommand(projectId, parent.getId(), "Login", null, null));
+
+            // Insertion semantics with null requested → appended at end.
+            assertThat(result.getParent()).isSameAs(parent);
+            assertThat(result.getSortOrder()).isEqualTo(3);
+            // Existing siblings keep their positions (0, 1, 2).
+            assertThat(existingA.getSortOrder()).isZero();
+            assertThat(existingB.getSortOrder()).isEqualTo(1);
+            assertThat(existingC.getSortOrder()).isEqualTo(2);
+        }
+
+        @Test
+        void createInsertsAtRequestedPositionAndShiftsSiblings() {
+            // Codex cycle-2 finding: explicit sortOrder must shift target
+            // siblings so the new folder lands at the requested position
+            // and ties are not possible.
+            var parent = folder("Suite", null, 0);
+            var existingA = folder("A", parent, 0);
+            var existingB = folder("B", parent, 1);
+            when(projectService.getById(projectId)).thenReturn(project);
+            when(folderRepository.findByIdAndProjectId(parent.getId(), projectId))
+                    .thenReturn(Optional.of(parent));
+            when(folderRepository.existsByProjectIdAndParentIdAndTitle(projectId, parent.getId(), "Mid"))
+                    .thenReturn(false);
+            when(folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, parent.getId()))
+                    .thenReturn(List.of(existingA, existingB));
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result =
+                    folderService.create(new CreateTestCaseFolderCommand(projectId, parent.getId(), "Mid", null, 1));
+
+            assertThat(result.getSortOrder()).isEqualTo(1);
+            // A stays at 0, B shifts from 1 → 2.
+            assertThat(existingA.getSortOrder()).isZero();
+            assertThat(existingB.getSortOrder()).isEqualTo(2);
+        }
+
+        @Test
+        void rejectsDuplicateTitleAtRoot() {
+            when(projectService.getById(projectId)).thenReturn(project);
+            when(folderRepository.existsRootByProjectIdAndTitle(projectId, "Smoke"))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() ->
+                            folderService.create(new CreateTestCaseFolderCommand(projectId, null, "Smoke", null, null)))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("already exists");
+        }
+
+        @Test
+        void rejectsParentInDifferentProject() {
+            when(projectService.getById(projectId)).thenReturn(project);
+            UUID unknownParent = UUID.randomUUID();
+            when(folderRepository.findByIdAndProjectId(unknownParent, projectId))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> folderService.create(
+                            new CreateTestCaseFolderCommand(projectId, unknownParent, "Smoke", null, null)))
+                    .isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void updatesTitleAndDescription() {
+            var existing = folder("Old", null, 0);
+            when(folderRepository.findByIdAndProjectId(existing.getId(), projectId))
+                    .thenReturn(Optional.of(existing));
+            when(folderRepository.existsRootByProjectIdAndTitle(projectId, "New"))
+                    .thenReturn(false);
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = folderService.update(
+                    projectId, existing.getId(), new UpdateTestCaseFolderCommand("New", "set", false));
+
+            assertThat(result.getTitle()).isEqualTo("New");
+            assertThat(result.getDescription()).isEqualTo("set");
+        }
+
+        @Test
+        void rejectsRenameOntoExistingSiblingTitle() {
+            var existing = folder("Old", null, 0);
+            when(folderRepository.findByIdAndProjectId(existing.getId(), projectId))
+                    .thenReturn(Optional.of(existing));
+            when(folderRepository.existsRootByProjectIdAndTitle(projectId, "Taken"))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() -> folderService.update(
+                            projectId, existing.getId(), new UpdateTestCaseFolderCommand("Taken", null, false)))
+                    .isInstanceOf(ConflictException.class);
+        }
+
+        @Test
+        void clearsDescription() {
+            var existing = folder("Old", null, 0);
+            existing.setDescription("had");
+            when(folderRepository.findByIdAndProjectId(existing.getId(), projectId))
+                    .thenReturn(Optional.of(existing));
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = folderService.update(
+                    projectId, existing.getId(), new UpdateTestCaseFolderCommand(null, null, true));
+
+            assertThat(result.getDescription()).isNull();
+        }
+    }
+
+    @Nested
+    class Move {
+
+        @Test
+        void movesFolderToNewParent() {
+            var source = folder("Login", null, 0);
+            var target = folder("New parent", null, 0);
+            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+            when(folderRepository.findByIdAndProjectId(target.getId(), projectId))
+                    .thenReturn(Optional.of(target));
+            when(folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, target.getId()))
+                    .thenReturn(List.of());
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result =
+                    folderService.move(projectId, source.getId(), new MoveTestCaseFolderCommand(target.getId(), null));
+
+            assertThat(result.getParent()).isSameAs(target);
+            // Empty target container → moved folder appends at pos=0.
+            assertThat(result.getSortOrder()).isZero();
+        }
+
+        @Test
+        void movesFolderToRoot() {
+            var oldParent = folder("Old parent", null, 0);
+            var source = folder("Login", oldParent, 0);
+            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+            when(folderRepository.findRootByProjectIdOrderBySortOrder(projectId))
+                    .thenReturn(List.of());
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = folderService.move(projectId, source.getId(), new MoveTestCaseFolderCommand(null, null));
+
+            assertThat(result.getParent()).isNull();
+            assertThat(result.getSortOrder()).isZero();
+        }
+
+        @Test
+        void rejectsMoveUnderSelf() {
+            var source = folder("Login", null, 0);
+            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+
+            assertThatThrownBy(() -> folderService.move(
+                            projectId, source.getId(), new MoveTestCaseFolderCommand(source.getId(), null)))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("itself");
+        }
+
+        @Test
+        void rejectsMoveUnderDescendant() {
+            var root = folder("Root", null, 0);
+            var middle = folder("Middle", root, 0);
+            var leaf = folder("Leaf", middle, 0);
+            when(folderRepository.findByIdAndProjectId(root.getId(), projectId)).thenReturn(Optional.of(root));
+            when(folderRepository.findByIdAndProjectId(leaf.getId(), projectId)).thenReturn(Optional.of(leaf));
+
+            // Move root under leaf (cycle: leaf → middle → root → ... )
+            assertThatThrownBy(() -> folderService.move(
+                            projectId, root.getId(), new MoveTestCaseFolderCommand(leaf.getId(), null)))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("descendants");
+        }
+
+        @Test
+        void rejectsMoveToUnknownFolder() {
+            var source = folder("Login", null, 0);
+            UUID unknown = UUID.randomUUID();
+            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+            when(folderRepository.findByIdAndProjectId(unknown, projectId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                            folderService.move(projectId, source.getId(), new MoveTestCaseFolderCommand(unknown, null)))
+                    .isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        void rejectsMoveCausingDuplicateTitleAtDestination() {
+            var source = folder("Login", null, 0);
+            var dest = folder("Dest", null, 1);
+            var existingChild = folder("Login", dest, 0); // same title under target
+            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+            when(folderRepository.findByIdAndProjectId(dest.getId(), projectId)).thenReturn(Optional.of(dest));
+            when(folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, dest.getId()))
+                    .thenReturn(List.of(existingChild));
+
+            assertThatThrownBy(() -> folderService.move(
+                            projectId, source.getId(), new MoveTestCaseFolderCommand(dest.getId(), null)))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("already exists");
+        }
+    }
+
+    @Nested
+    class SameContainerMoveNoOp {
+
+        @Test
+        void omittedSortOrderPreservesCurrentPlacement() {
+            var parent = folder("Parent", null, 0);
+            var source = folder("Child", parent, 5);
+            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+            when(folderRepository.findByIdAndProjectId(parent.getId(), projectId))
+                    .thenReturn(Optional.of(parent));
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result =
+                    folderService.move(projectId, source.getId(), new MoveTestCaseFolderCommand(parent.getId(), null));
+
+            // Same container + omitted sortOrder → no rebalancing.
+            assertThat(result.getSortOrder()).isEqualTo(5);
+        }
+
+        @Test
+        void explicitSortOrderShiftsSiblingsInSameContainer() {
+            // Codex cycle-2 insertion semantics: moving Child from pos 2 to
+            // pos 0 in [A, B, Child] must result in [Child, A, B] at [0,1,2].
+            var parent = folder("Parent", null, 0);
+            var a = folder("A", parent, 0);
+            var b = folder("B", parent, 1);
+            var source = folder("Child", parent, 2);
+            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+            when(folderRepository.findByIdAndProjectId(parent.getId(), projectId))
+                    .thenReturn(Optional.of(parent));
+            when(folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, parent.getId()))
+                    .thenReturn(List.of(a, b, source));
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result =
+                    folderService.move(projectId, source.getId(), new MoveTestCaseFolderCommand(parent.getId(), 0));
+
+            assertThat(result.getSortOrder()).isZero();
+            assertThat(a.getSortOrder()).isEqualTo(1);
+            assertThat(b.getSortOrder()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class Reorder {
+
+        @Test
+        void renumbersSiblingsInRequestedOrder() {
+            var a = folder("A", null, 0);
+            var b = folder("B", null, 1);
+            var c = folder("C", null, 2);
+            when(folderRepository.findRootByProjectIdOrderBySortOrder(projectId))
+                    .thenReturn(List.of(a, b, c));
+            when(folderRepository.save(any(TestCaseFolder.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            folderService.reorder(
+                    projectId, new ReorderTestCaseFoldersCommand(null, List.of(c.getId(), a.getId(), b.getId())));
+
+            assertThat(c.getSortOrder()).isZero();
+            assertThat(a.getSortOrder()).isEqualTo(1);
+            assertThat(b.getSortOrder()).isEqualTo(2);
+            verify(folderRepository, atLeastOnce()).save(any(TestCaseFolder.class));
+        }
+
+        @Test
+        void rejectsListThatOmitsASibling() {
+            var a = folder("A", null, 0);
+            var b = folder("B", null, 1);
+            when(folderRepository.findRootByProjectIdOrderBySortOrder(projectId))
+                    .thenReturn(List.of(a, b));
+
+            assertThatThrownBy(() -> folderService.reorder(
+                            projectId, new ReorderTestCaseFoldersCommand(null, List.of(a.getId()))))
+                    .isInstanceOf(ConflictException.class);
+        }
+
+        @Test
+        void rejectsListWithDuplicateIds() {
+            var a = folder("A", null, 0);
+            var b = folder("B", null, 1);
+            when(folderRepository.findRootByProjectIdOrderBySortOrder(projectId))
+                    .thenReturn(List.of(a, b));
+
+            assertThatThrownBy(() -> folderService.reorder(
+                            projectId, new ReorderTestCaseFoldersCommand(null, List.of(a.getId(), a.getId()))))
+                    .isInstanceOf(com.keplerops.groundcontrol.domain.exception.DomainValidationException.class);
+        }
+
+        @Test
+        void rejectsCrossProjectOrMissingParent() {
+            // Codex cycle-1 finding: when parentFolderId is supplied, the
+            // target must exist in the requesting project — otherwise
+            // reorder silently returns 204 against an empty sibling set.
+            UUID unknown = UUID.randomUUID();
+            when(folderRepository.findByIdAndProjectId(unknown, projectId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                            folderService.reorder(projectId, new ReorderTestCaseFoldersCommand(unknown, List.of())))
+                    .isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void deletesEmptyFolder() {
+            var f = folder("Empty", null, 0);
+            when(folderRepository.findByIdAndProjectId(f.getId(), projectId)).thenReturn(Optional.of(f));
+            when(folderRepository.countByParentId(f.getId())).thenReturn(0L);
+            when(testCaseRepository.countByParentFolderId(f.getId())).thenReturn(0L);
+
+            folderService.delete(projectId, f.getId());
+
+            verify(folderRepository).delete(f);
+        }
+
+        @Test
+        void rejectsDeletionWithSubfolder() {
+            var f = folder("Parent", null, 0);
+            when(folderRepository.findByIdAndProjectId(f.getId(), projectId)).thenReturn(Optional.of(f));
+            when(folderRepository.countByParentId(f.getId())).thenReturn(1L);
+
+            assertThatThrownBy(() -> folderService.delete(projectId, f.getId()))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("subfolders");
+            verify(folderRepository, never()).delete(any(TestCaseFolder.class));
+        }
+
+        @Test
+        void rejectsDeletionWithTestCases() {
+            var f = folder("Bucket", null, 0);
+            when(folderRepository.findByIdAndProjectId(f.getId(), projectId)).thenReturn(Optional.of(f));
+            when(folderRepository.countByParentId(f.getId())).thenReturn(0L);
+            when(testCaseRepository.countByParentFolderId(f.getId())).thenReturn(3L);
+
+            assertThatThrownBy(() -> folderService.delete(projectId, f.getId()))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("test cases");
+        }
+    }
+
+    @Nested
+    class Tree {
+
+        @Test
+        void emptyProjectReturnsEmptyTree() {
+            when(folderRepository.findByProjectIdOrderBySortOrder(projectId)).thenReturn(List.of());
+            when(testCaseRepository.findAllByProjectIdOrderBySortOrder(projectId))
+                    .thenReturn(List.of());
+
+            assertThat(folderService.getTree(projectId)).isEmpty();
+        }
+
+        @Test
+        void deeplyNestedTreeAssemblesIterativelyWithoutStackOverflow() {
+            // Codex cycle-1 class finding: TC-005 promises unlimited
+            // nesting. A 5000-folder linear chain would blow the JVM
+            // stack under recursive descent; the iterative builder must
+            // handle it without StackOverflowError.
+            List<TestCaseFolder> chain = new ArrayList<>();
+            TestCaseFolder parent = null;
+            for (int i = 0; i < 5000; i++) {
+                var node = new TestCaseFolder(project, parent, "F" + i, null, 0);
+                setField(node, "id", UUID.randomUUID());
+                setField(node, "createdAt", java.time.Instant.now());
+                chain.add(node);
+                parent = node;
+            }
+            when(folderRepository.findByProjectIdOrderBySortOrder(projectId)).thenReturn(chain);
+            when(testCaseRepository.findAllByProjectIdOrderBySortOrder(projectId))
+                    .thenReturn(List.of());
+
+            var tree = folderService.getTree(projectId);
+
+            assertThat(tree).hasSize(1);
+            // Walk down to confirm full depth is materialised.
+            var cursor = tree.get(0);
+            int depth = 0;
+            while (!cursor.children().isEmpty()) {
+                cursor = cursor.children().get(0);
+                depth++;
+            }
+            assertThat(depth).isEqualTo(4999);
+        }
+
+        @Test
+        void treeReturnsFoldersAndTestCasesInDeterministicOrder() {
+            var rootA = folder("RootA", null, 0);
+            var rootB = folder("RootB", null, 1);
+            var childOfA = folder("ChildA", rootA, 0);
+            var caseInA = testCase("TC-1", rootA, 0);
+            var rootCase = testCase("TC-2", null, 0);
+            when(folderRepository.findByProjectIdOrderBySortOrder(projectId))
+                    .thenReturn(List.of(rootA, rootB, childOfA));
+            when(testCaseRepository.findAllByProjectIdOrderBySortOrder(projectId))
+                    .thenReturn(List.of(caseInA, rootCase));
+
+            var tree = folderService.getTree(projectId);
+            assertThat(tree).hasSize(3);
+            assertThat(tree.get(0).kind()).isEqualTo(TestCaseTreeNode.Kind.FOLDER);
+            assertThat(tree.get(0).id()).isEqualTo(rootA.getId());
+            assertThat(tree.get(0).children()).hasSize(2);
+            assertThat(tree.get(0).children().get(0).kind()).isEqualTo(TestCaseTreeNode.Kind.FOLDER);
+            assertThat(tree.get(0).children().get(0).id()).isEqualTo(childOfA.getId());
+            assertThat(tree.get(0).children().get(1).kind()).isEqualTo(TestCaseTreeNode.Kind.TEST_CASE);
+            assertThat(tree.get(0).children().get(1).id()).isEqualTo(caseInA.getId());
+
+            assertThat(tree.get(1).kind()).isEqualTo(TestCaseTreeNode.Kind.FOLDER);
+            assertThat(tree.get(1).id()).isEqualTo(rootB.getId());
+
+            assertThat(tree.get(2).kind()).isEqualTo(TestCaseTreeNode.Kind.TEST_CASE);
+            assertThat(tree.get(2).id()).isEqualTo(rootCase.getId());
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseFolderServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseFolderServiceTest.java
@@ -158,8 +158,8 @@ class TestCaseFolderServiceTest {
             when(folderRepository.existsRootByProjectIdAndTitle(projectId, "Smoke"))
                     .thenReturn(true);
 
-            assertThatThrownBy(() ->
-                            folderService.create(new CreateTestCaseFolderCommand(projectId, null, "Smoke", null, null)))
+            var command = new CreateTestCaseFolderCommand(projectId, null, "Smoke", null, null);
+            assertThatThrownBy(() -> folderService.create(command))
                     .isInstanceOf(ConflictException.class)
                     .hasMessageContaining("already exists");
         }
@@ -171,9 +171,8 @@ class TestCaseFolderServiceTest {
             when(folderRepository.findByIdAndProjectId(unknownParent, projectId))
                     .thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> folderService.create(
-                            new CreateTestCaseFolderCommand(projectId, unknownParent, "Smoke", null, null)))
-                    .isInstanceOf(NotFoundException.class);
+            var command = new CreateTestCaseFolderCommand(projectId, unknownParent, "Smoke", null, null);
+            assertThatThrownBy(() -> folderService.create(command)).isInstanceOf(NotFoundException.class);
         }
     }
 
@@ -204,8 +203,9 @@ class TestCaseFolderServiceTest {
             when(folderRepository.existsRootByProjectIdAndTitle(projectId, "Taken"))
                     .thenReturn(true);
 
-            assertThatThrownBy(() -> folderService.update(
-                            projectId, existing.getId(), new UpdateTestCaseFolderCommand("Taken", null, false)))
+            var command = new UpdateTestCaseFolderCommand("Taken", null, false);
+            UUID existingId = existing.getId();
+            assertThatThrownBy(() -> folderService.update(projectId, existingId, command))
                     .isInstanceOf(ConflictException.class);
         }
 
@@ -266,11 +266,11 @@ class TestCaseFolderServiceTest {
         @Test
         void rejectsMoveUnderSelf() {
             var source = folder("Login", null, 0);
-            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
-                    .thenReturn(Optional.of(source));
+            UUID sourceId = source.getId();
+            when(folderRepository.findByIdAndProjectId(sourceId, projectId)).thenReturn(Optional.of(source));
 
-            assertThatThrownBy(() -> folderService.move(
-                            projectId, source.getId(), new MoveTestCaseFolderCommand(source.getId(), null)))
+            var command = new MoveTestCaseFolderCommand(sourceId, null);
+            assertThatThrownBy(() -> folderService.move(projectId, sourceId, command))
                     .isInstanceOf(ConflictException.class)
                     .hasMessageContaining("itself");
         }
@@ -280,12 +280,14 @@ class TestCaseFolderServiceTest {
             var root = folder("Root", null, 0);
             var middle = folder("Middle", root, 0);
             var leaf = folder("Leaf", middle, 0);
-            when(folderRepository.findByIdAndProjectId(root.getId(), projectId)).thenReturn(Optional.of(root));
-            when(folderRepository.findByIdAndProjectId(leaf.getId(), projectId)).thenReturn(Optional.of(leaf));
+            UUID rootId = root.getId();
+            UUID leafId = leaf.getId();
+            when(folderRepository.findByIdAndProjectId(rootId, projectId)).thenReturn(Optional.of(root));
+            when(folderRepository.findByIdAndProjectId(leafId, projectId)).thenReturn(Optional.of(leaf));
 
-            // Move root under leaf (cycle: leaf → middle → root → ... )
-            assertThatThrownBy(() -> folderService.move(
-                            projectId, root.getId(), new MoveTestCaseFolderCommand(leaf.getId(), null)))
+            // Move root under leaf — cycle: leaf -> middle -> root.
+            var command = new MoveTestCaseFolderCommand(leafId, null);
+            assertThatThrownBy(() -> folderService.move(projectId, rootId, command))
                     .isInstanceOf(ConflictException.class)
                     .hasMessageContaining("descendants");
         }
@@ -293,13 +295,13 @@ class TestCaseFolderServiceTest {
         @Test
         void rejectsMoveToUnknownFolder() {
             var source = folder("Login", null, 0);
+            UUID sourceId = source.getId();
             UUID unknown = UUID.randomUUID();
-            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
-                    .thenReturn(Optional.of(source));
+            when(folderRepository.findByIdAndProjectId(sourceId, projectId)).thenReturn(Optional.of(source));
             when(folderRepository.findByIdAndProjectId(unknown, projectId)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() ->
-                            folderService.move(projectId, source.getId(), new MoveTestCaseFolderCommand(unknown, null)))
+            var command = new MoveTestCaseFolderCommand(unknown, null);
+            assertThatThrownBy(() -> folderService.move(projectId, sourceId, command))
                     .isInstanceOf(NotFoundException.class);
         }
 
@@ -308,14 +310,15 @@ class TestCaseFolderServiceTest {
             var source = folder("Login", null, 0);
             var dest = folder("Dest", null, 1);
             var existingChild = folder("Login", dest, 0); // same title under target
-            when(folderRepository.findByIdAndProjectId(source.getId(), projectId))
-                    .thenReturn(Optional.of(source));
-            when(folderRepository.findByIdAndProjectId(dest.getId(), projectId)).thenReturn(Optional.of(dest));
-            when(folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, dest.getId()))
+            UUID sourceId = source.getId();
+            UUID destId = dest.getId();
+            when(folderRepository.findByIdAndProjectId(sourceId, projectId)).thenReturn(Optional.of(source));
+            when(folderRepository.findByIdAndProjectId(destId, projectId)).thenReturn(Optional.of(dest));
+            when(folderRepository.findByProjectIdAndParentIdOrderBySortOrder(projectId, destId))
                     .thenReturn(List.of(existingChild));
 
-            assertThatThrownBy(() -> folderService.move(
-                            projectId, source.getId(), new MoveTestCaseFolderCommand(dest.getId(), null)))
+            var command = new MoveTestCaseFolderCommand(destId, null);
+            assertThatThrownBy(() -> folderService.move(projectId, sourceId, command))
                     .isInstanceOf(ConflictException.class)
                     .hasMessageContaining("already exists");
         }
@@ -394,9 +397,8 @@ class TestCaseFolderServiceTest {
             when(folderRepository.findRootByProjectIdOrderBySortOrder(projectId))
                     .thenReturn(List.of(a, b));
 
-            assertThatThrownBy(() -> folderService.reorder(
-                            projectId, new ReorderTestCaseFoldersCommand(null, List.of(a.getId()))))
-                    .isInstanceOf(ConflictException.class);
+            var command = new ReorderTestCaseFoldersCommand(null, List.of(a.getId()));
+            assertThatThrownBy(() -> folderService.reorder(projectId, command)).isInstanceOf(ConflictException.class);
         }
 
         @Test
@@ -406,22 +408,21 @@ class TestCaseFolderServiceTest {
             when(folderRepository.findRootByProjectIdOrderBySortOrder(projectId))
                     .thenReturn(List.of(a, b));
 
-            assertThatThrownBy(() -> folderService.reorder(
-                            projectId, new ReorderTestCaseFoldersCommand(null, List.of(a.getId(), a.getId()))))
+            var command = new ReorderTestCaseFoldersCommand(null, List.of(a.getId(), a.getId()));
+            assertThatThrownBy(() -> folderService.reorder(projectId, command))
                     .isInstanceOf(com.keplerops.groundcontrol.domain.exception.DomainValidationException.class);
         }
 
         @Test
         void rejectsCrossProjectOrMissingParent() {
-            // Codex cycle-1 finding: when parentFolderId is supplied, the
-            // target must exist in the requesting project — otherwise
-            // reorder silently returns 204 against an empty sibling set.
+            // When parentFolderId is supplied, the target must exist in
+            // the requesting project — otherwise reorder would silently
+            // return 204 against an empty sibling set.
             UUID unknown = UUID.randomUUID();
             when(folderRepository.findByIdAndProjectId(unknown, projectId)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() ->
-                            folderService.reorder(projectId, new ReorderTestCaseFoldersCommand(unknown, List.of())))
-                    .isInstanceOf(NotFoundException.class);
+            var command = new ReorderTestCaseFoldersCommand(unknown, List.of());
+            assertThatThrownBy(() -> folderService.reorder(projectId, command)).isInstanceOf(NotFoundException.class);
         }
     }
 
@@ -443,10 +444,11 @@ class TestCaseFolderServiceTest {
         @Test
         void rejectsDeletionWithSubfolder() {
             var f = folder("Parent", null, 0);
-            when(folderRepository.findByIdAndProjectId(f.getId(), projectId)).thenReturn(Optional.of(f));
-            when(folderRepository.countByParentId(f.getId())).thenReturn(1L);
+            UUID fid = f.getId();
+            when(folderRepository.findByIdAndProjectId(fid, projectId)).thenReturn(Optional.of(f));
+            when(folderRepository.countByParentId(fid)).thenReturn(1L);
 
-            assertThatThrownBy(() -> folderService.delete(projectId, f.getId()))
+            assertThatThrownBy(() -> folderService.delete(projectId, fid))
                     .isInstanceOf(ConflictException.class)
                     .hasMessageContaining("subfolders");
             verify(folderRepository, never()).delete(any(TestCaseFolder.class));
@@ -455,11 +457,12 @@ class TestCaseFolderServiceTest {
         @Test
         void rejectsDeletionWithTestCases() {
             var f = folder("Bucket", null, 0);
-            when(folderRepository.findByIdAndProjectId(f.getId(), projectId)).thenReturn(Optional.of(f));
-            when(folderRepository.countByParentId(f.getId())).thenReturn(0L);
-            when(testCaseRepository.countByParentFolderId(f.getId())).thenReturn(3L);
+            UUID fid = f.getId();
+            when(folderRepository.findByIdAndProjectId(fid, projectId)).thenReturn(Optional.of(f));
+            when(folderRepository.countByParentId(fid)).thenReturn(0L);
+            when(testCaseRepository.countByParentFolderId(fid)).thenReturn(3L);
 
-            assertThatThrownBy(() -> folderService.delete(projectId, f.getId()))
+            assertThatThrownBy(() -> folderService.delete(projectId, fid))
                     .isInstanceOf(ConflictException.class)
                     .hasMessageContaining("test cases");
         }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseFolderTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseFolderTest.java
@@ -1,0 +1,84 @@
+package com.keplerops.groundcontrol.unit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
+import org.junit.jupiter.api.Test;
+
+class TestCaseFolderTest {
+
+    private static Project project() {
+        return new Project("ground-control", "Ground Control");
+    }
+
+    @Test
+    void constructorInitialisesRequiredFields() {
+        var folder = new TestCaseFolder(project(), null, "Smoke tests", "regression smoke set", 0);
+        assertThat(folder.getProject().getIdentifier()).isEqualTo("ground-control");
+        assertThat(folder.getParent()).isNull();
+        assertThat(folder.getTitle()).isEqualTo("Smoke tests");
+        assertThat(folder.getDescription()).isEqualTo("regression smoke set");
+        assertThat(folder.getSortOrder()).isZero();
+    }
+
+    @Test
+    void constructorAllowsNestingViaParent() {
+        var root = new TestCaseFolder(project(), null, "Suite", null, 0);
+        var child = new TestCaseFolder(project(), root, "Login flow", null, 0);
+        assertThat(child.getParent()).isSameAs(root);
+    }
+
+    @Test
+    void constructorRejectsNullProject() {
+        assertThatThrownBy(() -> new TestCaseFolder(null, null, "Folder", null, 0))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Project");
+    }
+
+    @Test
+    void constructorRejectsBlankTitle() {
+        var project = project();
+        assertThatThrownBy(() -> new TestCaseFolder(project, null, "", null, 0))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Title");
+        assertThatThrownBy(() -> new TestCaseFolder(project, null, "   ", null, 0))
+                .isInstanceOf(DomainValidationException.class);
+        assertThatThrownBy(() -> new TestCaseFolder(project, null, null, null, 0))
+                .isInstanceOf(DomainValidationException.class);
+    }
+
+    @Test
+    void constructorRejectsNegativeSortOrder() {
+        var project = project();
+        assertThatThrownBy(() -> new TestCaseFolder(project, null, "Folder", null, -1))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Sort order");
+    }
+
+    @Test
+    void setTitleRejectsBlank() {
+        var folder = new TestCaseFolder(project(), null, "Folder", null, 0);
+        assertThatThrownBy(() -> folder.setTitle(""))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Title");
+    }
+
+    @Test
+    void setSortOrderRejectsNegative() {
+        var folder = new TestCaseFolder(project(), null, "Folder", null, 0);
+        assertThatThrownBy(() -> folder.setSortOrder(-3))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Sort order");
+    }
+
+    @Test
+    void parentMayBeReassignedToRoot() {
+        var parent = new TestCaseFolder(project(), null, "Parent", null, 0);
+        var folder = new TestCaseFolder(project(), parent, "Child", null, 0);
+        folder.setParent(null);
+        assertThat(folder.getParent()).isNull();
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseServiceTest.java
@@ -4,6 +4,7 @@ import static com.keplerops.groundcontrol.TestUtil.setField;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,8 +14,13 @@ import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
+import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseFolderRepository;
 import com.keplerops.groundcontrol.domain.testcases.repository.TestCaseRepository;
+import com.keplerops.groundcontrol.domain.testcases.service.CopyTestCaseCommand;
 import com.keplerops.groundcontrol.domain.testcases.service.CreateTestCaseCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.MoveTestCaseCommand;
+import com.keplerops.groundcontrol.domain.testcases.service.ReorderTestCasesCommand;
 import com.keplerops.groundcontrol.domain.testcases.service.TestCaseGherkinService;
 import com.keplerops.groundcontrol.domain.testcases.service.TestCaseService;
 import com.keplerops.groundcontrol.domain.testcases.service.TestCaseStepService;
@@ -39,6 +45,9 @@ class TestCaseServiceTest {
 
     @Mock
     private TestCaseRepository testCaseRepository;
+
+    @Mock
+    private TestCaseFolderRepository folderRepository;
 
     @Mock
     private ProjectService projectService;
@@ -384,6 +393,188 @@ class TestCaseServiceTest {
             when(testCaseRepository.findByIdAndProjectId(unknownId, projectId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> testCaseService.delete(projectId, unknownId))
+                    .isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    @Nested
+    class Move {
+
+        @Test
+        void movesTestCaseToFolder() {
+            var existing = makeTestCase();
+            var folder = new TestCaseFolder(project, null, "Folder", null, 0);
+            setField(folder, "id", UUID.randomUUID());
+            when(testCaseRepository.findByIdAndProjectId(existing.getId(), projectId))
+                    .thenReturn(Optional.of(existing));
+            when(folderRepository.findByIdAndProjectId(folder.getId(), projectId))
+                    .thenReturn(Optional.of(folder));
+            when(testCaseRepository.save(any(TestCase.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result =
+                    testCaseService.move(projectId, existing.getId(), new MoveTestCaseCommand(folder.getId(), null));
+
+            assertThat(result.getParentFolder()).isSameAs(folder);
+            // Target folder empty (default mock) → moved test case appends at pos=0.
+            assertThat(result.getSortOrder()).isZero();
+        }
+
+        @Test
+        void movesTestCaseToRoot() {
+            var existing = makeTestCase();
+            var folder = new TestCaseFolder(project, null, "Folder", null, 0);
+            setField(folder, "id", UUID.randomUUID());
+            existing.setParentFolder(folder);
+            existing.setSortOrder(2);
+            when(testCaseRepository.findByIdAndProjectId(existing.getId(), projectId))
+                    .thenReturn(Optional.of(existing));
+            when(testCaseRepository.save(any(TestCase.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = testCaseService.move(projectId, existing.getId(), new MoveTestCaseCommand(null, null));
+
+            assertThat(result.getParentFolder()).isNull();
+            assertThat(result.getSortOrder()).isZero();
+        }
+
+        @Test
+        void rejectsMoveToFolderInOtherProject() {
+            var existing = makeTestCase();
+            UUID unknownFolder = UUID.randomUUID();
+            when(testCaseRepository.findByIdAndProjectId(existing.getId(), projectId))
+                    .thenReturn(Optional.of(existing));
+            when(folderRepository.findByIdAndProjectId(unknownFolder, projectId))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> testCaseService.move(
+                            projectId, existing.getId(), new MoveTestCaseCommand(unknownFolder, null)))
+                    .isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    @Nested
+    class Copy {
+
+        @Test
+        void copyCreatesNewTestCaseWithProvidedUid() {
+            var source = makeTestCase();
+            when(testCaseRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+            when(testCaseRepository.existsByProjectIdAndUid(projectId, "TC-002"))
+                    .thenReturn(false);
+            when(testCaseRepository.save(any(TestCase.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = testCaseService.copy(projectId, source.getId(), new CopyTestCaseCommand("TC-002", null, null));
+
+            assertThat(result.getUid()).isEqualTo("TC-002");
+            assertThat(result.getTitle()).isEqualTo(source.getTitle());
+            assertThat(result.getStatus()).isEqualTo(TestCaseStatus.DRAFT);
+            assertThat(result.getDescription()).isEqualTo(source.getDescription());
+            verify(testCaseStepService).copyStepsToTestCase(eq(source.getId()), any(TestCase.class));
+            verify(testCaseGherkinService).copyGherkinToTestCase(eq(source.getId()), any(TestCase.class));
+        }
+
+        @Test
+        void copyRejectsExistingUid() {
+            var source = makeTestCase();
+            when(testCaseRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+            when(testCaseRepository.existsByProjectIdAndUid(projectId, "TC-002"))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() -> testCaseService.copy(
+                            projectId, source.getId(), new CopyTestCaseCommand("TC-002", null, null)))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining("TC-002");
+        }
+
+        @Test
+        void copyRejectsBlankUid() {
+            var source = makeTestCase();
+            when(testCaseRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+
+            assertThatThrownBy(() ->
+                            testCaseService.copy(projectId, source.getId(), new CopyTestCaseCommand("  ", null, null)))
+                    .isInstanceOf(ConflictException.class);
+        }
+
+        @Test
+        void copyPlacesIntoSpecifiedFolder() {
+            var source = makeTestCase();
+            var folder = new TestCaseFolder(project, null, "Folder", null, 0);
+            setField(folder, "id", UUID.randomUUID());
+            when(testCaseRepository.findByIdAndProjectId(source.getId(), projectId))
+                    .thenReturn(Optional.of(source));
+            when(testCaseRepository.existsByProjectIdAndUid(projectId, "TC-002"))
+                    .thenReturn(false);
+            when(folderRepository.findByIdAndProjectId(folder.getId(), projectId))
+                    .thenReturn(Optional.of(folder));
+            when(testCaseRepository.save(any(TestCase.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = testCaseService.copy(
+                    projectId, source.getId(), new CopyTestCaseCommand("TC-002", folder.getId(), null));
+
+            assertThat(result.getParentFolder()).isSameAs(folder);
+            // Target folder empty (default mock); copy appends at pos=0.
+            assertThat(result.getSortOrder()).isZero();
+        }
+    }
+
+    @Nested
+    class Reorder {
+
+        private TestCase tcWithId(String uid) {
+            var tc = new TestCase(project, uid, "t", TestCaseType.MANUAL, TestCasePriority.LOW);
+            setField(tc, "id", UUID.randomUUID());
+            return tc;
+        }
+
+        @Test
+        void renumbersRootTestCasesInRequestedOrder() {
+            // Reorder lives in TestCaseService now (codex cycle-2 finding —
+            // aggregate-boundary fix; SiblingOrderingHelper carries the
+            // shared algorithm).
+            var a = tcWithId("TC-A");
+            var b = tcWithId("TC-B");
+            var c = tcWithId("TC-C");
+            when(testCaseRepository.findRootByProjectIdOrderBySortOrder(projectId))
+                    .thenReturn(List.of(a, b, c));
+            when(testCaseRepository.save(any(TestCase.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            testCaseService.reorder(
+                    projectId, new ReorderTestCasesCommand(null, List.of(c.getId(), a.getId(), b.getId())));
+
+            assertThat(c.getSortOrder()).isZero();
+            assertThat(a.getSortOrder()).isEqualTo(1);
+            assertThat(b.getSortOrder()).isEqualTo(2);
+        }
+
+        @Test
+        void renumbersFolderContainerInRequestedOrder() {
+            UUID folderId = UUID.randomUUID();
+            var folder = new TestCaseFolder(project, null, "f", null, 0);
+            setField(folder, "id", folderId);
+            var a = tcWithId("TC-A");
+            var b = tcWithId("TC-B");
+            when(folderRepository.findByIdAndProjectId(folderId, projectId)).thenReturn(Optional.of(folder));
+            when(testCaseRepository.findByProjectIdAndParentFolderIdOrderBySortOrder(projectId, folderId))
+                    .thenReturn(List.of(a, b));
+            when(testCaseRepository.save(any(TestCase.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            testCaseService.reorder(projectId, new ReorderTestCasesCommand(folderId, List.of(b.getId(), a.getId())));
+
+            assertThat(b.getSortOrder()).isZero();
+            assertThat(a.getSortOrder()).isEqualTo(1);
+        }
+
+        @Test
+        void verifiesFolderInProjectWhenSpecified() {
+            UUID unknownFolder = UUID.randomUUID();
+            when(folderRepository.findByIdAndProjectId(unknownFolder, projectId))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                            testCaseService.reorder(projectId, new ReorderTestCasesCommand(unknownFolder, List.of())))
                     .isInstanceOf(NotFoundException.class);
         }
     }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseServiceTest.java
@@ -445,8 +445,9 @@ class TestCaseServiceTest {
             when(folderRepository.findByIdAndProjectId(unknownFolder, projectId))
                     .thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> testCaseService.move(
-                            projectId, existing.getId(), new MoveTestCaseCommand(unknownFolder, null)))
+            var command = new MoveTestCaseCommand(unknownFolder, null);
+            UUID existingId = existing.getId();
+            assertThatThrownBy(() -> testCaseService.move(projectId, existingId, command))
                     .isInstanceOf(NotFoundException.class);
         }
     }
@@ -481,8 +482,9 @@ class TestCaseServiceTest {
             when(testCaseRepository.existsByProjectIdAndUid(projectId, "TC-002"))
                     .thenReturn(true);
 
-            assertThatThrownBy(() -> testCaseService.copy(
-                            projectId, source.getId(), new CopyTestCaseCommand("TC-002", null, null)))
+            var command = new CopyTestCaseCommand("TC-002", null, null);
+            UUID sourceId = source.getId();
+            assertThatThrownBy(() -> testCaseService.copy(projectId, sourceId, command))
                     .isInstanceOf(ConflictException.class)
                     .hasMessageContaining("TC-002");
         }
@@ -493,8 +495,9 @@ class TestCaseServiceTest {
             when(testCaseRepository.findByIdAndProjectId(source.getId(), projectId))
                     .thenReturn(Optional.of(source));
 
-            assertThatThrownBy(() ->
-                            testCaseService.copy(projectId, source.getId(), new CopyTestCaseCommand("  ", null, null)))
+            var command = new CopyTestCaseCommand("  ", null, null);
+            UUID sourceId = source.getId();
+            assertThatThrownBy(() -> testCaseService.copy(projectId, sourceId, command))
                     .isInstanceOf(ConflictException.class);
         }
 
@@ -573,8 +576,8 @@ class TestCaseServiceTest {
             when(folderRepository.findByIdAndProjectId(unknownFolder, projectId))
                     .thenReturn(Optional.empty());
 
-            assertThatThrownBy(() ->
-                            testCaseService.reorder(projectId, new ReorderTestCasesCommand(unknownFolder, List.of())))
+            var command = new ReorderTestCasesCommand(unknownFolder, List.of());
+            assertThatThrownBy(() -> testCaseService.reorder(projectId, command))
                     .isInstanceOf(NotFoundException.class);
         }
     }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.testcases.model.TestCase;
+import com.keplerops.groundcontrol.domain.testcases.model.TestCaseFolder;
 import com.keplerops.groundcontrol.domain.testcases.state.TestCasePriority;
 import com.keplerops.groundcontrol.domain.testcases.state.TestCaseStatus;
 import com.keplerops.groundcontrol.domain.testcases.state.TestCaseType;
@@ -133,5 +134,41 @@ class TestCaseTest {
     void setTitleRejectsBlank() {
         var testCase = new TestCase(project(), "TC-001", "t", TestCaseType.MANUAL, TestCasePriority.LOW);
         assertThatThrownBy(() -> testCase.setTitle("")).isInstanceOf(DomainValidationException.class);
+    }
+
+    @Test
+    void parentFolderDefaultsToRootAndSortOrderDefaultsToZero() {
+        var testCase = new TestCase(project(), "TC-001", "t", TestCaseType.MANUAL, TestCasePriority.LOW);
+        assertThat(testCase.getParentFolder()).isNull();
+        assertThat(testCase.getSortOrder()).isZero();
+    }
+
+    @Test
+    void setParentFolderAndSortOrderTrackPlacement() {
+        var project = project();
+        var folder = new TestCaseFolder(project, null, "Smoke", null, 0);
+        var testCase = new TestCase(project, "TC-001", "t", TestCaseType.MANUAL, TestCasePriority.LOW);
+        testCase.setParentFolder(folder);
+        testCase.setSortOrder(7);
+        assertThat(testCase.getParentFolder()).isSameAs(folder);
+        assertThat(testCase.getSortOrder()).isEqualTo(7);
+    }
+
+    @Test
+    void setSortOrderRejectsNegative() {
+        var testCase = new TestCase(project(), "TC-001", "t", TestCaseType.MANUAL, TestCasePriority.LOW);
+        assertThatThrownBy(() -> testCase.setSortOrder(-1))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Sort order");
+    }
+
+    @Test
+    void setParentFolderAcceptsNullForRoot() {
+        var project = project();
+        var folder = new TestCaseFolder(project, null, "Smoke", null, 0);
+        var testCase = new TestCase(project, "TC-001", "t", TestCaseType.MANUAL, TestCasePriority.LOW);
+        testCase.setParentFolder(folder);
+        testCase.setParentFolder(null);
+        assertThat(testCase.getParentFolder()).isNull();
     }
 }

--- a/changelog.d/672.added.md
+++ b/changelog.d/672.added.md
@@ -8,6 +8,6 @@
   `move`, `copy`, and per-folder `move`, `reorder`. Move preserves
   identity and audit; copy produces a new test case with a caller-
   supplied UID and clones step / Gherkin children. Tree assembly is
-  iterative O(n) (applies to `TestCaseFolderService` and
+  iterative O(n) (applies to both `TestCaseFolderService` and
   `documents.SectionService`) so deeply nested trees do not risk
   StackOverflowError. See ADR-043.

--- a/changelog.d/672.added.md
+++ b/changelog.d/672.added.md
@@ -1,0 +1,10 @@
+### Added
+
+- TC-005: hierarchical folder organization for test cases. New
+  `TestCaseFolder` aggregate with project-scoped self-referencing parent,
+  container-local sort order, and partial unique titles. `TestCase`
+  gains `parentFolderId` and `sortOrder`. New endpoints under
+  `/api/v1/test-cases/{folders,tree,reorder}` plus per-test-case
+  `move`, `copy`, and per-folder `move`, `reorder`. Move preserves
+  identity and audit; copy produces a new test case with a caller-
+  supplied UID and clones step / Gherkin children. See ADR-043.

--- a/changelog.d/672.added.md
+++ b/changelog.d/672.added.md
@@ -7,4 +7,7 @@
   `/api/v1/test-cases/{folders,tree,reorder}` plus per-test-case
   `move`, `copy`, and per-folder `move`, `reorder`. Move preserves
   identity and audit; copy produces a new test case with a caller-
-  supplied UID and clones step / Gherkin children. See ADR-043.
+  supplied UID and clones step / Gherkin children. Tree assembly is
+  iterative O(n) (applies to `TestCaseFolderService` and
+  `documents.SectionService`) so deeply nested trees do not risk
+  StackOverflowError. See ADR-043.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1121,6 +1121,67 @@ traces, file paths, or `Examples` cell content.
 Deleting the parent test case cascade-deletes the Gherkin document service-side so
 Envers captures the delete revision (mirrors the step-cascade pattern in ADR-041).
 
+### Test Case Hierarchical Organization (TC-005 / ADR-043)
+
+| Method | Path | Body | Status | Purpose |
+|--------|------|------|--------|---------|
+| POST | `/test-cases/folders` | TestCaseFolderRequest | 201 | Create a folder under a project (root) or under another folder |
+| GET | `/test-cases/folders` | — | 200 | List folders in a project (ordered by `sortOrder`) |
+| GET | `/test-cases/folders/{id}` | — | 200 | Get a folder by id |
+| PUT | `/test-cases/folders/{id}` | UpdateTestCaseFolderRequest | 200 | Rename / re-describe a folder |
+| DELETE | `/test-cases/folders/{id}` | — | 204 | Delete an **empty** folder (subfolders / test cases must be moved or deleted first) |
+| PUT | `/test-cases/folders/{id}/move` | MoveTestCaseFolderRequest | 200 | Move a folder to a new container (cycle / cross-project rejected) |
+| PUT | `/test-cases/folders/reorder` | ReorderTestCaseFoldersRequest | 204 | Bulk reorder folders within one container |
+| PUT | `/test-cases/{id}/move` | MoveTestCaseRequest | 200 | Move a test case into a folder (or to the project root) |
+| POST | `/test-cases/{id}/copy` | CopyTestCaseRequest | 201 | Copy a test case, cloning steps / Gherkin source |
+| PUT | `/test-cases/reorder` | ReorderTestCasesRequest | 204 | Bulk reorder test cases within one container |
+| GET | `/test-cases/tree` | — | 200 | Nested tree of folders and test cases for the project |
+
+A `TestCaseFolder` is the test-repository organisation aggregate. It is project-scoped, self-referencing
+(nullable `parent`), `@Audited`, container-locally ordered by `sortOrder`, and uniquely titled per
+container. `TestCase.parentFolderId` (nullable; null ⇒ project root) and `TestCase.sortOrder` carry the
+placement. See ADR-043.
+
+**TestCaseFolderRequest fields:** `title` (required, max 200), `description` (optional TEXT),
+`parentFolderId` (optional UUID; omit / null = root), `sortOrder` (optional non-negative `Integer`;
+omit / null = append at end of container).
+
+**UpdateTestCaseFolderRequest fields:** `title`, `description` (all optional, null-means-no-change),
+plus `clearDescription: true` to wipe `description` to null (same partial-update convention as
+`UpdateTestCaseRequest`).
+
+**MoveTestCaseFolderRequest / MoveTestCaseRequest fields:** `parentFolderId` (required; null = root),
+`sortOrder` (optional non-negative; omit = append).
+
+**ReorderTestCaseFoldersRequest / ReorderTestCasesRequest fields:** `parentFolderId` (required; null
+= root), `orderedFolderIds` / `orderedTestCaseIds` (required, must contain exactly the current
+siblings — partial reorders are rejected with HTTP 409).
+
+**CopyTestCaseRequest fields:** `newUid` (required, max 50, must not collide with an existing UID in
+the same project), `parentFolderId` (explicit target — same convention as `MoveTestCaseRequest`:
+`null` or omitted = project root, UUID = that folder), `sortOrder` (optional; defaults to max+1 in
+the target container). Callers that want to clone in place must pass the source's `parentFolderId`
+explicitly. The copy clones every immutable definition field (title, description, preconditions,
+postconditions, priority, type, format, estimatedDurationSeconds), resets `status` to `DRAFT`,
+and clones authored children via their owning services (`TestCaseStepService.copyStepsToTestCase`,
+`TestCaseGherkinService.copyGherkinToTestCase`). Step `actualResult` is **not** copied — it is
+run-time evidence, not part of the definition.
+
+**TestCaseFolderResponse fields:** `id`, `projectIdentifier`, `parentFolderId`, `title`,
+`description`, `sortOrder`, `createdAt`, `updatedAt`.
+
+**Tree response.** `GET /test-cases/tree` returns an array of `TestCaseTreeNode`. Each node carries
+`kind` (`FOLDER` or `TEST_CASE`), `id`, `parentFolderId`, `title`, `description`, `sortOrder`,
+`testCase` (populated only for `TEST_CASE` kind: `{uid, status, type, priority, format}`), and
+`children` (folders first by `sortOrder`, then test cases by `sortOrder`; leaves carry an empty
+array).
+
+**Error envelope.** Duplicate sibling title returns HTTP 409 `conflict`. Moving a folder under
+itself or any descendant returns HTTP 409. Cross-project moves / copies return HTTP 404 (the target
+is "not found" in the requesting project's scope). Deleting a non-empty folder returns HTTP 409
+with a message naming the contents class. Reordering with a non-matching id set returns HTTP 409.
+Copying with a colliding `newUid` returns HTTP 409.
+
 ## Request / Response Format
 
 JSON. Error responses use a nested envelope:

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -96,11 +96,7 @@ export const PACK_REGISTRY_IMPORT_FORMATS: PackRegistryImportFormat[] = [
   "OSCAL_JSON",
   "GC_MANIFEST",
 ];
-export type TestCaseStatus =
-  | "DRAFT"
-  | "APPROVED"
-  | "DEPRECATED"
-  | "ARCHIVED";
+export type TestCaseStatus = "DRAFT" | "APPROVED" | "DEPRECATED" | "ARCHIVED";
 export const TEST_CASE_STATUSES: TestCaseStatus[] = [
   "DRAFT",
   "APPROVED",
@@ -108,7 +104,11 @@ export const TEST_CASE_STATUSES: TestCaseStatus[] = [
   "ARCHIVED",
 ];
 export type TestCaseType = "MANUAL" | "AUTOMATED" | "HYBRID";
-export const TEST_CASE_TYPES: TestCaseType[] = ["MANUAL", "AUTOMATED", "HYBRID"];
+export const TEST_CASE_TYPES: TestCaseType[] = [
+  "MANUAL",
+  "AUTOMATED",
+  "HYBRID",
+];
 export type TestCasePriority = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
 export const TEST_CASE_PRIORITIES: TestCasePriority[] = [
   "CRITICAL",
@@ -169,6 +169,83 @@ export interface TestCaseGherkinRequest {
 
 export interface UpdateTestCaseGherkinRequest {
   source: string;
+}
+
+// TC-005 / ADR-043 — Hierarchical test repository organisation. Mirrors
+// the backend TestCaseFolderRequest / Response and the move/copy/reorder
+// request shapes.
+export interface TestCaseFolderResponse {
+  id: string;
+  projectIdentifier: string;
+  parentFolderId: string | null;
+  title: string;
+  description: string | null;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TestCaseFolderRequest {
+  parentFolderId?: string | null;
+  title: string;
+  description?: string | null;
+  sortOrder?: number | null;
+}
+
+export interface UpdateTestCaseFolderRequest {
+  title?: string;
+  description?: string | null;
+  clearDescription?: boolean;
+}
+
+export interface MoveTestCaseFolderRequest {
+  parentFolderId: string | null;
+  sortOrder?: number | null;
+}
+
+export interface ReorderTestCaseFoldersRequest {
+  parentFolderId: string | null;
+  orderedFolderIds: string[];
+}
+
+export interface MoveTestCaseRequest {
+  parentFolderId: string | null;
+  sortOrder?: number | null;
+}
+
+export interface CopyTestCaseRequest {
+  newUid: string;
+  parentFolderId?: string | null;
+  sortOrder?: number | null;
+}
+
+export interface ReorderTestCasesRequest {
+  parentFolderId: string | null;
+  orderedTestCaseIds: string[];
+}
+
+export type TestCaseTreeNodeKind = "FOLDER" | "TEST_CASE";
+
+export interface TestCaseTreeLeaf {
+  uid: string;
+  status: TestCaseStatus;
+  type: TestCaseType;
+  priority: TestCasePriority;
+  format: TestCaseFormat;
+}
+
+export interface TestCaseTreeNode {
+  kind: TestCaseTreeNodeKind;
+  id: string;
+  parentFolderId: string | null;
+  title: string;
+  description: string | null;
+  sortOrder: number;
+  // Populated for kind === "TEST_CASE"; null for folders.
+  testCase: TestCaseTreeLeaf | null;
+  // Folder nodes carry nested children (folders first by sortOrder, then
+  // test cases). Test-case nodes carry an empty children array.
+  children: TestCaseTreeNode[];
 }
 export type GraphEntityType =
   | "REQUIREMENT"

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -149,6 +149,10 @@ import {
   TEST_CASE_STATUSES, TEST_CASE_TYPES, TEST_CASE_PRIORITIES, TEST_CASE_FORMATS,
   // ---- test case steps (TC-002 / ADR-041) ----
   createTestCaseStep, updateTestCaseStep, deleteTestCaseStep,
+  // ---- test case folders + move/copy/reorder (TC-005 / ADR-043) ----
+  createTestCaseFolder, updateTestCaseFolder, deleteTestCaseFolder,
+  moveTestCaseFolder, reorderTestCaseFolders,
+  moveTestCase, copyTestCase, reorderTestCases,
   // ---- enums ----
   STATUSES, REQUIREMENT_TYPES, PRIORITIES, RELATION_TYPES,
   ARTIFACT_TYPES, LINK_TYPES, CHANGE_CATEGORIES, CONFIDENCE_LEVELS,
@@ -1566,6 +1570,9 @@ const TEST_CASE_ACTIONS = [
   "create", "update", "delete", "transition",
   "step-create", "step-update", "step-delete",
   "gherkin-create", "gherkin-update", "gherkin-delete",
+  // TC-005 / ADR-043 — Hierarchical organisation actions.
+  "folder-create", "folder-update", "folder-delete", "folder-move", "folder-reorder",
+  "move", "copy", "reorder",
 ];
 
 server.tool(
@@ -1611,6 +1618,16 @@ server.tool(
     // to avoid clashing with any other "source" field on future test_case
     // sub-resources); handler maps it to backend body `{ source }`.
     gherkin_source: z.string().optional(),
+    // TC-005 / ADR-043 — folder + move/copy/reorder action fields.
+    folder_id: z.string().uuid().optional(),
+    parent_folder_id: z.string().uuid().nullable().optional(),
+    sort_order: z.number().int().nonnegative().nullable().optional(),
+    folder_title: z.string().optional(),
+    folder_description: z.string().nullable().optional(),
+    clear_folder_description: z.boolean().optional(),
+    new_uid: z.string().optional(),
+    ordered_folder_ids: z.array(z.string().uuid()).optional(),
+    ordered_test_case_ids: z.array(z.string().uuid()).optional(),
   },
   async (args) => {
     try {
@@ -1619,7 +1636,37 @@ server.tool(
         "preconditions", "postconditions", "estimated_duration_seconds",
         "clear_description", "clear_preconditions", "clear_postconditions",
         "clear_estimated_duration",
+        // TC-005 / ADR-043 — Placement fields on create only. The
+        // backend's UpdateTestCaseRequest does NOT carry parent_folder_id
+        // or sort_order; if those were in the update allowlist the MCP
+        // call would accept them silently and Spring would drop them at
+        // deserialization (codex cycle-2 finding). Update uses a separate
+        // allowlist below; move/copy/reorder are dedicated actions.
+        "parent_folder_id", "sort_order",
       ];
+      const UPDATE_ENTITY_FIELDS = [
+        "title", "type", "priority", "description",
+        "preconditions", "postconditions", "estimated_duration_seconds",
+        "clear_description", "clear_preconditions", "clear_postconditions",
+        "clear_estimated_duration",
+      ];
+      // TC-005 / ADR-043 — TestCaseFolder request bodies. `folder_title` and
+      // `folder_description` are MCP-side names that map to the backend's
+      // `title` / `description` via lib.js FIELD_NAME_MAP; on update,
+      // `clear_folder_description` maps to `clearDescription`.
+      const folderCreateBody = () => {
+        const body = pick(args, ["parent_folder_id", "sort_order"]);
+        if (args.folder_title !== undefined) body.title = args.folder_title;
+        if (args.folder_description !== undefined) body.description = args.folder_description;
+        return body;
+      };
+      const folderUpdateBody = () => {
+        const body = {};
+        if (args.folder_title !== undefined) body.title = args.folder_title;
+        if (args.folder_description !== undefined) body.description = args.folder_description;
+        if (args.clear_folder_description !== undefined) body.clearDescription = args.clear_folder_description;
+        return body;
+      };
       const STEP_FIELDS = [
         "step_number", "expected_result", "actual_result", "clear_actual_result",
       ];
@@ -1644,7 +1691,7 @@ server.tool(
         case "update": {
           reqArg(args, "id", "update");
           return ok(JSON.stringify(
-            await updateTestCase(args.id, pick(args, ENTITY_FIELDS), args.project),
+            await updateTestCase(args.id, pick(args, UPDATE_ENTITY_FIELDS), args.project),
             null,
             2,
           ));
@@ -1716,6 +1763,84 @@ server.tool(
           reqArg(args, "test_case_id", "gherkin-delete");
           await deleteTestCaseGherkin(args.test_case_id, args.project);
           return ok("Deleted");
+        }
+        case "folder-create": {
+          reqArg(args, "folder_title", "folder-create");
+          return ok(JSON.stringify(
+            await createTestCaseFolder(folderCreateBody(), args.project),
+            null,
+            2,
+          ));
+        }
+        case "folder-update": {
+          reqArg(args, "folder_id", "folder-update");
+          return ok(JSON.stringify(
+            await updateTestCaseFolder(args.folder_id, folderUpdateBody(), args.project),
+            null,
+            2,
+          ));
+        }
+        case "folder-delete": {
+          reqArg(args, "folder_id", "folder-delete");
+          await deleteTestCaseFolder(args.folder_id, args.project);
+          return ok("Deleted");
+        }
+        case "folder-move": {
+          reqArg(args, "folder_id", "folder-move");
+          return ok(JSON.stringify(
+            await moveTestCaseFolder(
+              args.folder_id,
+              { parentFolderId: args.parent_folder_id ?? null, sortOrder: args.sort_order ?? null },
+              args.project,
+            ),
+            null,
+            2,
+          ));
+        }
+        case "folder-reorder": {
+          reqArg(args, "ordered_folder_ids", "folder-reorder");
+          await reorderTestCaseFolders(
+            { parentFolderId: args.parent_folder_id ?? null, orderedFolderIds: args.ordered_folder_ids },
+            args.project,
+          );
+          return ok("Reordered");
+        }
+        case "move": {
+          reqArg(args, "id", "move");
+          return ok(JSON.stringify(
+            await moveTestCase(
+              args.id,
+              { parentFolderId: args.parent_folder_id ?? null, sortOrder: args.sort_order ?? null },
+              args.project,
+            ),
+            null,
+            2,
+          ));
+        }
+        case "copy": {
+          reqArg(args, "id", "copy");
+          reqArg(args, "new_uid", "copy");
+          return ok(JSON.stringify(
+            await copyTestCase(
+              args.id,
+              {
+                newUid: args.new_uid,
+                parentFolderId: args.parent_folder_id ?? null,
+                sortOrder: args.sort_order ?? null,
+              },
+              args.project,
+            ),
+            null,
+            2,
+          ));
+        }
+        case "reorder": {
+          reqArg(args, "ordered_test_case_ids", "reorder");
+          await reorderTestCases(
+            { parentFolderId: args.parent_folder_id ?? null, orderedTestCaseIds: args.ordered_test_case_ids },
+            args.project,
+          );
+          return ok("Reordered");
         }
         default: return err(new Error(`Unknown action: ${args.action}`));
       }

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -547,6 +547,17 @@ const TO_CAMEL = {
   // gc_test_case); it maps to the backend's `source` body field via the
   // step-style explicit body construction in index.js, not via this table.
   // The `format` MCP arg is already snake-free, so no entry needed here.
+  // TC-005 / ADR-043 — TestCaseFolderRequest / move / copy / reorder fields.
+  // Same rationale: missing entries here would let `gc_test_case` forward
+  // snake-case names that Jackson silently drops on the backend.
+  parent_folder_id: "parentFolderId",
+  sort_order: "sortOrder",
+  folder_title: "title",
+  folder_description: "description",
+  clear_folder_description: "clearDescription",
+  new_uid: "newUid",
+  ordered_folder_ids: "orderedFolderIds",
+  ordered_test_case_ids: "orderedTestCaseIds",
   // GC-V001 finding adapter — backend FindingRequest / UpdateFindingRequest
   // use these camelCase field names. Mapping is needed so `gc_finding` reaches
   // backend Bean Validation with the right field names (issue #279).
@@ -7654,6 +7665,52 @@ export async function deleteTestCaseGherkin(testCaseId, project) {
   await request("DELETE", `/api/v1/test-cases/${encodeURIComponent(testCaseId)}/gherkin`, {
     params: { project },
   });
+}
+
+// TC-005 / ADR-043 — TestCaseFolder + move/copy/reorder wrappers.
+
+export async function createTestCaseFolder(data, project) {
+  return request("POST", "/api/v1/test-cases/folders", { body: data, params: { project } });
+}
+
+export async function updateTestCaseFolder(id, data, project) {
+  return request("PUT", `/api/v1/test-cases/folders/${encodeURIComponent(id)}`, {
+    body: data,
+    params: { project },
+  });
+}
+
+export async function deleteTestCaseFolder(id, project) {
+  await request("DELETE", `/api/v1/test-cases/folders/${encodeURIComponent(id)}`, { params: { project } });
+}
+
+export async function moveTestCaseFolder(id, data, project) {
+  return request("PUT", `/api/v1/test-cases/folders/${encodeURIComponent(id)}/move`, {
+    body: data,
+    params: { project },
+  });
+}
+
+export async function reorderTestCaseFolders(data, project) {
+  await request("PUT", "/api/v1/test-cases/folders/reorder", { body: data, params: { project } });
+}
+
+export async function moveTestCase(id, data, project) {
+  return request("PUT", `/api/v1/test-cases/${encodeURIComponent(id)}/move`, {
+    body: data,
+    params: { project },
+  });
+}
+
+export async function copyTestCase(id, data, project) {
+  return request("POST", `/api/v1/test-cases/${encodeURIComponent(id)}/copy`, {
+    body: data,
+    params: { project },
+  });
+}
+
+export async function reorderTestCases(data, project) {
+  await request("PUT", "/api/v1/test-cases/reorder", { body: data, params: { project } });
 }
 
 export async function createControl(data, project) {

--- a/mcp/ground-control/test-case-tools.test.js
+++ b/mcp/ground-control/test-case-tools.test.js
@@ -18,18 +18,26 @@ import {
   TEST_CASE_PRIORITIES,
   TEST_CASE_STATUSES,
   TEST_CASE_TYPES,
+  copyTestCase,
   createTestCase,
+  createTestCaseFolder,
   createTestCaseGherkin,
   createTestCaseStep,
   deleteTestCase,
+  deleteTestCaseFolder,
   deleteTestCaseGherkin,
   deleteTestCaseStep,
   getTestCase,
   getTestCaseByUid,
   getTestCaseGherkin,
   listTestCases,
+  moveTestCase,
+  moveTestCaseFolder,
+  reorderTestCaseFolders,
+  reorderTestCases,
   transitionTestCaseStatus,
   updateTestCase,
+  updateTestCaseFolder,
   updateTestCaseGherkin,
   updateTestCaseStep,
 } from "./lib.js";
@@ -526,5 +534,142 @@ describe("Error envelope propagation", () => {
       () => transitionTestCaseStatus(TEST_CASE_ID, "DRAFT", "ground-control"),
       (e) => e instanceof RequestError && e.status === 422 && e.code === "invalid_status_transition",
     );
+  });
+});
+
+// TC-005 / ADR-043 — folder + move/copy/reorder wrappers.
+describe("TestCaseFolder wrappers (gc_test_case TC-005)", () => {
+  const FOLDER_ID = "33333333-3333-3333-3333-333333333333";
+  const NEW_FOLDER_ID = "44444444-4444-4444-4444-444444444444";
+
+  it("createTestCaseFolder POSTs /api/v1/test-cases/folders with camelCase body", async () => {
+    setNextResponse({ body: { id: FOLDER_ID, title: "Smoke", parentFolderId: null, sortOrder: 0 } });
+    await createTestCaseFolder(
+      { title: "Smoke", description: "set", parentFolderId: null, sortOrder: 0 },
+      "ground-control",
+    );
+    const call = fetchCalls[0];
+    const url = parseUrl(call);
+    assert.equal(call.opts.method, "POST");
+    assert.equal(url.pathname, "/api/v1/test-cases/folders");
+    assert.equal(url.searchParams.get("project"), "ground-control");
+    assert.deepEqual(JSON.parse(call.opts.body), {
+      title: "Smoke",
+      description: "set",
+      parentFolderId: null,
+      sortOrder: 0,
+    });
+  });
+
+  it("updateTestCaseFolder PUTs /api/v1/test-cases/folders/{id}", async () => {
+    setNextResponse({ body: { id: FOLDER_ID, title: "Renamed" } });
+    await updateTestCaseFolder(FOLDER_ID, { title: "Renamed" }, "ground-control");
+    const call = fetchCalls[0];
+    const url = parseUrl(call);
+    assert.equal(call.opts.method, "PUT");
+    assert.equal(url.pathname, `/api/v1/test-cases/folders/${FOLDER_ID}`);
+    // Project param + JSON body: parity with TC-001 updateTestCase test —
+    // catches a regression that drops the body or sends wrong field names
+    // (test-quality cycle 2).
+    assert.equal(url.searchParams.get("project"), "ground-control");
+    assert.deepEqual(JSON.parse(call.opts.body), { title: "Renamed" });
+  });
+
+  it("deleteTestCaseFolder DELETEs /api/v1/test-cases/folders/{id}", async () => {
+    setNextResponse({ ok: true, status: 204 });
+    await deleteTestCaseFolder(FOLDER_ID, "ground-control");
+    const call = fetchCalls[0];
+    const url = parseUrl(call);
+    assert.equal(call.opts.method, "DELETE");
+    assert.equal(url.pathname, `/api/v1/test-cases/folders/${FOLDER_ID}`);
+    assert.equal(url.searchParams.get("project"), "ground-control");
+  });
+
+  it("moveTestCaseFolder PUTs /api/v1/test-cases/folders/{id}/move", async () => {
+    setNextResponse({ body: { id: FOLDER_ID, parentFolderId: NEW_FOLDER_ID, sortOrder: 2 } });
+    await moveTestCaseFolder(
+      FOLDER_ID,
+      { parentFolderId: NEW_FOLDER_ID, sortOrder: 2 },
+      "ground-control",
+    );
+    const call = fetchCalls[0];
+    const url = parseUrl(call);
+    assert.equal(call.opts.method, "PUT");
+    assert.equal(url.pathname, `/api/v1/test-cases/folders/${FOLDER_ID}/move`);
+    assert.equal(url.searchParams.get("project"), "ground-control");
+    assert.deepEqual(JSON.parse(call.opts.body), {
+      parentFolderId: NEW_FOLDER_ID,
+      sortOrder: 2,
+    });
+  });
+
+  it("reorderTestCaseFolders PUTs /api/v1/test-cases/folders/reorder", async () => {
+    setNextResponse({ ok: true, status: 204 });
+    await reorderTestCaseFolders(
+      { parentFolderId: null, orderedFolderIds: [FOLDER_ID, NEW_FOLDER_ID] },
+      "ground-control",
+    );
+    const call = fetchCalls[0];
+    const url = parseUrl(call);
+    assert.equal(call.opts.method, "PUT");
+    assert.equal(url.pathname, "/api/v1/test-cases/folders/reorder");
+    assert.equal(url.searchParams.get("project"), "ground-control");
+    assert.deepEqual(JSON.parse(call.opts.body), {
+      parentFolderId: null,
+      orderedFolderIds: [FOLDER_ID, NEW_FOLDER_ID],
+    });
+  });
+});
+
+describe("TestCase move/copy/reorder wrappers (gc_test_case TC-005)", () => {
+  it("moveTestCase PUTs /api/v1/test-cases/{id}/move", async () => {
+    setNextResponse({ body: { id: TEST_CASE_ID } });
+    await moveTestCase(
+      TEST_CASE_ID,
+      { parentFolderId: null, sortOrder: 0 },
+      "ground-control",
+    );
+    const call = fetchCalls[0];
+    const url = parseUrl(call);
+    assert.equal(call.opts.method, "PUT");
+    assert.equal(url.pathname, `/api/v1/test-cases/${TEST_CASE_ID}/move`);
+    assert.equal(url.searchParams.get("project"), "ground-control");
+    assert.deepEqual(JSON.parse(call.opts.body), { parentFolderId: null, sortOrder: 0 });
+  });
+
+  it("copyTestCase POSTs /api/v1/test-cases/{id}/copy with newUid", async () => {
+    setNextResponse({ body: { id: "99999999-9999-9999-9999-999999999999", uid: "TC-002" } });
+    await copyTestCase(
+      TEST_CASE_ID,
+      { newUid: "TC-002", parentFolderId: null, sortOrder: null },
+      "ground-control",
+    );
+    const call = fetchCalls[0];
+    const url = parseUrl(call);
+    assert.equal(call.opts.method, "POST");
+    assert.equal(url.pathname, `/api/v1/test-cases/${TEST_CASE_ID}/copy`);
+    assert.equal(url.searchParams.get("project"), "ground-control");
+    assert.deepEqual(JSON.parse(call.opts.body), {
+      newUid: "TC-002",
+      parentFolderId: null,
+      sortOrder: null,
+    });
+  });
+
+  it("reorderTestCases PUTs /api/v1/test-cases/reorder", async () => {
+    setNextResponse({ ok: true, status: 204 });
+    await reorderTestCases(
+      { parentFolderId: null, orderedTestCaseIds: [TEST_CASE_ID] },
+      "ground-control",
+    );
+    const call = fetchCalls[0];
+    const url = parseUrl(call);
+    assert.equal(call.opts.method, "PUT");
+    assert.equal(url.pathname, "/api/v1/test-cases/reorder");
+    assert.equal(url.searchParams.get("project"), "ground-control");
+    assert.deepEqual(JSON.parse(call.opts.body), {
+      parentFolderId: null,
+      orderedTestCaseIds: [TEST_CASE_ID],
+    });
   });
 });


### PR DESCRIPTION
## Summary

Hierarchical folder organisation for test cases (TC-005, Wave 1 MUST). Adds a project-scoped, @Audited TestCaseFolder aggregate; folder + move/copy/reorder endpoints under /api/v1/test-cases; insertion-semantics placement (explicit sortOrder shifts target siblings, no ties); iterative O(n) tree assembly (applied to TestCaseFolderService and SectionService so deep nesting can't blow the JVM stack); copy clones step/Gherkin children with the source unchanged and resets new test case to DRAFT; folder deletion rejected when non-empty.

## Requirement UIDs

- `TC-005`

## Related Issues

Closes #672

## ADR Impact

- ADR-043

## Changes

- Add TestCaseFolder entity + repository + service (create / update / delete / move / reorder / tree)
- Extend TestCase with parentFolderId and sortOrder; add move / copy / reorder to TestCaseService
- Insertion-semantics placement helpers shift target siblings on explicit sortOrder; (sortOrder, createdAt, id) tie-breaker on every list query
- Iterative O(n) post-order tree assembly in TestCaseFolderService and SectionService (no recursion, no per-node parent walk)
- TestCaseFolderController + TestCaseTreeController + TestCaseController.{move,copy,reorder}; @WebMvcTest coverage with ArgumentCaptor field assertions
- Flyway V080-V083: test_case_folder + audit + parent_folder_id/sort_order on test_case (+ audit), ROW_NUMBER() backfill for pre-V082 rows
- AuditRetentionJob, MigrationSmokeTest, RequirementsE2EIntegrationTest, ControllerPolicyTest parity
- MCP gc_test_case: 8 new actions (folder-create/update/delete/move/reorder + move/copy/reorder); split create vs update body allowlists so placement fields cannot reach UpdateTestCaseRequest silently; project query-param assertions on every adapter test
- Frontend src/types/api.ts mirrors new request/response types (TestCaseFolderResponse, MoveTestCaseRequest, CopyTestCaseRequest, TestCaseTreeNode discriminated union, ...)
- docs/API.md documents the new endpoints; ADR-043 records the decision
- **Migration reminder:** version lists in MigrationSmokeTest.java and RequirementsE2EIntegrationTest.java updated per .gc/plan-rules.md.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- Backend unit + integration tests via `make check` and `./gradlew integrationTest` (MigrationSmokeTest, TestCaseFolderControllerIntegrationTest, TestCaseControllerIntegrationTest, SectionServiceIntegrationTest)
- MCP test suite (767 tests) green
- Pre-push AI-assisted review cycles completed; findings recorded on the issue thread
- DO NOT MERGE — review and merge per workflow

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: TC-005 ← backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/model/TestCaseFolder.java, TC-005 ← backend/src/main/java/com/keplerops/groundcontrol/domain/testcases/service/TestCaseFolderService.java, TC-005 ← backend/src/main/java/com/keplerops/groundcontrol/api/testcases/TestCaseFolderController.java, TC-005 ← architecture/adrs/043-test-case-hierarchical-organization.md
- TESTS: TC-005 ← backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TestCaseFolderServiceTest.java, TC-005 ← backend/src/test/java/com/keplerops/groundcontrol/integration/TestCaseFolderControllerIntegrationTest.java, TC-005 ← backend/src/test/java/com/keplerops/groundcontrol/unit/api/TestCaseFolderControllerTest.java

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/672.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed