### PR TITLE
fix: truncate over-long review notes instead of discarding the review

### DIFF
--- a/changelog.d/955.fixed.md
+++ b/changelog.d/955.fixed.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Review-envelope parsing (`gc_codex_review` / `gc_test_quality_review`) no longer
+  discards an entire completed review when an advisory `notes[]` entry exceeds the
+  `REVIEW_NOTE_TEXT_MAX` length cap. The note is truncated (ellipsis-terminated)
+  via a shared `truncateReviewNoteText()` helper instead of throwing a parse error
+  that failed the whole review.

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -4503,6 +4503,19 @@ const FINDING_CATEGORY_SHAPE_MAX = 300;
 const FINDING_CLASSIFICATIONS = new Set(["one-off", "class"]);
 const FINDING_SWEEP_EVIDENCE_MAX = 500;
 const REVIEW_NOTE_TEXT_MAX = 300;
+// An advisory review note (codex or test-quality) that overruns the
+// length cap is truncated to the cap — last char replaced with an
+// ellipsis — rather than thrown. The note is non-blocking prose from
+// an LLM reviewer, which cannot be relied on to honour a hard char
+// budget; discarding an entire completed review over note length was
+// a brittle failure mode (surfaced by aptl issue #293). Verbatim
+// durability is unaffected: the full reviewer text is preserved
+// separately via buildCodexReviewFindingsComments' chunked comments;
+// notes[] is the parsed, already-capped structured summary.
+function truncateReviewNoteText(text) {
+  if (text.length <= REVIEW_NOTE_TEXT_MAX) return text;
+  return text.slice(0, REVIEW_NOTE_TEXT_MAX - 1) + "…";
+}
 // Block delimiter renamed from ===FINDINGS=== to ===REVIEW=== with the
 // verdict-envelope migration (issue #931). The new contract emits a JSON
 // object (verdict + architectural_read + blocking + notes), not a JSON array.
@@ -4685,10 +4698,7 @@ export function validateReviewEnvelope(raw, repoRoot) {
       if (typeof entry.text !== "string" || entry.text.trim() === "") {
         throw new Error(`notes[${idx}].text must be a non-empty string`);
       }
-      if (entry.text.length > REVIEW_NOTE_TEXT_MAX) {
-        throw new Error(`notes[${idx}].text must be ≤${REVIEW_NOTE_TEXT_MAX} chars (got ${entry.text.length})`);
-      }
-      return { text: entry.text };
+      return { text: truncateReviewNoteText(entry.text) };
     });
   }
   // Verdict / blocking consistency rules — shared with the decision-record
@@ -5882,10 +5892,7 @@ export function parseTestQualityReviewEnvelope(stdout) {
       if (typeof entry.text !== "string" || entry.text.trim() === "") {
         throw new Error(`test-quality review notes[${idx}].text must be a non-empty string`);
       }
-      if (entry.text.length > REVIEW_NOTE_TEXT_MAX) {
-        throw new Error(`test-quality review notes[${idx}].text must be ≤${REVIEW_NOTE_TEXT_MAX} chars`);
-      }
-      return { text: entry.text };
+      return { text: truncateReviewNoteText(entry.text) };
     });
   }
 

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -2617,6 +2617,24 @@ describe("parseCodexReviewFindingsTail (verdict envelope, #931)", () => {
     assert.throws(() => parseCodexReviewFindingsTail(stdout, repoRoot), /notes.*cap/i);
   });
 
+  it("truncates an over-long note instead of discarding the whole review (aptl #293)", () => {
+    // An LLM reviewer cannot be relied on to honour a hard char budget
+    // for advisory prose. A note that overruns REVIEW_NOTE_TEXT_MAX is
+    // truncated (ellipsis-terminated) so a completed review still
+    // parses, rather than throwing and losing the entire review.
+    const envelope = {
+      verdict: "ship",
+      architectural_read: "Reviewed.",
+      blocking: [],
+      notes: [{ text: "x".repeat(450) }],
+    };
+    const stdout = `===REVIEW===\n${JSON.stringify(envelope)}\n===END===`;
+    const { envelope: parsed } = parseCodexReviewFindingsTail(stdout, repoRoot);
+    assert.equal(parsed.notes.length, 1);
+    assert.equal(parsed.notes[0].text.length, 300);
+    assert.ok(parsed.notes[0].text.endsWith("…"));
+  });
+
   it("requires sweep_evidence on one-off findings (#931)", () => {
     // Note: this test deliberately omits sweep_evidence to exercise the
     // required-field check.
@@ -8091,6 +8109,22 @@ describe("parseTestQualityReviewFindings (verdict envelope, #931)", () => {
     const r = parseTestQualityReviewFindings(stdout);
     assert.deepEqual(r.findings, []);
     assert.equal(r.envelope.verdict, "ship");
+  });
+
+  it("truncates an over-long note instead of discarding the whole review (aptl #293)", () => {
+    // Regression: a test-quality review whose advisory note overran
+    // the char cap was thrown away wholesale, blocking the /implement
+    // workflow on a parse error despite a completed review.
+    const stdout = JSON.stringify({
+      verdict: "ship",
+      architectural_read: "Reviewed the test file.",
+      blocking: [],
+      notes: [{ text: "x".repeat(450) }],
+    });
+    const r = parseTestQualityReviewFindings(stdout);
+    assert.equal(r.envelope.notes.length, 1);
+    assert.equal(r.envelope.notes[0].text.length, 300);
+    assert.ok(r.envelope.notes[0].text.endsWith("…"));
   });
 
   it("parses a warning severity finding", () => {


### PR DESCRIPTION
## Summary

`validateReviewEnvelope` (codex review) and `parseTestQualityReviewEnvelope` (test-quality review) threw when an advisory `notes[].text` exceeded `REVIEW_NOTE_TEXT_MAX` (300 chars) — discarding a *completed* review (verdict, blocking findings and all) and failing the `/implement` workflow on a parse error. `notes[]` is non-blocking advisory prose from an LLM reviewer, which cannot be relied on to honour a hard character budget.

A shared `truncateReviewNoteText()` helper now truncates an over-long note (ellipsis-terminated) instead of throwing, applied in both the codex and test-quality envelope parsers. Verbatim durability is unaffected — the full reviewer text is preserved via the chunked issue-thread findings comments; `notes[]` is only the parsed, already-capped structured summary.

## Requirement UIDs

- GC-O007 — Gated Agentic Development Loop. Keeps the pre-push review gates from failing spuriously on an otherwise-complete review.

## ADR Impact

- No ADR required — localized parser bug fix, no architectural decision.

## Test Plan

- [x] 980 MCP tests pass (`npm test` in `mcp/ground-control`), including 2 new regression tests (codex + test-quality parse paths)
- [x] `bin/policy` passes
- [ ] CI green

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: `mcp/ground-control/lib.js` — the `truncateReviewNoteText()` helper and its use in the codex and test-quality envelope parsers.
- TESTS: `mcp/ground-control/lib.test.js` — codex and test-quality over-long-note regression tests.

Closes #955.