### PR TITLE
added: threat/risk-to-requirement traceability reads for GC-H002

### DIFF
--- a/architecture/notes/threat-scenario-requirement-linking-preflight.md
+++ b/architecture/notes/threat-scenario-requirement-linking-preflight.md
@@ -1,0 +1,149 @@
+# Threat Scenario-Requirement Linking Preflight
+
+Requirement: GC-H002
+Issue: #734
+
+This is architecture guardrail guidance for linking threat-model entries and
+risk scenarios to affected assets or boundaries and to mitigating requirements,
+controls, and artifacts. It is not an implementation plan.
+
+## Boundary
+
+GC-H002 is a traceability requirement over existing concepts, not a new
+all-purpose relationship aggregate.
+
+- `ThreatModel` remains the upstream threat-model entry: threat source, threat
+  event, affected context, and effect. It must not inherit risk-register,
+  treatment, likelihood, impact, or approval semantics.
+- `RiskScenario` remains the scoped risk scenario: threat source, threat event,
+  affected object, vulnerability, consequence, and time horizon. It must not
+  become the authoritative threat-model record.
+- `OperationalAsset`, including `AssetType.BOUNDARY`, remains the structured
+  operational scope. Free-text affected-object fields are context, not the graph
+  authority when a project-scoped asset or boundary exists.
+- `Requirement`, `Control`, evidence, audit, findings, and external artifacts
+  remain their own target concepts. Links connect them; they should not be
+  copied into threat or risk records as embedded mini-schemas.
+
+The canonical write side should reuse the existing dual-mode link surfaces:
+`ThreatModelLink` for threat-model-owned edges and `RiskScenarioLink` for
+risk-scenario-owned edges. `AssetLink` may support asset-owned traversal, but it
+should not become a second mandatory write for every threat/risk link unless a
+service-owned invariant keeps the projections consistent. `TraceabilityLink` is
+requirement-centric and artifact-oriented; do not use it as the new canonical
+internal target store for project-scoped threat/risk links.
+
+## Incumbents To Reuse
+
+- ADR-024: threat modeling stays distinct from risk management and owns
+  `ThreatModelLink`.
+- ADR-019 and ADR-020: affected assets and boundaries are `OperationalAsset`
+  records, with `AssetLink` available for asset-anchored cross-entity traversal.
+- Risk-domain services and links: `RiskScenario`, `RiskScenarioLink`,
+  `RiskScenarioLinkService`, and `RiskScenarioLinkRepository`.
+- Threat-domain services and links: `ThreatModel`, `ThreatModelLink`,
+  `ThreatModelLinkService`, and `ThreatModelLinkRepository`.
+- Project-scoped target validation: `GraphTargetResolverService`, using
+  `targetEntityId` for first-class internal targets and `targetIdentifier` only
+  for external or not-yet-modeled artifacts.
+- Mixed graph projection: `GraphEntityType`, `GraphIds`,
+  `GraphProjectionContributor`, `ThreatModelGraphProjectionContributor`,
+  `RiskGraphProjectionContributor`, `AssetGraphProjectionContributor`, and
+  `AgeGraphService`. JPA remains the source of truth.
+- Requirement artifact traceability: existing `TraceabilityLink` and
+  `TraceabilityService` are still valid for external artifacts and legacy
+  requirement-centric coverage, but not as a replacement for internal
+  project-scoped threat/risk links.
+- MCP link adapter shape: `link-create.js`, action-scoped body allowlists,
+  `pick`, `reqArg`, `toCamelCase`, `RequestError`, and backend error
+  propagation in `mcp/ground-control/lib.js`.
+
+## Cross-Cutting Layers
+
+- Security: any REST additions stay under `/api/v1/**` and the shared
+  `ApiSecurityConfig` / `BrowserSecurityConfig` path matrix. Bearer callers pass
+  `IpAllowlistFilter`, `BearerTokenAuthFilter`, Spring authorization, and
+  `ActorFilter`; browser callers use the ADR-037 browser chain with the same
+  API path matrix. Do not add route-local auth, actor request fields, or
+  feature-local token stores.
+- Request parsing and validation: Jackson enum binding and Bean Validation own
+  DTO shape. Services own same-project validation, internal-vs-external target
+  semantics, duplicate detection, lifecycle rules, and delete/reference checks.
+  Do not duplicate `GraphTargetResolverService` in controllers, MCP, or frontend
+  code.
+- Error envelope: throw existing `NotFoundException`, `ConflictException`, and
+  `DomainValidationException`; let `GlobalExceptionHandler` and `ErrorResponse`
+  serialize. Errors may name stable target type/id fields, but must not echo raw
+  threat narratives, exploit text, evidence payloads, Authorization headers,
+  bearer tokens, or stack traces.
+- Audit and observability: audited link/entity changes use Envers and service
+  deletion paths so audit rows are written. Actor provenance comes from
+  `ActorFilter`, `ActorHolder`, and `GroundControlRevisionListener`. Logs use
+  SLF4J with stable ids and low-cardinality enums, not raw request bodies.
+- Persistence: Flyway is the schema source of truth. Any new persisted enum
+  values, columns, or tables require audit-table parity, project-scope indexes,
+  reverse lookup indexes, and service-level delete handling that does not rely
+  on database cascade to write audit history.
+- Config and OS/runtime exposure: GC-H002 should require no new secrets,
+  environment bindings, subprocesses, network clients, or CLI argv token
+  handling. If a future importer adds them, use `@ConfigurationProperties` with
+  startup validation and keep secrets out of argv, logs, persisted narratives,
+  and error envelopes.
+- Contract mirrors: API-visible enum or DTO changes must update backend tests,
+  MCP constants/tests, frontend types/graph constants where mirrored, and the
+  ADR-034 inventory if the enum is covered there.
+
+## Extensibility
+
+The extensibility seam is the target inventory plus a graph/read-model query
+parameterized by project, source kind (`THREAT_MODEL` or `RISK_SCENARIO`), source
+id or uid, target type filters, and traversal depth where needed. Adding future
+targets such as audits, findings, scanner records, architecture artifacts, or
+control effectiveness results should extend the relevant target enum,
+`GraphTargetResolverService`, graph projection contributor, MCP/frontend mirrors,
+and tests; it should not require a new graph substrate or a second resolver
+family.
+
+Derived traceability such as "threat source/event -> asset/boundary ->
+requirement/control/evidence" belongs on the read side over the same persisted
+links and mixed graph. The read side may union threat-owned, risk-owned, and
+asset-owned edges, but writes need one canonical owner or an explicit service
+invariant that prevents divergent duplicate facts.
+
+## Gotchas And Anti-Patterns
+
+- Do not create a generic `ThreatScenarioRequirementLink` table when the
+  existing threat/risk link surfaces already model source-owned internal and
+  external targets.
+- Do not link first-class requirements, assets, controls, risk scenarios,
+  threat models, observations, findings, audits, evidence, or assessments by
+  raw UID/identifier when a project-scoped UUID target exists.
+- Do not treat `RiskScenarioService.findLinkedRequirements(...)`'s existing
+  `TraceabilityLink(ArtifactType.RISK_SCENARIO, scenario.uid)` lookup as the new
+  canonical internal-link contract. That path is requirement-centric,
+  identifier-based, and easy to mis-scope across projects if reused without a
+  project-aware query.
+- Do not require callers to create both a `ThreatModelLink`/`RiskScenarioLink`
+  and an `AssetLink` for the same semantic fact unless the service owns
+  mechanical consistency.
+- Do not store asset or boundary context only in `RiskScenario.affectedObject`,
+  `ThreatModel.narrative`, `Control.implementationScope`, or arbitrary metadata
+  when an `OperationalAsset` exists.
+- Do not write graph rows directly from controllers/services or add a
+  feature-specific AGE materialization path.
+- Do not add duplicate exception hierarchies, validators, auth filters, audit
+  writers, JSON serializers, workflow engines, or frontend-only schemas.
+
+## Non-Goals
+
+- No implementation of GC-H002 in this preflight.
+- No replacement of `ThreatModel`, `RiskScenario`, `OperationalAsset`,
+  `Requirement`, `Control`, `TraceabilityLink`, `AssetLink`,
+  `ThreatModelLink`, or `RiskScenarioLink` with a generic graph table.
+- No automatic risk scoring, residual-risk mutation, treatment-plan creation,
+  requirement status transition, control effectiveness evaluation, or threat
+  lifecycle transition from link creation.
+- No scanner, ticketing, GitHub, architecture-model import, or external threat
+  intelligence integration.
+- No new security scheme, config surface, audit writer, error envelope, graph
+  writer, or MCP transport helper.

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/threatmodels/ThreatModelController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/threatmodels/ThreatModelController.java
@@ -1,5 +1,6 @@
 package com.keplerops.groundcontrol.api.threatmodels;
 
+import com.keplerops.groundcontrol.api.requirements.RequirementResponse;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.threatmodels.service.CreateThreatModelCommand;
 import com.keplerops.groundcontrol.domain.threatmodels.service.ThreatModelService;
@@ -91,6 +92,15 @@ public class ThreatModelController {
     public void delete(@PathVariable UUID id, @RequestParam(required = false) String project) {
         var projectId = projectService.resolveProjectId(project);
         threatModelService.delete(projectId, id);
+    }
+
+    @GetMapping("/{id}/requirements")
+    public List<RequirementResponse> getLinkedRequirements(
+            @PathVariable UUID id, @RequestParam(required = false) String project) {
+        var projectId = projectService.requireProjectId(project);
+        return threatModelService.findLinkedRequirements(projectId, id).stream()
+                .map(RequirementResponse::from)
+                .toList();
     }
 
     @PutMapping("/{id}/status")

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/RiskScenarioService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/RiskScenarioService.java
@@ -11,7 +11,6 @@ import com.keplerops.groundcontrol.domain.findings.state.FindingLinkTargetType;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
-import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenario;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioLinkRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioRepository;
@@ -36,7 +35,6 @@ public class RiskScenarioService {
     private final FindingLinkRepository findingLinkRepository;
     private final AuditLinkRepository auditLinkRepository;
     private final ProjectService projectService;
-    private final TraceabilityLinkRepository traceabilityLinkRepository;
     private final RequirementRepository requirementRepository;
 
     public RiskScenarioService(
@@ -45,14 +43,12 @@ public class RiskScenarioService {
             FindingLinkRepository findingLinkRepository,
             AuditLinkRepository auditLinkRepository,
             ProjectService projectService,
-            TraceabilityLinkRepository traceabilityLinkRepository,
             RequirementRepository requirementRepository) {
         this.riskScenarioRepository = riskScenarioRepository;
         this.riskScenarioLinkRepository = riskScenarioLinkRepository;
         this.findingLinkRepository = findingLinkRepository;
         this.auditLinkRepository = auditLinkRepository;
         this.projectService = projectService;
-        this.traceabilityLinkRepository = traceabilityLinkRepository;
         this.requirementRepository = requirementRepository;
     }
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/RiskScenarioService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/RiskScenarioService.java
@@ -10,13 +10,15 @@ import com.keplerops.groundcontrol.domain.findings.repository.FindingLinkReposit
 import com.keplerops.groundcontrol.domain.findings.state.FindingLinkTargetType;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
+import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
-import com.keplerops.groundcontrol.domain.requirements.state.ArtifactType;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenario;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioLinkRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkTargetType;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioStatus;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +37,7 @@ public class RiskScenarioService {
     private final AuditLinkRepository auditLinkRepository;
     private final ProjectService projectService;
     private final TraceabilityLinkRepository traceabilityLinkRepository;
+    private final RequirementRepository requirementRepository;
 
     public RiskScenarioService(
             RiskScenarioRepository riskScenarioRepository,
@@ -42,13 +45,15 @@ public class RiskScenarioService {
             FindingLinkRepository findingLinkRepository,
             AuditLinkRepository auditLinkRepository,
             ProjectService projectService,
-            TraceabilityLinkRepository traceabilityLinkRepository) {
+            TraceabilityLinkRepository traceabilityLinkRepository,
+            RequirementRepository requirementRepository) {
         this.riskScenarioRepository = riskScenarioRepository;
         this.riskScenarioLinkRepository = riskScenarioLinkRepository;
         this.findingLinkRepository = findingLinkRepository;
         this.auditLinkRepository = auditLinkRepository;
         this.projectService = projectService;
         this.traceabilityLinkRepository = traceabilityLinkRepository;
+        this.requirementRepository = requirementRepository;
     }
 
     public RiskScenario create(CreateRiskScenarioCommand command) {
@@ -243,10 +248,14 @@ public class RiskScenarioService {
 
     @Transactional(readOnly = true)
     public List<Requirement> findLinkedRequirements(UUID projectId, UUID id) {
-        var scenario = findByIdOrThrow(projectId, id);
-        var links = traceabilityLinkRepository.findByArtifactTypeAndArtifactIdentifierWithRequirement(
-                ArtifactType.RISK_SCENARIO, scenario.getUid());
-        return links.stream().map(link -> link.getRequirement()).toList();
+        findByIdOrThrow(projectId, id);
+        var links = riskScenarioLinkRepository.findByRiskScenarioIdAndTargetType(
+                id, RiskScenarioLinkTargetType.REQUIREMENT);
+        return links.stream()
+                .map(link -> requirementRepository.findByIdAndProjectId(link.getTargetEntityId(), projectId))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
     }
 
     @Deprecated(forRemoval = false)

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/threatmodels/repository/ThreatModelLinkRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/threatmodels/repository/ThreatModelLinkRepository.java
@@ -14,6 +14,8 @@ public interface ThreatModelLinkRepository extends JpaRepository<ThreatModelLink
 
     List<ThreatModelLink> findByThreatModelId(UUID threatModelId);
 
+    List<ThreatModelLink> findByThreatModelIdAndTargetType(UUID threatModelId, ThreatModelLinkTargetType targetType);
+
     @Query("SELECT l FROM ThreatModelLink l JOIN FETCH l.threatModel WHERE l.threatModel.project.id = :projectId")
     List<ThreatModelLink> findByProjectId(@Param("projectId") UUID projectId);
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/threatmodels/service/ThreatModelService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/threatmodels/service/ThreatModelService.java
@@ -6,16 +6,20 @@ import com.keplerops.groundcontrol.domain.audit.ActorHolder;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
+import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioLinkRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkTargetType;
 import com.keplerops.groundcontrol.domain.threatmodels.model.ThreatModel;
 import com.keplerops.groundcontrol.domain.threatmodels.repository.ThreatModelLinkRepository;
 import com.keplerops.groundcontrol.domain.threatmodels.repository.ThreatModelRepository;
+import com.keplerops.groundcontrol.domain.threatmodels.state.ThreatModelLinkTargetType;
 import com.keplerops.groundcontrol.domain.threatmodels.state.ThreatModelStatus;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,18 +37,21 @@ public class ThreatModelService {
     private final ProjectService projectService;
     private final AssetLinkRepository assetLinkRepository;
     private final RiskScenarioLinkRepository riskScenarioLinkRepository;
+    private final RequirementRepository requirementRepository;
 
     public ThreatModelService(
             ThreatModelRepository threatModelRepository,
             ThreatModelLinkRepository threatModelLinkRepository,
             ProjectService projectService,
             AssetLinkRepository assetLinkRepository,
-            RiskScenarioLinkRepository riskScenarioLinkRepository) {
+            RiskScenarioLinkRepository riskScenarioLinkRepository,
+            RequirementRepository requirementRepository) {
         this.threatModelRepository = threatModelRepository;
         this.threatModelLinkRepository = threatModelLinkRepository;
         this.projectService = projectService;
         this.assetLinkRepository = assetLinkRepository;
         this.riskScenarioLinkRepository = riskScenarioLinkRepository;
+        this.requirementRepository = requirementRepository;
     }
 
     public ThreatModel create(CreateThreatModelCommand command) {
@@ -191,6 +198,18 @@ public class ThreatModelService {
                 threatModel.getId(),
                 threatModel.getUid(),
                 outboundLinks.size());
+    }
+
+    @Transactional(readOnly = true)
+    public List<Requirement> findLinkedRequirements(UUID projectId, UUID id) {
+        findByIdOrThrow(projectId, id);
+        var links =
+                threatModelLinkRepository.findByThreatModelIdAndTargetType(id, ThreatModelLinkTargetType.REQUIREMENT);
+        return links.stream()
+                .map(link -> requirementRepository.findByIdAndProjectId(link.getTargetEntityId(), projectId))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
     }
 
     private ThreatModel findByIdOrThrow(UUID projectId, UUID id) {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ThreatModelControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ThreatModelControllerTest.java
@@ -19,6 +19,7 @@ import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
 import com.keplerops.groundcontrol.domain.threatmodels.model.ThreatModel;
 import com.keplerops.groundcontrol.domain.threatmodels.service.CreateThreatModelCommand;
 import com.keplerops.groundcontrol.domain.threatmodels.service.ThreatModelService;
@@ -299,6 +300,35 @@ class ThreatModelControllerTest {
                 .andExpect(status().isNoContent());
 
         verify(threatModelService).delete(PROJECT_ID, TM_ID);
+    }
+
+    @Test
+    void getLinkedRequirementsReturnsRequirementList() throws Exception {
+        var project = new Project("ground-control", "Ground Control");
+        setField(project, "id", PROJECT_ID);
+        var req = new Requirement(
+                project, "GC-H002", "Threat linking", "System shall link threat models to requirements");
+        setField(req, "id", UUID.fromString("00000000-0000-0000-0000-000000000300"));
+        setField(req, "createdAt", NOW);
+        setField(req, "updatedAt", NOW);
+
+        when(projectService.requireProjectId(any())).thenReturn(PROJECT_ID);
+        when(threatModelService.findLinkedRequirements(PROJECT_ID, TM_ID)).thenReturn(List.of(req));
+
+        mockMvc.perform(get("/api/v1/threat-models/{id}/requirements", TM_ID).param("project", "ground-control"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].uid", is("GC-H002")));
+    }
+
+    @Test
+    void getLinkedRequirementsReturns404WhenThreatModelUnknown() throws Exception {
+        when(projectService.requireProjectId(any())).thenReturn(PROJECT_ID);
+        when(threatModelService.findLinkedRequirements(PROJECT_ID, TM_ID))
+                .thenThrow(new NotFoundException("Threat model not found: " + TM_ID));
+
+        mockMvc.perform(get("/api/v1/threat-models/{id}/requirements", TM_ID).param("project", "ground-control"))
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java
@@ -12,12 +12,17 @@ import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
+import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
 import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenario;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenarioLink;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.service.CreateRiskScenarioCommand;
 import com.keplerops.groundcontrol.domain.riskscenarios.service.RiskScenarioService;
 import com.keplerops.groundcontrol.domain.riskscenarios.service.UpdateRiskScenarioCommand;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkTargetType;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkType;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioStatus;
 import java.time.Instant;
 import java.util.List;
@@ -53,6 +58,9 @@ class RiskScenarioServiceTest {
     @SuppressWarnings("UnusedVariable") // needed by @InjectMocks for constructor injection
     @Mock
     private TraceabilityLinkRepository traceabilityLinkRepository;
+
+    @Mock
+    private RequirementRepository requirementRepository;
 
     @InjectMocks
     private RiskScenarioService riskScenarioService;
@@ -345,6 +353,84 @@ class RiskScenarioServiceTest {
             var result = riskScenarioService.listByProject(projectId);
 
             assertThat(result).hasSize(1);
+        }
+    }
+
+    @Nested
+    class FindLinkedRequirements {
+
+        @Test
+        void returnsRequirementsViaCanonicalRiskScenarioLinkPath() {
+            var rs = makeScenario();
+            var reqId = UUID.randomUUID();
+            var req = new Requirement(project, "GC-H002", "Threat linking", "System shall link");
+            setField(req, "id", reqId);
+
+            var link = new RiskScenarioLink(
+                    rs, RiskScenarioLinkTargetType.REQUIREMENT, reqId, null, RiskScenarioLinkType.AFFECTS);
+            setField(link, "id", UUID.randomUUID());
+
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+            when(riskScenarioLinkRepository.findByRiskScenarioIdAndTargetType(
+                            rs.getId(), RiskScenarioLinkTargetType.REQUIREMENT))
+                    .thenReturn(List.of(link));
+            when(requirementRepository.findByIdAndProjectId(reqId, projectId)).thenReturn(Optional.of(req));
+
+            var results = riskScenarioService.findLinkedRequirements(projectId, rs.getId());
+
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getUid()).isEqualTo("GC-H002");
+        }
+
+        @Test
+        void returnsEmptyWhenNoREQUIREMENTLinks() {
+            var rs = makeScenario();
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+            when(riskScenarioLinkRepository.findByRiskScenarioIdAndTargetType(
+                            rs.getId(), RiskScenarioLinkTargetType.REQUIREMENT))
+                    .thenReturn(List.of());
+
+            var results = riskScenarioService.findLinkedRequirements(projectId, rs.getId());
+
+            assertThat(results).isEmpty();
+        }
+
+        @Test
+        void isProjectScoped_crossProjectLinkNotReturned() {
+            // A RiskScenarioLink targeting a requirement UUID from another project
+            // must not appear in this project's result.
+            var rs = makeScenario();
+            var otherProjectReqId = UUID.randomUUID();
+
+            var link = new RiskScenarioLink(
+                    rs, RiskScenarioLinkTargetType.REQUIREMENT, otherProjectReqId, null, RiskScenarioLinkType.AFFECTS);
+            setField(link, "id", UUID.randomUUID());
+
+            when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
+                    .thenReturn(Optional.of(rs));
+            when(riskScenarioLinkRepository.findByRiskScenarioIdAndTargetType(
+                            rs.getId(), RiskScenarioLinkTargetType.REQUIREMENT))
+                    .thenReturn(List.of(link));
+            when(requirementRepository.findByIdAndProjectId(otherProjectReqId, projectId))
+                    .thenReturn(Optional.empty());
+
+            var results = riskScenarioService.findLinkedRequirements(projectId, rs.getId());
+
+            assertThat(results).isEmpty();
+            // The traceability-link repository must NOT be consulted — the canonical
+            // path is RiskScenarioLink, not TraceabilityLink (plan item 4).
+            org.mockito.Mockito.verifyNoInteractions(traceabilityLinkRepository);
+        }
+
+        @Test
+        void throws404WhenScenarioNotFound() {
+            var id = UUID.randomUUID();
+            when(riskScenarioRepository.findByIdAndProjectId(id, projectId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> riskScenarioService.findLinkedRequirements(projectId, id))
+                    .isInstanceOf(NotFoundException.class);
         }
     }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java
@@ -14,7 +14,6 @@ import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
 import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
-import com.keplerops.groundcontrol.domain.requirements.repository.TraceabilityLinkRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenario;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenarioLink;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioRepository;
@@ -54,10 +53,6 @@ class RiskScenarioServiceTest {
 
     @Mock
     private ProjectService projectService;
-
-    @SuppressWarnings("UnusedVariable") // needed by @InjectMocks for constructor injection
-    @Mock
-    private TraceabilityLinkRepository traceabilityLinkRepository;
 
     @Mock
     private RequirementRepository requirementRepository;
@@ -419,9 +414,6 @@ class RiskScenarioServiceTest {
             var results = riskScenarioService.findLinkedRequirements(projectId, rs.getId());
 
             assertThat(results).isEmpty();
-            // The traceability-link repository must NOT be consulted — the canonical
-            // path is RiskScenarioLink, not TraceabilityLink (plan item 4).
-            org.mockito.Mockito.verifyNoInteractions(traceabilityLinkRepository);
         }
 
         @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ThreatModelServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ThreatModelServiceTest.java
@@ -213,12 +213,12 @@ class ThreatModelServiceTest {
         @Test
         void rejectsBlankThreatSource() {
             var tm = makeThreatModel();
-            when(threatModelRepository.findByIdAndProjectId(tm.getId(), projectId))
-                    .thenReturn(Optional.of(tm));
+            var tmId = tm.getId();
+            when(threatModelRepository.findByIdAndProjectId(tmId, projectId)).thenReturn(Optional.of(tm));
 
             var command = new UpdateThreatModelCommand(null, " ", null, null, null, null, false, false);
 
-            assertThatThrownBy(() -> threatModelService.update(projectId, tm.getId(), command))
+            assertThatThrownBy(() -> threatModelService.update(projectId, tmId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("threatSource");
         }
@@ -226,12 +226,12 @@ class ThreatModelServiceTest {
         @Test
         void rejectsBlankEffect() {
             var tm = makeThreatModel();
-            when(threatModelRepository.findByIdAndProjectId(tm.getId(), projectId))
-                    .thenReturn(Optional.of(tm));
+            var tmId = tm.getId();
+            when(threatModelRepository.findByIdAndProjectId(tmId, projectId)).thenReturn(Optional.of(tm));
 
             var command = new UpdateThreatModelCommand(null, null, null, " ", null, null, false, false);
 
-            assertThatThrownBy(() -> threatModelService.update(projectId, tm.getId(), command))
+            assertThatThrownBy(() -> threatModelService.update(projectId, tmId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("effect");
         }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ThreatModelServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ThreatModelServiceTest.java
@@ -15,14 +15,20 @@ import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
+import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioLinkRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkTargetType;
 import com.keplerops.groundcontrol.domain.threatmodels.model.ThreatModel;
+import com.keplerops.groundcontrol.domain.threatmodels.model.ThreatModelLink;
+import com.keplerops.groundcontrol.domain.threatmodels.repository.ThreatModelLinkRepository;
 import com.keplerops.groundcontrol.domain.threatmodels.repository.ThreatModelRepository;
 import com.keplerops.groundcontrol.domain.threatmodels.service.CreateThreatModelCommand;
 import com.keplerops.groundcontrol.domain.threatmodels.service.ThreatModelService;
 import com.keplerops.groundcontrol.domain.threatmodels.service.UpdateThreatModelCommand;
 import com.keplerops.groundcontrol.domain.threatmodels.state.StrideCategory;
+import com.keplerops.groundcontrol.domain.threatmodels.state.ThreatModelLinkTargetType;
+import com.keplerops.groundcontrol.domain.threatmodels.state.ThreatModelLinkType;
 import com.keplerops.groundcontrol.domain.threatmodels.state.ThreatModelStatus;
 import java.time.Instant;
 import java.util.List;
@@ -43,8 +49,10 @@ class ThreatModelServiceTest {
     private ThreatModelRepository threatModelRepository;
 
     @Mock
-    private com.keplerops.groundcontrol.domain.threatmodels.repository.ThreatModelLinkRepository
-            threatModelLinkRepository;
+    private ThreatModelLinkRepository threatModelLinkRepository;
+
+    @Mock
+    private RequirementRepository requirementRepository;
 
     @Mock
     private ProjectService projectService;
@@ -203,6 +211,32 @@ class ThreatModelServiceTest {
         }
 
         @Test
+        void rejectsBlankThreatSource() {
+            var tm = makeThreatModel();
+            when(threatModelRepository.findByIdAndProjectId(tm.getId(), projectId))
+                    .thenReturn(Optional.of(tm));
+
+            var command = new UpdateThreatModelCommand(null, " ", null, null, null, null, false, false);
+
+            assertThatThrownBy(() -> threatModelService.update(projectId, tm.getId(), command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("threatSource");
+        }
+
+        @Test
+        void rejectsBlankEffect() {
+            var tm = makeThreatModel();
+            when(threatModelRepository.findByIdAndProjectId(tm.getId(), projectId))
+                    .thenReturn(Optional.of(tm));
+
+            var command = new UpdateThreatModelCommand(null, null, null, " ", null, null, false, false);
+
+            assertThatThrownBy(() -> threatModelService.update(projectId, tm.getId(), command))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("effect");
+        }
+
+        @Test
         void clearsStrideWhenFlagSet() {
             var tm = makeThreatModel();
             assertThat(tm.getStride()).isNotNull();
@@ -345,6 +379,82 @@ class ThreatModelServiceTest {
             var result = threatModelService.listByProject(projectId);
 
             assertThat(result).hasSize(1);
+        }
+    }
+
+    @Nested
+    class FindLinkedRequirements {
+
+        @Test
+        void returnsRequirementsForREQUIREMENTTypedLinks() {
+            var tm = makeThreatModel();
+            var reqId = UUID.randomUUID();
+            var req = new Requirement(project, "GC-H002", "Threat linking", "System shall link");
+            setField(req, "id", reqId);
+
+            var link = new ThreatModelLink(
+                    tm, ThreatModelLinkTargetType.REQUIREMENT, reqId, null, ThreatModelLinkType.AFFECTS);
+            setField(link, "id", UUID.randomUUID());
+
+            when(threatModelRepository.findByIdAndProjectId(tm.getId(), projectId))
+                    .thenReturn(Optional.of(tm));
+            when(threatModelLinkRepository.findByThreatModelIdAndTargetType(
+                            tm.getId(), ThreatModelLinkTargetType.REQUIREMENT))
+                    .thenReturn(List.of(link));
+            when(requirementRepository.findByIdAndProjectId(reqId, projectId)).thenReturn(Optional.of(req));
+
+            var results = threatModelService.findLinkedRequirements(projectId, tm.getId());
+
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getUid()).isEqualTo("GC-H002");
+        }
+
+        @Test
+        void returnsEmptyWhenNoREQUIREMENTLinks() {
+            var tm = makeThreatModel();
+            when(threatModelRepository.findByIdAndProjectId(tm.getId(), projectId))
+                    .thenReturn(Optional.of(tm));
+            when(threatModelLinkRepository.findByThreatModelIdAndTargetType(
+                            tm.getId(), ThreatModelLinkTargetType.REQUIREMENT))
+                    .thenReturn(List.of());
+
+            var results = threatModelService.findLinkedRequirements(projectId, tm.getId());
+
+            assertThat(results).isEmpty();
+        }
+
+        @Test
+        void throws404WhenThreatModelNotInProject() {
+            var id = UUID.randomUUID();
+            when(threatModelRepository.findByIdAndProjectId(id, projectId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> threatModelService.findLinkedRequirements(projectId, id))
+                    .isInstanceOf(NotFoundException.class);
+        }
+
+        @Test
+        void skipsLinkWhenRequirementNotFoundInProject() {
+            // A link may reference a UUID that exists in another project but not
+            // in this one — the canonical project-scoped lookup must silently
+            // filter such links rather than throwing.
+            var tm = makeThreatModel();
+            var orphanReqId = UUID.randomUUID();
+
+            var link = new ThreatModelLink(
+                    tm, ThreatModelLinkTargetType.REQUIREMENT, orphanReqId, null, ThreatModelLinkType.AFFECTS);
+            setField(link, "id", UUID.randomUUID());
+
+            when(threatModelRepository.findByIdAndProjectId(tm.getId(), projectId))
+                    .thenReturn(Optional.of(tm));
+            when(threatModelLinkRepository.findByThreatModelIdAndTargetType(
+                            tm.getId(), ThreatModelLinkTargetType.REQUIREMENT))
+                    .thenReturn(List.of(link));
+            when(requirementRepository.findByIdAndProjectId(orphanReqId, projectId))
+                    .thenReturn(Optional.empty());
+
+            var results = threatModelService.findLinkedRequirements(projectId, tm.getId());
+
+            assertThat(results).isEmpty();
         }
     }
 

--- a/changelog.d/+sonar-fixes.fixed.md
+++ b/changelog.d/+sonar-fixes.fixed.md
@@ -1,0 +1,1 @@
+Remove unused `traceabilityLinkRepository` field from `RiskScenarioService` and refactor single-throw lambda assertions in `ThreatModelServiceTest` to fix SonarCloud MAJOR findings (S1068, S5778).

--- a/changelog.d/734.added.md
+++ b/changelog.d/734.added.md
@@ -1,0 +1,1 @@
+Add `GET /api/v1/threat-models/{id}/requirements` endpoint that returns all requirements linked to a threat model via canonical `ThreatModelLink` rows; add matching `gc_threat_model requirements` action to the MCP tool.

--- a/changelog.d/734.fixed.md
+++ b/changelog.d/734.fixed.md
@@ -1,0 +1,1 @@
+Fix `GET /api/v1/risk-scenarios/{id}/requirements` to resolve linked requirements through the canonical project-scoped `RiskScenarioLink` path instead of the legacy `TraceabilityLink(ArtifactType.RISK_SCENARIO)` path, preventing cross-project requirement leakage.

--- a/docs/API.md
+++ b/docs/API.md
@@ -920,6 +920,7 @@ must be non-blank), `reason` (optional, max 500).
 | PUT | `/threat-models/{id}` | UpdateThreatModelRequest | 200 | Update mutable fields |
 | DELETE | `/threat-models/{id}` | — | 204 | Delete threat model (cascades to links) |
 | PUT | `/threat-models/{id}/status` | `{"status": "ACTIVE"}` | 200 | Transition lifecycle status |
+| GET | `/threat-models/{id}/requirements` | — | 200 | List requirements linked to a threat model |
 | POST | `/threat-models/{id}/links` | ThreatModelLinkRequest | 201 | Create threat-model link |
 | GET | `/threat-models/{id}/links` | — | 200 | List links for a threat model |
 | DELETE | `/threat-models/{id}/links/{linkId}` | — | 204 | Delete threat-model link |

--- a/mcp/ground-control/gc-threat-model.js
+++ b/mcp/ground-control/gc-threat-model.js
@@ -9,7 +9,8 @@ import {
   THREAT_MODEL_STATUSES, STRIDE_CATEGORIES,
   THREAT_MODEL_LINK_TARGET_TYPES, THREAT_MODEL_LINK_TYPES,
   createThreatModel, updateThreatModel, deleteThreatModel,
-  transitionThreatModelStatus, createThreatModelLink, deleteThreatModelLink,
+  transitionThreatModelStatus, getThreatModelLinkedRequirements,
+  createThreatModelLink, deleteThreatModelLink,
   pick, reqArg,
 } from "./lib.js";
 import {
@@ -18,7 +19,7 @@ import {
 } from "./link-create.js";
 
 export const GC_THREAT_MODEL_ACTIONS = [
-  "create", "update", "delete", "transition", "link_create", "link_delete",
+  "create", "update", "delete", "transition", "requirements", "link_create", "link_delete",
 ];
 
 // Snake_case body fields accepted by gc_threat_model.create — mirrors
@@ -70,6 +71,7 @@ export const GC_THREAT_MODEL_DESCRIPTION =
   `optional stride_category, narrative). update accepts the same fields minus uid plus ` +
   `clear_stride / clear_narrative to explicitly null optional fields. ` +
   `status is consumed only by the transition action (creation defaults to DRAFT). ` +
+  `requirements returns all requirements linked to the threat model (requires id). ` +
   `link_create requires target_type + link_type; for internal target types ` +
   `(ASSET / REQUIREMENT / CONTROL / RISK_SCENARIO / OBSERVATION / RISK_ASSESSMENT_RESULT / ` +
   `VERIFICATION_RESULT / FINDING / EVIDENCE) pass target_entity_id, ` +
@@ -102,6 +104,10 @@ export async function gcThreatModelToolHandler(args) {
       reqArg(args, "id", "transition");
       reqArg(args, "status", "transition");
       return transitionThreatModelStatus(args.id, args.status, args.project);
+    }
+    case "requirements": {
+      reqArg(args, "id", "requirements");
+      return getThreatModelLinkedRequirements(args.id, args.project);
     }
     case "link_create": {
       return performLinkCreate(args, "threat_model_id", createThreatModelLink);

--- a/mcp/ground-control/gc-threat-model.test.js
+++ b/mcp/ground-control/gc-threat-model.test.js
@@ -143,7 +143,7 @@ describe("GC_THREAT_MODEL_ACTIONS", () => {
   it("matches the action verbs the handler dispatches", () => {
     assert.deepEqual(
       [...GC_THREAT_MODEL_ACTIONS].sort(),
-      ["create", "delete", "link_create", "link_delete", "transition", "update"],
+      ["create", "delete", "link_create", "link_delete", "requirements", "transition", "update"],
     );
   });
 });
@@ -407,6 +407,23 @@ describe("gcThreatModelToolHandler other actions", () => {
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "DELETE");
     assert.match(calls[0].url, new RegExp(`/api/v1/threat-models/${ID}/links/${LINK_ID}`));
+  });
+
+  it("requirements GETs the requirements sub-resource", async () => {
+    const calls = makeFetchSpy({ body: [] });
+    await gcThreatModelToolHandler({ action: "requirements", id: ID });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "GET");
+    assert.match(calls[0].url, new RegExp(`/api/v1/threat-models/${ID}/requirements`));
+  });
+
+  it("requirements rejects missing id before any HTTP call", async () => {
+    const calls = makeFetchSpy();
+    await assert.rejects(
+      () => gcThreatModelToolHandler({ action: "requirements" }),
+      (e) => e.message.includes("'id' is required"),
+    );
+    assert.equal(calls.length, 0);
   });
 
   it("throws on an unknown action without issuing an HTTP call", async () => {

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -116,7 +116,7 @@ import {
   deleteRiskScenario, transitionRiskScenarioStatus, getRiskScenarioRequirements,
   createRiskScenarioLink, listRiskScenarioLinks, deleteRiskScenarioLink,
   createThreatModel, listThreatModels, getThreatModel, updateThreatModel,
-  deleteThreatModel, transitionThreatModelStatus,
+  deleteThreatModel, transitionThreatModelStatus, getThreatModelLinkedRequirements,
   createThreatModelLink, listThreatModelLinks, deleteThreatModelLink,
   createMethodologyProfile, listMethodologyProfiles, getMethodologyProfile,
   updateMethodologyProfile, deleteMethodologyProfile,

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -8498,6 +8498,10 @@ export async function transitionThreatModelStatus(id, status, project) {
   });
 }
 
+export async function getThreatModelLinkedRequirements(id, project) {
+  return request("GET", `/api/v1/threat-models/${encodeURIComponent(id)}/requirements`, { params: { project } });
+}
+
 export async function createThreatModelLink(threatModelId, data, project) {
   return request("POST", `/api/v1/threat-models/${encodeURIComponent(threatModelId)}/links`, {
     body: data,


### PR DESCRIPTION
## Summary

Closes the read-side traceability gaps for GC-H002. Threat-model entries and risk scenarios could already be linked to operational assets and requirements (write side), but the read side was incomplete: threat models had no way to surface their linked mitigating requirements, and risk-scenario requirement reads resolved through a legacy identifier-based path. This PR adds a threat-model requirements read endpoint and MCP action, and fixes the risk-scenario read to use the canonical project-scoped link path.

## Requirement UIDs

- `GC-H002`

## Related Issues

Closes #734

## ADR Impact

- No ADR required

## Changes

- Add GET /api/v1/threat-models/{id}/requirements with ThreatModelService.findLinkedRequirements resolving REQUIREMENT-typed ThreatModelLinks to project-scoped Requirement entities
- Add ThreatModelLinkRepository.findByThreatModelIdAndTargetType query
- Add a requirements action to the gc_threat_model MCP tool plus getThreatModelLinkedRequirements in lib.js
- Fix RiskScenarioService.findLinkedRequirements to resolve through the canonical project-scoped RiskScenarioLink REQUIREMENT path instead of the legacy identifier-based TraceabilityLink path
- Add @WebMvcTest controller slice and service-layer unit tests for both read paths and the MCP action

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GC-H002 ← backend/src/main/java/com/keplerops/groundcontrol/api/threatmodels/ThreatModelController.java, GC-H002 ← backend/src/main/java/com/keplerops/groundcontrol/domain/threatmodels/service/ThreatModelService.java, GC-H002 ← backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/RiskScenarioService.java
- TESTS: GC-H002 ← backend/src/test/java/com/keplerops/groundcontrol/unit/api/ThreatModelControllerTest.java, GC-H002 ← backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ThreatModelServiceTest.java, GC-H002 ← backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceTest.java

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/734.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed