### PR TITLE
fix: pin compose project name to gc-dev in committed docker-compose.yml

### DIFF
--- a/changelog.d/992.fixed.md
+++ b/changelog.d/992.fixed.md
@@ -1,0 +1,1 @@
+Pin compose project name to `gc-dev` in the committed `docker-compose.yml` so dev worktrees can no longer collide with the production stack at `/opt/gc`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,9 @@
+# Pin the compose project name so dev worktrees never collide with the
+# production stack at /opt/gc. Without this, `docker compose` derives the
+# project name from the worktree basename (`gc`), which matched the prod
+# project on 2026-05-24 and recreated `gc-db-1` against the dev volume.
+name: gc-dev
+
 services:
   db:
     image: apache/age:release_PG16_1.6.0


### PR DESCRIPTION
## Summary

Closes #992. Moves the host-local `name: gc-dev` pin from an intentionally-untracked `docker-compose.override.yml` into the committed `docker-compose.yml`. Eliminates the dev/prod project-namespace collision risk on every fresh worktree and stops `git-dev-clean` from tripping on the override file at every branch switch. Background: without a top-level `name:` field, `docker compose` derived the project name from the working-tree basename (`gc`) — which matched the production stack at `/opt/gc`. An unattended `docker compose up` on 2026-05-24 02:43 UTC recreated `gc-db-1` against the dev named volume and disconnected the production backend from `/data/postgres`.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #992

## ADR Impact

- ADR-021

## Changes

- docker-compose.yml: add `name: gc-dev` at the top with a short header comment explaining the production-collision context.
- changelog.d/992.fixed.md: one-line fragment.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- `docker compose config` from this worktree reports `name: gc-dev` after the change.
- `pre-commit run` passes on both changed files.
- `make policy` passes locally.

Operator notes: after this merges, contributors with a local `docker-compose.override.yml` carrying only `name: gc-dev` can delete it — the committed compose owns the pin. Overrides that carry other fields stay untouched.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/992.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed