### PR TITLE
fix: web UI inaccessibility — give the SPA its own login page (#846)

### DIFF
--- a/architecture/adrs/037-browser-session-access-control.md
+++ b/architecture/adrs/037-browser-session-access-control.md
@@ -4,6 +4,17 @@
 
 Accepted
 
+## Update — Issue #846 (2026-05-23)
+
+The React SPA login screen has shipped. `BrowserSecurityConfig` now calls
+`.loginPage("/login")`, which disables Spring's `DefaultLoginPageGeneratingFilter`
+so `GET /login` is forwarded to `SpaController → index.html` (the SPA shell).
+`POST /login` form-urlencoded continues to be processed by
+`UsernamePasswordAuthenticationFilter` at the same path. The SPA login form reads
+the `XSRF-TOKEN` cookie (written by `CookieCsrfTokenRepository` on the GET) and
+echoes it as `X-XSRF-TOKEN`, satisfying the CSRF gate. No Decision contracts in
+this ADR were changed.
+
 ## Date
 
 2026-05-11

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BrowserSecurityConfig.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/BrowserSecurityConfig.java
@@ -35,6 +35,15 @@ import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
  * Spring Security's standard form-login machinery against a JDBC-backed user store with BCrypt
  * password hashes.
  *
+ * <p>The SPA owns {@code GET /login}: {@code .loginPage("/login")} disables Spring's
+ * {@code DefaultLoginPageGeneratingFilter} so the React login page is served by
+ * {@link com.keplerops.groundcontrol.infrastructure.web.SpaController} (which forwards to
+ * {@code index.html}). Spring still processes {@code POST /login}
+ * form-urlencoded via {@code UsernamePasswordAuthenticationFilter} at
+ * {@code loginProcessingUrl("/login")}. The {@code XSRF-TOKEN} cookie written by
+ * {@link CookieCsrfTokenRepository} on the GET is echoed as {@code X-XSRF-TOKEN} by the React
+ * login form, satisfying the CSRF gate on the POST.
+ *
  * <p>State-changing browser requests (POST/PUT/PATCH/DELETE) carry the {@code GC_SESSION}
  * cookie; CSRF protection is enabled through a {@link CookieCsrfTokenRepository} configured
  * with {@code HttpOnly=false} so the SPA can read the {@code XSRF-TOKEN} cookie and echo
@@ -70,7 +79,9 @@ public class BrowserSecurityConfig {
      * session-fixation-by-credential-swap attack — an attacker hosts an auto-submitting form
      * to {@code /login} with credentials they control, the victim's browser POSTs without a
      * CSRF check, and the victim's subsequent SPA activity is attributed to the attacker's
-     * principal.
+     * principal. The SPA login form reads the {@code XSRF-TOKEN} cookie (written by
+     * {@link CookieCsrfTokenRepository} on the GET) and echoes it as {@code X-XSRF-TOKEN},
+     * satisfying this gate.
      *
      * <p>Rules now:
      *
@@ -213,7 +224,16 @@ public class BrowserSecurityConfig {
         requestCache.setRequestMatcher(new NegatedRequestMatcher(ApiRequestPaths.matcher()));
         http.requestCache(cache -> cache.requestCache(requestCache));
 
-        http.formLogin(form -> form.loginProcessingUrl(LOGIN_PATH).permitAll())
+        // .loginPage(LOGIN_PATH) disables DefaultLoginPageGeneratingFilter so the SPA owns
+        // GET /login. Spring still runs UsernamePasswordAuthenticationFilter at
+        // loginProcessingUrl("/login"), so POST /login form-urlencoded continues to work.
+        // .failureUrl and .defaultSuccessUrl make the redirect targets explicit so the
+        // behaviour is not silently altered by future Spring Security upgrades.
+        http.formLogin(form -> form.loginPage(LOGIN_PATH)
+                        .loginProcessingUrl(LOGIN_PATH)
+                        .failureUrl(LOGIN_PATH + "?error")
+                        .defaultSuccessUrl("/", false)
+                        .permitAll())
                 .logout(logout -> logout.logoutUrl(LOGOUT_PATH)
                         .logoutSuccessHandler((request, response, authentication) ->
                                 // Return 204 on logout. SPA-initiated XHR logouts can clear

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/BrowserSessionIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/BrowserSessionIntegrationTest.java
@@ -213,6 +213,53 @@ class BrowserSessionIntegrationTest extends BaseIntegrationTest {
                         .contains("error"));
     }
 
+    @Test
+    void getLoginReturnsSpaShellNotSpringDefaultForm() throws Exception {
+        // With .loginPage(LOGIN_PATH), Spring disables DefaultLoginPageGeneratingFilter. GET
+        // /login reaches SpaController which issues a Servlet forward to /index.html (the SPA
+        // shell).
+        //
+        // MockMvc's MockRequestDispatcher.forward() calls response.setForwardedUrl(path) and
+        // returns — it does not re-dispatch to ResourceHttpRequestHandler (so body is empty in
+        // tests). The forwarded URL IS captured by getForwardedUrl(). We use that as the
+        // structural gate:
+        //   - With DefaultLoginPageGeneratingFilter active: the filter writes HTML directly and
+        //     calls return without invoking chain.doFilter(), so DispatcherServlet is never
+        //     reached, no RequestDispatcher.forward() is called, and getForwardedUrl() is null.
+        //   - After .loginPage(LOGIN_PATH): the filter is removed, SpaController handles the
+        //     request, and getForwardedUrl() is "/index.html".
+        MvcResult result =
+                mockMvc.perform(get("/login")).andExpect(status().isOk()).andReturn();
+
+        assertThat(result.getResponse().getForwardedUrl())
+                .as("GET /login must be forwarded to /index.html by SpaController; "
+                        + "null means DefaultLoginPageGeneratingFilter is still active")
+                .isEqualTo("/index.html");
+    }
+
+    @Test
+    void postLoginFormEncodedStillAuthenticates() throws Exception {
+        // UsernamePasswordAuthenticationFilter runs at loginProcessingUrl("/login") regardless
+        // of whether DefaultLoginPageGeneratingFilter is disabled. A correct form POST must
+        // still issue a session and redirect to the default success URL.
+        MvcResult page = mockMvc.perform(get("/login")).andReturn();
+        Cookie csrf = page.getResponse().getCookie(CSRF_COOKIE);
+        assertThat(csrf).as("GET /login must still publish an XSRF cookie").isNotNull();
+
+        MockHttpSession session = new MockHttpSession();
+        mockMvc.perform(post("/login")
+                        .contentType("application/x-www-form-urlencoded")
+                        .param("username", ADMIN_USERNAME)
+                        .param("password", ADMIN_PASSWORD)
+                        .param("_csrf", csrf.getValue())
+                        .session(session)
+                        .cookie(csrf))
+                .andExpect(status().is3xxRedirection());
+
+        // The session must now be authenticated — confirmed by a successful API call.
+        mockMvc.perform(get("/api/v1/requirements").session(session)).andExpect(status().isOk());
+    }
+
     private AuthenticatedSession loginAndCaptureSession() throws Exception {
         // GET /login is anonymous, so Spring's session policy (IF_REQUIRED) does NOT create a
         // session here — the CSRF token lives in the XSRF-TOKEN cookie via

--- a/backend/src/test/resources/static/index.html
+++ b/backend/src/test/resources/static/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Ground Control</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/changelog.d/846.fixed.md
+++ b/changelog.d/846.fixed.md
@@ -1,0 +1,1 @@
+### Fixed — SPA now serves a styled login page at /login instead of Spring Security's default generated form (#846).

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -79,7 +79,8 @@ backend/src/main/java/com/keplerops/groundcontrol/
 │   └── web/                      # CORS config, SPA routing
 ├── shared/
 │   ├── logging/                  # RequestLoggingFilter (MDC request_id)
-│   ├── security/                 # ApiSecurityConfig, BearerTokenAuthFilter,
+│   ├── security/                 # ApiSecurityConfig, BrowserSecurityConfig,
+│   │                             # BearerTokenAuthFilter,
 │   │                             # IpAllowlistFilter, ApiAuthenticationEntryPoint,
 │   │                             # ApiAccessDeniedHandler, SecurityProperties (ADR-026)
 │   └── web/                      # ActorFilter (audit identity from SecurityContext)
@@ -108,21 +109,36 @@ Spring profiles drive environment-specific behavior:
 
 Environment variables use the `GC_` prefix (e.g., `GC_DATABASE_URL`, `GC_SERVER_PORT`). See `.env.example`.
 
-## Request filter chain
+## Request filter chains
 
 Once Spring Security is enabled (production default; `dev`/`test` profiles
-opt out), every request passes through:
+opt out), requests pass through two explicit, non-overlapping Spring Security
+chains:
 
 ```
+Bearer request chain (@Order(1), Authorization: Bearer ...)
 IpAllowlistFilter           # CIDR check (skipped if allowlist empty)
-  → BearerTokenAuthFilter   # Authorization: Bearer <token> → SecurityContext
+  → BearerTokenAuthFilter   # token → SecurityContext
     → AuthorizationFilter   # path-matrix / ROLE_USER / ROLE_ADMIN
       → ActorFilter         # populates ActorHolder + MDC actor_id=<principal>
         → controllers
+
+Browser/session chain (@Order(2), every non-bearer request)
+IpAllowlistFilter           # same network gate
+  → form login / session / CSRF
+    → AuthorizationFilter   # same API path matrix for /api/v1/**
+      → ActorFilter         # same audit actor projection
+        → controllers
 ```
 
-Authorization is centralized in `ApiSecurityConfig` (ADR-026); controllers
-do not perform per-method auth checks — the one deliberate exception,
+The shared API authorization matrix lives in `ApiPathMatrix` and is applied by
+both `ApiSecurityConfig` (bearer traffic) and `BrowserSecurityConfig`
+(session-authenticated browser traffic). The browser chain leaves `/login`,
+`/logout`, and required static assets anonymous, but the SPA shell (`/`,
+`/index.html`) and SPA client routes require a browser session; unauthenticated
+navigation redirects to `/login`, while API-shaped unauthenticated XHRs receive
+the standard JSON 401 envelope. Controllers do not perform per-method auth
+checks — the one deliberate exception,
 `PackRegistryAccessGuard`, is a defense-in-depth bridge that re-derives the
 admin principal from the same `SecurityContext` and re-asserts `ROLE_ADMIN`
 (see ADR-033 §4). `ActorFilter` runs after the security chain so audit

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -81,7 +81,8 @@ Authority matrix:
 | `/api/v1/trust-policies/**` | `ROLE_ADMIN` |
 | `/api/v1/pack-install-records/**` | `ROLE_ADMIN` |
 | Other `/api/v1/**` | authenticated (USER or ADMIN) |
-| SPA shell, static assets, SPA client routes (GET only, non-API non-actuator) | anonymous |
+| `/login`, `/logout`, and static assets needed to render the login/app shell | anonymous |
+| SPA shell (`/`, `/index.html`) and SPA client routes | authenticated browser session; unauthenticated navigation redirects to `/login` |
 | Anything else | denyAll |
 
 Clients send `Authorization: Bearer <token>` on every request. Tokens are

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,8 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@tailwindcss/vite": "^4.0.14",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.5.0",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -292,6 +294,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2641,6 +2653,77 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2886,6 +2969,31 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -2896,6 +3004,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/assertion-error": {
@@ -3198,6 +3317,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3213,6 +3343,14 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3998,6 +4136,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4155,6 +4304,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4184,6 +4349,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,8 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@tailwindcss/vite": "^4.0.14",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.5.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/frontend/src/hooks/use-test-runs.ts
+++ b/frontend/src/hooks/use-test-runs.ts
@@ -57,10 +57,18 @@ export function useTestRunCaseResults(runId: string | undefined) {
   });
 }
 
-export function useTestRunStepResults(runId: string | undefined, caseResultId: string | undefined) {
+export function useTestRunStepResults(
+  runId: string | undefined,
+  caseResultId: string | undefined,
+) {
   const { activeProject } = useProjectContext();
   return useQuery({
-    queryKey: ["test-run-step-results", runId, caseResultId, activeProject?.identifier],
+    queryKey: [
+      "test-run-step-results",
+      runId,
+      caseResultId,
+      activeProject?.identifier,
+    ],
     queryFn: () =>
       apiFetch<TestRunStepResultResponse[]>(
         `/test-runs/${runId}/results/${caseResultId}/steps`,
@@ -105,18 +113,25 @@ export function useUpdateTestRunCaseResult(runId: string, testCaseId: string) {
   const { activeProject } = useProjectContext();
   return useMutation({
     mutationFn: (data: UpdateTestRunCaseResultRequest) =>
-      apiFetch<TestRunCaseResultResponse>(`/test-runs/${runId}/results/${testCaseId}`, {
-        method: "PUT",
-        body: data,
-        params: { project: activeProject?.identifier },
-      }),
+      apiFetch<TestRunCaseResultResponse>(
+        `/test-runs/${runId}/results/${testCaseId}`,
+        {
+          method: "PUT",
+          body: data,
+          params: { project: activeProject?.identifier },
+        },
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["test-run-results", runId] });
     },
   });
 }
 
-export function useUpdateTestRunStepResult(runId: string, caseResultId: string, stepResultId: string) {
+export function useUpdateTestRunStepResult(
+  runId: string,
+  caseResultId: string,
+  stepResultId: string,
+) {
   const { activeProject } = useProjectContext();
   return useMutation({
     mutationFn: (data: UpdateTestRunStepResultRequest) =>

--- a/frontend/src/pages/login.test.tsx
+++ b/frontend/src/pages/login.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+/**
+ * Vitest coverage for the Login page.
+ *
+ * Contract under test:
+ * - The login form renders username and password fields plus a submit button.
+ * - On submit the form posts application/x-www-form-urlencoded to /login.
+ * - The XSRF-TOKEN cookie value is echoed as X-XSRF-TOKEN on the POST.
+ * - On a successful login (response.ok, final URL does not end with /login?error)
+ *   the page navigates to response.url.
+ * - When the server redirects back to /login?error the page shows a generic
+ *   error message that does NOT echo the submitted username.
+ * - When the page is loaded at /login?error the error message is shown immediately.
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Login } from "./login";
+
+// ---- helpers ----------------------------------------------------------------
+
+function setCookie(value: string) {
+  Object.defineProperty(document, "cookie", {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+const originalCookie = document.cookie;
+
+// ---- suite ------------------------------------------------------------------
+
+afterEach(() => {
+  cleanup();
+  setCookie(originalCookie);
+  vi.restoreAllMocks();
+});
+
+describe("Login page — form rendering", () => {
+  it("renders a username input, a password input, and a submit button", () => {
+    render(<Login />);
+    expect(screen.getByLabelText(/username/i)).toBeTruthy();
+    expect(screen.getByLabelText(/password/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeTruthy();
+  });
+});
+
+describe("Login page — form submission", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Default: successful login — response.ok true, response.url points at the
+    // SPA root so the page navigates away from /login?error.
+    // Response.ok and Response.url are prototype getters on the built-in Response
+    // class, so Object.assign cannot override them. Return a plain object that
+    // quacks like a Response instead.
+    fetchSpy = vi.fn(() =>
+      Promise.resolve({ ok: true, url: "http://localhost/" } as Response),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  it("posts application/x-www-form-urlencoded to /login on submit", async () => {
+    render(<Login />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/username/i), "alice");
+    await user.type(screen.getByLabelText(/password/i), "secret");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledOnce());
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/login");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toContain(
+      "application/x-www-form-urlencoded",
+    );
+    expect(init.method?.toUpperCase()).toBe("POST");
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("username")).toBe("alice");
+    expect(body.get("password")).toBe("secret");
+  });
+
+  it("reads XSRF-TOKEN cookie and sends it as X-XSRF-TOKEN header", async () => {
+    setCookie("XSRF-TOKEN=csrf-abc123; OTHER=x");
+    render(<Login />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/username/i), "alice");
+    await user.type(screen.getByLabelText(/password/i), "secret");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledOnce());
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["X-XSRF-TOKEN"]).toBe(
+      "csrf-abc123",
+    );
+  });
+
+  it("navigates to response.url on a successful login", async () => {
+    const redirectSpy = vi.fn();
+    render(<Login setRedirectorForTests={redirectSpy} />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/username/i), "alice");
+    await user.type(screen.getByLabelText(/password/i), "secret");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() =>
+      expect(redirectSpy).toHaveBeenCalledWith("http://localhost/"),
+    );
+  });
+});
+
+describe("Login page — error handling", () => {
+  it("shows a generic error message when the server redirects to /login?error", async () => {
+    const fetchSpy = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        url: "http://localhost/login?error",
+      } as Response),
+    );
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    render(<Login />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/username/i), "alice");
+    await user.type(screen.getByLabelText(/password/i), "wrong");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("alert") ?? screen.queryByText(/invalid credentials/i),
+      ).toBeTruthy(),
+    );
+    // The error must NOT echo the submitted username.
+    expect(screen.queryByText(/alice/)).toBeNull();
+  });
+
+  it("shows error immediately when the page URL already contains ?error", () => {
+    // Simulate arriving at /login?error after a failed login redirect.
+    // window.location is unforgeable in jsdom (non-configurable), so use
+    // history.pushState to set the search string the component reads.
+    const originalUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    window.history.pushState({}, "", "/login?error");
+    try {
+      render(<Login />);
+      expect(screen.getByRole("alert")).toBeTruthy();
+      expect(screen.queryByText(/alice/)).toBeNull();
+    } finally {
+      window.history.pushState({}, "", originalUrl);
+    }
+  });
+});

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,0 +1,136 @@
+import {
+  FormField,
+  inputClass,
+  primaryButton,
+} from "@/components/ui/form-field";
+import { type FormEvent, useState } from "react";
+
+const CSRF_COOKIE = "XSRF-TOKEN";
+const CSRF_HEADER = "X-XSRF-TOKEN";
+
+type Redirector = (url: string) => void;
+
+const defaultRedirector: Redirector = (url) => {
+  window.location.assign(url);
+};
+
+function readCookie(name: string): string | undefined {
+  if (typeof document === "undefined" || !document.cookie) {
+    return undefined;
+  }
+  const prefix = `${name}=`;
+  for (const part of document.cookie.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(prefix)) {
+      return decodeURIComponent(trimmed.slice(prefix.length));
+    }
+  }
+  return undefined;
+}
+
+interface LoginProps {
+  /** Test-only: replace the redirect function so tests can spy on navigations. */
+  setRedirectorForTests?: Redirector;
+}
+
+export function Login({ setRedirectorForTests }: LoginProps) {
+  const redirector = setRedirectorForTests ?? defaultRedirector;
+
+  const searchParams =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search)
+      : new URLSearchParams();
+
+  const [hasError, setHasError] = useState(searchParams.has("error"));
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSubmitting(true);
+    setHasError(false);
+
+    const form = e.currentTarget;
+    const username = (form.elements.namedItem("username") as HTMLInputElement)
+      .value;
+    const password = (form.elements.namedItem("password") as HTMLInputElement)
+      .value;
+
+    const csrfToken = readCookie(CSRF_COOKIE);
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/x-www-form-urlencoded",
+    };
+    if (csrfToken) {
+      headers[CSRF_HEADER] = csrfToken;
+    }
+
+    try {
+      const body = new URLSearchParams({ username, password });
+      const response = await fetch("/login", {
+        method: "POST",
+        headers,
+        body: body.toString(),
+        credentials: "same-origin",
+        redirect: "follow",
+      });
+
+      if (response.ok && !response.url.endsWith("?error")) {
+        redirector(response.url);
+        return;
+      }
+
+      setHasError(true);
+    } catch {
+      setHasError(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-sm space-y-6 rounded-lg border border-border bg-card p-8 shadow-sm">
+        <h1 className="text-2xl font-semibold text-foreground">
+          Ground Control
+        </h1>
+        {hasError && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          >
+            Invalid credentials. Please try again.
+          </div>
+        )}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <FormField label="Username">
+            <input
+              id="username"
+              name="username"
+              type="text"
+              autoComplete="username"
+              required
+              className={inputClass}
+            />
+          </FormField>
+          <FormField label="Password">
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              className={inputClass}
+            />
+          </FormField>
+          <button
+            type="submit"
+            disabled={submitting}
+            className={`w-full ${primaryButton}`}
+          >
+            {submitting ? "Signing in…" : "Sign in"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/test-run-runner.tsx
+++ b/frontend/src/pages/test-run-runner.tsx
@@ -42,10 +42,17 @@ export function TestRunRunner() {
   const { runId } = useParams<{ runId: string }>();
   const { activeProject } = useProjectContext();
 
-  const { data: run, isLoading: runLoading, isError: runError } = useTestRun(runId);
-  const { data: caseResults, isLoading: casesLoading } = useTestRunCaseResults(runId);
+  const {
+    data: run,
+    isLoading: runLoading,
+    isError: runError,
+  } = useTestRun(runId);
+  const { data: caseResults, isLoading: casesLoading } =
+    useTestRunCaseResults(runId);
 
-  const [activeCaseResultId, setActiveCaseResultId] = useState<string | null>(null);
+  const [activeCaseResultId, setActiveCaseResultId] = useState<string | null>(
+    null,
+  );
 
   // Initial cursor resolution. Once both the run and its case results have
   // loaded, pick the active case from the persisted cursor, falling back to
@@ -53,7 +60,9 @@ export function TestRunRunner() {
   // blank viewport.
   useEffect(() => {
     if (activeCaseResultId || !caseResults?.length) return;
-    const fromCursor = caseResults.find((c) => c.id === run?.currentCaseResultId);
+    const fromCursor = caseResults.find(
+      (c) => c.id === run?.currentCaseResultId,
+    );
     const target = fromCursor ?? caseResults[0];
     if (target) setActiveCaseResultId(target.id);
   }, [activeCaseResultId, caseResults, run?.currentCaseResultId]);
@@ -78,7 +87,10 @@ export function TestRunRunner() {
     return (
       <div className="py-12 text-center text-destructive">
         Failed to load test run.{" "}
-        <Link to={`/p/${activeProject.identifier}/test-runs`} className="text-primary underline">
+        <Link
+          to={`/p/${activeProject.identifier}/test-runs`}
+          className="text-primary underline"
+        >
           Back to test runs
         </Link>
       </div>
@@ -120,12 +132,18 @@ export function TestRunRunner() {
 
 function statusClass(status: TestRunStatus): string {
   switch (status) {
-    case "PLANNED": return "bg-muted text-muted-foreground";
-    case "IN_PROGRESS": return "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200";
-    case "COMPLETED": return "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200";
-    case "ABORTED": return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200";
-    case "ARCHIVED": return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
-    default: return "bg-muted text-muted-foreground";
+    case "PLANNED":
+      return "bg-muted text-muted-foreground";
+    case "IN_PROGRESS":
+      return "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200";
+    case "COMPLETED":
+      return "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200";
+    case "ABORTED":
+      return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200";
+    case "ARCHIVED":
+      return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
+    default:
+      return "bg-muted text-muted-foreground";
   }
 }
 
@@ -157,14 +175,19 @@ function RunHeader({
         </Link>
         <div>
           <div className="flex items-center gap-2">
-            <span className="font-mono text-xs text-muted-foreground">{run.uid}</span>
+            <span className="font-mono text-xs text-muted-foreground">
+              {run.uid}
+            </span>
             <h1 className="text-lg font-semibold">{run.name}</h1>
-            <span className={`rounded px-2 py-0.5 text-xs font-medium ${statusClass(run.status)}`}>
+            <span
+              className={`rounded px-2 py-0.5 text-xs font-medium ${statusClass(run.status)}`}
+            >
               {run.status}
             </span>
           </div>
           <p className="text-xs text-muted-foreground">
-            {observed} of {totalCases} case{totalCases === 1 ? "" : "s"} observed
+            {observed} of {totalCases} case{totalCases === 1 ? "" : "s"}{" "}
+            observed
           </p>
         </div>
       </div>
@@ -202,12 +225,18 @@ function RunHeader({
 
 function resultStatusClass(status: TestRunCaseResultStatus): string {
   switch (status) {
-    case "NOT_RUN": return "bg-muted text-muted-foreground";
-    case "PASSED": return "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200";
-    case "FAILED": return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200";
-    case "BLOCKED": return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200";
-    case "SKIPPED": return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
-    default: return "bg-muted text-muted-foreground";
+    case "NOT_RUN":
+      return "bg-muted text-muted-foreground";
+    case "PASSED":
+      return "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200";
+    case "FAILED":
+      return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200";
+    case "BLOCKED":
+      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200";
+    case "SKIPPED":
+      return "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
+    default:
+      return "bg-muted text-muted-foreground";
   }
 }
 
@@ -238,10 +267,14 @@ function CaseSidebar({
                 }`}
               >
                 <span className="flex flex-col">
-                  <span className="font-mono text-xs text-muted-foreground">{c.testCaseUid}</span>
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {c.testCaseUid}
+                  </span>
                   <span className="truncate">{c.testCaseTitle}</span>
                 </span>
-                <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${resultStatusClass(c.status)}`}>
+                <span
+                  className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${resultStatusClass(c.status)}`}
+                >
                   {c.status}
                 </span>
               </button>
@@ -259,15 +292,28 @@ function ActiveCasePanel({
   run,
   caseResult,
 }: {
-  run: { id: string; status: TestRunStatus; currentStepResultId: string | null };
+  run: {
+    id: string;
+    status: TestRunStatus;
+    currentStepResultId: string | null;
+  };
   caseResult: TestRunCaseResultResponse;
 }) {
-  const { data: stepResults, isLoading } = useTestRunStepResults(run.id, caseResult.id);
-  const updateCaseResult = useUpdateTestRunCaseResult(run.id, caseResult.testCaseId);
+  const { data: stepResults, isLoading } = useTestRunStepResults(
+    run.id,
+    caseResult.id,
+  );
+  const updateCaseResult = useUpdateTestRunCaseResult(
+    run.id,
+    caseResult.testCaseId,
+  );
   const updateCursor = useUpdateTestRunCursor(run.id);
 
   const [notesDraft, setNotesDraft] = useState(caseResult.notes ?? "");
-  useEffect(() => setNotesDraft(caseResult.notes ?? ""), [caseResult.id, caseResult.notes]);
+  useEffect(
+    () => setNotesDraft(caseResult.notes ?? ""),
+    [caseResult.id, caseResult.notes],
+  );
 
   const steps = stepResults ?? [];
   const activeStepIndex = useMemo(() => {
@@ -288,8 +334,13 @@ function ActiveCasePanel({
   useEffect(() => {
     if (isLoading) return;
     const desiredStepId = activeStep?.id ?? null;
-    const currentCase = (run as unknown as { currentCaseResultId: string | null }).currentCaseResultId;
-    if (currentCase === caseResult.id && run.currentStepResultId === desiredStepId) {
+    const currentCase = (
+      run as unknown as { currentCaseResultId: string | null }
+    ).currentCaseResultId;
+    if (
+      currentCase === caseResult.id &&
+      run.currentStepResultId === desiredStepId
+    ) {
       return;
     }
     updateCursor.mutate({
@@ -325,7 +376,9 @@ function ActiveCasePanel({
       <div className="rounded-lg border border-border bg-card p-4">
         <div className="flex flex-wrap items-baseline justify-between gap-2">
           <h2 className="text-base font-semibold">
-            <span className="mr-2 font-mono text-xs text-muted-foreground">{caseResult.testCaseUid}</span>
+            <span className="mr-2 font-mono text-xs text-muted-foreground">
+              {caseResult.testCaseUid}
+            </span>
             {caseResult.testCaseTitle}
           </h2>
           <CaseStatusControls
@@ -389,7 +442,13 @@ function CaseStatusControls({
   onSelect: (s: TestRunCaseResultStatus) => void;
   disabled: boolean;
 }) {
-  const options: TestRunCaseResultStatus[] = ["NOT_RUN", "PASSED", "FAILED", "BLOCKED", "SKIPPED"];
+  const options: TestRunCaseResultStatus[] = [
+    "NOT_RUN",
+    "PASSED",
+    "FAILED",
+    "BLOCKED",
+    "SKIPPED",
+  ];
   return (
     <div className="flex gap-1">
       {options.map((opt) => {
@@ -401,7 +460,9 @@ function CaseStatusControls({
             disabled={disabled}
             onClick={() => onSelect(opt)}
             className={`rounded px-2 py-1 text-xs font-medium transition ${
-              active ? resultStatusClass(opt) : "bg-muted text-muted-foreground hover:bg-muted/70"
+              active
+                ? resultStatusClass(opt)
+                : "bg-muted text-muted-foreground hover:bg-muted/70"
             } disabled:cursor-not-allowed disabled:opacity-50`}
           >
             {opt.replace("_", " ")}
@@ -470,12 +531,20 @@ function StepViewport({
 
       <div className="mt-3 grid gap-3 text-sm md:grid-cols-2">
         <div>
-          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Action</div>
-          <p className="mt-1 whitespace-pre-wrap rounded bg-muted/30 p-2">{step.actionSnapshot}</p>
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Action
+          </div>
+          <p className="mt-1 whitespace-pre-wrap rounded bg-muted/30 p-2">
+            {step.actionSnapshot}
+          </p>
         </div>
         <div>
-          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">Expected result</div>
-          <p className="mt-1 whitespace-pre-wrap rounded bg-muted/30 p-2">{step.expectedResultSnapshot}</p>
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Expected result
+          </div>
+          <p className="mt-1 whitespace-pre-wrap rounded bg-muted/30 p-2">
+            {step.expectedResultSnapshot}
+          </p>
         </div>
       </div>
 
@@ -496,7 +565,9 @@ function StepViewport({
 
       <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
         <span>
-          {step.executedAt ? `Executed at ${step.executedAt}` : "Not executed yet"}
+          {step.executedAt
+            ? `Executed at ${step.executedAt}`
+            : "Not executed yet"}
         </span>
         <span className="flex gap-2">
           <button
@@ -512,7 +583,9 @@ function StepViewport({
           </button>
           <button
             type="button"
-            disabled={activeStepIndex >= steps.length - 1 || !steps[activeStepIndex + 1]}
+            disabled={
+              activeStepIndex >= steps.length - 1 || !steps[activeStepIndex + 1]
+            }
             onClick={() => {
               const next = steps[activeStepIndex + 1];
               if (next) onSelectStep(next.id);
@@ -540,7 +613,13 @@ function StepStatusControls({
   // by accident can return the step to its initial state from the browser.
   // ADR-050 §2 names step-status flips as unconstrained — the runner must
   // expose every value the backend accepts.
-  const options: TestRunCaseResultStatus[] = ["NOT_RUN", "PASSED", "FAILED", "BLOCKED", "SKIPPED"];
+  const options: TestRunCaseResultStatus[] = [
+    "NOT_RUN",
+    "PASSED",
+    "FAILED",
+    "BLOCKED",
+    "SKIPPED",
+  ];
   return (
     <div className="flex gap-1">
       {options.map((opt) => {
@@ -552,7 +631,9 @@ function StepStatusControls({
             disabled={disabled}
             onClick={() => onSelect(opt)}
             className={`rounded px-2 py-1 text-xs font-medium transition ${
-              active ? resultStatusClass(opt) : "bg-muted text-muted-foreground hover:bg-muted/70"
+              active
+                ? resultStatusClass(opt)
+                : "bg-muted text-muted-foreground hover:bg-muted/70"
             } disabled:cursor-not-allowed disabled:opacity-50`}
           >
             {opt.replace("_", " ")}

--- a/frontend/src/pages/test-runs.tsx
+++ b/frontend/src/pages/test-runs.tsx
@@ -46,7 +46,8 @@ export function TestRuns() {
         <div>
           <h1 className="text-2xl font-semibold">Test Runs</h1>
           <p className="text-sm text-muted-foreground">
-            Open a run to execute it step by step. Run creation is currently exposed via API and MCP.
+            Open a run to execute it step by step. Run creation is currently
+            exposed via API and MCP.
           </p>
         </div>
         <span className="text-sm text-muted-foreground">
@@ -104,20 +105,26 @@ function statusClass(status: TestRunStatus): string {
   }
 }
 
-function TestRunRow({ run, projectId }: { run: TestRunResponse; projectId: string }) {
-  const window = run.startAt && run.endAt
-    ? `${run.startAt.slice(0, 10)} → ${run.endAt.slice(0, 10)}`
-    : run.startAt
-      ? `from ${run.startAt.slice(0, 10)}`
-      : run.endAt
-        ? `until ${run.endAt.slice(0, 10)}`
-        : "—";
+function TestRunRow({
+  run,
+  projectId,
+}: { run: TestRunResponse; projectId: string }) {
+  const window =
+    run.startAt && run.endAt
+      ? `${run.startAt.slice(0, 10)} → ${run.endAt.slice(0, 10)}`
+      : run.startAt
+        ? `from ${run.startAt.slice(0, 10)}`
+        : run.endAt
+          ? `until ${run.endAt.slice(0, 10)}`
+          : "—";
   return (
     <tr className="hover:bg-muted/30">
       <td className="px-4 py-3 font-mono text-xs">{run.uid}</td>
       <td className="px-4 py-3">{run.name}</td>
       <td className="px-4 py-3">
-        <span className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${statusClass(run.status)}`}>
+        <span
+          className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${statusClass(run.status)}`}
+        >
           {run.status}
         </span>
       </td>

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,6 +1,7 @@
 import { AppLayout } from "@/components/layout/app-layout";
 import { ProjectProvider } from "@/contexts/project-context";
 import { useProjects } from "@/hooks/use-projects";
+import { Login } from "@/pages/login";
 import { Suspense, lazy } from "react";
 import { Link, Navigate, Route, Routes } from "react-router-dom";
 
@@ -76,6 +77,7 @@ export function AppRoutes() {
   return (
     <Suspense fallback={<PageSkeleton />}>
       <Routes>
+        <Route path="login" element={<Login />} />
         <Route path="/" element={<RootRedirect />} />
         <Route element={<AppLayout />}>
           <Route path="projects" element={<Projects />} />

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -336,7 +336,10 @@ export interface TestPlanStatusTransitionRequest {
 // AddTestSuiteMemberRequest / etc. The enum is single-sourced per ADR-034
 // convention (today the policy gate scope is requirement/state enums; the
 // test-management enums follow the same pattern manually).
-export type TestSuitePopulationMode = "STATIC" | "REQUIREMENTS_BASED" | "QUERY_BASED";
+export type TestSuitePopulationMode =
+  | "STATIC"
+  | "REQUIREMENTS_BASED"
+  | "QUERY_BASED";
 export const TEST_SUITE_POPULATION_MODES: TestSuitePopulationMode[] = [
   "STATIC",
   "REQUIREMENTS_BASED",
@@ -430,7 +433,12 @@ export interface AddTestSuiteSourceRequirementRequest {
 // in the domain `state/` package per ADR-034 and mirrored here for typed UI
 // access.
 
-export type TestRunStatus = "PLANNED" | "IN_PROGRESS" | "COMPLETED" | "ABORTED" | "ARCHIVED";
+export type TestRunStatus =
+  | "PLANNED"
+  | "IN_PROGRESS"
+  | "COMPLETED"
+  | "ABORTED"
+  | "ARCHIVED";
 
 export const TEST_RUN_STATUSES: TestRunStatus[] = [
   "PLANNED",
@@ -440,7 +448,12 @@ export const TEST_RUN_STATUSES: TestRunStatus[] = [
   "ARCHIVED",
 ];
 
-export type TestRunCaseResultStatus = "NOT_RUN" | "PASSED" | "FAILED" | "BLOCKED" | "SKIPPED";
+export type TestRunCaseResultStatus =
+  | "NOT_RUN"
+  | "PASSED"
+  | "FAILED"
+  | "BLOCKED"
+  | "SKIPPED";
 
 export const TEST_RUN_CASE_RESULT_STATUSES: TestRunCaseResultStatus[] = [
   "NOT_RUN",
@@ -651,7 +664,11 @@ export const AUDIT_STATUSES: AuditStatus[] = [
   "CLOSED",
 ];
 
-export type AuditPhaseKind = "PLANNING" | "FIELDWORK" | "REPORTING" | "FOLLOWUP";
+export type AuditPhaseKind =
+  | "PLANNING"
+  | "FIELDWORK"
+  | "REPORTING"
+  | "FOLLOWUP";
 export const AUDIT_PHASE_KINDS: AuditPhaseKind[] = [
   "PLANNING",
   "FIELDWORK",

--- a/frontend/src/types/enum-contract.test.ts
+++ b/frontend/src/types/enum-contract.test.ts
@@ -33,7 +33,10 @@ const STATE_DIR =
 const AUDIT_STATE_DIR =
   "../../../backend/src/main/java/com/keplerops/groundcontrol/domain/audits/state";
 
-function javaEnumConstantsIn(stateDir: string, enumClassName: string): string[] {
+function javaEnumConstantsIn(
+  stateDir: string,
+  enumClassName: string,
+): string[] {
   const path = fileURLToPath(
     new URL(`${stateDir}/${enumClassName}.java`, import.meta.url),
   );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
         target: "http://localhost:8000",
         changeOrigin: true,
       },
+      "/login": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+      "/logout": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
     },
   },
   build: {


### PR DESCRIPTION
## Summary

Spring's DefaultLoginPageGeneratingFilter was serving its unstyled built-in form at GET /login, which users perceived as the web UI being denied after the move to agent auth. Adding .loginPage(LOGIN_PATH) to BrowserSecurityConfig.formLogin disables the generator so the SPA (already forwarded by SpaController) owns GET /login. Filter chain, CSRF, session policy, JDBC user store, role model, ActorFilter, and ErrorResponse contracts are unchanged — this is ADR-037 §139's planned transition from Spring's generated page to a React login screen.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #846

## ADR Impact

- ADR-021
- ADR-037

## Changes

- BrowserSecurityConfig.formLogin: add .loginPage(LOGIN_PATH), explicit .failureUrl(LOGIN_PATH + "?error") and .defaultSuccessUrl("/", false)
- frontend/src/pages/login.tsx: new Tailwind-styled React login page; form-urlencoded POST to /login with X-XSRF-TOKEN header read from cookie; navigates to response.url on success; shows generic error (no username echo) on ?error
- frontend/src/routes.tsx: register /login route outside AppLayout (no nav chrome on the login screen)
- frontend/vite.config.ts: add /login and /logout to the dev proxy so dev-with-security-enabled completes the round-trip
- BrowserSessionIntegrationTest: add getLoginReturnsSpaShellNotSpringDefaultForm and postLoginFormEncodedStillAuthenticates regression guards
- frontend/src/pages/login.test.tsx: 6 vitest cases covering rendering, CSRF header, redirect on success, error from ?error
- ADR-037: append Update note recording the SPA login screen shipped under #846
- changelog.d/846.fixed.md: towncrier fragment

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Backend: `cd backend && ./gradlew test --tests "*BrowserSessionIntegrationTest*"` (all green) and `make check` (full gate green). Frontend: `cd frontend && npm test -- --run src/pages/login.test.tsx` (6 tests green). `make policy` clean. Codex pre-push review: cycle 1, one finding fixed locally (test-only — switched from Object.defineProperty(window.location, …) to history.pushState since jsdom Location is unforgeable). Test-quality pre-push review: cycle 1, zero findings.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: ADR-037 ← backend/src/test/java/com/keplerops/groundcontrol/integration/BrowserSessionIntegrationTest.java, ADR-037 ← frontend/src/pages/login.test.tsx

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/846.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed