### PR TITLE
fix: restore the codex implementation review from a silent no-op

### DIFF
--- a/changelog.d/966.fixed.md
+++ b/changelog.d/966.fixed.md
@@ -1,9 +1,14 @@
 ### Fixed
 
-- `gc_codex_review_cycle` no longer silently discards every codex review
-  finding. The shared review-cycle seam read findings from
-  `reviewResult.findings`, but `runCodexReview` returns them under `comments` —
-  so each codex production-readiness review was flattened to "0 findings /
-  clean" and the pre-push implementation review was an effective no-op since
-  #935. A new `reviewCycleFindings()` helper reconciles the field name across
-  the codex and test-quality review tools.
+- The pre-push codex implementation review (`gc_codex_review_cycle`, Step 6.5)
+  is no longer a silent no-op. Three defects, all since #935:
+  - The shared review-cycle seam read findings from `reviewResult.findings`,
+    but `runCodexReview` returns them under `comments` — so every codex review
+    was flattened to "0 findings / clean" and the workflow auto-advanced.
+  - The durable findings record was fed the pre-`===REVIEW===` prose, which is
+    ~always empty under the #931 verdict-envelope contract, so the comment
+    showed `## Core review _(empty)_` regardless of the review. It now renders
+    the parsed envelope — verdict, architectural read, and blocking findings.
+  - The per-cycle decision record now carries the reviewer's architectural
+    read, surfaced by `runCodexReview` / `runTestQualityReview` and forwarded
+    through the cycle wrapper.

--- a/changelog.d/966.fixed.md
+++ b/changelog.d/966.fixed.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- `gc_codex_review_cycle` no longer silently discards every codex review
+  finding. The shared review-cycle seam read findings from
+  `reviewResult.findings`, but `runCodexReview` returns them under `comments` —
+  so each codex production-readiness review was flattened to "0 findings /
+  clean" and the pre-push implementation review was an effective no-op since
+  #935. A new `reviewCycleFindings()` helper reconciles the field name across
+  the codex and test-quality review tools.

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -6508,6 +6508,7 @@ export async function runTestQualityReview({
     cap: decision.cap,
     finding_count: findings.length,
     findings,
+    architectural_read: parsed.envelope?.architectural_read,
     next_action: nextAction,
     findings_comment_url: markerWriteResult.recordUrl,
     changed_test_files: changedTestFiles,
@@ -7162,8 +7163,8 @@ export async function runCodexReview({
         issueNumber: recordIssueNumber,
         prNumber: uncommitted ? null : effectivePr,
         branch: prePushOwnership ? prePushOwnership.branchName : null,
-        coreReviewText: core.body,
-        securityReviewText: security.body,
+        coreReviewText: renderReviewerEnvelope(core),
+        securityReviewText: renderReviewerEnvelope(security),
         postedComments: comments,
       });
       // #804 review-cycle-1 finding 2: route the rendered body through the
@@ -7344,6 +7345,13 @@ export async function runCodexReview({
     error: partialFailure ? "review_partial_failure" : undefined,
     finding_count: comments.length,
     comments,
+    // architectural_read merges both reviewers' reads for the decision record
+    // (issue #966). `verdict` is intentionally NOT surfaced for the cycle
+    // wrapper: the decision-record consistency validator keys structural
+    // blocking on `classification === "class"` only, so a codex `don't-ship`
+    // justified by a one-off structural_blocker would fail validation. The
+    // findings list already conveys the outcome.
+    architectural_read: mergeReviewerArchitecturalReads(core, security),
     post_failures: postFailures,
     parse_errors: parseErrors,
     core_review_text: core.body,
@@ -7514,6 +7522,62 @@ function chunkText(text, chunkSize) {
 // a continuation header.
 //
 // Pure function: testable without IO.
+// Render a parsed reviewer envelope ({verdict, architectural_read, blocking,
+// notes}) into the Markdown the durable findings record shows. Post-#931 codex
+// writes its substance INSIDE the ===REVIEW=== block, so `body` (the prose
+// before the block) is ~always empty — feeding `body` to the findings-record
+// renderer made the comment show `## Core review _(empty)_` regardless of what
+// codex returned (issue #966, ex-#965). Rendering the parsed envelope is what
+// makes the findings comment actually show the review. Falls back to the raw
+// `body` when the envelope is absent (parse failure).
+export function renderReviewerEnvelope(reviewer) {
+  const env = reviewer?.envelope;
+  if (!env || typeof env !== "object") {
+    return typeof reviewer?.body === "string" ? reviewer.body.trim() : "";
+  }
+  const lines = [];
+  if (typeof env.verdict === "string" && env.verdict !== "") {
+    lines.push(`**Verdict:** \`${env.verdict}\``, "");
+  }
+  if (typeof env.architectural_read === "string" && env.architectural_read.trim() !== "") {
+    lines.push(env.architectural_read.trim(), "");
+  }
+  const blocking = Array.isArray(env.blocking) ? env.blocking : [];
+  if (blocking.length === 0) {
+    lines.push("_No blocking findings._");
+  } else {
+    lines.push(`**Blocking findings (${blocking.length}):**`, "");
+    blocking.forEach((f, i) => {
+      const cls = f?.classification === "class" ? "class" : "one-off";
+      let loc = "";
+      if (typeof f?.path === "string" && f.path !== "") {
+        loc = typeof f?.line === "number" ? ` — \`${f.path}:${f.line}\`` : ` — \`${f.path}\``;
+      }
+      lines.push(`${i + 1}. **[${cls}]** ${f?.title ?? "(no title)"}${loc}`);
+      if (typeof f?.body === "string" && f.body.trim() !== "") {
+        lines.push(`   ${f.body.trim().replace(/\n/g, "\n   ")}`);
+      }
+    });
+  }
+  return lines.join("\n").trim();
+}
+
+// Merge the core + security reviewers' architectural_read into one string for
+// the decision record. Each reviewer's read is required-non-empty by
+// validateReviewEnvelope; returns undefined only when neither envelope parsed.
+export function mergeReviewerArchitecturalReads(core, security) {
+  const parts = [];
+  const coreRead = core?.envelope?.architectural_read;
+  const secRead = security?.envelope?.architectural_read;
+  if (typeof coreRead === "string" && coreRead.trim() !== "") {
+    parts.push(`**Core reviewer:** ${coreRead.trim()}`);
+  }
+  if (typeof secRead === "string" && secRead.trim() !== "") {
+    parts.push(`**Security reviewer:** ${secRead.trim()}`);
+  }
+  return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
 export function buildCodexReviewFindingsComments({
   cycleNumber,
   cap,
@@ -12237,6 +12301,13 @@ async function _runReviewCycleShared({
       cycle: cycle ?? 1,
       reviewer,
       findings: decisionFindings,
+      // Forward the reviewer's architectural read so the decision record
+      // carries the review's reasoning, not just a finding count (issue #966).
+      // Omitted when absent so the record falls back to the legacy shape.
+      ...(typeof reviewResult.architectural_read === "string"
+        && reviewResult.architectural_read.trim() !== ""
+        ? { architectural_read: reviewResult.architectural_read }
+        : {}),
     });
   } catch (e) {
     return {

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -12165,6 +12165,20 @@ export function normalizeReviewCycleNextAction(reviewerAction, status) {
   return reviewerAction;
 }
 
+// Both cycle wrappers feed _runReviewCycleShared, but the two underlying
+// review tools name their findings array differently: runTestQualityReview
+// returns it as `findings`, while runCodexReview returns it as `comments` (a
+// legacy name from when codex review posted PR inline comments). The shared
+// seam must read whichever the tool produced — without this reconciliation
+// gc_codex_review_cycle saw `reviewResult.findings === undefined`, flattened
+// every codex review to "0 findings / clean", and the codex implementation
+// review was a silent no-op (issue #966).
+export function reviewCycleFindings(reviewResult) {
+  if (Array.isArray(reviewResult?.findings)) return reviewResult.findings;
+  if (Array.isArray(reviewResult?.comments)) return reviewResult.comments;
+  return [];
+}
+
 async function _runReviewCycleShared({
   reviewer,
   reviewResult,
@@ -12180,7 +12194,7 @@ async function _runReviewCycleShared({
   const cycle =
     typeof reviewResult.cycle === "number" ? reviewResult.cycle : null;
   const cap = typeof reviewResult.cap === "number" ? reviewResult.cap : null;
-  const findings = Array.isArray(reviewResult.findings) ? reviewResult.findings : [];
+  const findings = reviewCycleFindings(reviewResult);
   const nextAction =
     typeof reviewResult.next_action === "string" ? reviewResult.next_action : "";
   const status = _statusForReviewerAction(nextAction, findings.length > 0);

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -4996,9 +4996,11 @@ process.stdin.on("end", () => {
     const end = "-----";
     const keyTail = "PRIVATE " + "KEY" + end;
     const sensitiveBody = `Reviewer prose ... ${begin}${keyTail}\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ...`;
-    // The codex shim emits a security review with secret-shaped content,
-    // forcing the security_review_text into the findings body.
-    const codexTail = `${sensitiveBody}\n\n===REVIEW===\n{"verdict":"ship","architectural_read":"Reviewed.","blocking":[]}\n===END===\n`;
+    // The codex shim emits a review whose architectural_read carries
+    // secret-shaped content. Post-#966 the findings-record renderer renders
+    // the parsed verdict envelope (architectural_read + blocking findings) —
+    // the sensitive text must be caught there before the record is posted.
+    const codexTail = `===REVIEW===\n${JSON.stringify({ verdict: "ship", architectural_read: `Reviewed. ${sensitiveBody}`, blocking: [] })}\n===END===\n`;
 
     const shim = makeFullShimRepo({
       branch: "998-add-thing",
@@ -10965,5 +10967,73 @@ describe("reviewCycleFindings — cycle-seam field reconciliation (issue #966)",
     assert.deepEqual(reviewCycleFindings({ ok: true }), []);
     assert.deepEqual(reviewCycleFindings(null), []);
     assert.deepEqual(reviewCycleFindings(undefined), []);
+  });
+});
+
+describe("renderReviewerEnvelope — findings-record renderer (issue #966)", () => {
+  it("renders verdict, architectural read, and blocking findings from the envelope", async () => {
+    const { renderReviewerEnvelope } = await import("./lib.js");
+    const out = renderReviewerEnvelope({
+      body: "",
+      envelope: {
+        verdict: "ship-with-fixes",
+        architectural_read: "The change is sound but leaks an envelope.",
+        blocking: [
+          { classification: "one-off", title: "Null deref", path: "a.js", line: 12, body: "fix it" },
+          { classification: "class", title: "Unvalidated input", path: "b.js" },
+        ],
+      },
+    });
+    assert.match(out, /ship-with-fixes/);
+    assert.match(out, /leaks an envelope/);
+    assert.match(out, /Blocking findings \(2\)/);
+    assert.match(out, /\[one-off\]\*\* Null deref — `a\.js:12`/);
+    assert.match(out, /\[class\]\*\* Unvalidated input/);
+  });
+
+  it("shows the architectural read and 'no blocking findings' on a clean review", async () => {
+    const { renderReviewerEnvelope } = await import("./lib.js");
+    const out = renderReviewerEnvelope({
+      body: "",
+      envelope: { verdict: "ship", architectural_read: "Clean — well-scoped.", blocking: [] },
+    });
+    assert.match(out, /Clean — well-scoped\./);
+    assert.match(out, /No blocking findings/);
+    assert.doesNotMatch(out, /_\(empty\)_/);
+  });
+
+  it("falls back to the raw body when the envelope is absent (parse failure)", async () => {
+    const { renderReviewerEnvelope } = await import("./lib.js");
+    assert.equal(renderReviewerEnvelope({ body: "raw prose" }), "raw prose");
+    assert.equal(renderReviewerEnvelope({}), "");
+    assert.equal(renderReviewerEnvelope(null), "");
+  });
+});
+
+describe("mergeReviewerArchitecturalReads — decision-record read (issue #966)", () => {
+  it("merges both reviewers' reads with labels", async () => {
+    const { mergeReviewerArchitecturalReads } = await import("./lib.js");
+    const out = mergeReviewerArchitecturalReads(
+      { envelope: { architectural_read: "core says ok" } },
+      { envelope: { architectural_read: "security flags a token" } },
+    );
+    assert.match(out, /\*\*Core reviewer:\*\* core says ok/);
+    assert.match(out, /\*\*Security reviewer:\*\* security flags a token/);
+  });
+
+  it("returns just the present reviewer when one envelope is missing", async () => {
+    const { mergeReviewerArchitecturalReads } = await import("./lib.js");
+    const out = mergeReviewerArchitecturalReads(
+      { envelope: { architectural_read: "core only" } },
+      { body: "parse failed" },
+    );
+    assert.match(out, /\*\*Core reviewer:\*\* core only/);
+    assert.doesNotMatch(out, /Security reviewer/);
+  });
+
+  it("returns undefined when neither envelope parsed", async () => {
+    const { mergeReviewerArchitecturalReads } = await import("./lib.js");
+    assert.equal(mergeReviewerArchitecturalReads({ body: "x" }, { body: "y" }), undefined);
+    assert.equal(mergeReviewerArchitecturalReads(null, null), undefined);
   });
 });

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -10932,3 +10932,38 @@ describe("async review-job registry (gc_codex_job, issue #937)", () => {
     assert.throws(() => startReviewJob("codex_review", null), /runFn must be a function/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// reviewCycleFindings — codex/test-quality field reconciliation (issue #966)
+// ---------------------------------------------------------------------------
+
+describe("reviewCycleFindings — cycle-seam field reconciliation (issue #966)", () => {
+  it("reads test-quality findings from .findings", async () => {
+    const { reviewCycleFindings } = await import("./lib.js");
+    const r = reviewCycleFindings({ ok: true, findings: [{ title: "a" }, { title: "b" }] });
+    assert.equal(r.length, 2);
+  });
+
+  it("reads codex findings from .comments when .findings is absent", async () => {
+    const { reviewCycleFindings } = await import("./lib.js");
+    // runCodexReview returns its findings array under `comments`, not
+    // `findings`. Before #966 the cycle seam read only `.findings`, so every
+    // codex review was flattened to "0 findings" and the review was a no-op.
+    const r = reviewCycleFindings({ ok: true, comments: [{ title: "x" }, { title: "y" }, { title: "z" }] });
+    assert.equal(r.length, 3);
+  });
+
+  it("prefers .findings when both are present", async () => {
+    const { reviewCycleFindings } = await import("./lib.js");
+    const r = reviewCycleFindings({ findings: [{ title: "a" }], comments: [{ title: "b" }, { title: "c" }] });
+    assert.equal(r.length, 1);
+    assert.equal(r[0].title, "a");
+  });
+
+  it("returns [] when neither field is present or input is nullish", async () => {
+    const { reviewCycleFindings } = await import("./lib.js");
+    assert.deepEqual(reviewCycleFindings({ ok: true }), []);
+    assert.deepEqual(reviewCycleFindings(null), []);
+    assert.deepEqual(reviewCycleFindings(undefined), []);
+  });
+});


### PR DESCRIPTION
## Summary

`gc_codex_review_cycle` (Step 6.5, the pre-push codex implementation review) has been an effective no-op since #935. Three defects, all fixed here:

1. **Cycle-seam findings field.** `_runReviewCycleShared` read findings from `reviewResult.findings`, but `runCodexReview` returns them under `.comments` (a legacy name from when codex posted PR inline comments). `runTestQualityReview` uses `.findings`, so the shared seam worked for test-quality but flattened every codex review to "0 findings / clean". New `reviewCycleFindings()` helper reconciles the field.

2. **Findings-record renderer.** The durable findings comment was fed the pre-`===REVIEW===` prose. Under the #931 verdict-envelope contract codex writes its substance *inside* the block, so that prose is ~always empty — the comment showed `## Core review _(empty)_` regardless of the review. New `renderReviewerEnvelope()` renders the parsed envelope (verdict, architectural read, blocking findings). (Folded in from #965.)

3. **Decision-record architectural read.** `runCodexReview` / `runTestQualityReview` now surface `architectural_read` (merged across codex's core + security reviewers); the cycle wrapper forwards it to `gc_post_decision_record`. `verdict` is intentionally not forwarded — the decision-record consistency validator keys structural blocking on `classification` alone and cannot reconcile a one-off structural-blocker `don't-ship`; the findings list conveys the outcome.

test-quality review behaviour is unchanged (it already used `.findings`); it additionally gains the architectural read in its decision record.

## Requirement UIDs

- GC-O007 — Gated Agentic Development Loop. Restores the pre-push codex review gate from a silent no-op to an enforcing, visible review.

## ADR Impact

- No ADR required — bug fixes in the review-tool / cycle-seam plumbing, no architectural decision.

## Test Plan

- [x] 995 MCP tests pass (`npm test` in `mcp/ground-control`), including 10 new tests (`reviewCycleFindings`, `renderReviewerEnvelope`, `mergeReviewerArchitecturalReads`)
- [x] `bin/policy` passes (pre-commit `repo-policy`)
- [ ] CI green

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: `mcp/ground-control/lib.js` — `reviewCycleFindings()`, `renderReviewerEnvelope()`, `mergeReviewerArchitecturalReads()`, and their wiring into `runCodexReview` / `runTestQualityReview` / `_runReviewCycleShared`.
- TESTS: `mcp/ground-control/lib.test.js` — field-reconciliation, envelope-render, and architectural-read-merge regression tests.

Closes #966.