### PR TITLE
fix: truncate all over-long review prose fields, not just notes

### DIFF
--- a/changelog.d/955.fixed.md
+++ b/changelog.d/955.fixed.md
@@ -1,7 +1,9 @@
 ### Fixed
 
 - Review-envelope parsing (`gc_codex_review` / `gc_test_quality_review`) no longer
-  discards an entire completed review when an advisory `notes[]` entry exceeds the
-  `REVIEW_NOTE_TEXT_MAX` length cap. The note is truncated (ellipsis-terminated)
-  via a shared `truncateReviewNoteText()` helper instead of throwing a parse error
-  that failed the whole review.
+  discards an entire completed review when an LLM-authored prose field exceeds its
+  length cap. Advisory `notes[].text` and the per-finding `title`, `body`,
+  `category.shape`, and `sweep_evidence` fields are now truncated
+  (ellipsis-terminated) via a shared `truncateReviewProse()` helper instead of
+  throwing a parse error that failed the whole review. Structural fields — paths,
+  line numbers, enums, instance locators — still reject on violation.

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -4503,18 +4503,22 @@ const FINDING_CATEGORY_SHAPE_MAX = 300;
 const FINDING_CLASSIFICATIONS = new Set(["one-off", "class"]);
 const FINDING_SWEEP_EVIDENCE_MAX = 500;
 const REVIEW_NOTE_TEXT_MAX = 300;
-// An advisory review note (codex or test-quality) that overruns the
-// length cap is truncated to the cap — last char replaced with an
-// ellipsis — rather than thrown. The note is non-blocking prose from
-// an LLM reviewer, which cannot be relied on to honour a hard char
-// budget; discarding an entire completed review over note length was
-// a brittle failure mode (surfaced by aptl issue #293). Verbatim
-// durability is unaffected: the full reviewer text is preserved
-// separately via buildCodexReviewFindingsComments' chunked comments;
-// notes[] is the parsed, already-capped structured summary.
-function truncateReviewNoteText(text) {
-  if (text.length <= REVIEW_NOTE_TEXT_MAX) return text;
-  return text.slice(0, REVIEW_NOTE_TEXT_MAX - 1) + "…";
+// LLM-authored prose fields in a review envelope — advisory notes plus
+// the per-finding `title`, `body`, `category.shape`, and
+// `sweep_evidence` — are truncated to their cap (last char replaced
+// with an ellipsis) rather than thrown on. An LLM reviewer cannot be
+// relied on to honour a hard char budget for prose; discarding an
+// entire completed review because one field overran by a few
+// characters was a brittle failure mode that blocked the /implement
+// workflow (surfaced by aptl issue #293). Structural fields — paths,
+// line numbers, enums, instance locators — still throw, because those
+// are correctness constraints, not prose length. Verbatim durability
+// is unaffected: the full reviewer text is preserved separately via
+// buildCodexReviewFindingsComments' chunked comments; the envelope
+// carries the parsed, already-capped structured summary.
+function truncateReviewProse(text, max) {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + "…";
 }
 // Block delimiter renamed from ===FINDINGS=== to ===REVIEW=== with the
 // verdict-envelope migration (issue #931). The new contract emits a JSON
@@ -4698,7 +4702,7 @@ export function validateReviewEnvelope(raw, repoRoot) {
       if (typeof entry.text !== "string" || entry.text.trim() === "") {
         throw new Error(`notes[${idx}].text must be a non-empty string`);
       }
-      return { text: truncateReviewNoteText(entry.text) };
+      return { text: truncateReviewProse(entry.text, REVIEW_NOTE_TEXT_MAX) };
     });
   }
   // Verdict / blocking consistency rules — shared with the decision-record
@@ -4745,18 +4749,8 @@ function validateFinding(raw, idx, repoRoot) {
   if (typeof raw.title !== "string" || raw.title.trim() === "") {
     throw new Error(`finding at index ${idx} is missing required field 'title' (must be a non-empty string)`);
   }
-  if (raw.title.length > FINDING_TITLE_MAX) {
-    throw new Error(
-      `finding at index ${idx} has 'title' longer than ${FINDING_TITLE_MAX} chars (${raw.title.length})`,
-    );
-  }
   if (typeof raw.body !== "string" || raw.body.trim() === "") {
     throw new Error(`finding at index ${idx} is missing required field 'body' (must be a non-empty string)`);
-  }
-  if (raw.body.length > FINDING_BODY_MAX) {
-    throw new Error(
-      `finding at index ${idx} has 'body' longer than ${FINDING_BODY_MAX} chars (${raw.body.length})`,
-    );
   }
   // classification (#830): every finding declares whether it is a one-off or
   // one instance of a recurring category, so the agent designs the fix at the
@@ -4781,11 +4775,6 @@ function validateFinding(raw, idx, repoRoot) {
     if (typeof raw.category.shape !== "string" || raw.category.shape.trim() === "") {
       throw new Error(
         `finding at index ${idx} 'category.shape' must be a non-empty string`,
-      );
-    }
-    if (raw.category.shape.length > FINDING_CATEGORY_SHAPE_MAX) {
-      throw new Error(
-        `finding at index ${idx} 'category.shape' longer than ${FINDING_CATEGORY_SHAPE_MAX} chars (${raw.category.shape.length})`,
       );
     }
     if (!Array.isArray(raw.category.instances) || raw.category.instances.length === 0) {
@@ -4836,7 +4825,10 @@ function validateFinding(raw, idx, repoRoot) {
         `finding at index ${idx} 'category.instances' must include this finding's own site ${JSON.stringify(ownSite)}`,
       );
     }
-    category = { shape: raw.category.shape, instances: normalized };
+    category = {
+      shape: truncateReviewProse(raw.category.shape, FINDING_CATEGORY_SHAPE_MAX),
+      instances: normalized,
+    };
   } else if (raw.category !== undefined && raw.category !== null) {
     throw new Error(
       `finding at index ${idx} has classification "one-off" but also carries a 'category' — omit it (or set null) for one-off findings`,
@@ -4853,12 +4845,7 @@ function validateFinding(raw, idx, repoRoot) {
         `finding at index ${idx} has classification "one-off" but is missing required field 'sweep_evidence' (a one-line statement of what you grepped/scanned and what you did NOT find — see the prompt's sweep-evidence rule)`,
       );
     }
-    if (raw.sweep_evidence.length > FINDING_SWEEP_EVIDENCE_MAX) {
-      throw new Error(
-        `finding at index ${idx} 'sweep_evidence' longer than ${FINDING_SWEEP_EVIDENCE_MAX} chars (${raw.sweep_evidence.length})`,
-      );
-    }
-    sweepEvidence = raw.sweep_evidence.trim();
+    sweepEvidence = truncateReviewProse(raw.sweep_evidence.trim(), FINDING_SWEEP_EVIDENCE_MAX);
   } else if (raw.sweep_evidence !== undefined && raw.sweep_evidence !== null) {
     // class findings carry their evidence in category.instances; sweep_evidence
     // is reserved for one-off so the two paths don't drift.
@@ -4883,7 +4870,13 @@ function validateFinding(raw, idx, repoRoot) {
     }
     structuralBlocker = raw.structural_blocker === true;
   }
-  const finding = { path, line, title: raw.title, body: raw.body, classification: raw.classification };
+  const finding = {
+    path,
+    line,
+    title: truncateReviewProse(raw.title, FINDING_TITLE_MAX),
+    body: truncateReviewProse(raw.body, FINDING_BODY_MAX),
+    classification: raw.classification,
+  };
   if (category !== null) finding.category = category;
   if (sweepEvidence !== null) finding.sweep_evidence = sweepEvidence;
   if (structuralBlocker) finding.structural_blocker = true;
@@ -5892,7 +5885,7 @@ export function parseTestQualityReviewEnvelope(stdout) {
       if (typeof entry.text !== "string" || entry.text.trim() === "") {
         throw new Error(`test-quality review notes[${idx}].text must be a non-empty string`);
       }
-      return { text: truncateReviewNoteText(entry.text) };
+      return { text: truncateReviewProse(entry.text, REVIEW_NOTE_TEXT_MAX) };
     });
   }
 
