### PR TITLE
test: add per-internal-type rejection coverage for ControlLink target validation

### DIFF
--- a/architecture/notes/risk-treatment-plan-preflight.md
+++ b/architecture/notes/risk-treatment-plan-preflight.md
@@ -141,6 +141,22 @@ meaning. Any migration versions added here must be listed in
 
 ## Cross-Cutting Layers
 
+- Control-link target validation (#860 / C4): `ControlLinkService.create` must
+  keep using `GraphTargetResolverService.validateControlTarget` as the only
+  internal-vs-external dispatch point before duplicate detection and save.
+  `targetEntityId` is the persisted slot for every first-class target the
+  resolver currently treats as internal: `ASSET`, `RISK_SCENARIO`,
+  `RISK_REGISTER_RECORD`, `RISK_ASSESSMENT_RESULT`, `TREATMENT_PLAN`,
+  `METHODOLOGY_PROFILE`, `OBSERVATION`, `REQUIREMENT`, `FINDING`, and
+  `EVIDENCE`. `targetIdentifier` remains the slot for `CODE`, `CONFIGURATION`,
+  `OPERATIONAL_ARTIFACT`, and `EXTERNAL`.
+- Substrate drift guardrail: do not reclassify `FINDING` or `EVIDENCE` as
+  external just because older GC-T004 issue text names them that way. ADR-038
+  promotes inbound `FINDING` link targets to modeled graph nodes, and the
+  current evidence projection alignment treats `EVIDENCE` links as
+  `EvidenceArtifact` UUID references. Any future target-type classification
+  change belongs in `GraphTargetResolverService`, the matching graph projection
+  contributor, docs/API.md, and resolver/service tests together.
 - Security: `/api/v1/treatment-plans/**` stays inside the `ApiSecurityConfig`
   path matrix. In production the request must pass `IpAllowlistFilter`,
   `BearerTokenAuthFilter`, Spring authorization, and then `ActorFilter`.
@@ -238,6 +254,9 @@ tool, a parallel DTO translator, or entity-specific request plumbing.
   linkage merely because it has free-text action items.
 - Do not duplicate `AssetLink`, `ControlLink`, `RiskScenarioLink`, graph IDs,
   traceability links, or audit tables to make treatment-specific variants.
+- Do not persist an internal `ControlLinkTargetType` through the
+  `targetIdentifier` path to match stale issue text; use the resolver's current
+  modeled-target classification.
 - Do not hide methodology-specific strategy values in arbitrary action-item
   keys when the API enum or methodology profile should carry the contract.
 - Do not let a treatment plan reference a risk scenario outside the linked risk

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlLinkServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlLinkServiceTest.java
@@ -4,6 +4,9 @@ import static com.keplerops.groundcontrol.TestUtil.setField;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +30,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -105,23 +110,42 @@ class ControlLinkServiceTest {
             assertThat(result.getLinkType()).isEqualTo(ControlLinkType.PROTECTS);
         }
 
-        @Test
-        void rejectsCrossProjectInternalTarget() {
-            // Issue #875: ControlLinkService used to persist targetEntityId
-            // without validating project scope. GraphTargetResolverService now
-            // does the existence/project check; a target from another project
-            // surfaces as DomainValidationException with "not found".
-            var foreignAssetId = UUID.randomUUID();
+        // PR #875 security provenance: ControlLinkService used to persist targetEntityId
+        // without validating project scope. GraphTargetResolverService now owns the
+        // existence/project check for all internal types. At the service layer the
+        // resolver is mocked, so "non-existent UUID" and "cross-project UUID" are
+        // observationally identical — one parameterized test covers both per type
+        // without duplicating a 10× matrix.
+        @ParameterizedTest
+        @EnumSource(
+                value = ControlLinkTargetType.class,
+                names = {
+                    "ASSET",
+                    "REQUIREMENT",
+                    "RISK_SCENARIO",
+                    "RISK_REGISTER_RECORD",
+                    "RISK_ASSESSMENT_RESULT",
+                    "TREATMENT_PLAN",
+                    "METHODOLOGY_PROFILE",
+                    "OBSERVATION",
+                    "FINDING",
+                    "EVIDENCE"
+                })
+        void rejectsInternalTargetWhenResolverThrows(ControlLinkTargetType targetType) {
+            var targetEntityId = UUID.randomUUID();
             when(controlService.getById(projectId, controlId)).thenReturn(control);
             when(graphTargetResolverService.validateControlTarget(
-                            projectId, ControlLinkTargetType.ASSET, foreignAssetId, null))
-                    .thenThrow(new DomainValidationException("Asset target not found in the requested project"));
+                            eq(projectId), eq(targetType), any(UUID.class), isNull()))
+                    .thenThrow(new DomainValidationException(
+                            targetType.name() + " target not found in the requested project"));
 
             var command = new com.keplerops.groundcontrol.domain.controls.service.CreateControlLinkCommand(
-                    ControlLinkTargetType.ASSET, foreignAssetId, null, ControlLinkType.PROTECTS, null, null);
+                    targetType, targetEntityId, null, ControlLinkType.ASSOCIATED, null, null);
             assertThatThrownBy(() -> controlLinkService.create(projectId, controlId, command))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("not found in the requested project");
+
+            verify(controlLinkRepository, never()).save(any());
         }
 
         @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GraphTargetResolverServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GraphTargetResolverServiceTest.java
@@ -298,14 +298,34 @@ class GraphTargetResolverServiceTest {
                 .hasMessageContaining("Finding");
     }
 
-    @Test
-    void validateControlTargetRejectsMissingFinding() {
-        when(findingRepository.existsByIdAndProjectId(targetId, projectId)).thenReturn(false);
+    // PR #875 security provenance: an attacker passing a UUID from project B into
+    // project A's ControlLink used to silently persist a cross-project edge. The
+    // resolver now enforces project-scoped existence for every internal type, so a
+    // non-existent UUID and a cross-project UUID are observationally identical here —
+    // both produce DomainValidationException("not found in the requested project").
+    // This single parameterized test subsumes the old per-type singletons.
+    @ParameterizedTest
+    @EnumSource(
+            value = ControlLinkTargetType.class,
+            names = {
+                "ASSET",
+                "REQUIREMENT",
+                "RISK_SCENARIO",
+                "RISK_REGISTER_RECORD",
+                "RISK_ASSESSMENT_RESULT",
+                "TREATMENT_PLAN",
+                "METHODOLOGY_PROFILE",
+                "OBSERVATION",
+                "FINDING",
+                "EVIDENCE"
+            })
+    void validateControlTargetRejectsInternalTargets(ControlLinkTargetType targetType) {
+        stubControlInternalTarget(targetType, false);
 
-        assertThatThrownBy(() -> graphTargetResolverService.validateControlTarget(
-                        projectId, ControlLinkTargetType.FINDING, targetId, null))
+        assertThatThrownBy(
+                        () -> graphTargetResolverService.validateControlTarget(projectId, targetType, targetId, null))
                 .isInstanceOf(DomainValidationException.class)
-                .hasMessageContaining("Finding");
+                .hasMessageContaining("not found in the requested project");
     }
 
     @Test
@@ -360,19 +380,6 @@ class GraphTargetResolverServiceTest {
                         projectId, ControlLinkTargetType.ASSET, null, null))
                 .isInstanceOf(DomainValidationException.class)
                 .hasMessageContaining("targetEntityId");
-    }
-
-    @Test
-    void validateControlTargetRejectsCrossProjectInternalTarget() {
-        // Issue #875: an attacker passing a UUID from project B with the
-        // current control's project A used to silently persist a cross-project
-        // edge. The resolver now enforces project-scoped existence.
-        when(requirementRepository.existsByIdAndProjectId(targetId, projectId)).thenReturn(false);
-
-        assertThatThrownBy(() -> graphTargetResolverService.validateControlTarget(
-                        projectId, ControlLinkTargetType.REQUIREMENT, targetId, null))
-                .isInstanceOf(DomainValidationException.class)
-                .hasMessageContaining("not found");
     }
 
     @Test
