### PR TITLE
fixed: bring gc_asset and gc_observation MCP tools to REST parity (GC-L008)

### DIFF
--- a/architecture/notes/asset-observation-mcp-operations-preflight.md
+++ b/architecture/notes/asset-observation-mcp-operations-preflight.md
@@ -1,0 +1,151 @@
+# Asset And Observation MCP Operations Preflight
+
+Issue: #730
+Requirement: GC-L008
+
+This is architecture guardrail guidance for MCP parity over graph-native asset,
+topology, observation, and evidence operations. It is not an implementation
+plan.
+
+## Boundary
+
+GC-L008 is an MCP adapter requirement over existing REST/domain behavior. The
+Spring REST API remains the semantic authority; MCP must not become a second
+controller layer or a second validation hierarchy.
+
+Keep these concepts separate:
+
+- `OperationalAsset` is asset identity, classification, ownership/scope, subtype
+  metadata, lifecycle, and knowledge state.
+- `AssetRelation` is asset-to-asset topology. It is not a cross-entity link and
+  it is not an observation.
+- `AssetLink` is asset-to-other-entity linking through
+  `GraphTargetResolverService`; it must keep internal UUID targets separate from
+  external string identifiers.
+- `Observation` is a time-bounded state fact about an asset. The latest/current
+  state surface is a read projection over observation history.
+- `EvidenceArtifact` is an append-only summarized-evidence aggregate with source
+  references and supersession; it is not an update path for observations.
+- The mixed graph (`GraphEntityType`, `GraphIds`, projection contributors, and
+  `MixedGraphService`) is the traversal/query surface over canonical JPA data.
+  Do not write AGE rows or graph-only records from MCP operations.
+
+## Incumbents To Reuse
+
+- REST controllers and DTOs: `AssetController`, `ObservationController`,
+  `EvidenceArtifactController`, `GraphController`, and their request/response
+  records. MCP field lists must mirror these records, not older docs or local
+  naming guesses.
+- Domain services and command DTOs: `AssetService`, `AssetTopologyService`,
+  `ObservationService`, `EvidenceArtifactService`,
+  `Create*Command` / `Update*Command`, and `ProjectService`.
+- Project-scoped repositories:
+  `OperationalAssetRepository`, `AssetRelationRepository`,
+  `AssetLinkRepository`, `AssetExternalIdRepository`, `ObservationRepository`,
+  and `EvidenceArtifactRepository`.
+- Graph seams: `GraphTargetResolverService`, `GraphTraversalLimits`,
+  `GraphProjectionContributor`, `AssetGraphProjectionContributor`,
+  `EvidenceArtifactGraphProjectionContributor`, and `MixedGraphService`.
+- MCP adapter seams: `request`, `buildUrl`, `addAuthorizationHeader`,
+  `RequestError`, `parseErrorBody`, `pick`, `reqArg`, `toCamelCase` /
+  `TO_CAMEL`, `link-create.js`, `gc-query.js`, `gc-evidence.js`, and the
+  consolidated `gc_asset`, `gc_observation`, `gc_evidence`, and `gc_graph`
+  surfaces.
+- Docs and gates: `docs/API.md`, `mcp/ground-control/README.md`,
+  adapter-level MCP tests, controller `@WebMvcTest` slices, and `make policy`.
+
+## Cross-Cutting Layers
+
+- Security: every backend call issued by MCP must enter the ADR-026 path matrix
+  under `/api/v1/**`, using `addAuthorizationHeader` and the repo-local token
+  resolution. MCP must not accept caller-supplied headers, bearer tokens,
+  methods, absolute URLs, or admin paths outside the existing `GC_MCP_ADMIN`
+  catalog gate.
+- Actor provenance: backend mutations flow through `ActorFilter`,
+  `ActorHolder`, MDC `actor_id`, and Envers. MCP may send its standard
+  `X-Actor: mcp-server` fallback, but production actor identity comes from the
+  authenticated principal. Do not add request-body actor fields or MCP actor
+  override arguments.
+- Request validation: Zod schemas enforce MCP argument shape and enum values;
+  `reqArg` enforces action-required fields; `pick` enforces per-action body
+  allowlists; Jackson enum binding and Bean Validation own REST DTO shape; domain
+  services own semantic rules such as same-project checks, duplicate detection,
+  subtype metadata validation, observation temporal checks, evidence source
+  dual-mode validation, and supersede-once behavior.
+- Error envelopes: backend errors must pass through `GlobalExceptionHandler` and
+  `ErrorResponse`; MCP errors should reuse `RequestError` / `parseErrorBody`.
+  Do not create MCP-only exception codes for domain failures that the backend
+  already returns.
+- Logging and observability: use the existing request logs, actor MDC, Envers,
+  and low-cardinality service logs. Do not log raw observation values, evidence
+  summaries, subtype metadata, external identifiers that may contain secrets,
+  request bodies, authorization headers, or tokens.
+- Graph cost and injection limits: traversal/query operations must use the
+  existing REST graph endpoints, `GraphTraversalLimits`, `MixedGraphService`,
+  and ADR-032 AGE construction boundary. No Cypher passthrough, no dynamic graph
+  labels from MCP input, no unbounded depth/root/entity-type lists.
+- `gc_query` boundary: pure reads that are not curated actions should use
+  `gc_query` with relative allowlisted paths and flat primitive params. Write
+  parity belongs in action-discriminated entity tools, not a generic
+  `method`/`body` escape hatch.
+- Enum and field mirrors: any API-visible enum or request field exposed through
+  MCP must use the canonical Java enum/DTO vocabulary and update JS constants,
+  Zod schemas, `TO_CAMEL`, README/API docs, and adapter tests together.
+
+## Extensibility Seams
+
+- The entity-tool seam is action-discriminated. Extend `gc_asset` /
+  `gc_observation` only with action names that map to existing REST semantics;
+  keep reads on `gc_query` unless the operation is write-like or compute-heavy.
+- The field-mapping seam is the per-action body allowlist plus `TO_CAMEL`.
+  Add a REST DTO field once at this seam and test the forwarded backend body.
+  Do not rely on recursive camelization for user-defined metadata maps.
+- The link seam is `link-create.js` plus `GraphTargetResolverService`. MCP should
+  expose both `target_entity_id` and `target_identifier`, require only
+  `target_type` and `link_type`, and let the backend decide which target mode is
+  valid for the chosen type.
+- The graph seam is node IDs of the form `GraphEntityType:UUID`, entity-type
+  filters, and bounded traversal depth. Future graph-native entity types should
+  join through a `GraphProjectionContributor`, not through bespoke MCP graph
+  serialization.
+- The state-aware query seam is low-cardinality canonical state already on the
+  model: `knowledgeState` for assets/relations, observation `observedAt` /
+  `expiresAt`, evidence `derivedAt` / `supersededByArtifactId`, and existing
+  type/category filters. If more state facets are needed, add them to the
+  canonical REST/domain surface first, then mirror to MCP.
+
+## Gotchas And Anti-Patterns
+
+- Do not mirror old observation names. The current REST DTO uses
+  `observationKey`, `observationValue`, `source`, `observedAt`, `expiresAt`,
+  `confidence`, and `evidenceRef`; MCP snake_case must map to those exact
+  fields. `title`, `statement`, `valid_until`, and arbitrary `metadata` are not
+  the current observation contract.
+- Do not implement REST parity by adding one MCP tool per endpoint. ADR-035's
+  consolidated surface is binding: one action-discriminated entity tool plus
+  `gc_query` for pure reads.
+- Do not duplicate project-scoping checks, target validation, subtype metadata
+  validation, evidence-source validation, observation temporal validation, graph
+  bounds, error envelopes, audit writers, or security filters in MCP.
+- Do not use deprecated UUID-only service overloads on any new backend path.
+  MCP must pass `project` through to REST and let controllers/services enforce
+  same-project access.
+- Do not model observations as topology, topology as observations, external IDs
+  as unknown dependencies, or evidence artifacts as mutable observation
+  summaries.
+- Do not add generic path/method/body write proxies, Cypher passthrough, custom
+  auth headers, caller-supplied token args, shell-outs, or token-in-argv flows.
+- Do not expose admin graph materialization through default MCP sessions; it
+  belongs behind the existing `gc_admin` / `GC_MCP_ADMIN` gate.
+
+## Non-Goals
+
+- No implementation of GC-L008 behavior in this preflight note.
+- No new REST endpoints, migrations, graph schema, AGE adapter, frontend views,
+  importers, scanners, schedulers, or workflow engine.
+- No replacement of `OperationalAsset`, `AssetRelation`, `AssetLink`,
+  `Observation`, `EvidenceArtifact`, `GraphTargetResolverService`,
+  `MixedGraphService`, `gc_query`, or the consolidated MCP tool model.
+- No change to ADR-026 security, ADR-032 AGE query construction, ADR-033 actor
+  provenance, ADR-034 enum mirror policy, ADR-035 MCP curation, ADR-045 evidence
+  append-only semantics, or ADR-046 partial-knowledge semantics.

--- a/changelog.d/730.added.md
+++ b/changelog.d/730.added.md
@@ -1,0 +1,1 @@
+`gc_asset` now exposes a `relation_update` action (`PUT /api/v1/assets/{assetId}/relations/{relationId}`) matching the backend `UpdateAssetRelationRequest`: accepts `description`, `source_system`, `external_source_id`, `collected_at`, `confidence`, and `knowledge_state`.

--- a/changelog.d/730.fixed.md
+++ b/changelog.d/730.fixed.md
@@ -1,0 +1,5 @@
+`gc_observation` now uses the correct backend field names — `observation_key`, `observation_value`, `source`, `observed_at`, `expires_at`, `confidence`, `evidence_ref` — replacing the old `title`, `statement`, `valid_until`, and `metadata` fields that did not match `ObservationRequest`. The update action now uses a separate, narrower body allowlist (`observation_value`, `expires_at`, `confidence`, `evidence_ref`) matching `UpdateObservationRequest`.
+
+`gc_asset relation_create` now forwards all `AssetRelationRequest` body fields — `description`, `source_system`, `external_source_id`, `collected_at`, `confidence`, `knowledge_state` — in addition to `target_id` and `relation_type`; previously only four fields were forwarded and five were silently dropped.
+
+Both `gc_asset` and `gc_observation` are extracted from the inline `index.js` implementation into standalone testable modules (`gc-asset.js`, `gc-observation.js`) matching the `gc-evidence.js` / `gc-finding.js` pattern.

--- a/docs/API.md
+++ b/docs/API.md
@@ -593,6 +593,8 @@ Validation errors return HTTP `422` with the canonical `ErrorResponse` envelope 
 
 Relation types: `CONTAINS`, `DEPENDS_ON`, `COMMUNICATES_WITH`, `TRUST_BOUNDARY`, `SUPPORTS`, `ACCESSES`, `DATA_FLOW`
 
+MCP surface: `gc_asset` with actions `relation_create`, `relation_update`, `relation_delete`. `relation_create` requires `source_id`, `target_id`, `relation_type`; optional body fields are `description`, `source_system`, `external_source_id`, `collected_at`, `confidence`, `knowledge_state`. `relation_update` requires `asset_id`, `relation_id`; accepts the same optional fields (excludes `target_id` and `relation_type` which are immutable after creation). `source_id` is a path parameter, not a body field.
+
 ### Asset Links (Cross-Entity Linking)
 
 | Method | Path | Body | Status | Purpose |
@@ -642,6 +644,51 @@ Link types: `IMPLEMENTS`, `MITIGATES`, `SUBJECT_OF`, `EVIDENCED_BY`, `GOVERNED_B
   "relations": [{ "id": "uuid", "sourceUid": "ASSET-001", "targetUid": "ASSET-002", "relationType": "DEPENDS_ON" }]
 }
 ```
+
+### Observations
+
+Time-bounded state facts about an asset. Each observation records a discrete
+observed value at a point in time; the `/observations/latest` projection surfaces
+the most recent non-expired observation per key.
+
+| Method | Path | Body | Status | Purpose |
+|--------|------|------|--------|---------|
+| POST | `/assets/{id}/observations?project=` | ObservationRequest | 201 | Create observation |
+| GET | `/assets/{id}/observations?project=` | — | 200 | List observations |
+| GET | `/assets/{id}/observations/{obsId}` | — | 200 | Get observation by UUID |
+| PUT | `/assets/{id}/observations/{obsId}` | UpdateObservationRequest | 200 | Update mutable fields |
+| DELETE | `/assets/{id}/observations/{obsId}` | — | 204 | Delete observation |
+| GET | `/assets/{id}/observations/latest?project=` | — | 200 | Latest non-expired observation per key |
+
+**ObservationRequest** (`category`, `observationKey`, `observationValue`, `source`, `observedAt` are required):
+
+```json
+{
+  "category": "CONFIGURATION",
+  "observationKey": "cis.1.1.patch_state",
+  "observationValue": "compliant",
+  "source": "vuln-scanner-v2",
+  "observedAt": "2026-05-01T12:00:00Z",
+  "expiresAt": "2026-11-01T12:00:00Z",
+  "confidence": "0.95",
+  "evidenceRef": "EVD-0042"
+}
+```
+
+**UpdateObservationRequest** (all fields optional):
+
+```json
+{
+  "observationValue": "non-compliant",
+  "expiresAt": "2026-08-01T12:00:00Z",
+  "confidence": "0.80",
+  "evidenceRef": "EVD-0043"
+}
+```
+
+Observation categories: `CONFIGURATION`, `EXPOSURE`, `IDENTITY`, `DEPLOYMENT`, `PATCH_STATE`, `RELATIONSHIP`, `OTHER`
+
+MCP surface: `gc_observation` with actions `create`, `update`, `delete`, `latest`. Snake_case MCP args map to camelCase DTO fields via the adapter's `TO_CAMEL` table — `observation_key` → `observationKey`, `observation_value` → `observationValue`, `observed_at` → `observedAt`, `expires_at` → `expiresAt`, `evidence_ref` → `evidenceRef`. The old field names (`title`, `statement`, `valid_until`, `metadata`) were removed in GC-L008.
 
 ### Quality Gates
 

--- a/mcp/ground-control/README.md
+++ b/mcp/ground-control/README.md
@@ -127,7 +127,7 @@ skills' SKILL.md prose, kept unchanged):
 | `gc_adr` | create, update, delete, transition, requirements |
 | `gc_document` | create, update, delete, grammar_set, grammar_delete, reading_order |
 | `gc_section` | create, update, delete, tree, content_add, content_update, content_delete |
-| `gc_asset` | create, update, delete, archive, relation_*, link_*, external_id_* |
+| `gc_asset` | create, update, delete, archive, relation_create, relation_update, relation_delete, link_*, external_id_*, subtype_schema_*, detect_cycles, impact_analysis, extract_subgraph |
 | `gc_observation` | create, update, delete, latest |
 | `gc_risk_scenario` | create, update, delete, transition, requirements, link_* |
 | `gc_threat_model` | create, update, delete, transition, link_* |