@@ -5981,11 +5974,6 @@ function validateTestQualityFinding(raw, i) {
         `test-quality review blocking[${i}] has classification 'one-off' but is missing required 'sweep_evidence' (one-line statement of what you swept)`,
       );
     }
-    if (raw.sweep_evidence.length > FINDING_SWEEP_EVIDENCE_MAX) {
-      throw new Error(
-        `test-quality review blocking[${i}].sweep_evidence longer than ${FINDING_SWEEP_EVIDENCE_MAX} chars`,
-      );
-    }
   }
 
   let structuralBlocker = false;
@@ -6011,7 +5999,7 @@ function validateTestQualityFinding(raw, i) {
   };
   if (category !== null) finding.category = category;
   if (raw.sweep_evidence != null && classification === "one-off") {
-    finding.sweep_evidence = raw.sweep_evidence.trim();
+    finding.sweep_evidence = truncateReviewProse(raw.sweep_evidence.trim(), FINDING_SWEEP_EVIDENCE_MAX);
   }
   if (structuralBlocker) finding.structural_blocker = true;
   return finding;

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -2635,6 +2635,46 @@ describe("parseCodexReviewFindingsTail (verdict envelope, #931)", () => {
     assert.ok(parsed.notes[0].text.endsWith("…"));
   });
 