@@ -802,17 +809,6 @@ class GraphTargetResolverServiceTest {
 
         assertThatThrownBy(() -> graphTargetResolverService.validateThreatModelTarget(
                         projectId, ThreatModelLinkTargetType.EVIDENCE, targetId, null))
-                .isInstanceOf(DomainValidationException.class)
-                .hasMessageContaining("Evidence");
-    }
-
-    @Test
-    void validateControlTargetRejectsMissingEvidenceArtifact() {
-        when(evidenceArtifactRepository.findByIdAndProjectId(targetId, projectId))
-                .thenReturn(java.util.Optional.empty());
-
-        assertThatThrownBy(() -> graphTargetResolverService.validateControlTarget(
-                        projectId, ControlLinkTargetType.EVIDENCE, targetId, null))
                 .isInstanceOf(DomainValidationException.class)
                 .hasMessageContaining("Evidence");
     }

--- a/changelog.d/860.changed.md
+++ b/changelog.d/860.changed.md
@@ -1,0 +1,1 @@
+Add per-internal-type rejection coverage for `ControlLink` target validation (GC-T004 / C4).


### PR DESCRIPTION
## Summary

Closes the per-internal-type rejection test coverage gap for ControlLink target validation (GC-T004 / C4). The production-side fix landed in PR #875 / commit bcb0f4d; `ControlLinkService.create` already routes every internal `ControlLinkTargetType` through `GraphTargetResolverService.validateControlTarget`, which enforces project-scoped existence for all 10 internal modeled types and routes `CODE`/`CONFIGURATION`/`OPERATIONAL_ARTIFACT`/`EXTERNAL` through `targetIdentifier`. This PR adds parameterized rejection tests at both layers and clarifies the FINDING/EVIDENCE substrate-drift guardrail in the preflight note.

## Requirement UIDs

- `GC-T004`

## Related Issues

Closes #860

## ADR Impact

- ADR-021

## Changes

- GraphTargetResolverServiceTest: replace three scattered rejection singletons (`validateControlTargetRejectsMissingFinding`, `…RejectsCrossProjectInternalTarget`, `…RejectsMissingEvidenceArtifact`) with one parameterized `validateControlTargetRejectsInternalTargets` covering all 10 internal `ControlLinkTargetType` values via the existing `stubControlInternalTarget(type, false)` helper. Asserts `DomainValidationException` with `not found in the requested project`.
- ControlLinkServiceTest: replace the single-type `rejectsCrossProjectInternalTarget` with a parameterized `rejectsInternalTargetWhenResolverThrows` covering the same 10 internal types. Mocks `validateControlTarget` to throw and verifies the service propagates the exception and never calls `controlLinkRepository.save`.
- architecture/notes/risk-treatment-plan-preflight.md: add #860/C4 cross-cutting-layer guidance and the substrate-drift guardrail explaining why FINDING/EVIDENCE remain internal modeled targets despite stale issue text.
- changelog.d/860.changed.md: one-line fragment per ADR-021 changelog policy.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

All gradle checks pass via pre-commit (`gradle check`: build + unit tests + static analysis + coverage). Per-cycle reviewers (codex + test-quality) returned clean on cycle 1 of 1.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GC-T004 ← ControlLinkService.java (existing, via PR #875), GC-T004 ← GraphTargetResolverService.validateControlTarget (existing, via PR #875)
- TESTS: GC-T004 ← GraphTargetResolverServiceTest#validateControlTargetRejectsInternalTargets, GC-T004 ← ControlLinkServiceTest#rejectsInternalTargetWhenResolverThrows

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/860.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed