### PR TITLE
Wire Vale prose linter into pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Repo policy checks (push)
         if: github.event_name != 'pull_request'
         run: python3 bin/policy --skip-pr-body
+      # Vale prose linting (ADR-054). Lints only docs touched in this PR's diff
+      # — untouched docs migrate organically per #896. Skipped on push events
+      # because there's no base ref to diff against; the on-PR pass is the
+      # authoritative gate (a doc only reaches main via a PR).
+      - name: Vale prose lint (changed docs)
+        if: github.event_name == 'pull_request'
+        run: make vale-lint BASE_REF=origin/${{ github.base_ref }}
 
   policy-live:
     # Deliberate exception to the github-hosted default. `vars.GC_BASE_URL`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,13 @@ repos:
         files: ^(AGENTS\.md|\.claude/|\.github/|architecture/|backend/|docs/|mcp/|specs/|tools/)
         pass_filenames: false
 
+      - id: vale-prose-lint
+        name: Vale prose lint (ADR-054)
+        entry: tools/vale-lint-hook.sh
+        language: system
+        types_or: [markdown]
+        exclude: ^(CHANGELOG\.md|node_modules/|\.tools/|\.vale/)
+
       - id: pr-body-policy
         name: pr body template (only on push, when a PR exists)
         entry: scripts/check-pr-body.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: rapid build test test-cov test-quality format lint check integration verify policy policy-tests policy-live \
-       assert-backup-policy test-backup-restore-local vale-install \
+       assert-backup-policy test-backup-restore-local vale-install vale-lint \
        ground-control-mcp-install sync-ground-control-policy scaffold-controller scaffold-audited-entity \
        scaffold-l2-state-machine sync-packs trigger-pack-sync dev clean up down docker-build smoke frontend-install frontend-dev \
        frontend-build frontend-lint frontend-format frontend-test deploy deploy-infra
@@ -46,12 +46,23 @@ policy-tests: ## Run unit tests for repo policy tooling
 vale-install: ## Install Vale prose linter (tools/install-vale.sh → .tools/vale/)
 	bash tools/install-vale.sh
 
-policy: policy-tests assert-backup-policy vale-install ## Run repo-native policy checks shared by Claude and Codex
+# BASE_REF defaults to origin/dev for local invocation. CI sets it to
+# origin/<base-branch> for the current pull_request event.
+vale-lint: vale-install ## Run Vale on .md docs touched in the diff vs BASE_REF (default origin/dev)
+	@BASE_REF="$${BASE_REF:-origin/dev}"; \
+	CHANGED_DOCS=$$(git diff --name-only --diff-filter=ACMR $$BASE_REF...HEAD 2>/dev/null | grep -E '\.(md|markdown)$$' || true); \
+	if [ -z "$$CHANGED_DOCS" ]; then \
+	  echo "vale-lint: no changed docs vs $$BASE_REF"; \
+	  exit 0; \
+	fi; \
+	if [ ! -x .tools/vale/current/vale ]; then \
+	  echo "vale-lint: Vale not installed at .tools/vale/current/vale; run 'make vale-install'" >&2; \
+	  exit 1; \
+	fi; \
+	.tools/vale/current/vale --config=.vale.ini $$CHANGED_DOCS
+
+policy: policy-tests assert-backup-policy vale-lint ## Run repo-native policy checks shared by Claude and Codex
 	python3 bin/policy --skip-pr-body
-	@CHANGED_DOCS=$$(git diff --name-only --diff-filter=ACMR origin/dev...HEAD 2>/dev/null | grep -E '\.(md|markdown)$$' || true); \
-	if [ -n "$$CHANGED_DOCS" ] && [ -x .tools/vale/current/vale ]; then \
-	  .tools/vale/current/vale --config=.vale.ini $$CHANGED_DOCS; \
-	fi
 
 assert-backup-policy: ## Assert GC-P021 backup cadence / retention / verification defaults are intact
 	bash scripts/assert-backup-policy.sh

--- a/changelog.d/979.changed.md
+++ b/changelog.d/979.changed.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Vale prose linter now runs in CI and pre-commit, not only when a developer invokes `make policy` locally. The Makefile gains a `vale-lint` target (parameterized by `BASE_REF`) that the `policy` target depends on; CI's policy job runs `make vale-lint BASE_REF=origin/<base>` on pull requests; `.pre-commit-config.yaml` gains a Vale hook via `tools/vale-lint-hook.sh` that gracefully skips when Vale is not installed locally (closes #979).

--- a/tools/vale-lint-hook.sh
+++ b/tools/vale-lint-hook.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# pre-commit wrapper around Vale (ADR-054).
+#
+# Lints the staged .md / .markdown files passed by pre-commit. Skips
+# gracefully (exit 0) when Vale is not installed on the contributor's
+# machine, so a fresh clone does not start failing every commit before
+# the developer has had a chance to run `make vale-install`. CI is the
+# enforcement layer; the pre-commit hook is the early-warning layer.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VALE_BIN="${REPO_ROOT}/.tools/vale/current/vale"
+VALE_INI="${REPO_ROOT}/.vale.ini"
+
+if [ ! -x "${VALE_BIN}" ]; then
+  echo "vale-lint-hook: Vale not installed at ${VALE_BIN}; run 'make vale-install' to enable doc style lint" >&2
+  exit 0
+fi
+
+if [ ! -f "${VALE_INI}" ]; then
+  echo "vale-lint-hook: missing ${VALE_INI}" >&2
+  exit 1
+fi
+
+exec "${VALE_BIN}" --config="${VALE_INI}" "$@"


### PR DESCRIPTION
## Summary

Vale was wired into `make policy` by PR #974 but not into pre-commit or CI, because CI calls `python3 bin/policy` directly (skipping the Makefile's post-`bin/policy` Vale shell step) and the pre-commit `repo-policy` hook calls the same `python3 bin/policy --staged`. Docs with Google-style violations could pass both gates today.

## Requirement UIDs

- GC-O010 — Documentation Coverage Workflow Gate
- ADR-021

## Related Issues

Closes #979

## ADR Impact

- ADR-021
- ADR-054 (the gate this PR finishes wiring)

## Changes

- Refactor the inline Vale shell snippet in `Makefile`'s `policy` target into a `vale-lint` target parameterized by `BASE_REF` (default `origin/dev`). `policy` depends on `vale-lint` (which itself depends on `vale-install`).
- Add a Vale prose lint step in `.github/workflows/ci.yml`'s `policy` job that runs `make vale-lint BASE_REF=origin/${{ github.base_ref }}` on `pull_request` events. Push-event runs are skipped because there's no base ref to diff against; the on-PR pass is the authoritative gate.
- Add `tools/vale-lint-hook.sh` — a pre-commit wrapper that lints staged `.md` / `.markdown` files and skips gracefully (exit 0) when Vale is not installed on the contributor's machine, with a one-line hint to run `make vale-install`.
- Wire the hook into `.pre-commit-config.yaml` via `types_or: [markdown]`. Lints only staged files, so the organic-migration model (#896) is preserved — untouched docs do not fail unrelated commits.

## Documentation

Verified unchanged: ADR-054 already states the gate is enforced via `make policy`; that wording remains accurate after this PR (Vale just runs in more places now). DOC_STYLE.md describes the Google + Diátaxis baseline that Vale enforces — also unchanged. The /implement skill Step 6 already references "make policy runs Vale" (skills/implement/steps/step-06-completion-gate.md:20), which is still true. No new prose-surfaces introduced.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local verification:
- `make vale-lint` → "no changed docs vs origin/dev" (clean exit 0)
- `make policy` → all six checks green; Vale step runs via `vale-lint` dependency
- `pre-commit run` on the staged change set → 18 hooks pass, including new "Vale prose lint (ADR-054)" hook
- Vale hook tested against `docs/DOC_STYLE.md` + the changelog fragment → passes

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GC-O010 ← Makefile (vale-lint target), .github/workflows/ci.yml (CI Vale step), .pre-commit-config.yaml (Vale hook), tools/vale-lint-hook.sh (wrapper)
- TESTS: (none — wiring change verified by `make policy` + `pre-commit run` end-to-end; CI itself is the authoritative gate after merge)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/979.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed (no — wiring only)