+  it("truncates over-long finding prose (title/body/sweep_evidence) instead of discarding the review (aptl #293)", () => {
+    // Same brittleness as notes[]: an LLM reviewer overrunning a hard
+    // char budget on a finding's prose fields must not discard the
+    // whole completed review. Structural fields still throw.
+    const stdout = makeReviewTail([
+      {
+        path: "src/foo.java",
+        line: 42,
+        title: "T".repeat(900),
+        body: "B".repeat(70000),
+        classification: "one-off",
+        sweep_evidence: "S".repeat(900),
+      },
+    ]);
+    const { envelope } = parseCodexReviewFindingsTail(stdout, repoRoot);
+    const f = envelope.blocking[0];
+    assert.equal(f.title.length, 200);
+    assert.ok(f.title.endsWith("…"));
+    assert.equal(f.body.length, 65535 - 213 - 800);
+    assert.ok(f.body.endsWith("…"));
+    assert.equal(f.sweep_evidence.length, 500);
+    assert.ok(f.sweep_evidence.endsWith("…"));
+  });
+
+  it("truncates an over-long category.shape on a class finding (aptl #293)", () => {
+    const stdout = makeReviewTail([
+      {
+        path: "src/foo.java",
+        line: 42,
+        title: "x",
+        body: "y",
+        classification: "class",
+        category: { shape: "C".repeat(600), instances: ["src/foo.java:42"] },
+      },
+    ]);
+    const { envelope } = parseCodexReviewFindingsTail(stdout, repoRoot);
+    assert.equal(envelope.blocking[0].category.shape.length, 300);
+    assert.ok(envelope.blocking[0].category.shape.endsWith("…"));
+  });
+
   it("requires sweep_evidence on one-off findings (#931)", () => {
     // Note: this test deliberately omits sweep_evidence to exercise the
     // required-field check.
@@ -2700,18 +2740,8 @@ describe("parseCodexReviewFindingsTail (verdict envelope, #931)", () => {
     assert.throws(() => parseCodexReviewFindingsTail(stdout, repoRoot), /title/);
   });
 
-  it("throws when `title` exceeds 200 chars", () => {
-    const stdout = makeReviewTail([{ path: "src/foo.java", line: 42, title: "x".repeat(201), body: "y", classification: "one-off", sweep_evidence: SWEEP }]);
-    assert.throws(() => parseCodexReviewFindingsTail(stdout, repoRoot), /title/);
-  });
-
   it("throws when `body` is empty", () => {
     const stdout = makeReviewTail([{ path: "src/foo.java", line: 42, title: "x", body: "", classification: "one-off", sweep_evidence: SWEEP }]);
-    assert.throws(() => parseCodexReviewFindingsTail(stdout, repoRoot), /body/);
-  });
-
-  it("throws when `body` exceeds the cap", () => {
-    const stdout = makeReviewTail([{ path: "src/foo.java", line: 42, title: "x", body: "y".repeat(65336), classification: "one-off", sweep_evidence: SWEEP }]);
     assert.throws(() => parseCodexReviewFindingsTail(stdout, repoRoot), /body/);
   });
 
@@ -8125,6 +8155,28 @@ describe("parseTestQualityReviewFindings (verdict envelope, #931)", () => {
     assert.equal(r.envelope.notes.length, 1);
     assert.equal(r.envelope.notes[0].text.length, 300);
     assert.ok(r.envelope.notes[0].text.endsWith("…"));
+  });
+
+  it("truncates an over-long finding sweep_evidence instead of discarding the review (aptl #293)", () => {
+    const stdout = JSON.stringify({
+      verdict: "ship-with-fixes",
+      architectural_read: "Reviewed the test file.",
+      blocking: [
+        {
+          severity: "warning",
+          location: "tests/test_x.py::test_y",
+          problem: "weak assertion",
+          why_it_matters: "would not catch a regression",
+          fix: "assert on the value",
+          classification: "one-off",
+          sweep_evidence: "S".repeat(900),
+        },
+      ],
+    });
+    const r = parseTestQualityReviewFindings(stdout);
+    assert.equal(r.findings.length, 1);
+    assert.equal(r.findings[0].sweep_evidence.length, 500);
+    assert.ok(r.findings[0].sweep_evidence.endsWith("…"));
   });
 
   it("parses a warning severity finding", () => {


### PR DESCRIPTION
## Summary

Follow-up to #957. That PR truncated over-long `notes[].text` in the codex / test-quality review parsers instead of throwing. The same hard-throw existed on four sibling per-finding prose fields — `title`, `body`, `category.shape`, `sweep_evidence` — so a review whose finding overran one of those caps was still discarded wholesale, failing the `/implement` workflow on a parse error.

`truncateReviewNoteText()` is generalised to `truncateReviewProse(text, max)`. All five LLM-authored prose fields now truncate (ellipsis-terminated) rather than throw, on both the codex and test-quality parse paths. Structural fields — paths, line numbers, enums, instance locators — still reject on violation; correctness constraints are unchanged.

## Requirement UIDs

- GC-O007 — Gated Agentic Development Loop. Keeps the pre-push review gates from failing spuriously on an otherwise-complete review.

## ADR Impact

- No ADR required — localized parser bug fix extending #957, no architectural decision.

## Test Plan

- [x] MCP tests pass (`node --test lib.test.js` in `mcp/ground-control`) — 662 pass, 0 fail, including new regression tests for `title` / `body` / `category.shape` / `sweep_evidence` truncation on both parsers
- [x] Two stale tests asserting the old `title` / `body` throw behaviour removed
- [x] `bin/policy` passes
- [ ] CI green

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: `mcp/ground-control/lib.js` — the generalised `truncateReviewProse()` helper and its use in the codex (`validateFinding`) and test-quality (`validateTestQualityFinding`) envelope parsers.
- TESTS: `mcp/ground-control/lib.test.js` — regression tests covering truncation of every prose field on both parse paths.

Refs #955.