--- a/mcp/ground-control/gc-asset.js
+++ b/mcp/ground-control/gc-asset.js
@@ -1,0 +1,309 @@
+// gc_asset: action-discriminated MCP adapter for the backend operational-asset
+// REST surface (GC-L008). Mirrors gc-finding.js — handler logic stays testable
+// in isolation, while index.js registers the tool and wraps the return value in
+// the MCP `ok()` envelope.
+//
+// Defect-2 fix: relation_create body allowlist now includes all AssetRelationRequest
+// fields — description, source_system, external_source_id, collected_at, confidence
+// — not just source_id/target_id/relation_type/knowledge_state.
+//
+// Defect-3 fix: relation_update action added (PUT /api/v1/assets/{assetId}/relations/{relationId}).
+
+import { z } from "zod";
+import {
+  ASSET_TYPES, ASSET_RELATION_TYPES, ASSET_LINK_TARGET_TYPES, ASSET_LINK_TYPES,
+  ASSET_CRITICALITIES, ASSET_ENVIRONMENTS, ASSET_SCOPES, KNOWLEDGE_STATES,
+  createAsset, updateAsset, deleteAsset, archiveAsset,
+  createAssetRelation, updateAssetRelation, deleteAssetRelation,
+  detectAssetCycles, assetImpactAnalysis, extractAssetSubgraph,
+  createAssetLink, deleteAssetLink,
+  createAssetExternalId, updateAssetExternalId, deleteAssetExternalId,
+  registerAssetSubtypeSchema, listAssetSubtypeSchemas, getAssetSubtypeSchema,
+  getActiveAssetSubtypeSchema, updateAssetSubtypeSchema, deprecateAssetSubtypeSchema,
+  pick, reqArg,
+} from "./lib.js";
+import {
+  linkCreateOptionalSharedZodFields,
+  performLinkCreate,
+} from "./link-create.js";
+
+export const GC_ASSET_ACTIONS = [
+  "create", "update", "delete", "archive",
+  "relation_create", "relation_update", "relation_delete",
+  "detect_cycles", "impact_analysis", "extract_subgraph",
+  "link_create", "link_delete",
+  "external_id_create", "external_id_update", "external_id_delete",
+  // GC-M011 subtype-schema registry actions.
+  "subtype_schema_create", "subtype_schema_update", "subtype_schema_deprecate",
+  "subtype_schema_get", "subtype_schema_get_active", "subtype_schema_list",
+];
+
+// Body fields for the asset create / update actions (mirrors AssetRequest /
+// UpdateAssetRequest). Used by both create and update — the backend ignores
+// unknown fields in the PUT body.
+export const GC_ASSET_FIELDS = [
+  "uid",
+  "name",
+  "description",
+  "asset_type",
+  "parent_id",
+  // GC-M012 ownership/criticality/scope metadata + clear flags.
+  "owner",
+  "steward",
+  "environment",
+  "criticality",
+  "business_context",
+  "scope_designation",
+  "clear_owner",
+  "clear_steward",
+  "clear_environment",
+  "clear_criticality",
+  "clear_business_context",
+  "clear_scope_designation",
+  // GC-M011 subtype + metadata + clear flags.
+  "subtype",
+  "metadata",
+  "clear_subtype",
+  "clear_metadata",
+  // GC-M018 knowledge / completeness state.
+  "knowledge_state",
+];
+
+// Body fields for relation_create — mirrors AssetRelationRequest.
+// Defect-2: source_id is the path param, NOT a body field. All remaining
+// AssetRelationRequest fields are forwarded.
+export const GC_RELATION_CREATE_FIELDS = [
+  "target_id",
+  "relation_type",
+  "description",
+  "source_system",
+  "external_source_id",
+  "collected_at",
+  "confidence",
+  "knowledge_state",
+];
+
+// Body fields for relation_update — mirrors UpdateAssetRelationRequest.
+// Defect-3: intentionally excludes target_id and relation_type (not updatable).
+export const GC_RELATION_UPDATE_FIELDS = [
+  "description",
+  "source_system",
+  "external_source_id",
+  "collected_at",
+  "confidence",
+  "knowledge_state",
+];
+
+// External-id body fields.
+const EXT_ID_FIELDS = ["namespace", "external_id"];
+
+export const gcAssetZodShape = {
+  action: z.enum(GC_ASSET_ACTIONS),
+  id: z.string().uuid().optional(),
+  uid: z.string().optional(),
+  project: z.string().optional(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  asset_type: z.enum(ASSET_TYPES).optional(),
+  // GC-M012 metadata: ownership, stewardship, environment, criticality,
+  // business/mission context, and assurance scope.
+  owner: z.string().optional(),
+  steward: z.string().optional(),
+  environment: z.enum(ASSET_ENVIRONMENTS).optional(),
+  criticality: z.enum(ASSET_CRITICALITIES).optional(),
+  business_context: z.string().optional(),
+  scope_designation: z.enum(ASSET_SCOPES).optional(),
+  // GC-M012 clear flags.
+  clear_owner: z.boolean().optional(),
+  clear_steward: z.boolean().optional(),
+  clear_environment: z.boolean().optional(),
+  clear_criticality: z.boolean().optional(),
+  clear_business_context: z.boolean().optional(),
+  clear_scope_designation: z.boolean().optional(),
+  // GC-M011: subtype discriminator + extensible metadata bag.
+  subtype: z.string().optional(),
+  metadata: z.record(z.any()).optional(),
+  clear_subtype: z.boolean().optional(),
+  clear_metadata: z.boolean().optional(),
+  // GC-M018: knowledge / completeness dimension on asset AND relation.
+  knowledge_state: z.enum(KNOWLEDGE_STATES).optional(),
+  // GC-M011: subtype-schema registry parameters.
+  schema_id: z.string().uuid().optional(),
+  schema_version: z.string().optional(),
+  schema_body: z.record(z.any()).optional(),
+  schema_description: z.string().optional(),
+  clear_schema_description: z.boolean().optional(),
+  clear_schema_body: z.boolean().optional(),
+  parent_id: z.string().uuid().nullable().optional(),
+  // relations — Defect-2/3: added source_system, external_source_id, collected_at, confidence
+  source_id: z.string().uuid().optional(),
+  target_id: z.string().uuid().optional(),
+  relation_type: z.enum(ASSET_RELATION_TYPES).optional(),
+  relation_id: z.string().uuid().optional(),
+  source_system: z.string().optional(),
+  external_source_id: z.string().optional(),
+  collected_at: z.string().optional(),
+  confidence: z.string().optional(),
+  // links
+  asset_id: z.string().uuid().optional(),
+  target_type: z.enum(ASSET_LINK_TARGET_TYPES).optional(),
+  link_type: z.enum(ASSET_LINK_TYPES).optional(),
+  ...linkCreateOptionalSharedZodFields,
+  link_id: z.string().uuid().optional(),
+  // external IDs
+  namespace: z.string().optional(),
+  external_id: z.string().optional(),
+  external_id_record_id: z.string().uuid().optional(),
+  roots: z.array(z.string()).optional(),
+  max_depth: z.number().int().optional(),
+};
+
+export const GC_ASSET_DESCRIPTION =
+  `Operational asset operations incl. relations, links, external IDs (GC-L008). ` +
+  `Actions: ${GC_ASSET_ACTIONS.join(", ")}. ` +
+  `link_create requires target_type + link_type; pass target_entity_id for internal ` +
+  `target types or target_identifier for external types. target_url / target_title are optional. ` +
+  `Reads (list, get, get_by_uid, find_by_external_id, links, external_ids) route through gc_query.`;
+
+/**
+ * Pure adapter handler for gc_asset. Validates required fields, picks
+ * action-scoped body fields, and dispatches to the corresponding lib.js call.
+ * Returns the raw value the lib call produces (or null for delete-style 204s);
+ * the index.js registration wraps the return in the MCP `ok()` envelope.
+ */
+export async function gcAssetToolHandler(args) {
+  switch (args.action) {
+    case "create": {
+      reqArg(args, "uid", "create");
+      reqArg(args, "name", "create");
+      reqArg(args, "asset_type", "create");
+      return createAsset(pick(args, GC_ASSET_FIELDS), args.project);
+    }
+    case "update": {
+      reqArg(args, "id", "update");
+      return updateAsset(args.id, pick(args, GC_ASSET_FIELDS), args.project);
+    }
+    case "delete": {
+      reqArg(args, "id", "delete");
+      await deleteAsset(args.id, args.project);
+      return null;
+    }
+    case "archive": {
+      reqArg(args, "id", "archive");
+      return archiveAsset(args.id, args.project);
+    }
+    case "relation_create": {
+      // lib.js: createAssetRelation(assetId, data, project)
+      // source_id is the path arg; body uses GC_RELATION_CREATE_FIELDS (Defect-2 fix).
+      reqArg(args, "source_id", "relation_create");
+      reqArg(args, "target_id", "relation_create");
+      reqArg(args, "relation_type", "relation_create");
+      return createAssetRelation(args.source_id, pick(args, GC_RELATION_CREATE_FIELDS), args.project);
+    }
+    case "relation_update": {
+      // lib.js: updateAssetRelation(assetId, relationId, data, project) — Defect-3 fix.
+      reqArg(args, "asset_id", "relation_update");
+      reqArg(args, "relation_id", "relation_update");
+      return updateAssetRelation(args.asset_id, args.relation_id, pick(args, GC_RELATION_UPDATE_FIELDS), args.project);
+    }
+    case "relation_delete": {
+      // lib.js: deleteAssetRelation(assetId, relationId, project)
+      reqArg(args, "asset_id", "relation_delete");
+      reqArg(args, "relation_id", "relation_delete");
+      await deleteAssetRelation(args.asset_id, args.relation_id, args.project);
+      return null;
+    }
+    case "detect_cycles":
+      return detectAssetCycles(args.project);
+    case "impact_analysis": {
+      reqArg(args, "id", "impact_analysis");
+      return assetImpactAnalysis(args.id, args.project);
+    }
+    case "extract_subgraph": {
+      reqArg(args, "roots", "extract_subgraph");
+      return extractAssetSubgraph({ roots: args.roots, maxDepth: args.max_depth }, args.project);
+    }
+    case "link_create": {
+      // lib.js: createAssetLink(assetId, data, project). Body shape +
+      // target_type/link_type preconditions live in link-create.js so
+      // every consolidated link_create surface stays in sync with the
+      // backend link DTO.
+      return performLinkCreate(args, "asset_id", createAssetLink);
+    }
+    case "link_delete": {
+      // lib.js: deleteAssetLink(assetId, linkId, project)
+      reqArg(args, "asset_id", "link_delete");
+      reqArg(args, "link_id", "link_delete");
+      await deleteAssetLink(args.asset_id, args.link_id, args.project);
+      return null;
+    }
+    case "external_id_create": {
+      // lib.js: createAssetExternalId(assetId, data, project)
+      reqArg(args, "asset_id", "external_id_create");
+      reqArg(args, "namespace", "external_id_create");
+      reqArg(args, "external_id", "external_id_create");
+      return createAssetExternalId(args.asset_id, pick(args, EXT_ID_FIELDS), args.project);
+    }
+    case "external_id_update": {
+      // lib.js: updateAssetExternalId(assetId, extIdId, data, project)
+      reqArg(args, "asset_id", "external_id_update");
+      reqArg(args, "external_id_record_id", "external_id_update");
+      return updateAssetExternalId(args.asset_id, args.external_id_record_id, pick(args, EXT_ID_FIELDS), args.project);
+    }
+    case "external_id_delete": {
+      // lib.js: deleteAssetExternalId(assetId, extIdId, project)
+      reqArg(args, "asset_id", "external_id_delete");
+      reqArg(args, "external_id_record_id", "external_id_delete");
+      await deleteAssetExternalId(args.asset_id, args.external_id_record_id, args.project);
+      return null;
+    }
+    case "subtype_schema_create": {
+      reqArg(args, "asset_type", "subtype_schema_create");
+      reqArg(args, "subtype", "subtype_schema_create");
+      reqArg(args, "schema_version", "subtype_schema_create");
+      // schema_body is required at the MCP boundary too — the backend rejects
+      // ACTIVE registry rows without a non-empty `fields` map.
+      reqArg(args, "schema_body", "subtype_schema_create");
+      const body = {
+        assetType: args.asset_type,
+        subtype: args.subtype,
+        schemaVersion: args.schema_version,
+        description: args.schema_description,
+        schemaBody: args.schema_body,
+      };
+      return registerAssetSubtypeSchema(body, args.project);
+    }
+    case "subtype_schema_update": {
+      reqArg(args, "schema_id", "subtype_schema_update");
+      const body = {
+        description: args.schema_description,
+        schemaBody: args.schema_body,
+        clearDescription: args.clear_schema_description,
+        clearSchemaBody: args.clear_schema_body,
+      };
+      return updateAssetSubtypeSchema(args.schema_id, body, args.project);
+    }
+    case "subtype_schema_deprecate": {
+      reqArg(args, "schema_id", "subtype_schema_deprecate");
+      return deprecateAssetSubtypeSchema(args.schema_id, args.project);
+    }
+    case "subtype_schema_get": {
+      reqArg(args, "schema_id", "subtype_schema_get");
+      return getAssetSubtypeSchema(args.schema_id, args.project);
+    }
+    case "subtype_schema_get_active": {
+      reqArg(args, "asset_type", "subtype_schema_get_active");
+      reqArg(args, "subtype", "subtype_schema_get_active");
+      return getActiveAssetSubtypeSchema(args.asset_type, args.subtype, args.project);
+    }
+    case "subtype_schema_list": {
+      return listAssetSubtypeSchemas({
+        project: args.project,
+        assetType: args.asset_type,
+        subtype: args.subtype,
+      });
+    }
+    default:
+      throw new Error(`Unknown action: ${args.action}`);
+  }
+}

--- a/mcp/ground-control/gc-asset.test.js
+++ b/mcp/ground-control/gc-asset.test.js
@@ -1,0 +1,466 @@
+// Adapter-level tests for the gc_asset MCP handler. Exercises Zod-parsed args
+// → handler dispatch → backend HTTP call (mocked fetch) → wire body shape.
+// Guards Defect-2 (relation_create missing fields) and Defect-3 (relation_update
+// missing action).
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import {
+  GC_ASSET_ACTIONS,
+  GC_RELATION_CREATE_FIELDS,
+  GC_RELATION_UPDATE_FIELDS,
+  gcAssetZodShape,
+  gcAssetToolHandler,
+} from "./gc-asset.js";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_BASE_URL = process.env.GC_BASE_URL;
+const ORIGINAL_API_TOKEN = process.env.GROUND_CONTROL_API_TOKEN;
+
+function makeFetchSpy({ status = 201, body = { id: "asset-uuid" } } = {}) {
+  const calls = [];
+  globalThis.fetch = async (url, opts) => {
+    const parsedBody = opts && opts.body ? JSON.parse(opts.body) : null;
+    calls.push({ url: url.toString(), method: opts?.method ?? "GET", body: parsedBody });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.GC_BASE_URL = "https://gc.test";
+  delete process.env.GROUND_CONTROL_API_TOKEN;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_BASE_URL === undefined) delete process.env.GC_BASE_URL;
+  else process.env.GC_BASE_URL = ORIGINAL_BASE_URL;
+  if (ORIGINAL_API_TOKEN === undefined) delete process.env.GROUND_CONTROL_API_TOKEN;
+  else process.env.GROUND_CONTROL_API_TOKEN = ORIGINAL_API_TOKEN;
+});
+
+// ── Zod shape ────────────────────────────────────────────────────────────────
+
+describe("gcAssetZodShape", () => {
+  it("rejects an unknown action", () => {
+    const schema = z.object(gcAssetZodShape);
+    const result = schema.safeParse({ action: "purge" });
+    assert.equal(result.success, false);
+  });
+
+  it("includes relation_update in the action enum (Defect-3)", () => {
+    assert.equal(GC_ASSET_ACTIONS.includes("relation_update"), true);
+  });
+
+  it("includes new relation Zod fields: source_system, external_source_id, collected_at, confidence", () => {
+    const schema = z.object(gcAssetZodShape);
+    const result = schema.safeParse({
+      action: "relation_create",
+      source_id: "11111111-1111-1111-1111-111111111111",
+      target_id: "22222222-2222-2222-2222-222222222222",
+      relation_type: "DEPENDS_ON",
+      source_system: "cmdb",
+      external_source_id: "ext-123",
+      collected_at: "2026-05-01T00:00:00Z",
+      confidence: "HIGH",
+    });
+    assert.equal(result.success, true);
+    assert.equal(result.data.source_system, "cmdb");
+    assert.equal(result.data.external_source_id, "ext-123");
+    assert.equal(result.data.collected_at, "2026-05-01T00:00:00Z");
+    assert.equal(result.data.confidence, "HIGH");
+  });
+});
+
+// ── create action ─────────────────────────────────────────────────────────────
+
+describe("gcAssetToolHandler — create", () => {
+  it("POSTs /assets with correct body and project param", async () => {
+    const calls = makeFetchSpy({ status: 201, body: { id: "a1" } });
+    await gcAssetToolHandler({
+      action: "create",
+      project: "test-proj",
+      uid: "ASSET-001",
+      name: "Web Server",
+      asset_type: "APPLICATION",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, /\/api\/v1\/assets(\?|$)/);
+    assert.match(calls[0].url, /project=test-proj/);
+    assert.equal(calls[0].body.uid, "ASSET-001");
+    assert.equal(calls[0].body.name, "Web Server");
+    assert.equal(calls[0].body.assetType, "APPLICATION");
+  });
+
+  it("create rejects when uid is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "create", name: "N", asset_type: "APPLICATION" }),
+      /uid/,
+    );
+  });
+
+  it("create rejects when name is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "create", uid: "U", asset_type: "APPLICATION" }),
+      /name/,
+    );
+  });
+
+  it("create rejects when asset_type is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "create", uid: "U", name: "N" }),
+      /asset_type/,
+    );
+  });
+});
+
+// ── update action ─────────────────────────────────────────────────────────────
+
+describe("gcAssetToolHandler — update", () => {
+  it("PUTs /assets/{id} with body", async () => {
+    const calls = makeFetchSpy({ status: 200, body: { id: "a1" } });
+    await gcAssetToolHandler({
+      action: "update",
+      id: "11111111-1111-1111-1111-111111111111",
+      name: "Renamed",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, /\/api\/v1\/assets\/11111111-1111-1111-1111-111111111111/);
+    assert.equal(calls[0].body.name, "Renamed");
+  });
+
+  it("update rejects when id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "update", name: "N" }),
+      /id/,
+    );
+  });
+});
+
+// ── delete action ─────────────────────────────────────────────────────────────
+
+describe("gcAssetToolHandler — delete", () => {
+  it("DELETEs /assets/{id} and returns null", async () => {
+    const calls = makeFetchSpy({ status: 200, body: {} });
+    const result = await gcAssetToolHandler({
+      action: "delete",
+      id: "22222222-2222-2222-2222-222222222222",
+    });
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.match(calls[0].url, /\/api\/v1\/assets\/22222222-2222-2222-2222-222222222222/);
+  });
+
+  it("delete rejects when id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(gcAssetToolHandler({ action: "delete" }), /id/);
+  });
+});
+
+// ── archive action ────────────────────────────────────────────────────────────
+
+describe("gcAssetToolHandler — archive", () => {
+  it("POSTs /assets/{id}/archive", async () => {
+    const calls = makeFetchSpy({ status: 200, body: { id: "a1", archived: true } });
+    await gcAssetToolHandler({
+      action: "archive",
+      id: "33333333-3333-3333-3333-333333333333",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, /\/api\/v1\/assets\/33333333-3333-3333-3333-333333333333\/archive/);
+  });
+
+  it("archive rejects when id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(gcAssetToolHandler({ action: "archive" }), /id/);
+  });
+});
+
+// ── relation_create action (Defect-2) ─────────────────────────────────────────
+
+describe("gcAssetToolHandler — relation_create", () => {
+  it("POSTs /assets/{sourceId}/relations with full body incl. description, source_system, etc. (Defect-2)", async () => {
+    const calls = makeFetchSpy({ status: 201, body: { id: "rel-1" } });
+    const sourceId = "44444444-4444-4444-4444-444444444444";
+    const targetId = "55555555-5555-5555-5555-555555555555";
+    await gcAssetToolHandler({
+      action: "relation_create",
+      source_id: sourceId,
+      target_id: targetId,
+      relation_type: "DEPENDS_ON",
+      description: "network hop",
+      source_system: "cmdb",
+      external_source_id: "ext-123",
+      collected_at: "2026-05-01T00:00:00Z",
+      confidence: "HIGH",
+      knowledge_state: "CONFIRMED",
+      project: "p",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${sourceId}/relations`));
+    // Defect-2: all body fields must reach the wire
+    assert.equal(calls[0].body.targetId, targetId);
+    assert.equal(calls[0].body.relationType, "DEPENDS_ON");
+    assert.equal(calls[0].body.description, "network hop");
+    assert.equal(calls[0].body.sourceSystem, "cmdb");
+    assert.equal(calls[0].body.externalSourceId, "ext-123");
+    assert.equal(calls[0].body.collectedAt, "2026-05-01T00:00:00Z");
+    assert.equal(calls[0].body.confidence, "HIGH");
+    assert.equal(calls[0].body.knowledgeState, "CONFIRMED");
+    // source_id is the path arg, not a body field
+    assert.equal(calls[0].body.sourceId, undefined);
+  });
+
+  it("relation_create rejects when source_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({
+        action: "relation_create",
+        target_id: "55555555-5555-5555-5555-555555555555",
+        relation_type: "DEPENDS_ON",
+      }),
+      /source_id/,
+    );
+  });
+
+  it("relation_create rejects when target_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({
+        action: "relation_create",
+        source_id: "44444444-4444-4444-4444-444444444444",
+        relation_type: "DEPENDS_ON",
+      }),
+      /target_id/,
+    );
+  });
+
+  it("relation_create rejects when relation_type is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({
+        action: "relation_create",
+        source_id: "44444444-4444-4444-4444-444444444444",
+        target_id: "55555555-5555-5555-5555-555555555555",
+      }),
+      /relation_type/,
+    );
+  });
+
+  it("RELATION_CREATE_FIELDS contains all backend AssetRelationRequest body fields", () => {
+    for (const f of ["target_id", "relation_type", "description", "source_system",
+      "external_source_id", "collected_at", "confidence", "knowledge_state"]) {
+      assert.equal(GC_RELATION_CREATE_FIELDS.includes(f), true,
+        `GC_RELATION_CREATE_FIELDS must contain: ${f}`);
+    }
+    // source_id is a path arg, NOT a body field
+    assert.equal(GC_RELATION_CREATE_FIELDS.includes("source_id"), false,
+      "source_id must NOT be in the relation create body fields");
+  });
+});
+
+// ── relation_delete action ────────────────────────────────────────────────────
+
+describe("gcAssetToolHandler — relation_delete", () => {
+  it("DELETEs /assets/{assetId}/relations/{relationId} and returns null", async () => {
+    const calls = makeFetchSpy({ status: 200, body: {} });
+    const assetId = "66666666-6666-6666-6666-666666666666";
+    const relId = "77777777-7777-7777-7777-777777777777";
+    const result = await gcAssetToolHandler({
+      action: "relation_delete",
+      asset_id: assetId,
+      relation_id: relId,
+    });
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${assetId}/relations/${relId}`));
+  });
+
+  it("relation_delete rejects when asset_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "relation_delete", relation_id: "77777777-7777-7777-7777-777777777777" }),
+      /asset_id/,
+    );
+  });
+
+  it("relation_delete rejects when relation_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "relation_delete", asset_id: "66666666-6666-6666-6666-666666666666" }),
+      /relation_id/,
+    );
+  });
+});
+
+// ── relation_update action (Defect-3) ─────────────────────────────────────────
+
+describe("gcAssetToolHandler — relation_update", () => {
+  it("PUTs /assets/{assetId}/relations/{relationId} with update allowlist (Defect-3)", async () => {
+    const calls = makeFetchSpy({ status: 200, body: { id: "rel-1" } });
+    const assetId = "88888888-8888-8888-8888-888888888888";
+    const relId = "99999999-9999-9999-9999-999999999999";
+    await gcAssetToolHandler({
+      action: "relation_update",
+      asset_id: assetId,
+      relation_id: relId,
+      description: "updated desc",
+      source_system: "cmdb-v2",
+      external_source_id: "ext-456",
+      collected_at: "2026-06-01T00:00:00Z",
+      confidence: "MEDIUM",
+      knowledge_state: "INFERRED",
+      project: "p",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${assetId}/relations/${relId}`));
+    assert.equal(calls[0].body.description, "updated desc");
+    assert.equal(calls[0].body.sourceSystem, "cmdb-v2");
+    assert.equal(calls[0].body.externalSourceId, "ext-456");
+    assert.equal(calls[0].body.collectedAt, "2026-06-01T00:00:00Z");
+    assert.equal(calls[0].body.confidence, "MEDIUM");
+    assert.equal(calls[0].body.knowledgeState, "INFERRED");
+  });
+
+  it("relation_update rejects when asset_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "relation_update", relation_id: "99999999-9999-9999-9999-999999999999" }),
+      /asset_id/,
+    );
+  });
+
+  it("relation_update rejects when relation_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "relation_update", asset_id: "88888888-8888-8888-8888-888888888888" }),
+      /relation_id/,
+    );
+  });
+
+  it("RELATION_UPDATE_FIELDS contains update-allowed fields and not create-only fields", () => {
+    for (const f of ["description", "source_system", "external_source_id",
+      "collected_at", "confidence", "knowledge_state"]) {
+      assert.equal(GC_RELATION_UPDATE_FIELDS.includes(f), true,
+        `GC_RELATION_UPDATE_FIELDS must contain: ${f}`);
+    }
+    // target_id and relation_type are create-only, not updatable
+    assert.equal(GC_RELATION_UPDATE_FIELDS.includes("target_id"), false);
+    assert.equal(GC_RELATION_UPDATE_FIELDS.includes("relation_type"), false);
+  });
+});
+
+// ── link_delete action ────────────────────────────────────────────────────────
+
+describe("gcAssetToolHandler — link_delete", () => {
+  it("DELETEs /assets/{assetId}/links/{linkId} and returns null", async () => {
+    const calls = makeFetchSpy({ status: 200, body: {} });
+    const assetId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const linkId = "ffffffff-0000-1111-2222-333333333333";
+    const result = await gcAssetToolHandler({
+      action: "link_delete",
+      asset_id: assetId,
+      link_id: linkId,
+    });
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${assetId}/links/${linkId}`));
+  });
+
+  it("link_delete rejects when asset_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "link_delete", link_id: "ffffffff-0000-1111-2222-333333333333" }),
+      /asset_id/,
+    );
+  });
+
+  it("link_delete rejects when link_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "link_delete", asset_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }),
+      /link_id/,
+    );
+  });
+});
+
+// ── external_id_create action ─────────────────────────────────────────────────
+
+describe("gcAssetToolHandler — external_id_create", () => {
+  it("POSTs /assets/{assetId}/external-ids with namespace + external_id", async () => {
+    const calls = makeFetchSpy({ status: 201, body: { id: "eid-1" } });
+    const assetId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    await gcAssetToolHandler({
+      action: "external_id_create",
+      asset_id: assetId,
+      namespace: "cmdb",
+      external_id: "cmdb-001",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${assetId}/external-ids`));
+    assert.equal(calls[0].body.namespace, "cmdb");
+    // external_id has no TO_CAMEL entry so it passes through as-is to the backend
+    assert.equal(calls[0].body.external_id, "cmdb-001");
+  });
+
+  it("external_id_create rejects when asset_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "external_id_create", namespace: "ns", external_id: "id" }),
+      /asset_id/,
+    );
+  });
+});
+
+// ── external_id_delete action ─────────────────────────────────────────────────
+
+describe("gcAssetToolHandler — external_id_delete", () => {
+  it("DELETEs /assets/{assetId}/external-ids/{extIdId} and returns null", async () => {
+    const calls = makeFetchSpy({ status: 200, body: {} });
+    const assetId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const extIdId = "44444444-5555-6666-7777-888888888888";
+    const result = await gcAssetToolHandler({
+      action: "external_id_delete",
+      asset_id: assetId,
+      external_id_record_id: extIdId,
+    });
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${assetId}/external-ids/${extIdId}`));
+  });
+
+  it("external_id_delete rejects when asset_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "external_id_delete", external_id_record_id: "44444444-5555-6666-7777-888888888888" }),
+      /asset_id/,
+    );
+  });
+
+  it("external_id_delete rejects when external_id_record_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcAssetToolHandler({ action: "external_id_delete", asset_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" }),
+      /external_id_record_id/,
+    );
+  });
+});

--- a/mcp/ground-control/gc-observation.js
+++ b/mcp/ground-control/gc-observation.js
@@ -1,0 +1,113 @@
+// gc_observation: action-discriminated MCP adapter for the backend observation
+// REST surface (GC-L008). Mirrors gc-finding.js — handler logic stays testable
+// in isolation, while index.js registers the tool and wraps the return value in
+// the MCP `ok()` envelope.
+//
+// Defect-1 fix: the inline gc_observation used title/statement/valid_until/
+// metadata. The backend ObservationRequest uses category/observationKey/
+// observationValue/source/observedAt/expiresAt/confidence/evidenceRef. All old
+// field names are dropped and replaced here.
+
+import { z } from "zod";
+import {
+  OBSERVATION_CATEGORIES,
+  createObservation,
+  updateObservation,
+  deleteObservation,
+  listLatestObservations,
+  pick,
+  reqArg,
+} from "./lib.js";
+
+export const GC_OBSERVATION_ACTIONS = ["create", "update", "delete", "latest"];
+
+// Snake_case body fields accepted by gc_observation.create — mirrors backend
+// ObservationRequest.
+export const GC_OBSERVATION_CREATE_FIELDS = [
+  "category",
+  "observation_key",
+  "observation_value",
+  "source",
+  "observed_at",
+  "expires_at",
+  "confidence",
+  "evidence_ref",
+];
+
+// Required fields for the create action (maps to @NotBlank / @NotNull on
+// ObservationRequest).
+export const GC_OBSERVATION_CREATE_REQUIRED_FIELDS = [
+  "asset_id",
+  "category",
+  "observation_key",
+  "observation_value",
+  "source",
+  "observed_at",
+];
+
+// Snake_case body fields accepted by gc_observation.update — mirrors backend
+// UpdateObservationRequest. Intentionally separate from create to enforce that
+// create-only fields (category, observation_key, source, observed_at) are never
+// forwarded on update.
+export const GC_OBSERVATION_UPDATE_FIELDS = [
+  "observation_value",
+  "expires_at",
+  "confidence",
+  "evidence_ref",
+];
+
+export const gcObservationZodShape = {
+  action: z.enum(GC_OBSERVATION_ACTIONS),
+  id: z.string().uuid().optional(),
+  project: z.string().optional(),
+  asset_id: z.string().uuid().optional(),
+  category: z.enum(OBSERVATION_CATEGORIES).optional(),
+  observation_key: z.string().optional(),
+  observation_value: z.string().optional(),
+  source: z.string().optional(),
+  observed_at: z.string().optional(),
+  expires_at: z.string().optional(),
+  confidence: z.string().optional(),
+  evidence_ref: z.string().optional(),
+};
+
+export const GC_OBSERVATION_DESCRIPTION =
+  `Time-bounded state observations about an asset (GC-L008). ` +
+  `Actions: ${GC_OBSERVATION_ACTIONS.join(", ")}. ` +
+  `create requires: ${GC_OBSERVATION_CREATE_REQUIRED_FIELDS.join(", ")}. ` +
+  `update requires asset_id + id; accepts observation_value, expires_at, confidence, evidence_ref. ` +
+  `delete requires asset_id + id. ` +
+  `latest requires asset_id. ` +
+  `Reads (list, get) route through gc_query.`;
+
+/**
+ * Pure adapter handler for gc_observation. Validates required fields, picks
+ * action-scoped body fields, and dispatches to the corresponding lib.js call.
+ * Returns the raw value the lib call produces (or null for delete-style 204s);
+ * the index.js registration wraps the return in the MCP `ok()` envelope.
+ */
+export async function gcObservationToolHandler(args) {
+  switch (args.action) {
+    case "create": {
+      for (const key of GC_OBSERVATION_CREATE_REQUIRED_FIELDS) reqArg(args, key, "create");
+      return createObservation(args.asset_id, pick(args, GC_OBSERVATION_CREATE_FIELDS), args.project);
+    }
+    case "update": {
+      reqArg(args, "asset_id", "update");
+      reqArg(args, "id", "update");
+      return updateObservation(args.asset_id, args.id, pick(args, GC_OBSERVATION_UPDATE_FIELDS), args.project);
+    }
+    case "delete": {
+      reqArg(args, "asset_id", "delete");
+      reqArg(args, "id", "delete");
+      await deleteObservation(args.asset_id, args.id, args.project);
+      return null;
+    }
+    case "latest": {
+      reqArg(args, "asset_id", "latest");
+      return listLatestObservations(args.asset_id, args.project);
+    }
+    default:
+      throw new Error(`Unknown action: ${args.action}`);
+  }
+}

--- a/mcp/ground-control/gc-observation.test.js
+++ b/mcp/ground-control/gc-observation.test.js
@@ -1,0 +1,386 @@
+// Adapter-level tests for the gc_observation MCP handler. Exercises Zod-parsed
+// args → handler dispatch → backend HTTP call (mocked fetch) → wire body
+// shape. Guards the Defect-1 regression: observation field names must match the
+// backend ObservationRequest / UpdateObservationRequest DTOs — observationKey,
+// observationValue, source, observedAt, expiresAt, confidence, evidenceRef —
+// and must NOT forward the old field names: title, statement, valid_until, metadata.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { z } from "zod";
+import {
+  GC_OBSERVATION_ACTIONS,
+  GC_OBSERVATION_CREATE_REQUIRED_FIELDS,
+  GC_OBSERVATION_UPDATE_FIELDS,
+  gcObservationZodShape,
+  gcObservationToolHandler,
+} from "./gc-observation.js";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_BASE_URL = process.env.GC_BASE_URL;
+const ORIGINAL_API_TOKEN = process.env.GROUND_CONTROL_API_TOKEN;
+
+function makeFetchSpy({ status = 201, body = { id: "obs-uuid" } } = {}) {
+  const calls = [];
+  globalThis.fetch = async (url, opts) => {
+    const parsedBody = opts && opts.body ? JSON.parse(opts.body) : null;
+    calls.push({ url: url.toString(), method: opts?.method ?? "GET", body: parsedBody });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return calls;
+}
+
+beforeEach(() => {
+  process.env.GC_BASE_URL = "https://gc.test";
+  delete process.env.GROUND_CONTROL_API_TOKEN;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_BASE_URL === undefined) delete process.env.GC_BASE_URL;
+  else process.env.GC_BASE_URL = ORIGINAL_BASE_URL;
+  if (ORIGINAL_API_TOKEN === undefined) delete process.env.GROUND_CONTROL_API_TOKEN;
+  else process.env.GROUND_CONTROL_API_TOKEN = ORIGINAL_API_TOKEN;
+});
+
+// ── Zod shape ────────────────────────────────────────────────────────────────
+
+describe("gcObservationZodShape", () => {
+  it("rejects an unknown action", () => {
+    const schema = z.object(gcObservationZodShape);
+    const result = schema.safeParse({ action: "patch" });
+    assert.equal(result.success, false);
+  });
+
+  it("only allows create / update / delete / latest actions", () => {
+    assert.deepEqual([...GC_OBSERVATION_ACTIONS].sort(), ["create", "delete", "latest", "update"]);
+  });
+
+  it("accepts all correct fields (no title/statement/valid_until/metadata)", () => {
+    const schema = z.object(gcObservationZodShape);
+    const result = schema.safeParse({
+      action: "create",
+      project: "test-proj",
+      asset_id: "11111111-1111-1111-1111-111111111111",
+      category: "CONFIGURATION",
+      observation_key: "cis.1.1",
+      observation_value: "passing",
+      source: "scanner-v1",
+      observed_at: "2026-05-01T00:00:00Z",
+      expires_at: "2026-11-01T00:00:00Z",
+      confidence: "HIGH",
+      evidence_ref: "evd-001",
+    });
+    assert.equal(result.success, true);
+  });
+
+  it("does NOT have title/statement/valid_until/metadata as accepted Zod fields", () => {
+    // Zod 'strip' (default) silently drops unknown keys, so this test
+    // confirms the shape doesn't declare them by checking the parsed output.
+    const schema = z.object(gcObservationZodShape);
+    const result = schema.safeParse({
+      action: "create",
+      title: "old-field",
+      statement: "old-field",
+      valid_until: "old-field",
+      metadata: { key: "val" },
+    });
+    // Strip mode means safeParse succeeds but the old fields are absent.
+    assert.equal(result.success, true);
+    assert.equal(result.data.title, undefined);
+    assert.equal(result.data.statement, undefined);
+    assert.equal(result.data.valid_until, undefined);
+    assert.equal(result.data.metadata, undefined);
+  });
+});
+
+// ── create action ─────────────────────────────────────────────────────────────
+
+describe("gcObservationToolHandler — create", () => {
+  it("POSTs /assets/{assetId}/observations with correct camelCase body (Defect-1 regression guard)", async () => {
+    const calls = makeFetchSpy({ status: 201, body: { id: "obs-1" } });
+    const assetId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    await gcObservationToolHandler({
+      action: "create",
+      project: "test-proj",
+      asset_id: assetId,
+      category: "CONFIGURATION",
+      observation_key: "cis.1.1",
+      observation_value: "passing",
+      source: "scanner-v1",
+      observed_at: "2026-05-01T00:00:00Z",
+      expires_at: "2026-11-01T00:00:00Z",
+      confidence: "HIGH",
+      evidence_ref: "evd-001",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "POST");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${assetId}/observations`));
+    assert.match(calls[0].url, /project=test-proj/);
+    // Defect-1 assertion: camelCase field names must reach the wire
+    assert.equal(calls[0].body.observationKey, "cis.1.1");
+    assert.equal(calls[0].body.observationValue, "passing");
+    assert.equal(calls[0].body.source, "scanner-v1");
+    assert.equal(calls[0].body.observedAt, "2026-05-01T00:00:00Z");
+    assert.equal(calls[0].body.expiresAt, "2026-11-01T00:00:00Z");
+    assert.equal(calls[0].body.confidence, "HIGH");
+    assert.equal(calls[0].body.evidenceRef, "evd-001");
+    assert.equal(calls[0].body.category, "CONFIGURATION");
+    // Old field names must NOT be present on the wire
+    assert.equal(calls[0].body.title, undefined);
+    assert.equal(calls[0].body.statement, undefined);
+    assert.equal(calls[0].body.valid_until, undefined);
+    assert.equal(calls[0].body.metadata, undefined);
+  });
+
+  it("create rejects when asset_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({
+        action: "create",
+        category: "CONFIGURATION",
+        observation_key: "k",
+        observation_value: "v",
+        source: "s",
+        observed_at: "2026-05-01T00:00:00Z",
+      }),
+      /asset_id/,
+    );
+  });
+
+  it("create rejects when category is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({
+        action: "create",
+        asset_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        observation_key: "k",
+        observation_value: "v",
+        source: "s",
+        observed_at: "2026-05-01T00:00:00Z",
+      }),
+      /category/,
+    );
+  });
+
+  it("create rejects when observation_key is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({
+        action: "create",
+        asset_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        category: "CONFIGURATION",
+        observation_value: "v",
+        source: "s",
+        observed_at: "2026-05-01T00:00:00Z",
+      }),
+      /observation_key/,
+    );
+  });
+
+  it("create rejects when observation_value is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({
+        action: "create",
+        asset_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        category: "CONFIGURATION",
+        observation_key: "k",
+        source: "s",
+        observed_at: "2026-05-01T00:00:00Z",
+      }),
+      /observation_value/,
+    );
+  });
+
+  it("create rejects when source is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({
+        action: "create",
+        asset_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        category: "CONFIGURATION",
+        observation_key: "k",
+        observation_value: "v",
+        observed_at: "2026-05-01T00:00:00Z",
+      }),
+      /source/,
+    );
+  });
+
+  it("create rejects when observed_at is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({
+        action: "create",
+        asset_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        category: "CONFIGURATION",
+        observation_key: "k",
+        observation_value: "v",
+        source: "s",
+      }),
+      /observed_at/,
+    );
+  });
+
+  it("create does NOT forward title/statement/valid_until/metadata fields", async () => {
+    const calls = makeFetchSpy({ status: 201 });
+    await gcObservationToolHandler({
+      action: "create",
+      asset_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      category: "CONFIGURATION",
+      observation_key: "k",
+      observation_value: "v",
+      source: "s",
+      observed_at: "2026-05-01T00:00:00Z",
+      // old field names that must be silently ignored
+      title: "must-be-dropped",
+      statement: "must-be-dropped",
+      valid_until: "must-be-dropped",
+      metadata: { bad: "field" },
+    });
+    assert.equal(calls[0].body.title, undefined);
+    assert.equal(calls[0].body.statement, undefined);
+    assert.equal(calls[0].body.valid_until, undefined);
+    assert.equal(calls[0].body.metadata, undefined);
+  });
+
+  it("required-fields list exactly matches the create contract", () => {
+    assert.deepEqual(GC_OBSERVATION_CREATE_REQUIRED_FIELDS, [
+      "asset_id", "category", "observation_key", "observation_value", "source", "observed_at",
+    ]);
+  });
+});
+
+// ── update action ─────────────────────────────────────────────────────────────
+
+describe("gcObservationToolHandler — update", () => {
+  it("PUTs /assets/{assetId}/observations/{id} with update-only allowlist", async () => {
+    const calls = makeFetchSpy({ status: 200, body: { id: "obs-1" } });
+    const assetId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const obsId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    await gcObservationToolHandler({
+      action: "update",
+      asset_id: assetId,
+      id: obsId,
+      project: "proj",
+      observation_value: "updated-value",
+      expires_at: "2027-01-01T00:00:00Z",
+      confidence: "MEDIUM",
+      evidence_ref: "evd-002",
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "PUT");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${assetId}/observations/${obsId}`));
+    assert.equal(calls[0].body.observationValue, "updated-value");
+    assert.equal(calls[0].body.expiresAt, "2027-01-01T00:00:00Z");
+    assert.equal(calls[0].body.confidence, "MEDIUM");
+    assert.equal(calls[0].body.evidenceRef, "evd-002");
+    // create-only fields must NOT appear in update body
+    assert.equal(calls[0].body.observationKey, undefined);
+    assert.equal(calls[0].body.source, undefined);
+    assert.equal(calls[0].body.observedAt, undefined);
+    assert.equal(calls[0].body.category, undefined);
+  });
+
+  it("update rejects when asset_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({ action: "update", id: "cccccccc-cccc-cccc-cccc-cccccccccccc" }),
+      /asset_id/,
+    );
+  });
+
+  it("update rejects when id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({
+        action: "update",
+        asset_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      }),
+      /id/,
+    );
+  });
+
+  it("update-fields list is separate from create-fields (Defect-1 separation guard)", () => {
+    // update fields must not contain create-only fields
+    for (const f of ["observation_key", "source", "observed_at", "category"]) {
+      assert.equal(GC_OBSERVATION_UPDATE_FIELDS.includes(f), false,
+        `update allowlist must not contain create-only field: ${f}`);
+    }
+    // update fields must contain the update-allowed fields
+    for (const f of ["observation_value", "expires_at", "confidence", "evidence_ref"]) {
+      assert.equal(GC_OBSERVATION_UPDATE_FIELDS.includes(f), true,
+        `update allowlist must contain: ${f}`);
+    }
+  });
+});
+
+// ── delete action ─────────────────────────────────────────────────────────────
+
+describe("gcObservationToolHandler — delete", () => {
+  it("DELETEs /assets/{assetId}/observations/{id} and returns null", async () => {
+    // Use status 200 with empty body in the spy — lib.js interprets the real
+    // backend 204 as null internally; the test just verifies method + URL + null
+    // return value from the handler.
+    const calls = makeFetchSpy({ status: 200, body: {} });
+    const assetId = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    const obsId = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    const result = await gcObservationToolHandler({
+      action: "delete",
+      asset_id: assetId,
+      id: obsId,
+      project: "proj",
+    });
+    // handler returns null after awaiting delete (regardless of spy body)
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "DELETE");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${assetId}/observations/${obsId}`));
+  });
+
+  it("delete rejects when asset_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({ action: "delete", id: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee" }),
+      /asset_id/,
+    );
+  });
+
+  it("delete rejects when id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({ action: "delete", asset_id: "dddddddd-dddd-dddd-dddd-dddddddddddd" }),
+      /id/,
+    );
+  });
+});
+
+// ── latest action ─────────────────────────────────────────────────────────────
+
+describe("gcObservationToolHandler — latest", () => {
+  it("GETs /assets/{assetId}/observations/latest and returns data", async () => {
+    const calls = makeFetchSpy({ status: 200, body: [{ id: "obs-latest" }] });
+    const assetId = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+    const result = await gcObservationToolHandler({
+      action: "latest",
+      asset_id: assetId,
+      project: "proj",
+    });
+    assert.deepEqual(result, [{ id: "obs-latest" }]);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "GET");
+    assert.match(calls[0].url, new RegExp(`/api/v1/assets/${assetId}/observations/latest`));
+  });
+
+  it("latest rejects when asset_id is missing", async () => {
+    makeFetchSpy();
+    await assert.rejects(
+      gcObservationToolHandler({ action: "latest" }),
+      /asset_id/,
+    );
+  });
+});

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -241,6 +241,16 @@ import {
   linkCreateOptionalSharedZodFields,
   performLinkCreate,
 } from "./link-create.js";
+import {
+  gcAssetZodShape,
+  gcAssetToolHandler,
+  GC_ASSET_DESCRIPTION,
+} from "./gc-asset.js";
+import {
+  gcObservationZodShape,
+  gcObservationToolHandler,
+  GC_OBSERVATION_DESCRIPTION,
+} from "./gc-observation.js";
 
 // Load .env from cwd before any auth header is composed.
 function loadDotenvFromCwd() {
@@ -1303,299 +1313,34 @@ server.tool(
   },
 );
 
-const ASSET_ACTIONS = [
-  "create", "update", "delete", "archive",
-  "relation_create", "relation_delete", "detect_cycles", "impact_analysis", "extract_subgraph",
-  "link_create", "link_delete",
-  "external_id_create", "external_id_update", "external_id_delete",
-  // GC-M011 subtype-schema registry actions.
-  "subtype_schema_create", "subtype_schema_update", "subtype_schema_deprecate",
-  "subtype_schema_get", "subtype_schema_get_active", "subtype_schema_list",
-];
-
+// gc_asset: GC-L008. Operational asset operations incl. relations (incl.
+// relation_update — Defect-3 fix), links, external IDs, and subtype-schema
+// registry. Handler logic lives in gc-asset.js for testability.
 server.tool(
   "gc_asset",
-  `Operational asset operations incl. relations, links, external IDs. Actions: ${ASSET_ACTIONS.join(", ")}. ` +
-    `link_create requires target_type + link_type; pass target_entity_id for internal target types ` +
-    `or target_identifier for external types. target_url / target_title are optional. ` +
-    `Reads (list, get, get_by_uid, find_by_external_id, links, external_ids) route through gc_query.`,
-  {
-    action: z.enum(ASSET_ACTIONS),
-    id: z.string().uuid().optional(),
-    uid: z.string().optional(),
-    project: z.string().optional(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    asset_type: z.enum(ASSET_TYPES).optional(),
-    // GC-M012 metadata: ownership, stewardship, environment, criticality,
-    // business/mission context, and assurance scope.
-    owner: z.string().optional(),
-    steward: z.string().optional(),
-    environment: z.enum(ASSET_ENVIRONMENTS).optional(),
-    criticality: z.enum(ASSET_CRITICALITIES).optional(),
-    business_context: z.string().optional(),
-    scope_designation: z.enum(ASSET_SCOPES).optional(),
-    // GC-M012 clear flags: reset a previously-designated metadata field back
-    // to NULL ("not designated") on update. Clear wins over a same-payload
-    // assignment to keep the semantic unambiguous; see UpdateAssetCommand.
-    clear_owner: z.boolean().optional(),
-    clear_steward: z.boolean().optional(),
-    clear_environment: z.boolean().optional(),
-    clear_criticality: z.boolean().optional(),
-    clear_business_context: z.boolean().optional(),
-    clear_scope_designation: z.boolean().optional(),
-    // GC-M011: subtype discriminator + extensible metadata bag.
-    subtype: z.string().optional(),
-    metadata: z.record(z.any()).optional(),
-    clear_subtype: z.boolean().optional(),
-    clear_metadata: z.boolean().optional(),
-    // GC-M018: knowledge / completeness dimension on asset AND relation.
-    // Distinct from confidence; see the preflight note. There is no
-    // clear flag — the underlying column is NOT NULL and null on
-    // update means "leave unchanged".
-    knowledge_state: z.enum(KNOWLEDGE_STATES).optional(),
-    // GC-M011: subtype-schema registry parameters. Schema body is an
-    // any-shape object so callers can mint registry entries without the
-    // MCP enforcing the validator's wire shape — the backend validator is
-    // the authority.
-    schema_id: z.string().uuid().optional(),
-    schema_version: z.string().optional(),
-    schema_body: z.record(z.any()).optional(),
-    schema_description: z.string().optional(),
-    clear_schema_description: z.boolean().optional(),
-    clear_schema_body: z.boolean().optional(),
-    parent_id: z.string().uuid().nullable().optional(),
-    // relations
-    source_id: z.string().uuid().optional(),
-    target_id: z.string().uuid().optional(),
-    relation_type: z.enum(ASSET_RELATION_TYPES).optional(),
-    relation_id: z.string().uuid().optional(),
-    // links
-    asset_id: z.string().uuid().optional(),
-    target_type: z.enum(ASSET_LINK_TARGET_TYPES).optional(),
-    link_type: z.enum(ASSET_LINK_TYPES).optional(),
-    ...linkCreateOptionalSharedZodFields,
-    link_id: z.string().uuid().optional(),
-    // external IDs
-    namespace: z.string().optional(),
-    external_id: z.string().optional(),
-    external_id_record_id: z.string().uuid().optional(),
-    roots: z.array(z.string()).optional(),
-    max_depth: z.number().int().optional(),
-  },
+  GC_ASSET_DESCRIPTION,
+  gcAssetZodShape,
   async (args) => {
     try {
-      const ASSET_FIELDS = [
-        // `uid` is @NotBlank on the backend AssetRequest; without it on the
-        // forwarded field list, the create path drops the caller-supplied
-        // uid and the backend rejects the body (codex cycle-3 finding 1).
-        "uid",
-        "name",
-        "description",
-        "asset_type",
-        "parent_id",
-        // GC-M012 ownership/criticality/scope metadata + clear flags.
-        "owner",
-        "steward",
-        "environment",
-        "criticality",
-        "business_context",
-        "scope_designation",
-        "clear_owner",
-        "clear_steward",
-        "clear_environment",
-        "clear_criticality",
-        "clear_business_context",
-        "clear_scope_designation",
-        // GC-M011 subtype + metadata + clear flags.
-        "subtype",
-        "metadata",
-        "clear_subtype",
-        "clear_metadata",
-        // GC-M018 knowledge / completeness state. Pinned to the
-        // forwarded fields so create / update paths thread the value
-        // through to the backend's CreateAssetCommand /
-        // UpdateAssetCommand.
-        "knowledge_state",
-      ];
-      const RELATION_FIELDS = ["source_id", "target_id", "relation_type", "knowledge_state"];
-      const EXT_ID_FIELDS = ["namespace", "external_id"];
-      switch (args.action) {
-        case "create": {
-          reqArg(args, "uid", "create"); reqArg(args, "name", "create"); reqArg(args, "asset_type", "create");
-          return ok(JSON.stringify(await createAsset(pick(args, ASSET_FIELDS), args.project), null, 2));
-        }
-        case "update": {
-          reqArg(args, "id", "update");
-          return ok(JSON.stringify(await updateAsset(args.id, pick(args, ASSET_FIELDS), args.project), null, 2));
-        }
-        case "delete": {
-          reqArg(args, "id", "delete");
-          await deleteAsset(args.id, args.project);
-          return ok("Deleted");
-        }
-        case "archive": {
-          reqArg(args, "id", "archive");
-          return ok(JSON.stringify(await archiveAsset(args.id, args.project), null, 2));
-        }
-        case "relation_create": {
-          // lib.js: createAssetRelation(assetId, data, project)
-          reqArg(args, "source_id", "relation_create"); reqArg(args, "target_id", "relation_create"); reqArg(args, "relation_type", "relation_create");
-          return ok(JSON.stringify(await createAssetRelation(args.source_id, pick(args, RELATION_FIELDS), args.project), null, 2));
-        }
-        case "relation_delete": {
-          // lib.js: deleteAssetRelation(assetId, relationId, project)
-          reqArg(args, "asset_id", "relation_delete"); reqArg(args, "relation_id", "relation_delete");
-          await deleteAssetRelation(args.asset_id, args.relation_id, args.project);
-          return ok("Deleted");
-        }
-        case "detect_cycles": return ok(JSON.stringify(await detectAssetCycles(args.project), null, 2));
-        case "impact_analysis": {
-          reqArg(args, "id", "impact_analysis");
-          return ok(JSON.stringify(await assetImpactAnalysis(args.id, args.project), null, 2));
-        }
-        case "extract_subgraph": {
-          reqArg(args, "roots", "extract_subgraph");
-          return ok(JSON.stringify(await extractAssetSubgraph({ roots: args.roots, maxDepth: args.max_depth }, args.project), null, 2));
-        }
-        case "link_create": {
-          // lib.js: createAssetLink(assetId, data, project). Body shape +
-          // target_type/link_type preconditions live in link-create.js so
-          // every consolidated link_create surface stays in sync with the
-          // backend link DTO (target_entity_id, target_identifier, target_url,
-          // target_title are all forwarded).
-          return ok(JSON.stringify(await performLinkCreate(args, "asset_id", createAssetLink), null, 2));
-        }
-        case "link_delete": {
-          // lib.js: deleteAssetLink(assetId, linkId, project)
-          reqArg(args, "asset_id", "link_delete"); reqArg(args, "link_id", "link_delete");
-          await deleteAssetLink(args.asset_id, args.link_id, args.project);
-          return ok("Deleted");
-        }
-        case "external_id_create": {
-          // lib.js: createAssetExternalId(assetId, data, project)
-          reqArg(args, "asset_id", "external_id_create"); reqArg(args, "namespace", "external_id_create"); reqArg(args, "external_id", "external_id_create");
-          return ok(JSON.stringify(await createAssetExternalId(args.asset_id, pick(args, EXT_ID_FIELDS), args.project), null, 2));
-        }
-        case "external_id_update": {
-          // lib.js: updateAssetExternalId(assetId, extIdId, data, project)
-          reqArg(args, "asset_id", "external_id_update"); reqArg(args, "external_id_record_id", "external_id_update");
-          return ok(JSON.stringify(await updateAssetExternalId(args.asset_id, args.external_id_record_id, pick(args, EXT_ID_FIELDS), args.project), null, 2));
-        }
-        case "external_id_delete": {
-          // lib.js: deleteAssetExternalId(assetId, extIdId, project)
-          reqArg(args, "asset_id", "external_id_delete"); reqArg(args, "external_id_record_id", "external_id_delete");
-          await deleteAssetExternalId(args.asset_id, args.external_id_record_id, args.project);
-          return ok("Deleted");
-        }
-        case "subtype_schema_create": {
-          reqArg(args, "asset_type", "subtype_schema_create");
-          reqArg(args, "subtype", "subtype_schema_create");
-          reqArg(args, "schema_version", "subtype_schema_create");
-          // schema_body is required at the MCP boundary too — the backend
-          // rejects ACTIVE registry rows without a non-empty `fields` map
-          // (AssetService.registerSubtypeSchema invokes validateSchemaBody
-          // with requireFields=true). Failing fast here surfaces the
-          // contract instead of round-tripping a 422 (codex cycle-3 #1).
-          reqArg(args, "schema_body", "subtype_schema_create");
-          const body = {
-            assetType: args.asset_type,
-            subtype: args.subtype,
-            schemaVersion: args.schema_version,
-            description: args.schema_description,
-            schemaBody: args.schema_body,
-          };
-          return ok(JSON.stringify(await registerAssetSubtypeSchema(body, args.project), null, 2));
-        }
-        case "subtype_schema_update": {
-          reqArg(args, "schema_id", "subtype_schema_update");
-          const body = {
-            description: args.schema_description,
-            schemaBody: args.schema_body,
-            clearDescription: args.clear_schema_description,
-            clearSchemaBody: args.clear_schema_body,
-          };
-          return ok(JSON.stringify(await updateAssetSubtypeSchema(args.schema_id, body, args.project), null, 2));
-        }
-        case "subtype_schema_deprecate": {
-          reqArg(args, "schema_id", "subtype_schema_deprecate");
-          return ok(JSON.stringify(await deprecateAssetSubtypeSchema(args.schema_id, args.project), null, 2));
-        }
-        case "subtype_schema_get": {
-          reqArg(args, "schema_id", "subtype_schema_get");
-          return ok(JSON.stringify(await getAssetSubtypeSchema(args.schema_id, args.project), null, 2));
-        }
-        case "subtype_schema_get_active": {
-          reqArg(args, "asset_type", "subtype_schema_get_active");
-          reqArg(args, "subtype", "subtype_schema_get_active");
-          return ok(JSON.stringify(
-            await getActiveAssetSubtypeSchema(args.asset_type, args.subtype, args.project),
-            null,
-            2,
-          ));
-        }
-        case "subtype_schema_list": {
-          return ok(JSON.stringify(
-            await listAssetSubtypeSchemas({
-              project: args.project,
-              assetType: args.asset_type,
-              subtype: args.subtype,
-            }),
-            null,
-            2,
-          ));
-        }
-        default: return err(new Error(`Unknown action: ${args.action}`));
-      }
+      const result = await gcAssetToolHandler(args);
+      return result === null ? ok("Deleted") : ok(JSON.stringify(result, null, 2));
     } catch (e) { return err(e); }
   },
 );
 
-const OBSERVATION_ACTIONS = ["create", "update", "delete", "latest"];
-
+// gc_observation: GC-L008. Time-bounded state observations about an asset.
+// Defect-1 fix: uses correct ObservationRequest field names (observationKey,
+// observationValue, source, observedAt, expiresAt, confidence, evidenceRef)
+// instead of old title/statement/valid_until/metadata names. Handler logic
+// lives in gc-observation.js for testability.
 server.tool(
   "gc_observation",
-  `Time-bounded state observations. Actions: ${OBSERVATION_ACTIONS.join(", ")}. ` +
-    `Reads (list, get) route through gc_query.`,
-  {
-    action: z.enum(OBSERVATION_ACTIONS),
-    id: z.string().uuid().optional(),
-    project: z.string().optional(),
-    asset_id: z.string().uuid().optional(),
-    category: z.enum(OBSERVATION_CATEGORIES).optional(),
-    title: z.string().optional(),
-    statement: z.string().optional(),
-    observed_at: z.string().optional(),
-    valid_until: z.string().optional(),
-    metadata: z.record(z.any()).optional(),
-  },
+  GC_OBSERVATION_DESCRIPTION,
+  gcObservationZodShape,
   async (args) => {
     try {
-      const ENTITY_FIELDS = ["category", "title", "statement", "observed_at", "valid_until", "metadata"];
-      switch (args.action) {
-        case "create": {
-          // lib.js: createObservation(assetId, data, project)
-          reqArg(args, "asset_id", "create"); reqArg(args, "category", "create"); reqArg(args, "title", "create");
-          return ok(JSON.stringify(await createObservation(args.asset_id, pick(args, ENTITY_FIELDS), args.project), null, 2));
-        }
-        case "update": {
-          // lib.js: updateObservation(assetId, observationId, data, project)
-          reqArg(args, "asset_id", "update"); reqArg(args, "id", "update");
-          return ok(JSON.stringify(await updateObservation(args.asset_id, args.id, pick(args, ENTITY_FIELDS), args.project), null, 2));
-        }
-        case "delete": {
-          // lib.js: deleteObservation(assetId, observationId, project)
-          reqArg(args, "asset_id", "delete"); reqArg(args, "id", "delete");
-          await deleteObservation(args.asset_id, args.id, args.project);
-          return ok("Deleted");
-        }
-        case "latest": {
-          // lib.js: listLatestObservations(assetId, project) — requires assetId
-          reqArg(args, "asset_id", "latest");
-          return ok(JSON.stringify(await listLatestObservations(args.asset_id, args.project), null, 2));
-        }
-        default: return err(new Error(`Unknown action: ${args.action}`));
-      }
+      const result = await gcObservationToolHandler(args);
+      return result === null ? ok("Deleted") : ok(JSON.stringify(result, null, 2));
     } catch (e) { return err(e); }
   },
 );

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -8225,6 +8225,14 @@ export async function deleteAssetRelation(assetId, relationId, project) {
   );
 }
 
+export async function updateAssetRelation(assetId, relationId, data, project) {
+  return request(
+    "PUT",
+    `/api/v1/assets/${encodeURIComponent(assetId)}/relations/${encodeURIComponent(relationId)}`,
+    { body: data, params: { project } },
+  );
+}
+
 export async function detectAssetCycles(project) {
   return request("GET", "/api/v1/assets/topology/cycles", { params: { project } });
 }

--- a/mcp/ground-control/package.json
+++ b/mcp/ground-control/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node --test lib.test.js gc-query.test.js gc-threat-model.test.js gc-risk-scenario.test.js gc-risk-governance.test.js gc-control.test.js gc-finding.test.js gc-evidence.test.js gc-analyze.test.js link-create.test.js test-case-tools.test.js traceability-tools.test.js",
+    "test": "node --test lib.test.js gc-query.test.js gc-threat-model.test.js gc-risk-scenario.test.js gc-risk-governance.test.js gc-control.test.js gc-finding.test.js gc-evidence.test.js gc-analyze.test.js link-create.test.js test-case-tools.test.js traceability-tools.test.js gc-asset.test.js gc-observation.test.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },


### PR DESCRIPTION
## Summary

GC-L008 requires the MCP surface for graph-native asset, topology, observation, and evidence entities to reach parity with the REST API. Codebase assessment found the surface mostly present but with three concrete parity defects, all in the two MCP tools (gc_asset, gc_observation) that still lived inline in index.js. This PR fixes all three defects and, in the process, extracts both tools into the repo's standard testable gc-*.js module pattern (mirroring gc-evidence.js) so the parity behavior is locked down by adapter tests — the two tools previously had zero adapter test coverage. gc_evidence and gc_graph were already at parity and are untouched.

## Requirement UIDs

- `GC-L008`

## Related Issues

Closes #730

## ADR Impact

- No ADR required

## Changes

- gc_observation: corrected the Zod schema and body allowlists to the real ObservationRequest DTO field names (observationKey, observationValue, source, observedAt, expiresAt, confidence, evidenceRef), replacing the old title/statement/valid_until/metadata names that the backend rejected; create and update now use separate allowlists matching ObservationRequest vs UpdateObservationRequest
- gc_asset relation_create: restored the five AssetRelationRequest fields (description, sourceSystem, externalSourceId, collectedAt, confidence) that were silently dropped by the old four-field allowlist
- gc_asset relation_update: added the missing action (PUT /api/v1/assets/{id}/relations/{relationId}) plus the updateAssetRelation function in lib.js, mirroring UpdateAssetRelationRequest
- Extracted gc_asset and gc_observation from inline index.js definitions into testable gc-asset.js / gc-observation.js modules following the gc-evidence.js pattern; index.js now registers them via thin module-backed wrappers
- Added 55 adapter tests across gc-asset.test.js and gc-observation.test.js covering action enums, required-field enforcement, create-vs-update wire shape, and the relation parity fixes
- Updated docs/API.md and mcp/ground-control/README.md for the corrected observation fields and the new relation_update action

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

MCP adapter tests: cd mcp/ground-control && npm test (871 tests pass). Full gate: make check and make policy both pass. Pre-commit (gradle check + OpenJML ESC) passes.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GC-L008 ← mcp/ground-control/gc-asset.js, GC-L008 ← mcp/ground-control/gc-observation.js, GC-L008 ← mcp/ground-control/lib.js
- TESTS: GC-L008 ← mcp/ground-control/gc-asset.test.js, GC-L008 ← mcp/ground-control/gc-observation.test.js

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/730.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed