### PR TITLE
docs: fix ADR-053 title line (renumber follow-up to #916)

### DIFF
--- a/architecture/adrs/053-conversation-surface-hardening.md
+++ b/architecture/adrs/053-conversation-surface-hardening.md
@@ -1,4 +1,4 @@
-# ADR-036: Conversation Surface Hardening
+# ADR-053: Conversation Surface Hardening
 
 ## Status
 


### PR DESCRIPTION
## Summary

PR #916 renumbered the conversation-surface ADR from 036 to 053 but the title line inside the file was not updated in the merged commit (the title-fix force-push landed after the merge). This PR fixes that one-line inconsistency so the filename and the in-file `# ADR-053:` title agree.

## Requirement UIDs

- `SEC-001`

## ADR Impact

- ADR-053 (title-line correction; no semantic change)

## Changes

- `architecture/adrs/053-conversation-surface-hardening.md`: change the title line from `# ADR-036: Conversation Surface Hardening` to `# ADR-053: Conversation Surface Hardening`.

## Test Plan

- [x] `make policy` passes locally (pre-commit `repo policy guardrails` hook ran on this commit and passed)
- Unit / integration tests: N/A — docs-only one-character substitution

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: SEC-001 ← architecture/adrs/053-conversation-surface-hardening.md (link already exists in Ground Control from PR #916; this PR does not add a new traceability link)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- Changelog fragment: N/A — docs-only diff
- [x] Architectural docs updated if stack, package structure, or key behaviors changed