### PR TITLE
feat(research): add literature-review workflow skills + citation MCP (#1032)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,6 +9,17 @@
         "GH_REPO": "KeplerOps/Ground-Control"
       }
     },
+    "citation": {
+      "type": "stdio",
+      "command": "mcp/citation/bin/citation-mcp.sh",
+      "args": [],
+      "env": {
+        "CITATION_MCP_MAILTO": "${CITATION_MCP_MAILTO:-j.bradley.edwards@gmail.com}",
+        "PERSONAL_ZOTERO_ID": "${PERSONAL_ZOTERO_ID:-}",
+        "PERSONAL_ZOTERO_KEY": "${PERSONAL_ZOTERO_KEY:-}",
+        "TRANSLATION_SERVER_URL": "${TRANSLATION_SERVER_URL:-http://localhost:1969}"
+      }
+    },
     "sonarqube": {
       "type": "stdio",
       "command": "docker",

--- a/.vale.ini
+++ b/.vale.ini
@@ -4,3 +4,14 @@ Packages = Google
 
 [*.md]
 BasedOnStyles = Google, GoogleProject
+
+# Ported research workflow skill prose (ADR-055): the skills carry their
+# own writing-style contract (see skills/lit-review-draft/writing-style.md,
+# Part A7 — em-dashes carry content) and are not external-facing docs.
+[skills/**]
+BasedOnStyles =
+
+# Historical knowledge-base ports — verbatim record value outweighs
+# enforcing Google style on ingested research material.
+[docs/knowledge/**]
+BasedOnStyles =

--- a/architecture/adrs/055-research-workflow-skills-and-citation-mcp.md
+++ b/architecture/adrs/055-research-workflow-skills-and-citation-mcp.md
@@ -1,0 +1,97 @@
+# ADR-055: Research workflow skills and citation MCP
+
+## Status
+
+accepted
+
+## Date
+
+2026-05-26
+
+## Context
+
+Ground Control's research project type needs working artifact infrastructure: a methodology contract, an executable literature-review plan, a citation-grounded search and charting workflow, an argument-architecture phase, and a drafting phase whose prose can only cite sources present in the evidence base. The 14 GC-RSCH-F* requirements in scope for issue #1032 (F005–F009, F012, F014, F017, F019, F020, F024, F028, F030, F038) name what that infrastructure must do; F038 specifically calls for explicit rationale when a working asset is replaced rather than reused.
+
+A separate single-purpose repository (now retired) developed and field-tested most of these artifacts against real failure modes—citation hallucination (88 partially hallucinated references in one drafting run), domain leakage into methodology outputs, invented procedural detail, imported framing without provenance, and synthesis claims unsupported by the charted corpus. The two most valuable disciplines it ended on are:
+
+- methodology requirements extracted from primary methodology sources, never paraphrased from memory; and
+- the two-state source rule: a source is either fully in the review with full text read and charted, or recorded as an access gap and not charted.
+
+The implementation cost of rebuilding these from scratch is high; the value of every individual discipline was earned against an observed failure that would recur in any independent rebuild.
+
+ADR-029 establishes the GitHub issue thread as the durable workflow record; ADR-031 separates structured findings from the privileged GitHub writes the MCP server performs; ADR-036 mandates deterministic renderers and opt-in routing/telemetry. This ADR adds research workflow surfaces under those existing constraints rather than introducing parallel ones.
+
+## Decision
+
+Ground Control ships five Claude skills, one methodology catalog, one deterministic citation MCP, and supporting documentation as the research project type's first-class artifact infrastructure. Content is sourced from the retired research repository; layout, naming, and conventions follow Ground Control's own.
+
+**Skills (under `skills/`).**
+
+| Skill | Purpose |
+|---|---|
+| `lit-review` | Phase 1—pick the methodology; read the catalog's primary sources; extract the requirements specification a downstream plan must satisfy. |
+| `lit-review-plan` | Phase 2—fill the phase-1 requirements with domain content; produce an executable lit-review plan. |
+| `lit-review-search` | Phase 3—run the plan: search, screen, chart fully in sources, record access gaps, synthesise. Output is the evidence base, not paper prose. |
+| `lit-review-argument` | Phase 4—build the paper's argument architecture: section outline plus validated Argdown argument map with grounded premises and modelled objections. |
+| `lit-review-draft` | Phase 5—draft the manuscript from the phase-4 architecture and the phase-3 evidence base; cite only included-set sources; apply the voice contract; pass the model-tell blocklist. |
+
+Skill chaining: `lit-review` auto-chains into `lit-review-plan` into `lit-review-search` (one user invocation, three phases). `lit-review-argument` is user-invoked after evidence review; `lit-review-draft` is user-invoked after argument review. Gates are surfaced with recommendation + reasoning as they arise, never punted to an end-of-document backlog.
+
+**Methodology catalog (`skills/lit-review/methodology/catalog.yaml`).**
+
+Co-located with the phase-1 skill that loads it. Method key → primary methodology source Zotero keys + titles + PDF availability. Lookup-only—no prose summaries. Ships with seven entries: `scoping`, `systematic`, `mapping`, `critical`, `narrative_conceptual`, `targeted_related_work`, `taxonomy_development`.
+
+**Citation MCP (`mcp/citation/`).**
+
+A Python FastMCP server (`citation-mcp` package) exposing seven deterministic bibliographic tools: `cite_resolve`, `cite_search`, `cite_forward`, `zotero_add`, `oa_locate`, `zotero_attach_pdf`, `zotero_search`. Backs onto Crossref, OpenAlex, Unpaywall, the Zotero translation-server, and the Zotero Web API. The agent's role is identifier-shaped (DOI / arXiv / PMID / search string); citation metadata is produced by authoritative services, never from model memory. OA-only PDF attachment is enforced via a 15-minute cache of `oa_locate` results.
+
+Registered in `.mcp.json` under server name `citation`; skills reference its tools as `mcp__citation__*`. Renaming the server breaks every internal skill cross-reference and is therefore out of scope.
+
+**Documentation.**
+
+- `docs/research/RESEARCH_WORKFLOW.md`—Ground Control-native overview of the five-phase pipeline, the citation MCP, and the bootstrap steps.
+- `docs/knowledge/research-workflow/auto-research-requirements-and-oss-assessment.md`—historical FR/NFR + OSS landscape assessment retained as a knowledge-base reference for future build-vs-adopt calls.
+
+## Asset disposition
+
+Sourced from the retired research repository. Disposition reflects what each asset earned its place against.
+
+| Source asset | Disposition | Rationale |
+|---|---|---|
+| 5 phase skills | KEPT (renamed: drop source-repo prefix) | Each asset earned its place against an observed failure mode; rebuilding would recreate the failures the discipline addresses. |
+| `methodology/catalog.yaml` | KEPT verbatim, relocated | Catalog is lookup-only; co-locating with the skill that loads it removes a top-level directory the host repo does not need. |
+| Argdown validation tooling (`validate-argument-map.sh`, `check-argument-structure.mjs`, tests) | KEPT verbatim | Structural argument checking is the only mechanical guard against unreconstructed-support, ungrounded-premise, and unanswered-objection failures. |
+| Voice contract (`writing-style.md`) | KEPT verbatim | Model-tell blocklist is the only mechanical guard against language-model writing tells. |
+| Citation MCP Python package | KEPT verbatim (renamed) | Determinism in bibliographic resolution is not replaced by stronger model reasoning—see `auto-research-requirements-and-oss-assessment.md`. |
+| Project handoff (`AGENTS.md`) | DROPPED in favor of `docs/research/RESEARCH_WORKFLOW.md` | Host-repo-specific overview deserves a Ground Control-native rewrite, not a port of source-repo bootstrap text. |
+| Source repo's `pyproject.toml` for citation MCP | ADAPTED | Package name dropped to `citation-mcp` (no source-repo prefix). Dependencies unchanged. |
+| Source repo's `.ground-control.yaml`, `.gc/plan-rules.md` | DROPPED | Ground Control already has its own; duplicating would conflict. |
+| OSS landscape assessment note | KEPT verbatim, relocated to `docs/knowledge/research-workflow/` | Historical record of the build-vs-adopt analysis; lasting reference value for future re-evaluation. |
+
+## Naming and conventions
+
+- Skill names drop the source-repo prefix. They are first-class Ground Control skills now, not "ported" assets.
+- Python package: `citation-mcp` under `mcp/citation/` (sibling of the existing JS `mcp/ground-control/`).
+- MCP server name in `.mcp.json`: `citation` (generic; the tool prefix `mcp__citation__*` referenced inside the skills depends on this name).
+- Methodology catalog: `skills/lit-review/methodology/catalog.yaml` (co-located with the loader).
+- Skill cross-references inside SKILL.md files use the new (un-prefixed) skill names.
+
+## Consequences
+
+- The 14 GC-RSCH-F* requirements in scope for issue #1032 are satisfiable by the skills + MCP + documentation shipped here. The clause-mapping step in `/implement` (Step 4.5) creates the IMPLEMENTS / DOCUMENTS traceability links.
+- The citation MCP requires a Python ≥ 3.11 environment and a running Zotero translation-server (`docker run -d --rm -p 1969:1969 zotero/translation-server`) for `zotero_add`. Bootstrap is documented in `mcp/citation/README.md`.
+- `.mcp.json` carries a new `citation` entry whose `command` assumes a venv at `mcp/citation/.venv/`. Operators bootstrap the venv with `python -m venv mcp/citation/.venv && mcp/citation/.venv/bin/pip install -e mcp/citation/`.
+- Skills run in workspaces the user chooses; per-paper artifacts (`requirements.md`, `lit-review-plan.md`, `synthesis.md`, etc.) live in the workspace, not in this repository.
+- ADR-029 still applies: workflow decisions during a research run belong on the issue thread, not in workspace-local files.
+- The drafting phase emits IEEE-format LaTeX manuscripts; this introduces no new repository-level requirement on Ground Control, since manuscripts live in workspaces.
+- Future work: a project-type registration on the Java domain side (so a Ground Control project can be marked `RESEARCH`) is out of scope for this ADR—existing project plumbing already accepts user-applied type labels. If a typed enum is later wanted, that is a separate ADR.
+
+## Alternatives considered
+
+**Rebuild from scratch in TypeScript alongside `mcp/ground-control/`.** Rejected: the deterministic bibliographic resolution depends on Python libraries (`pyzotero`, FastMCP) where the equivalent JS path is significantly thinner; cost without offsetting benefit; would lose the field-tested resilience the existing implementation has accumulated.
+
+**Keep the source-repo prefix in skill names for provenance.** Rejected: provenance belongs in this ADR, not in every cross-reference for the next five years. Treating these as Ground Control's skills going forward is correct.
+
+**Place the methodology catalog at the repository root.** Rejected: the catalog is only loaded by one skill, and the host repository has no other top-level data directories. Co-location with the loader keeps the skill self-contained.
+
+**Adopt PaperQA / LatteReview / AgentSLR / STORM as the core rather than the source-repo design.** Rejected per `auto-research-requirements-and-oss-assessment.md`: no single existing OSS project provides method-aware requirements contract + strict source-state discipline + Zotero/citation grounding + systematic charting + synthesis traceability as a coherent tool. Those projects are useful as bounded adapters (full-text Q&A, screening, extraction, drafting) downstream of an evidence base—not as governance.

--- a/changelog.d/1032.added.md
+++ b/changelog.d/1032.added.md
@@ -1,0 +1,32 @@
+### Added
+
+- **Research workflow skills (ADR-055)**: five-phase literature-review pipeline
+  added under `skills/`—`lit-review` (methodology selection + requirements
+  extraction), `lit-review-plan` (domain-aware planning), `lit-review-search`
+  (search + screening + charting + synthesis), `lit-review-argument` (validated
+  Argdown argument architecture), and `lit-review-draft` (IEEE-format manuscript
+  draft with Zotero-generated `references.bib`). Phases 1 → 2 → 3 auto-chain;
+  phases 4 and 5 are user-invoked checkpoints.
+- **Methodology catalog** at `skills/lit-review/methodology/catalog.yaml`:
+  lookup-only, seven methods—`scoping`, `systematic`, `mapping`, `critical`,
+  `narrative_conceptual`, `targeted_related_work`, `taxonomy_development`. Each
+  entry names the primary methodology source Zotero keys; the phase-1 skill
+  reads the actual source PDFs to ground its method choice.
+- **Citation MCP** at `mcp/citation/` (Python FastMCP, registered as `citation`
+  in `.mcp.json`): seven deterministic bibliographic tools—`cite_resolve`,
+  `cite_search`, `cite_forward`, `oa_locate`, `zotero_search`, `zotero_add`,
+  `zotero_attach_pdf`. Backs onto Crossref, OpenAlex, Unpaywall, Zotero
+  translation-server, and the Zotero Web API. Bootstrap via
+  `python -m venv mcp/citation/.venv && mcp/citation/.venv/bin/pip install -e
+  mcp/citation/`. Argdown validation tooling
+  (`validate-argument-map.sh`, `check-argument-structure.mjs`, tests) ships
+  alongside the phase-4 skill.
+- **Documentation**: `docs/research/RESEARCH_WORKFLOW.md` (Ground Control
+  research workflow overview) and
+  `docs/knowledge/research-workflow/auto-research-requirements-and-oss-assessment.md`
+  (FR/NFR catalog plus OSS landscape build-vs-adopt assessment retained as a
+  knowledge-base reference).
+
+Satisfies GC-RSCH-F005, GC-RSCH-F006, GC-RSCH-F007, GC-RSCH-F008, GC-RSCH-F009,
+GC-RSCH-F012, GC-RSCH-F014, GC-RSCH-F017, GC-RSCH-F019, GC-RSCH-F020,
+GC-RSCH-F024, GC-RSCH-F028, GC-RSCH-F030, GC-RSCH-F038.

--- a/docs/knowledge/research-workflow/auto-research-requirements-and-oss-assessment.md
+++ b/docs/knowledge/research-workflow/auto-research-requirements-and-oss-assessment.md
@@ -1,0 +1,510 @@
+# Auto-Research Requirements and OSS Assessment
+
+Date: 2026-05-26
+
+## Purpose
+
+This note captures requirements for extending Reactor beyond its current methodology-selection, literature-review planning, and source-grounded search workflow into broader literature-based and writing automation.
+
+The question answered here is practical:
+
+> Is there already open-source software that can satisfy all or part of these requirements, or is this a fresh build?
+
+Short answer: this is not a fresh-from-zero build, but it is a fresh integration/orchestration build. Existing OSS covers useful parts of retrieval, RAG, screening, extraction, survey generation, and report writing. I did not find a single OSS system that already provides Reactor's method-aware requirements contract, strict source-state discipline, Zotero/citation grounding, systematic charting, synthesis traceability, and downstream paper-writing workflow as one coherent tool.
+
+## Reactor Baseline
+
+Current Reactor already has a strong, unusual core:
+
+- `reactor-lit-review`: selects an appropriate review/taxonomy methodology and extracts formal requirements from primary methodology sources.
+- `reactor-lit-review-plan`: fills those requirements into a domain-aware executable literature-review protocol.
+- `reactor-lit-review-search`: executes the protocol through citation-grounded search, screening, full-text reading, charting, and synthesis.
+- `citation_mcp`: deterministic citation MCP backed by Crossref, OpenAlex, Unpaywall, Zotero translation-server, and Zotero Web API. It exposes `cite_resolve`, `cite_search`, `cite_forward`, `zotero_search`, `zotero_add`, `oa_locate`, and `zotero_attach_pdf`.
+- `methodology/catalog.yaml`: a lookup from methodology key to primary methodology sources. It deliberately contains no prose summaries.
+
+Reactor's most important discipline is not automation volume; it is preventing scientific-looking hallucination. Its two most valuable constraints are:
+
+- Methodology requirements must be extracted from primary methodology sources, not guessed.
+- Review sources are either fully in the review, with full text read and charted, or recorded as access gaps. There is no abstract-only charting state.
+
+## Source Base Reviewed
+
+Local Reactor files:
+
+- `.claude/skills/reactor-lit-review/SKILL.md`
+- `.claude/skills/reactor-lit-review-plan/SKILL.md`
+- `.claude/skills/reactor-lit-review-search/SKILL.md`
+- `citation_mcp/server.py`
+- `citation_mcp/search.py`
+- `citation_mcp/resolve.py`
+- `methodology/catalog.yaml`
+
+Representative OSS repos inspected:
+
+- `SakanaAI/AI-Scientist` at `1de1dbc`
+- `SamuelSchmidgall/AgentLaboratory` at `d9017d9`
+- `Future-House/paper-qa` at `d2c3c69`
+- `AutoResearch/autora` at `fc5cc3e`
+- `stanford-oval/storm` at `fb951af`
+- `snap-stanford/MLAgentBench` at `5d71205`
+- `codelion/openevolve` at `80945ed`
+- `karpathy/autoresearch` at `228791f`
+- `langchain-ai/open_deep_research` at `4b61120`
+- `assafelovic/gpt-researcher` at `92bfc03`
+- `AutoSurveys/AutoSurvey` at `5e8f389`
+- `OpenBMB/AgentCPM` at `4a43561`
+- `PouriaRouzrokh/LatteReview` at `ffee2fc`
+- `OxRML/AgentSLR` at `3111fcf`
+- `JimAchterbergLUMC/OpenExtract` at `db33814`
+- `GPT-Laboratory/SLR-automation` at `f0d9ee4`
+
+Primary / project sources checked:
+
+- AI Scientist: https://arxiv.org/abs/2408.06292
+- Agent Laboratory: https://arxiv.org/abs/2501.04227
+- PaperQA2: https://arxiv.org/abs/2409.13740
+- AutoRA JOSS: https://doi.org/10.21105/joss.06839
+- STORM: https://doi.org/10.18653/v1/2024.naacl-long.347
+- Co-STORM: https://doi.org/10.18653/v1/2024.emnlp-main.554
+- MLAgentBench: https://arxiv.org/abs/2310.03302
+- Coscientist: https://doi.org/10.1038/s41586-023-06792-0
+- Robot Scientist Adam: https://doi.org/10.1126/science.1165620
+- Google AI co-scientist: https://research.google/blog/accelerating-scientific-breakthroughs-with-an-ai-co-scientist/
+- AlphaEvolve: https://deepmind.google/blog/alphaevolve-a-gemini-powered-coding-agent-for-designing-advanced-algorithms/
+- PRISMA-S: https://doi.org/10.1186/s13643-020-01542-z
+- PRISMA 2020: https://doi.org/10.1136/bmj.n71
+- FAIR principles: https://doi.org/10.1038/sdata.2016.18
+- W3C PROV-DM: https://www.w3.org/TR/prov-dm/
+- Ten Simple Rules for Reproducible Computational Research: https://doi.org/10.1371/journal.pcbi.1003285
+
+## Top-Level Requirements
+
+R-1. The system shall distinguish methodology selection, protocol planning, source search, screening, charting, synthesis, argument construction, and prose drafting as separate lifecycle stages.
+
+R-2. The system shall never treat model memory as scientific evidence. Claims require source evidence, experiment artifacts, or explicit unsupported/inferred labeling.
+
+R-3. The system shall support autonomous and copilot modes, with configurable human gates at method, protocol, search, synthesis, and writing decisions.
+
+R-4. The system shall maintain a full provenance chain from user goal to methodology source, query, candidate source, full text, charting cell, synthesis claim, argument move, and final prose.
+
+R-5. The system shall treat generated code, browser activity, lab/hardware actions, and external writes as high-risk operations requiring sandboxing and explicit authorization.
+
+R-6. The system shall produce reproducible research artifacts: protocol, search log, source set, exclusions, access gaps, charting data, synthesis, decisions, and final draft inputs.
+
+R-7. The system shall distinguish literature-based work from experiment-running auto-research. Reactor's immediate extension target is literature and writing automation, not wet-lab or compute-discovery automation.
+
+## Functional Requirements
+
+### Intake and Workflow Control
+
+FR-1. Capture research goal, paper context, target contribution type, intended output, autonomy level, allowed tools, privacy constraints, and cost/compute budget.
+
+FR-2. Classify the task as methodology extraction, domain protocol planning, systematic/scoping/mapping search, taxonomy development, related-work generation, evidence synthesis, or paper prose drafting.
+
+FR-3. Maintain an explicit state machine for phases and prevent downstream phases from running when required upstream artifacts are missing.
+
+FR-4. Provide human gates with recommendation and rationale. Gates shall be logged immediately in `decisions.md` or equivalent state.
+
+### Methodology and Protocol
+
+FR-5. Select review methodology from a catalog and explicitly justify rejected alternatives.
+
+FR-6. Read every primary methodology source required by the catalog before producing methodology requirements.
+
+FR-7. Extract formal requirements from methodology sources without filling domain answers into phase-1 output.
+
+FR-8. Produce an executable protocol that traces every requirement to a filled answer, user gate, or explicit deferral.
+
+FR-9. Support method-specific outputs for scoping reviews, systematic reviews, systematic maps, critical/integrative reviews, targeted related work, and taxonomy development.
+
+### Scholarly Search and Source Management
+
+FR-10. Generate, execute, and log search strategies across scholarly APIs and user libraries.
+
+FR-11. Preserve exact queries, dates, databases, filters, limits, and candidate counts in PRISMA-S-compatible form.
+
+FR-12. Resolve every candidate source through deterministic bibliographic services such as DOI, arXiv, PMID, Crossref, OpenAlex, or Zotero.
+
+FR-13. Add every candidate source that enters screening to a durable source store, preferably Zotero collection plus local artifacts.
+
+FR-14. Support backward snowballing from actual reference arrays and forward snowballing from OpenAlex/citation indexes.
+
+FR-15. Record every excluded source with exclusion stage and reason.
+
+### Full Text, Reading, and Charting
+
+FR-16. Locate full text through Zotero attachments, legitimate OA sources, or user-provided PDFs.
+
+FR-17. Enforce the two-state rule: fully-in sources are resolved, stored, full-text read, and charted; access-gap sources are resolved and stored but not charted.
+
+FR-18. Convert PDFs to text/markdown with source location preservation where feasible.
+
+FR-19. Apply charting forms with field-level provenance: source section/page/span, quote or paraphrase, uncertainty, and reviewer/agent identity.
+
+FR-20. Support pilot charting and emergent coding where the methodology allows or requires it.
+
+FR-21. Support multi-reviewer or multi-agent screening and abstraction with disagreement handling.
+
+### Evidence Synthesis
+
+FR-22. Generate numerical summaries only from charted cells.
+
+FR-23. Generate thematic or conceptual synthesis only from charted evidence and declared coding schemes.
+
+FR-24. Produce evidence matrices linking source IDs to charted fields, codes, and synthesis claims.
+
+FR-25. Preserve conflicts and uncertainty rather than flattening contradictory evidence into a single answer.
+
+FR-26. Emit method-limit warnings when a requested claim exceeds what the chosen method can establish.
+
+### Writing Automation
+
+FR-27. Build paper sections only after evidence artifacts exist. Writing from raw search results is prohibited for scholarly claims.
+
+FR-28. Support argument planning: claim, warrant, backing evidence, limitations, counter-evidence, and citation targets.
+
+FR-29. Draft related-work, methodology, review-results, taxonomy, limitations, and appendix prose from the evidence base.
+
+FR-30. Ensure generated prose cites only source IDs present in the evidence database.
+
+FR-31. Detect unsupported citations, uncited claims, citation/source mismatch, and prose claims that overstate charted evidence.
+
+FR-32. Export drafts and source data to Markdown, BibTeX/RIS/CSL-JSON, CSV/JSONL, and optionally Quarto/Pandoc-compatible manuscript formats.
+
+### Review, Evaluation, and Iteration
+
+FR-33. Run automated review against factual grounding, method compliance, synthesis traceability, citation integrity, and paper-argument coherence.
+
+FR-34. Support human review comments and resolution tracking.
+
+FR-35. Provide benchmark/evaluation harnesses for retrieval recall, screening agreement, extraction accuracy, citation validity, and writing groundedness.
+
+FR-36. Support checkpoint/resume after every material action.
+
+FR-37. Track cost, token use, wall-clock time, provider/model versions, and failure modes.
+
+## Non-Functional Requirements
+
+NFR-1. Factuality: every scientific claim shall be traceable to a source, charted cell, computation, or explicit inference.
+
+NFR-2. Provenance: provenance should be representable in W3C PROV-like terms: entities, activities, agents, timestamps, and derivation edges.
+
+NFR-3. Reproducibility: outputs shall record code commit, prompts, model/provider versions, parameters, seeds, environment, source identifiers, and command/tool calls.
+
+NFR-4. Auditability: prompts, tool calls, model outputs, source retrievals, edits, approvals, exclusions, and charting decisions shall be retained unless explicitly redacted.
+
+NFR-5. Security: generated code and browser activity shall run with least privilege, sandboxing, scoped credentials, and network/filesystem policy.
+
+NFR-6. Privacy: unpublished papers, private libraries, credentials, reviewer notes, and proprietary PDFs shall not be sent to external services unless explicitly allowed.
+
+NFR-7. Reliability: the system shall use retries, timeouts, checkpointing, idempotent operations, and partial-failure recovery.
+
+NFR-8. Cost control: the system shall have budgets and hard stops for tokens, API calls, PDF/OCR operations, embedding, and wall-clock time.
+
+NFR-9. Interoperability: the system should integrate with Zotero, Crossref, OpenAlex, Unpaywall, arXiv, PubMed, DOI, BibTeX, RIS, CSL-JSON, Git, and local markdown.
+
+NFR-10. Extensibility: methods, search providers, reviewers, extraction schemas, writing templates, and output formats should be plugin-like.
+
+NFR-11. Observability: users shall be able to see current phase, pending gates, source counts, errors, access gaps, cost, and artifact readiness.
+
+NFR-12. Explainability: methodology choice, search decisions, exclusions, charted values, synthesis claims, and writing claims shall expose their rationale.
+
+NFR-13. Human accountability: final outputs shall disclose AI-generated parts, human approvals, and unresolved uncertainty.
+
+NFR-14. Robustness to prompt injection: retrieved papers, web pages, PDFs, and metadata shall be treated as untrusted input.
+
+NFR-15. Maintainability: prompts, schemas, requirements, and workflow policies shall be versioned and regression tested because small changes can alter scientific behavior.
+
+NFR-16. Scientific humility: outputs shall expose negative results, failed searches, access gaps, missing evidence, method limits, and non-claims.
+
+## OSS Coverage Assessment
+
+### Strong Candidates for Reuse
+
+#### PaperQA
+
+Use for: scholarly RAG over PDFs/local text, metadata fetching, citation-grounded Q&A, answer generation from retrieved contexts, local indexing.
+
+Fit: high for source-level Q&A and evidence retrieval. PaperQA already encodes a useful principle: answer from context and cite only retrieved evidence.
+
+Gap: it does not provide Reactor's methodology-selection contract, PRISMA-style protocol execution, two-state full-text discipline, charting workflow, or writing-stage argument provenance.
+
+Recommendation: adopt or wrap for local full-text retrieval and evidence-question answering after Reactor has already admitted sources into the evidence base.
+
+#### LatteReview
+
+Use for: title/abstract screening, multi-agent review workflows, structured outputs, certainty scores, RIS input, batch review, cost tracking.
+
+Fit: high for screening and some abstraction tasks.
+
+Gap: it is a flexible reviewer package, not an end-to-end literature-review operating system. It does not solve source acquisition, methodology grounding, full-text provenance, or synthesis traceability on its own.
+
+Recommendation: seriously consider as a dependency or reference implementation for screening/abstraction agents.
+
+#### AgentSLR
+
+Use for: pipeline architecture: metadata harvest, PDF download, OCR, abstract screening, full-text screening, structured extraction, report generation, evaluation against ground truth.
+
+Fit: high as a reference design for systematic-review execution and evaluation.
+
+Gap: current harness is strongly domain-shaped around epidemiological pathogen reviews and the PERG dataset. It is not a general Reactor replacement.
+
+Recommendation: mine for workflow structure, data-workspace layout, OCR/PDF handling, and evaluation patterns. Do not adopt wholesale unless Reactor targets epidemiology-specific SLRs.
+
+#### OpenExtract
+
+Use for: structured extraction from PDFs using RAG over relevant chunks and question schemas.
+
+Fit: medium-high for charting-field extraction.
+
+Gap: currently oriented around multiple-choice extraction and health-review examples. It lacks method selection, screening, synthesis, and writing governance.
+
+Recommendation: useful as an extraction module pattern, especially for charting-form fields that can be expressed as explicit questions.
+
+#### STORM / Co-STORM
+
+Use for: pre-writing research, outline generation, perspective-guided question asking, citation-aware long-form article generation, human-AI collaborative knowledge curation.
+
+Fit: medium for writing and knowledge curation.
+
+Gap: STORM writes Wikipedia-like articles from web research. It is not a systematic/scoping review engine and does not enforce Reactor's source states or methodology constraints.
+
+Recommendation: use as a reference for collaborative outline/prose generation after Reactor's evidence base exists, not as a source-selection authority.
+
+#### Open Deep Research
+
+Use for: configurable LangGraph report agent, section planning, search, compression, final report writing, MCP compatibility, evaluation on Deep Research Bench.
+
+Fit: medium for general research report generation and agent orchestration.
+
+Gap: report benchmark quality is not the same as scholarly review validity. It does not enforce methodology catalogs, Zotero source states, charting forms, or PRISMA-style evidence records.
+
+Recommendation: useful as a reference for LangGraph orchestration, configurable models/search tools, and report-writing loops.
+
+#### GPT Researcher
+
+Use for: web/local research reports, planner/executor/publisher architecture, source aggregation, markdown/PDF/Word exports, MCP retriever support.
+
+Fit: medium for general report writing and export.
+
+Gap: web research agent, not a rigorous literature-review protocol executor. Citation behavior is prompt-enforced rather than evidence-database-enforced.
+
+Recommendation: mine for report export, MCP retriever integration, UI/API packaging, and planner/executor/publisher decomposition.
+
+### Useful but Narrower
+
+#### AutoSurvey
+
+Use for: automated literature survey generation over a large arXiv abstract database, outline generation, subsection drafting, citation post-processing, survey evaluation.
+
+Fit: medium for survey-writing ideas in CS/AI.
+
+Gap: requires a prepared database, primarily uses abstracts unless full-content database is obtained, and does not enforce full-text charting or methodology protocols.
+
+Recommendation: use as a reference for outline/subsection decomposition and citation checking, not as Reactor's source-of-truth pipeline.
+
+#### AgentCPM-Report
+
+Use for: local/offline deep-research report generation over private knowledge bases.
+
+Fit: medium for privacy-sensitive long-form report writing.
+
+Gap: model/report system rather than method-aware scholarly workflow. Needs Reactor evidence and governance around it.
+
+Recommendation: optional writing backend candidate if local/offline deployment becomes a hard requirement.
+
+#### AI Scientist / Agent Laboratory / AutoRA / OpenEvolve / karpathy/autoresearch
+
+Use for: closed-loop experiment automation, code execution, experiment logging, novelty review, paper drafting from experiments.
+
+Fit: low-to-medium for Reactor's immediate literature/writing scope, high for future auto-research beyond literature.
+
+Gap: these systems focus on experiment loops or full scientific-agent demos. Reactor needs literature-method compliance and source-grounded synthesis first.
+
+Recommendation: borrow lifecycle ideas: novelty checks, review loops, sandboxing, experiment/run ledgers, and reproducibility discipline. Do not use as core literature-review software.
+
+#### SLR-automation
+
+Use for: proof-of-concept UI/backend for SLR content generation.
+
+Fit: low.
+
+Gap: appears immature relative to Reactor's evidence-grounding requirements.
+
+Recommendation: do not adopt, except as a reminder that UI alone is not the hard part.
+
+## Requirement Coverage by Existing OSS
+
+| Requirement Area | Existing OSS Coverage | Best Sources | Assessment |
+|---|---:|---|---|
+| Methodology selection from primary sources | Low | Reactor only | Fresh Reactor-owned build |
+| Requirements contract before protocol | Low | Reactor only | Fresh Reactor-owned build |
+| Scholarly metadata resolution | High | Reactor citation MCP, PaperQA | Already usable |
+| Zotero library integration | Medium-high | Reactor citation MCP | Already usable; extend |
+| Search logging / PRISMA-S reporting | Medium | Reactor, AgentSLR | Build around Reactor |
+| Screening | Medium-high | LatteReview, AgentSLR | Reuse/adapt |
+| Full-text PDF/OCR pipeline | Medium | AgentSLR, OpenExtract, PaperQA | Reuse/adapt |
+| Structured charting / extraction | Medium | OpenExtract, LatteReview, AgentSLR | Reuse ideas; Reactor schema needed |
+| Evidence matrices | Low-medium | Reactor conceptually, AgentSLR outputs | Fresh Reactor-owned artifact model |
+| Synthesis traceability | Low-medium | Reactor discipline, PaperQA contexts | Fresh integration needed |
+| Related-work prose drafting | Medium | STORM, AutoSurvey, GPT Researcher, Open Deep Research | Reuse as writing backends only |
+| Citation validation in prose | Medium | PaperQA, AutoSurvey, Reactor rules | Fresh enforcement layer needed |
+| Paper argument planning | Low | no strong OSS match found | Fresh build |
+| Human gates / decision logs | Low-medium | Reactor, Open Deep Research legacy | Reactor-owned |
+| Provenance / audit model | Low-medium | Reactor logs, OpenEvolve traces, MLAgentBench logs | Fresh build with borrowed patterns |
+| Evaluation harness | Medium | AgentSLR, MLAgentBench, Open Deep Research | Reuse patterns |
+| Privacy/local mode | Medium | AgentCPM, PaperQA local modes | Optional backend work |
+
+## Build-vs-Adopt Conclusion
+
+No single existing OSS project should replace Reactor.
+
+The closest candidates cover adjacent slices:
+
+- PaperQA: source-grounded scholarly RAG.
+- LatteReview: multi-agent screening and abstraction.
+- AgentSLR: end-to-end systematic-review harness, but domain-specific.
+- OpenExtract: structured extraction from full-text documents.
+- STORM / Open Deep Research / GPT Researcher / AgentCPM-Report: report and prose generation.
+- AutoSurvey: survey-writing workflow over prepared arXiv corpora.
+
+The missing core is Reactor's core: method-aware contract generation, phase separation, primary-source methodology grounding, strict source-state handling, charting-to-synthesis traceability, and paper-writing claims constrained by the evidence base.
+
+Therefore the right path is:
+
+1. Keep Reactor as the orchestration and governance layer.
+2. Extend Reactor's artifact model from methodology/plan/search into argument and prose phases.
+3. Reuse or wrap existing OSS for bounded modules:
+   - PaperQA for full-text retrieval and evidence Q&A.
+   - LatteReview for screening/abstraction review workflows.
+   - AgentSLR/OpenExtract for PDF/OCR/extraction patterns.
+   - STORM/Open Deep Research/GPT Researcher for prose generation patterns after evidence is locked.
+4. Avoid adopting a general "deep research" agent as the core. Those systems optimize report generation; Reactor optimizes defensible scholarly process.
+
+## Model-Era Assessment
+
+As of 2026 frontier models, the main value of these OSS systems is not "make a weak model act smart." OpenAI's current model docs describe GPT-5.2/GPT-5.1 as coding and agentic-task models, with built-in support for tool use, structured outputs, file search, web search, MCP, and long context. Anthropic's Claude 4.x line likewise targets long-horizon reasoning/coding and agentic workflows. That changes the value calculation.
+
+The current bottleneck is less often raw language-model competence. The bottleneck is state, evidence discipline, provenance, permissions, source acquisition, workflow boundaries, and validation.
+
+This means the OSS projects fall into three categories:
+
+### Still Valuable with Frontier Models
+
+These are valuable because they encode workflow, data model, integration, or evaluation discipline that a frontier model still needs.
+
+- PaperQA: useful because it provides a scholarly-document RAG substrate, metadata handling, local indexing, and answer-from-context behavior.
+- LatteReview: useful because it models reviewer roles, rounds, structured outputs, certainty, batch processing, cost, and disagreement workflows.
+- AgentSLR: useful because it shows an end-to-end SLR harness with harvest, PDF retrieval, OCR, screening, extraction, report outputs, and ground-truth evaluation.
+- OpenExtract: useful because it makes extraction a schema/question-driven process over full text.
+- MLAgentBench/OpenEvolve/karpathy-autoresearch: useful as references for run ledgers, experiment isolation, keep/discard loops, failure classification, and traceability.
+- Reactor citation MCP: especially valuable because deterministic bibliographic plumbing is not replaced by better model reasoning.
+
+### Less Valuable Than They Used To Be
+
+These are less valuable if their main contribution is prompt scaffolding around weaker models.
+
+- elaborate planner/executor prompt chains for generic report writing;
+- multi-agent debate used mainly to compensate for weak single-agent reasoning;
+- hand-built reflection loops with no artifact-level validation;
+- survey generators that operate mostly over abstracts;
+- rigid SLM-oriented stacks where the architecture exists to make a small model barely perform a task that frontier models can now do directly.
+
+These may still contain useful prompts or decomposition ideas, but they should not drive Reactor's architecture.
+
+### Useful Only as Backends, Not Governance
+
+These can accelerate prose or broad research exploration, but they should sit downstream of Reactor's evidence base.
+
+- STORM / Co-STORM
+- GPT Researcher
+- Open Deep Research
+- AgentCPM-Report
+- AutoSurvey
+
+With current frontier models, using these as the core would be the wrong abstraction. They are optimized to produce plausible, comprehensive reports. Reactor needs defensible scholarly artifacts.
+
+## Updated Usefulness Ranking
+
+For Reactor's literature and writing automation, the expected payoff is:
+
+1. High: keep and extend Reactor's citation/provenance/source-state core.
+2. High: evaluate PaperQA as a full-text evidence Q&A layer.
+3. High: evaluate LatteReview for screening and abstraction workflows.
+4. Medium-high: mine AgentSLR for workspace layout, PDF/OCR handling, and evaluation.
+5. Medium: mine OpenExtract for schema-driven extraction.
+6. Medium: use STORM/Open Deep Research/GPT Researcher/AgentCPM-Report as optional drafting/report backends after evidence is locked.
+7. Low for core Reactor: adopt whole auto-scientist/autonomous-experiment frameworks. Borrow lessons only.
+8. Low: adopt older generic SLR/report apps that mostly wrap prompts and UI.
+
+The practical conclusion is neither "today's models make these obsolete" nor "these solve today's model problems." The answer is: frontier models make many prompt-compensation layers obsolete, but make robust external workflow layers more valuable. The better the model, the more damage it can do if it writes fluent prose without a hard evidence ledger.
+
+## Recommended Architecture
+
+### Reactor Core
+
+Own these components in Reactor:
+
+- Methodology catalog and source-reading discipline.
+- Phase state machine.
+- Requirements/protocol/evidence/argument/draft artifact schemas.
+- User-gate and decision-log mechanism.
+- Source-state rules and access-gap handling.
+- Charting and synthesis traceability rules.
+- Citation/prose validation.
+
+### Reusable Engines
+
+Integrate as swappable adapters:
+
+- `citation_mcp`: keep and extend for source discovery and Zotero operations.
+- PaperQA adapter: query admitted full-text corpus.
+- LatteReview adapter: title/abstract/full-text screening and abstraction rounds.
+- Extraction adapter: OpenExtract-like schema-driven full-text extraction.
+- Writing adapter: STORM/Open Deep Research/GPT Researcher-style outline/section drafting against Reactor evidence only.
+- Export adapter: Markdown/CSV/JSONL/BibTeX/RIS/CSL-JSON/Quarto.
+
+### Required New Artifacts
+
+Add these beyond current Reactor outputs:
+
+- `source-registry.jsonl`: every source candidate, ID, provenance, state, Zotero key, full-text status, role.
+- `screening-log.csv`: candidate, stage, decision, reason, reviewer/agent, timestamp.
+- `charting-data.jsonl`: source, field, value, evidence span, confidence, reviewer/agent.
+- `claim-ledger.jsonl`: claim, supporting charted cells, limitations, prose locations.
+- `argument-plan.md`: paper-section claim structure before drafting.
+- `draft.md`: generated prose.
+- `draft-grounding-report.md`: unsupported claims, missing citations, overclaims, source mismatches.
+
+## Practical Recommendation
+
+This should be treated as a fresh Reactor product layer, not a generic auto-research adoption.
+
+The implementation should start narrow:
+
+1. Automate the existing phase outputs into a durable state/artifact registry.
+2. Add an argument/prose phase that can only cite from the evidence matrix.
+3. Add a validation pass that fails unsupported prose.
+4. Only then plug in external engines for screening, extraction, and prose acceleration.
+
+Do not start by wiring in a general deep-research agent. That would recreate the failure modes Reactor was built to prevent: plausible prose before defensible evidence.
+
+---
+
+I added this assessment to the note: [notes/auto-research-requirements-and-oss-assessment.md](/home/atomik/src/reactor/notes/auto-research-requirements-and-oss-assessment.md:383).
+
+My take: it’s neither “today’s models make these obsolete” nor “these solve today’s model problems.”
+
+Current frontier models reduce the value of old prompt-compensation architecture: role-play committees, brittle planner/executor chains, reflection loops with no artifact validation, and SLM-first stacks whose main purpose is making a weak model limp through the task. OpenAI’s current model docs emphasize agentic/coding/tool/MCP capabilities in GPT-5.x models, and Anthropic’s current Claude 4.x material is in the same long-horizon agentic direction. Sources: [OpenAI models](https://platform.openai.com/docs/models), [Anthropic models](https://docs.anthropic.com/en/docs/about-claude/models/overview).
+
+But stronger models make the external discipline more important, not less. For Reactor, the hard problems are still source truth, provenance, full-text state, charting discipline, exclusion logs, claim ledgers, permissions, and validation. A smarter model can write a more convincing unsupported literature review. That is worse unless the system constrains it.
+
+Ranking for value:
+
+- **High value:** PaperQA, LatteReview, Reactor citation MCP. These solve evidence retrieval, structured review, metadata, and source-grounding problems that frontier models do not magically solve.
+- **Medium-high:** AgentSLR and OpenExtract. Good pipeline/extraction/OCR/evaluation patterns, but not drop-in Reactor replacements.
+- **Medium:** STORM, Open Deep Research, GPT Researcher, AgentCPM-Report, AutoSurvey. Useful as drafting or exploration backends after Reactor locks the evidence base. Bad as governance.
+- **Low for Reactor core:** AI Scientist, Agent Laboratory, AutoRA, OpenEvolve, karpathy/autoresearch. Relevant to future experiment automation, not the literature/writing core.
+- **Low:** generic older SLR/report apps that are mostly prompts plus UI.
+
+So the useful build posture is: fewer “agent brain” frameworks, more artifact infrastructure. Keep the frontier model as the smart worker; make Reactor the evidence contract, state machine, provenance ledger, and validator.

--- a/docs/research/RESEARCH_WORKFLOW.md
+++ b/docs/research/RESEARCH_WORKFLOW.md
@@ -1,0 +1,87 @@
+# Research workflow
+
+Ground Control's research project type ships a five-phase literature-review pipeline implemented as Claude skills, a methodology catalog, and a deterministic citation MCP. The pipeline answers one question for a given research paper:
+
+> What are the formal requirements a literature-review plan must meet to satisfy the appropriate methodology, and how do we execute that plan, build the paper's argument, and draft it without fabricating citations or asserting findings the evidence base does not carry?
+
+See ADR-055 for the architectural decision and asset disposition.
+
+## Phases
+
+| Phase | Skill | Output | Chaining |
+|---|---|---|---|
+| 1—methodology selection + requirements extraction | `lit-review` | `requirements.md`—chosen method, primary sources read, formal requirements extracted | auto-chains into phase 2 |
+| 2—domain-aware planning | `lit-review-plan` | `lit-review-plan.md`—phase-1 requirements filled with domain content for the specific paper | auto-chains into phase 3 |
+| 3—search execution | `lit-review-search` | Evidence base: `charting-data.csv`, `coding-scheme.md`, `evidence-matrix.md`, `synthesis.md`, `search-log.md` | does NOT auto-chain—evidence base is a user-review checkpoint |
+| 4—argument architecture | `lit-review-argument` | `paper-outline.md`, validated `argument-map.argdown` (premises grounded in evidence, objections modelled) | does NOT auto-chain—argument architecture is a user-review checkpoint |
+| 5—drafting | `lit-review-draft` | `manuscript.tex` (IEEE format) + `references.bib` (generated from Zotero collection) + `manuscript.md` rendering | final phase |
+
+The user invokes `lit-review` once and phases 1 → 2 → 3 run end-to-end with gates surfaced mid-flow. After reviewing the evidence base, the user invokes `lit-review-argument`; after reviewing the argument architecture, the user invokes `lit-review-draft`.
+
+## Disciplines
+
+Each phase enforces specific disciplines against observed failure modes. The full failure-mode catalog lives in the individual SKILL.md files; the highest-leverage ones:
+
+- **Citation hallucination → deterministic citation MCP only.** Every citation must come from `cite_resolve`, `cite_search`, `cite_forward`, or a Zotero record the agent opened—never from training memory. The citation MCP exists to make this enforceable.
+- **Two-state source rule (phase 3).** A source is in exactly one of two states: (a) fully in the review—resolved, stored in the Zotero collection, full text read, charted; or (b) access gap—resolved, stored, full text not obtainable, not charted. There is no "charted from the abstract" or "charted from memory" state.
+- **Procedural-invention guard (phase 1).** Phase 1 emits *requirements the plan must satisfy*, not the answers. If the methodology source does not specify a particular database / date range / coding category, neither does the phase-1 output. Domain content is phase 2's job.
+- **Argument grounding (phase 4).** Every Argdown premise carries an `{evidence: ...}` tag pointing at a specific section of the evidence base—or is itself the conclusion of another reconstructed argument. `validate-argument-map.sh` mechanically flags ungrounded premises, unreconstructed support arguments, unanswered objections, and circular support.
+- **Manuscript-not-memo guard (phase 5).** The manuscript reads cold for a reviewer who has never heard of Ground Control. No phase vocabulary, no internal-artifact names, no "the evidence matrix shows" gestures. Every load-bearing empirical claim is demonstrated on the page—inline citation, numbered table, or quoted example—not asserted.
+- **Voice contract (phase 5).** `skills/lit-review-draft/writing-style.md` is a voice profile plus a model-tell blocklist. The style pass runs the blocklist literally against the draft; zero hits is the bar.
+
+## Artifacts on disk
+
+Per-paper artifacts live in the user's chosen workspace, not in the Ground Control repo. The typical layout, after a full run:
+
+```
+workspace/
+  program/
+    <paper_id>.md            # the paper's stanza (primary claim, RQs, non-claims, venue posture)
+  requirements.md            # phase 1
+  lit-review-plan.md         # phase 2
+  search-log.md              # phase 3
+  charting-data.csv          # phase 3
+  coding-scheme.md           # phase 3
+  evidence-matrix.md         # phase 3
+  synthesis.md               # phase 3
+  paper-outline.md           # phase 4
+  argument-map.argdown       # phase 4
+  manuscript.tex             # phase 5
+  references.bib             # phase 5 (generated from Zotero)
+  manuscript.md              # phase 5 (markdown rendering)
+  decisions.md               # extended across all phases
+  self-review.md             # extended across all phases
+```
+
+## Components in this repo
+
+| Surface | Path |
+|---|---|
+| Phase skills | `skills/lit-review/`, `skills/lit-review-plan/`, `skills/lit-review-search/`, `skills/lit-review-argument/`, `skills/lit-review-draft/` |
+| Methodology catalog | `skills/lit-review/methodology/catalog.yaml` |
+| Argdown validation tooling | `skills/lit-review-argument/{validate-argument-map.sh, check-argument-structure.mjs, tests/}` |
+| Voice contract | `skills/lit-review-draft/writing-style.md` |
+| Citation MCP | `mcp/citation/` (Python; see `mcp/citation/README.md` for bootstrap) |
+| MCP registration | `.mcp.json` → `citation` server (provides `mcp__citation__*` tools) |
+| OSS landscape assessment | `docs/knowledge/research-workflow/auto-research-requirements-and-oss-assessment.md` |
+| Architectural decision | `architecture/adrs/055-research-workflow-skills-and-citation-mcp.md` |
+
+## Methodology catalog
+
+The catalog at `skills/lit-review/methodology/catalog.yaml` is a lookup, not a paraphrase: method key → primary methodology source Zotero keys + titles + PDF availability. The phase-1 skill reads the actual source PDFs to ground its method choice; the catalog only tells it *which* sources to read.
+
+Methods shipped: `scoping`, `systematic`, `mapping`, `critical`, `narrative_conceptual`, `targeted_related_work`, `taxonomy_development`.
+
+Adding a method: append a new entry with the primary methodology source Zotero keys. Do not add prose summaries—the phase-1 skill reads the sources directly.
+
+## Citation MCP
+
+See `mcp/citation/README.md` for the bootstrap (`python -m venv`, `pip install -e`, optional `zotero/translation-server` Docker), the tool inventory, and the environment variables.
+
+The MCP is registered in `.mcp.json` as `citation`. Tools surface to the skills as `mcp__citation__cite_resolve`, `mcp__citation__cite_search`, etc.
+
+## How this earned its place
+
+Every discipline in the skills addresses a failure mode that has been observed in real paper drafting—citation hallucination (88 partially hallucinated references in one round), domain leakage into methodology outputs, invented procedural detail, imported framing without provenance, synthesis claims unsupported by the charted corpus, manuscripts that read as workflow memos. The OSS landscape assessment under `docs/knowledge/research-workflow/` records the build-vs-adopt analysis that established no single existing tool provides the combined discipline these skills enforce.
+
+If a future failure mode appears that genuinely cannot be addressed by skill instructions and source reading, the smallest possible support for that specific failure mode goes in—and the observed failure it addresses is written down so it can be defended later. Speculative additions against theoretical failure modes get cut.

--- a/mcp/citation/README.md
+++ b/mcp/citation/README.md
@@ -1,0 +1,48 @@
+# citation-mcp
+
+Deterministic citation resolution and Zotero ingest MCP for Ground Control research workflows. Backs onto Crossref, OpenAlex, Unpaywall, the Zotero translation-server, and the Zotero Web API.
+
+Used by the `lit-review`, `lit-review-plan`, `lit-review-search`, `lit-review-argument`, and `lit-review-draft` skills under `skills/` (see ADR-055). Skills reference its tools as `mcp__citation__*`; that prefix depends on the MCP server being registered as `citation` in `.mcp.json`.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `cite_resolve` | Resolve `doi:` / `arxiv:` / `pmid:` / `isbn:` identifiers to canonical CSL-JSON. |
+| `cite_search` | Search OpenAlex (default) or Crossref for candidate works by title / keywords / author. |
+| `cite_forward` | Forward citations (works that cite a given DOI) via OpenAlex—closes backward + forward snowballing. |
+| `oa_locate` | Look up OA locations for a DOI via Unpaywall. Caches results 15 min so `zotero_attach_pdf` can enforce OA-only attachment. |
+| `zotero_search` | Search the user's Zotero library for existing items. |
+| `zotero_add` | Ingest a citation into the user's Zotero library via translation-server. Idempotent on DOI. |
+| `zotero_attach_pdf` | Attach an OA PDF to an existing Zotero item. Refuses non-OA URLs (15 min cache from `oa_locate`). |
+
+## Bootstrap
+
+The launcher `mcp/citation/bin/citation-mcp.sh` auto-bootstraps the venv on first run (idempotent), so the `.mcp.json` `citation` entry just invokes the launcher and the venv is created on demand. Manual bootstrap is only needed if you want to run the self-test before Claude Code first starts the server.
+
+```sh
+# From repo root—manual bootstrap (optional; the launcher does this lazily)
+python3 -m venv mcp/citation/.venv
+mcp/citation/.venv/bin/pip install -e mcp/citation/
+
+# Required for zotero_add (one-time, idempotent restart)
+docker run -d --rm -p 1969:1969 zotero/translation-server
+
+# Offline self-test—no network, no Zotero
+mcp/citation/bin/citation-mcp.sh --self-test
+```
+
+## Environment
+
+| Variable | Required for | Default |
+|---|---|---|
+| `CITATION_MCP_MAILTO` | Crossref / OpenAlex polite-pool identification | `j.bradley.edwards@gmail.com` |
+| `PERSONAL_ZOTERO_ID` | `zotero_search`, `zotero_add`, `zotero_attach_pdf` | unset (those tools error without it) |
+| `PERSONAL_ZOTERO_KEY` | as above | unset |
+| `TRANSLATION_SERVER_URL` | `zotero_add` | `http://localhost:1969` |
+
+The skills set these via the `.mcp.json` `citation` server entry; an operator running the MCP outside of Claude Code provides them via the shell environment.
+
+## Why deterministic
+
+Citation hallucination is the highest-cost failure mode the research workflow guards against. The agent's role here is identifier-shaped (DOI / arXiv / PMID / search string); every step of bibliographic-data production happens through deterministic external services so the agent never generates citation data from memory. See `docs/knowledge/research-workflow/auto-research-requirements-and-oss-assessment.md` for the full build-vs-adopt analysis and ADR-055 for the architectural decision.

--- a/mcp/citation/bin/citation-mcp.sh
+++ b/mcp/citation/bin/citation-mcp.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# citation-mcp launcher.
+#
+# Locates the venv relative to this script's directory so the `.mcp.json`
+# entry can use a repo-relative `command` instead of a hard-coded absolute
+# path. Auto-bootstraps the venv on first run (idempotent); subsequent
+# launches are a pure exec.
+#
+# .mcp.json:
+#   "citation": {
+#     "type": "stdio",
+#     "command": "mcp/citation/bin/citation-mcp.sh",
+#     "args": [],
+#     "env": { ... }
+#   }
+#
+# Standalone:
+#   mcp/citation/bin/citation-mcp.sh                 # starts the MCP server
+#   mcp/citation/bin/citation-mcp.sh --self-test     # offline self-test
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENV="$PKG_DIR/.venv"
+
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "[citation-mcp] bootstrapping venv at $VENV" >&2
+  python3 -m venv "$VENV"
+  "$VENV/bin/pip" install --quiet --upgrade pip >&2
+  "$VENV/bin/pip" install --quiet -e "$PKG_DIR" >&2
+fi
+
+exec "$VENV/bin/python" -m citation_mcp.server "$@"

--- a/mcp/citation/citation_mcp/__init__.py
+++ b/mcp/citation/citation_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""citation MCP — deterministic citation resolution and Zotero ingest."""
+
+__version__ = "0.1.0"

--- a/mcp/citation/citation_mcp/http.py
+++ b/mcp/citation/citation_mcp/http.py
@@ -1,0 +1,23 @@
+"""Shared HTTP client with polite-pool mailto for Crossref / OpenAlex / Unpaywall."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+USER_AGENT = "Citation-MCP/0.1 (+https://github.com/KeplerOps/Ground-Control; mailto:{mailto})"
+DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+
+def mailto() -> str:
+    return os.environ.get("CITATION_MCP_MAILTO", "j.bradley.edwards@gmail.com")
+
+
+def client(timeout: httpx.Timeout | float | None = None) -> httpx.Client:
+    """Return a configured httpx.Client. Caller closes it."""
+    return httpx.Client(
+        headers={"User-Agent": USER_AGENT.format(mailto=mailto())},
+        timeout=timeout or DEFAULT_TIMEOUT,
+        follow_redirects=True,
+    )

--- a/mcp/citation/citation_mcp/oa.py
+++ b/mcp/citation/citation_mcp/oa.py
@@ -1,0 +1,45 @@
+"""Unpaywall OA-location lookup."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import http
+
+
+def unpaywall_lookup(doi: str) -> dict[str, Any]:
+    """Return {is_oa, oa_status, locations: [...], doi} or {error}."""
+    doi = doi.strip()
+    if doi.startswith("https://doi.org/"):
+        doi = doi[len("https://doi.org/"):]
+    url = f"https://api.unpaywall.org/v2/{doi}"
+    params = {"email": http.mailto()}
+    with http.client() as c:
+        resp = c.get(url, params=params)
+    if resp.status_code == 404:
+        return {"error": f"Unpaywall has no record of DOI {doi}", "doi": doi}
+    if resp.status_code >= 400:
+        return {"error": f"Unpaywall HTTP {resp.status_code} for DOI {doi}", "doi": doi}
+    data = resp.json()
+    locations: list[dict[str, Any]] = []
+    for loc in data.get("oa_locations") or []:
+        locations.append(
+            {
+                "host_type": loc.get("host_type"),
+                "version": loc.get("version"),
+                "url": loc.get("url"),
+                "url_for_pdf": loc.get("url_for_pdf"),
+                "url_for_landing_page": loc.get("url_for_landing_page"),
+                "license": loc.get("license"),
+                "is_best": loc == data.get("best_oa_location"),
+            }
+        )
+    return {
+        "doi": doi,
+        "is_oa": data.get("is_oa", False),
+        "oa_status": data.get("oa_status"),
+        "title": data.get("title"),
+        "year": data.get("year"),
+        "journal": data.get("journal_name"),
+        "locations": locations,
+    }

--- a/mcp/citation/citation_mcp/resolve.py
+++ b/mcp/citation/citation_mcp/resolve.py
@@ -1,0 +1,283 @@
+"""Identifier resolution to canonical CSL-JSON.
+
+Supported prefixes: doi:, arxiv:, pmid:, isbn: (best-effort).
+Each source uses the authoritative external service:
+- doi: → DOI content negotiation (Crossref / DataCite / mEDRA)
+- arxiv: → arXiv API (Atom XML), mapped to CSL-JSON
+- pmid: → NCBI E-utilities (esummary)
+- isbn: → Crossref query as fallback (no dedicated ISBN registry); declared best-effort
+"""
+
+from __future__ import annotations
+
+import re
+import time
+import xml.etree.ElementTree as ET
+from html.parser import HTMLParser
+from typing import Any
+
+from . import http
+
+PREFIX_RE = re.compile(r"^([a-z]+):(.+)$")
+ARXIV_API_COOLDOWN_SECONDS = 600.0
+_ARXIV_API_COOLDOWN_UNTIL = 0.0
+
+
+def parse_identifier(identifier: str) -> tuple[str, str]:
+    """Split 'doi:10.x/y' into ('doi', '10.x/y'). Returns ('raw', identifier) if no prefix."""
+    m = PREFIX_RE.match(identifier.strip())
+    if not m:
+        return ("raw", identifier.strip())
+    return (m.group(1).lower(), m.group(2).strip())
+
+
+def resolve_identifier(identifier: str) -> dict[str, Any]:
+    """Resolve a prefixed identifier to CSL-JSON or return a structured error."""
+    prefix, accession = parse_identifier(identifier)
+    try:
+        if prefix == "doi":
+            return resolve_doi(accession)
+        if prefix == "arxiv":
+            return resolve_arxiv(accession)
+        if prefix in ("pmid", "pubmed"):
+            return resolve_pmid(accession)
+        if prefix == "isbn":
+            return resolve_isbn(accession)
+        if prefix == "raw":
+            return {"error": f"identifier has no recognised prefix: {identifier!r}", "supported": ["doi", "arxiv", "pmid", "isbn"]}
+        return {"error": f"unsupported identifier prefix: {prefix!r}", "supported": ["doi", "arxiv", "pmid", "isbn"]}
+    except Exception as e:
+        return {"error": f"resolution failed for {identifier!r}: {type(e).__name__}: {e}"}
+
+
+def resolve_doi(doi: str) -> dict[str, Any]:
+    """DOI content negotiation → CSL-JSON."""
+    url = f"https://doi.org/{doi}"
+    with http.client() as c:
+        resp = c.get(url, headers={"Accept": "application/vnd.citationstyles.csl+json"})
+    if resp.status_code == 404:
+        return {"error": f"DOI not found: {doi}", "tried": [url]}
+    if resp.status_code >= 400:
+        return {"error": f"DOI lookup HTTP {resp.status_code}: {doi}", "tried": [url]}
+    try:
+        data = resp.json()
+    except Exception as e:
+        return {"error": f"DOI returned non-JSON: {e}", "tried": [url]}
+    return {"csl": data, "source": "doi-content-negotiation", "identifier": f"doi:{doi}"}
+
+
+def resolve_arxiv(arxiv_id: str) -> dict[str, Any]:
+    """arXiv API → CSL-JSON. arXiv returns Atom XML."""
+    global _ARXIV_API_COOLDOWN_UNTIL
+    arxiv_id = arxiv_id.strip()
+    url = f"https://export.arxiv.org/api/query?id_list={arxiv_id}"
+    if time.monotonic() < _ARXIV_API_COOLDOWN_UNTIL:
+        return resolve_arxiv_abs_page(arxiv_id, tried=[f"{url} (skipped: arXiv API cooldown)"])
+    try:
+        with http.client(timeout=10.0) as c:
+            resp = c.get(url)
+    except Exception as exc:
+        _ARXIV_API_COOLDOWN_UNTIL = time.monotonic() + ARXIV_API_COOLDOWN_SECONDS
+        return resolve_arxiv_abs_page(arxiv_id, tried=[f"{url} ({type(exc).__name__})"])
+    if resp.status_code >= 400:
+        if resp.status_code == 429:
+            _ARXIV_API_COOLDOWN_UNTIL = time.monotonic() + ARXIV_API_COOLDOWN_SECONDS
+            return resolve_arxiv_abs_page(arxiv_id, tried=[url])
+        return {"error": f"arXiv HTTP {resp.status_code}: {arxiv_id}", "tried": [url]}
+    ns = {"atom": "http://www.w3.org/2005/Atom", "arxiv": "http://arxiv.org/schemas/atom"}
+    try:
+        root = ET.fromstring(resp.text)
+    except ET.ParseError as e:
+        return {"error": f"arXiv returned malformed XML: {e}", "tried": [url]}
+    entry = root.find("atom:entry", ns)
+    if entry is None:
+        return {"error": f"arXiv entry not found for {arxiv_id}", "tried": [url]}
+
+    def text_of(elem):
+        return (elem.text or "").strip() if elem is not None else None
+
+    title = text_of(entry.find("atom:title", ns))
+    summary = text_of(entry.find("atom:summary", ns))
+    published = text_of(entry.find("atom:published", ns))
+    primary_doi = None
+    doi_elem = entry.find("arxiv:doi", ns)
+    if doi_elem is not None:
+        primary_doi = text_of(doi_elem)
+
+    authors: list[dict[str, str]] = []
+    for a in entry.findall("atom:author", ns):
+        name = text_of(a.find("atom:name", ns)) or ""
+        parts = name.rsplit(" ", 1)
+        if len(parts) == 2:
+            authors.append({"given": parts[0], "family": parts[1]})
+        else:
+            authors.append({"literal": name})
+
+    csl: dict[str, Any] = {
+        "id": f"arxiv:{arxiv_id}",
+        "type": "article",
+        "title": title,
+        "author": authors,
+        "abstract": summary,
+        "publisher": "arXiv",
+        "URL": f"https://arxiv.org/abs/{arxiv_id}",
+    }
+    if primary_doi:
+        csl["DOI"] = primary_doi
+    if published:
+        year = published[:4]
+        if year.isdigit():
+            csl["issued"] = {"date-parts": [[int(year)]]}
+            csl["date-published-arxiv"] = published
+    return {"csl": csl, "source": "arxiv", "identifier": f"arxiv:{arxiv_id}"}
+
+
+class _ArxivMetaParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.metadata: dict[str, list[str]] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "meta":
+            return
+        attr_map = {key.lower(): value for key, value in attrs if value is not None}
+        name = attr_map.get("name") or attr_map.get("property")
+        content = attr_map.get("content")
+        if not name or content is None:
+            return
+        self.metadata.setdefault(name, []).append(content.strip())
+
+
+def resolve_arxiv_abs_page(arxiv_id: str, tried: list[str] | None = None) -> dict[str, Any]:
+    """arXiv abstract-page metadata fallback for API 429 responses."""
+    url = f"https://arxiv.org/abs/{arxiv_id}"
+    tried = [*(tried or []), url]
+    with http.client() as c:
+        resp = c.get(url)
+    if resp.status_code >= 400:
+        return {"error": f"arXiv abstract page HTTP {resp.status_code}: {arxiv_id}", "tried": tried}
+
+    parser = _ArxivMetaParser()
+    parser.feed(resp.text)
+    meta = parser.metadata
+
+    title = _first(meta, "citation_title", "og:title")
+    if not title:
+        return {"error": f"arXiv abstract page missing citation metadata: {arxiv_id}", "tried": tried}
+
+    authors = [_name_to_csl(author) for author in meta.get("citation_author", [])]
+    published = _first(meta, "citation_date", "citation_online_date")
+    doi = _first(meta, "citation_doi")
+
+    csl: dict[str, Any] = {
+        "id": f"arxiv:{arxiv_id}",
+        "type": "article",
+        "title": title,
+        "author": authors,
+        "abstract": _first(meta, "citation_abstract", "og:description"),
+        "publisher": "arXiv",
+        "URL": url,
+    }
+    if doi:
+        csl["DOI"] = doi
+    if published:
+        year = published[:4]
+        if year.isdigit():
+            csl["issued"] = {"date-parts": [[int(year)]]}
+            csl["date-published-arxiv"] = published
+    return {"csl": csl, "source": "arxiv-abs-page", "identifier": f"arxiv:{arxiv_id}", "tried": tried}
+
+
+def _first(metadata: dict[str, list[str]], *keys: str) -> str | None:
+    for key in keys:
+        values = metadata.get(key)
+        if values:
+            return values[0]
+    return None
+
+
+def _name_to_csl(name: str) -> dict[str, str]:
+    if "," in name:
+        family, given = [part.strip() for part in name.split(",", 1)]
+        return {"given": given, "family": family}
+    parts = name.rsplit(" ", 1)
+    if len(parts) == 2:
+        return {"given": parts[0], "family": parts[1]}
+    return {"literal": name}
+
+
+def resolve_pmid(pmid: str) -> dict[str, Any]:
+    """NCBI E-utilities esummary → CSL-JSON (subset)."""
+    pmid = pmid.strip()
+    url = f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id={pmid}&retmode=json"
+    with http.client() as c:
+        resp = c.get(url)
+    if resp.status_code >= 400:
+        return {"error": f"NCBI HTTP {resp.status_code}: pmid {pmid}", "tried": [url]}
+    data = resp.json()
+    result = data.get("result", {})
+    if pmid not in result:
+        return {"error": f"PMID not found: {pmid}", "tried": [url]}
+    rec = result[pmid]
+    authors = [{"literal": a.get("name", "")} for a in rec.get("authors", []) if a.get("name")]
+    pub_year = (rec.get("pubdate") or "")[:4]
+    issued: dict[str, Any] | None = None
+    if pub_year.isdigit():
+        issued = {"date-parts": [[int(pub_year)]]}
+    doi = None
+    for aid in rec.get("articleids", []):
+        if aid.get("idtype") == "doi":
+            doi = aid.get("value")
+            break
+    csl: dict[str, Any] = {
+        "id": f"pmid:{pmid}",
+        "type": "article-journal",
+        "title": rec.get("title"),
+        "container-title": rec.get("fulljournalname") or rec.get("source"),
+        "volume": rec.get("volume"),
+        "issue": rec.get("issue"),
+        "page": rec.get("pages"),
+        "author": authors,
+        "PMID": pmid,
+    }
+    if doi:
+        csl["DOI"] = doi
+    if issued:
+        csl["issued"] = issued
+    return {"csl": csl, "source": "ncbi-eutils", "identifier": f"pmid:{pmid}"}
+
+
+def resolve_isbn(isbn: str) -> dict[str, Any]:
+    """Best-effort ISBN resolution via OpenLibrary. Declared best-effort."""
+    isbn_clean = re.sub(r"[^0-9Xx]", "", isbn).upper()
+    url = f"https://openlibrary.org/api/books?bibkeys=ISBN:{isbn_clean}&format=json&jscmd=data"
+    with http.client() as c:
+        resp = c.get(url)
+    if resp.status_code >= 400:
+        return {"error": f"OpenLibrary HTTP {resp.status_code}: isbn {isbn}", "tried": [url]}
+    data = resp.json()
+    key = f"ISBN:{isbn_clean}"
+    if key not in data:
+        return {"error": f"ISBN not found in OpenLibrary: {isbn}", "tried": [url]}
+    rec = data[key]
+    authors = [{"literal": a.get("name", "")} for a in rec.get("authors", []) if a.get("name")]
+    pub_year = None
+    pd = rec.get("publish_date")
+    if pd:
+        m = re.search(r"(\d{4})", pd)
+        if m:
+            pub_year = int(m.group(1))
+    publishers = rec.get("publishers") or []
+    publisher = publishers[0]["name"] if publishers and isinstance(publishers[0], dict) else None
+    csl: dict[str, Any] = {
+        "id": f"isbn:{isbn_clean}",
+        "type": "book",
+        "title": rec.get("title"),
+        "author": authors,
+        "publisher": publisher,
+        "ISBN": isbn_clean,
+        "URL": rec.get("url"),
+    }
+    if pub_year:
+        csl["issued"] = {"date-parts": [[pub_year]]}
+    return {"csl": csl, "source": "openlibrary", "identifier": f"isbn:{isbn_clean}"}

--- a/mcp/citation/citation_mcp/search.py
+++ b/mcp/citation/citation_mcp/search.py
@@ -1,0 +1,173 @@
+"""Citation search across OpenAlex (primary) and Crossref (fallback)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import http
+
+
+def search(query: str, limit: int = 10, source: str = "openalex") -> dict[str, Any]:
+    """Search for candidate works. Returns {results: [...], source, total} or {error}."""
+    if not query or not query.strip():
+        return {"error": "empty query", "results": []}
+    source = source.lower()
+    if source == "openalex":
+        return search_openalex(query, limit)
+    if source == "crossref":
+        return search_crossref(query, limit)
+    return {"error": f"unknown source: {source!r}", "supported": ["openalex", "crossref"]}
+
+
+def _normalise_openalex_work(w: dict[str, Any]) -> dict[str, Any]:
+    doi = w.get("doi")
+    if doi and doi.startswith("https://doi.org/"):
+        doi = doi[len("https://doi.org/"):]
+    authors_raw = w.get("authorships") or []
+    authors = [a.get("author", {}).get("display_name") for a in authors_raw if a.get("author", {}).get("display_name")]
+    return {
+        "doi": doi,
+        "title": w.get("title") or w.get("display_name"),
+        "authors": authors,
+        "year": w.get("publication_year"),
+        "venue": ((w.get("primary_location") or {}).get("source") or {}).get("display_name"),
+        "openalex_id": w.get("id"),
+        "type": w.get("type"),
+        "cited_by_count": w.get("cited_by_count"),
+        "relevance_score": w.get("relevance_score"),
+    }
+
+
+def search_forward(doi: str, limit: int = 25) -> dict[str, Any]:
+    """Return works that CITE the given DOI (forward citations), via OpenAlex.
+
+    Backward citations (works a paper cites) come from cite_resolve's reference
+    array. This closes the other direction so snowballing does not depend on a
+    hand-search that could fabricate "cited by" entries.
+    """
+    doi = (doi or "").strip()
+    if not doi:
+        return {"error": "empty doi", "results": []}
+    if doi.startswith("https://doi.org/"):
+        doi = doi[len("https://doi.org/"):]
+    with http.client() as c:
+        # Resolve the DOI to an OpenAlex work to obtain its work ID.
+        work_resp = c.get(
+            f"https://api.openalex.org/works/https://doi.org/{doi}",
+            params={"mailto": http.mailto()},
+        )
+        if work_resp.status_code == 404:
+            return {"error": f"OpenAlex has no record of DOI {doi}", "doi": doi, "results": []}
+        if work_resp.status_code >= 400:
+            return {"error": f"OpenAlex HTTP {work_resp.status_code} resolving DOI {doi}", "doi": doi}
+        work = work_resp.json()
+        cited_by_count = work.get("cited_by_count", 0)
+        work_id = work.get("id") or ""
+        # work_id is a URL like https://openalex.org/W2075950485; the cites:
+        # filter wants the bare ID.
+        short_id = work_id.rstrip("/").rsplit("/", 1)[-1] if work_id else ""
+        if not short_id:
+            return {"error": f"OpenAlex returned no work ID for DOI {doi}", "doi": doi}
+        cite_resp = c.get(
+            "https://api.openalex.org/works",
+            params={
+                "filter": f"cites:{short_id}",
+                "per_page": min(max(limit, 1), 100),
+                "mailto": http.mailto(),
+            },
+        )
+    if cite_resp.status_code >= 400:
+        return {"error": f"OpenAlex HTTP {cite_resp.status_code} on cites query", "doi": doi}
+    data = cite_resp.json()
+    results = [_normalise_openalex_work(w) for w in data.get("results", [])]
+    return {
+        "source": "openalex-forward",
+        "doi": doi,
+        "cited_by_count": cited_by_count,
+        "total": data.get("meta", {}).get("count", 0),
+        "results": results,
+    }
+
+
+def search_openalex(query: str, limit: int) -> dict[str, Any]:
+    url = "https://api.openalex.org/works"
+    params = {
+        "search": query,
+        "per_page": min(max(limit, 1), 50),
+        "mailto": http.mailto(),
+    }
+    with http.client() as c:
+        resp = c.get(url, params=params)
+    if resp.status_code >= 400:
+        return {"error": f"OpenAlex HTTP {resp.status_code}", "url": str(resp.url)}
+    data = resp.json()
+    results: list[dict[str, Any]] = []
+    for w in data.get("results", []):
+        doi = w.get("doi")
+        if doi and doi.startswith("https://doi.org/"):
+            doi = doi[len("https://doi.org/"):]
+        authors_raw = w.get("authorships") or []
+        authors = [a.get("author", {}).get("display_name") for a in authors_raw if a.get("author", {}).get("display_name")]
+        results.append(
+            {
+                "doi": doi,
+                "title": w.get("title") or w.get("display_name"),
+                "authors": authors,
+                "year": w.get("publication_year"),
+                "venue": ((w.get("primary_location") or {}).get("source") or {}).get("display_name"),
+                "openalex_id": w.get("id"),
+                "type": w.get("type"),
+                "cited_by_count": w.get("cited_by_count"),
+                "relevance_score": w.get("relevance_score"),
+            }
+        )
+    return {
+        "source": "openalex",
+        "query": query,
+        "total": data.get("meta", {}).get("count", 0),
+        "results": results,
+    }
+
+
+def search_crossref(query: str, limit: int) -> dict[str, Any]:
+    url = "https://api.crossref.org/works"
+    params = {
+        "query": query,
+        "rows": min(max(limit, 1), 50),
+        "mailto": http.mailto(),
+    }
+    with http.client() as c:
+        resp = c.get(url, params=params)
+    if resp.status_code >= 400:
+        return {"error": f"Crossref HTTP {resp.status_code}", "url": str(resp.url)}
+    data = resp.json()
+    items = data.get("message", {}).get("items", [])
+    results: list[dict[str, Any]] = []
+    for item in items:
+        authors_raw = item.get("author") or []
+        authors = [
+            (a.get("given", "") + " " + a.get("family", "")).strip() if a.get("family") else a.get("name", "")
+            for a in authors_raw
+        ]
+        title_list = item.get("title") or []
+        venue_list = item.get("container-title") or []
+        date_parts = (item.get("issued") or {}).get("date-parts") or [[None]]
+        year = date_parts[0][0] if date_parts and date_parts[0] else None
+        results.append(
+            {
+                "doi": item.get("DOI"),
+                "title": title_list[0] if title_list else None,
+                "authors": [a for a in authors if a],
+                "year": year,
+                "venue": venue_list[0] if venue_list else None,
+                "type": item.get("type"),
+                "cited_by_count": item.get("is-referenced-by-count"),
+                "relevance_score": item.get("score"),
+            }
+        )
+    return {
+        "source": "crossref",
+        "query": query,
+        "total": data.get("message", {}).get("total-results", 0),
+        "results": results,
+    }

--- a/mcp/citation/citation_mcp/server.py
+++ b/mcp/citation/citation_mcp/server.py
@@ -1,0 +1,171 @@
+"""FastMCP server exposing five citation/Zotero tools.
+
+The agent's role here is identifier-shaped (DOI / arXiv / PMID / ISBN / search
+string). Every step of bibliographic-data production happens through deterministic
+external services (Crossref, OpenAlex, Unpaywall, Zotero translation-server,
+Zotero Web API), so the agent never generates citation data from memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from . import oa, resolve, search, zotero_ingest
+
+mcp = FastMCP("citation")
+
+
+@mcp.tool()
+def cite_resolve(identifier: str) -> dict[str, Any]:
+    """Resolve a prefixed persistent identifier to canonical CSL-JSON.
+
+    Supported prefixes: doi:, arxiv:, pmid:, isbn: (best-effort).
+    Examples:
+      cite_resolve("doi:10.1186/1748-5908-5-69")
+      cite_resolve("arxiv:1706.03762")
+      cite_resolve("pmid:19490148")
+    Returns the source's canonical CSL-JSON in `csl`, or an error dict.
+    No metadata is generated from memory.
+    """
+    return resolve.resolve_identifier(identifier)
+
+
+@mcp.tool()
+def cite_search(query: str, limit: int = 10, source: str = "openalex") -> dict[str, Any]:
+    """Search for candidate works by title / keywords / author.
+
+    source: "openalex" (default, broadest) or "crossref" (DOI registry).
+    Returns ranked candidates with DOI, title, authors, year, venue, score.
+    Use when you have partial info but no identifier; pick a candidate and
+    call cite_resolve or zotero_add with its DOI.
+    """
+    return search.search(query, limit=limit, source=source)
+
+
+@mcp.tool()
+def zotero_add(
+    identifier: str,
+    collection_key: str | None = None,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Ingest a citation into the user's Zotero library via translation-server.
+
+    Idempotent on DOI: returns the existing key if the item is already in the
+    library. Translation-server must be running (see error hint if not).
+    `tags` must not include read-status tags (forbidden).
+    """
+    return zotero_ingest.add_to_zotero(identifier, collection_key=collection_key, tags=tags)
+
+
+@mcp.tool()
+def oa_locate(doi: str) -> dict[str, Any]:
+    """Look up OA locations for a DOI via Unpaywall.
+
+    Returns the locations Unpaywall identifies as legitimately open access,
+    with host_type, version, and PDF URLs. Side effect: caches the returned
+    URLs for 15 minutes so zotero_attach_pdf can enforce its OA-only policy.
+    Does not download anything.
+    """
+    result = oa.unpaywall_lookup(doi)
+    if "error" not in result and result.get("locations"):
+        zotero_ingest.remember_oa_urls(result["doi"], result["locations"])
+    return result
+
+
+@mcp.tool()
+def zotero_attach_pdf(
+    zotero_key: str,
+    pdf_url: str,
+    source_note: str | None = None,
+) -> dict[str, Any]:
+    """Attach a PDF to an existing Zotero item, OA-only.
+
+    Refuses to download `pdf_url` unless it appears in a recent oa_locate
+    result for the parent item's DOI (15-minute cache). Verifies content
+    is a PDF before attaching. Never attaches paywalled content.
+    """
+    return zotero_ingest.attach_pdf(zotero_key, pdf_url, source_note=source_note)
+
+
+@mcp.tool()
+def zotero_search(
+    query: str = "",
+    limit: int = 10,
+    qmode: str = "titleCreatorYear",
+    tags: list[str] | None = None,
+    item_type: str | None = None,
+) -> dict[str, Any]:
+    """Search the user's Zotero library for existing items.
+
+    Use this to check what is already in the library before considering
+    zotero_add, to find items by partial title / author / year, or to
+    list items by tag (e.g., methodology, research-catalog).
+
+    query: free-text query; empty string + tag filter is valid for tag-only listing.
+    limit: max results (1-100, default 10).
+    qmode: "titleCreatorYear" (default), "title", or "everything". DOI strings
+        do not index reliably under "everything" — search by title or author
+        instead and check the DOI field on returned items.
+    tags: list of tag names that returned items must have (AND filter).
+    item_type: optional Zotero itemType filter (e.g., "journalArticle", "report").
+
+    Returns: {results: [{zotero_key, title, creators, year, itemType, DOI, url, tags, collections}, ...], count, ...}.
+    Attachments are excluded from results.
+    """
+    return zotero_ingest.search_zotero(
+        query=query, limit=limit, qmode=qmode, tags=tags, item_type=item_type
+    )
+
+
+@mcp.tool()
+def cite_forward(doi: str, limit: int = 25) -> dict[str, Any]:
+    """Return works that CITE the given DOI — forward citations, via OpenAlex.
+
+    Use for forward snowballing during a literature search. Backward
+    citations (works a paper cites) are already available in the
+    `reference` array returned by cite_resolve; this closes the other
+    direction so snowballing never depends on a hand-search that could
+    fabricate "cited by" entries.
+
+    Returns {results: [{doi, title, authors, year, venue, ...}], total,
+    cited_by_count, ...} or an error dict.
+    """
+    return search.search_forward(doi, limit=limit)
+
+
+def _self_test() -> int:
+    """Offline self-test: list tools, verify imports, exit. No network."""
+    print("[citation-mcp] self-test starting", file=sys.stderr)
+    tools = sorted(t.name for t in mcp._tool_manager.list_tools())
+    print(f"[citation-mcp] {len(tools)} tools registered: {tools}", file=sys.stderr)
+    expected = {"cite_resolve", "cite_search", "cite_forward", "zotero_add", "oa_locate", "zotero_attach_pdf", "zotero_search"}
+    missing = expected - set(tools)
+    extra = set(tools) - expected
+    if missing or extra:
+        print(f"[citation-mcp] tool set mismatch — missing={missing} extra={extra}", file=sys.stderr)
+        return 2
+    # Verify imports work
+    from . import http as _http, resolve as _r, search as _s, oa as _o, zotero_ingest as _zi  # noqa: F401
+
+    print(f"[citation-mcp] mailto: {_http.mailto()}", file=sys.stderr)
+    print(f"[citation-mcp] translation_server_url: {_zi.translation_server_url()}", file=sys.stderr)
+    print("[citation-mcp] self-test passed", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="citation-mcp")
+    parser.add_argument("--self-test", action="store_true", help="run offline self-test and exit")
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return _self_test()
+    mcp.run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mcp/citation/citation_mcp/zotero_ingest.py
+++ b/mcp/citation/citation_mcp/zotero_ingest.py
@@ -1,0 +1,500 @@
+"""Zotero ingest via translation-server + pyzotero, plus OA-policy-gated PDF attach."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from . import http
+from . import oa as oa_module
+from .resolve import parse_identifier
+
+
+def translation_server_url() -> str:
+    return os.environ.get("TRANSLATION_SERVER_URL", "http://localhost:1969").rstrip("/")
+
+
+def zotero_client():
+    """Return a pyzotero client. Raises if env vars are missing."""
+    library_id = os.environ.get("PERSONAL_ZOTERO_ID")
+    api_key = os.environ.get("PERSONAL_ZOTERO_KEY")
+    if not library_id or not api_key:
+        raise RuntimeError("PERSONAL_ZOTERO_ID / PERSONAL_ZOTERO_KEY not set in environment")
+    from pyzotero import zotero
+
+    return zotero.Zotero(library_id, "user", api_key)
+
+
+def _normalise_zotero_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a pyzotero item dict to a stable result shape."""
+    data = item.get("data", {})
+    creators: list[str] = []
+    for c in data.get("creators") or []:
+        if c.get("name"):
+            creators.append(c["name"])
+        elif c.get("lastName") or c.get("firstName"):
+            creators.append(f"{c.get('lastName','')}, {c.get('firstName','')}".strip(", "))
+    year = None
+    date = data.get("date") or ""
+    for token in date.replace("-", " ").split():
+        if token.isdigit() and len(token) == 4:
+            year = int(token)
+            break
+    doi = data.get("DOI")
+    if not doi and (data.get("extra") or ""):
+        for line in data["extra"].splitlines():
+            if line.strip().lower().startswith("doi:"):
+                doi = line.split(":", 1)[1].strip()
+                break
+    return {
+        "zotero_key": item.get("key"),
+        "title": data.get("title"),
+        "creators": creators,
+        "year": year,
+        "itemType": data.get("itemType"),
+        "DOI": doi,
+        "url": data.get("url"),
+        "tags": sorted({t.get("tag") for t in data.get("tags", []) if t.get("tag")}),
+        "collections": list(data.get("collections", [])),
+    }
+
+
+def search_zotero(
+    query: str = "",
+    limit: int = 10,
+    qmode: str = "titleCreatorYear",
+    tags: list[str] | None = None,
+    item_type: str | None = None,
+) -> dict[str, Any]:
+    """Search the user's Zotero library.
+
+    qmode: one of "titleCreatorYear" (default), "title", "everything".
+    tags: list of tag names to require (AND-filter). Empty/None = no tag filter.
+    item_type: optional Zotero itemType filter (e.g., "journalArticle"). Attachments
+    are always excluded.
+    """
+    limit = max(1, min(int(limit), 100))
+    valid_modes = {"titleCreatorYear", "title", "everything"}
+    if qmode not in valid_modes:
+        return {"error": f"qmode must be one of {sorted(valid_modes)}", "got": qmode}
+
+    z = zotero_client()
+    kwargs: dict[str, Any] = {"limit": limit, "qmode": qmode}
+    if query:
+        kwargs["q"] = query
+    if tags:
+        kwargs["tag"] = list(tags)
+    if item_type:
+        kwargs["itemType"] = item_type
+
+    try:
+        raw = z.items(**kwargs)
+    except Exception as e:
+        return {"error": f"Zotero search failed: {type(e).__name__}: {e}"}
+
+    results = []
+    for item in raw:
+        data = item.get("data", {})
+        if data.get("itemType") == "attachment":
+            continue
+        results.append(_normalise_zotero_item(item))
+
+    return {
+        "query": query,
+        "qmode": qmode,
+        "tags_filter": tags or [],
+        "item_type_filter": item_type,
+        "count": len(results),
+        "results": results,
+    }
+
+
+# Cache of recent oa_locate results: {doi: (timestamp, allowed_urls_set)}.
+# 15-minute TTL. Used by attach_pdf to enforce the OA-policy gate.
+_OA_CACHE: dict[str, tuple[float, set[str]]] = {}
+_OA_CACHE_TTL = 15 * 60
+
+
+def remember_oa_urls(doi: str, locations: list[dict[str, Any]]) -> None:
+    urls: set[str] = set()
+    for loc in locations or []:
+        for k in ("url", "url_for_pdf", "url_for_landing_page"):
+            if loc.get(k):
+                urls.add(loc[k])
+    _OA_CACHE[doi.strip().lower()] = (time.time(), urls)
+
+
+def _allowed_oa_urls(doi: str) -> set[str] | None:
+    entry = _OA_CACHE.get(doi.strip().lower())
+    if not entry:
+        return None
+    ts, urls = entry
+    if time.time() - ts > _OA_CACHE_TTL:
+        _OA_CACHE.pop(doi.strip().lower(), None)
+        return None
+    return urls
+
+
+def translate_identifier(identifier: str) -> dict[str, Any]:
+    """POST identifier to translation-server. Returns {items: [...]} or {error}.
+
+    Identifiers acceptable to /search: DOI, ISBN, PMID, arXiv ID (with prefix or bare).
+    For URL inputs use /web.
+    """
+    prefix, accession = parse_identifier(identifier)
+    body = accession if prefix == "raw" else f"{prefix}:{accession}"
+    base = translation_server_url()
+
+    try:
+        with http.client(timeout=30.0) as c:
+            resp = c.post(
+                f"{base}/search",
+                content=body.encode("utf-8"),
+                headers={"Content-Type": "text/plain"},
+            )
+    except (httpx.ConnectError, httpx.ReadError, httpx.ConnectTimeout) as e:
+        return {
+            "error": "translation-server unreachable",
+            "url": base,
+            "hint": "Start translation-server with: docker run -d --rm -p 1969:1969 zotero/translation-server",
+            "detail": str(e),
+        }
+
+    if resp.status_code == 501:
+        return {"error": "translation-server could not handle identifier", "identifier": identifier}
+    if resp.status_code == 300:
+        return {"error": "translation-server returned multiple items requiring selection (not handled in v1)"}
+    if resp.status_code >= 400:
+        return {"error": f"translation-server HTTP {resp.status_code}", "body": resp.text[:300]}
+    try:
+        items = resp.json()
+    except Exception as e:
+        return {"error": f"translation-server returned non-JSON: {e}"}
+    if not isinstance(items, list) or not items:
+        return {"error": "translation-server returned no items"}
+    return {"items": items}
+
+
+def find_by_doi(doi: str, title_hint: str | None = None) -> dict[str, Any] | None:
+    """Search the user's Zotero library for an existing item with matching DOI.
+
+    Zotero's full-text search does not reliably index DOI strings (slashes and
+    dots tokenize as separators), so `q=<doi>` often misses even when the
+    DOI is set on an existing item. Workaround: search by a title hint when
+    available, then verify DOI match in the candidates. Falls back to the
+    DOI's suffix and finally to the raw DOI string.
+    """
+    doi = (doi or "").strip().lower()
+    if not doi:
+        return None
+    z = zotero_client()
+
+    def _check(item):
+        data = item.get("data", {})
+        if data.get("itemType") == "attachment":
+            return False
+        if (data.get("DOI") or "").lower() == doi:
+            return True
+        if doi in (data.get("extra") or "").lower():
+            return True
+        return False
+
+    # Primary: title-based search, verify DOI in candidates.
+    if title_hint:
+        try:
+            for item in z.items(q=title_hint, qmode="titleCreatorYear", limit=25):
+                if _check(item):
+                    return item
+        except Exception:
+            pass
+
+    # Fallback: DOI suffix (after the "/"). Often matches URL fields containing
+    # https://doi.org/<suffix>.
+    suffix = doi.split("/", 1)[1] if "/" in doi else doi
+    try:
+        for item in z.items(q=suffix, qmode="everything", limit=25):
+            if _check(item):
+                return item
+    except Exception:
+        pass
+
+    # Last resort: raw DOI.
+    try:
+        for item in z.items(q=doi, qmode="everything", limit=25):
+            if _check(item):
+                return item
+    except Exception:
+        pass
+
+    return None
+
+
+def _doi_from_translation(item: dict[str, Any]) -> str | None:
+    doi = item.get("DOI") or item.get("doi")
+    if doi:
+        return doi.strip()
+    # Some translators put DOI in extra
+    extra = item.get("extra") or ""
+    for line in extra.splitlines():
+        if line.strip().lower().startswith("doi:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def add_to_zotero(
+    identifier: str,
+    collection_key: str | None = None,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Ingest via translation-server + pyzotero. Idempotent on DOI."""
+    if tags:
+        forbidden = {t for t in tags if t.lower() in ("read", "unread")}
+        if forbidden:
+            return {"error": f"forbidden tags: {sorted(forbidden)} (read-status tags not allowed)"}
+
+    translation = translate_identifier(identifier)
+    if "error" in translation:
+        return translation
+    items = translation["items"]
+    # translation-server can return auxiliary entries — standalone notes or
+    # attachments — alongside the bibliographic record (the arXiv translator,
+    # for one, emits the paper's "comment" as a separate note). Those are not
+    # citations; keep only the real bibliographic item(s).
+    biblio = [it for it in items if it.get("itemType") not in ("note", "attachment", "annotation")]
+    if not biblio:
+        return {
+            "error": "translation-server returned no bibliographic item",
+            "item_types": [it.get("itemType") for it in items],
+        }
+    if len(biblio) > 1:
+        return {
+            "error": f"translation-server returned {len(biblio)} distinct bibliographic "
+            f"items; cannot disambiguate in v1",
+            "candidates": [
+                {"itemType": it.get("itemType"), "title": it.get("title")} for it in biblio
+            ],
+        }
+    item = dict(biblio[0])
+
+    # Dedup
+    doi = _doi_from_translation(item)
+    existing = None
+    if doi:
+        try:
+            existing = find_by_doi(doi, title_hint=item.get("title"))
+        except Exception as e:
+            return {"error": f"Zotero search failed: {type(e).__name__}: {e}"}
+    if existing:
+        # Merge any requested tags / collection into the existing item.
+        # Without this, callers who pass tags expecting them to be applied
+        # discover that dedup silently dropped them.
+        existing_data = existing["data"]
+        merge_diff = {"tags_added": [], "collection_added": False}
+        if tags:
+            existing_tag_set = {t.get("tag") for t in existing_data.get("tags", []) if t.get("tag")}
+            new_tags = [t for t in tags if t not in existing_tag_set]
+            if new_tags:
+                existing_data["tags"] = list(existing_data.get("tags", [])) + [{"tag": t} for t in new_tags]
+                merge_diff["tags_added"] = new_tags
+        if collection_key:
+            cols = list(existing_data.get("collections") or [])
+            if collection_key not in cols:
+                cols.append(collection_key)
+                existing_data["collections"] = cols
+                merge_diff["collection_added"] = True
+        if merge_diff["tags_added"] or merge_diff["collection_added"]:
+            try:
+                z = zotero_client()
+                z.update_item(existing)
+            except Exception as e:
+                return {
+                    "error": f"Zotero update_item failed during dedup-merge: {type(e).__name__}: {e}",
+                    "zotero_key": existing["key"],
+                }
+        return {
+            "zotero_key": existing["key"],
+            "was_new": False,
+            "doi": doi,
+            "title": existing_data.get("title"),
+            "itemType": existing_data.get("itemType"),
+            "merge_diff": merge_diff,
+        }
+
+    # Apply collection + tags
+    if collection_key:
+        item["collections"] = list({*item.get("collections", []), collection_key})
+    if tags:
+        existing_tags = {t.get("tag") for t in item.get("tags", []) if isinstance(t, dict)}
+        for t in tags:
+            if t not in existing_tags:
+                item.setdefault("tags", []).append({"tag": t})
+
+    # pyzotero create
+    try:
+        z = zotero_client()
+        resp = z.create_items([item])
+    except Exception as e:
+        return {"error": f"Zotero create failed: {type(e).__name__}: {e}"}
+
+    success = resp.get("success") or resp.get("successful") or {}
+    failed = resp.get("failed") or {}
+    if failed:
+        return {"error": "Zotero create reported failures", "failed": failed}
+    if not success:
+        return {"error": "Zotero create returned empty success map", "response": resp}
+    created = next(iter(success.values()))
+    key = created if isinstance(created, str) else (
+        created.get("key") or created.get("data", {}).get("key")
+    )
+    return {
+        "zotero_key": key,
+        "was_new": True,
+        "doi": doi,
+        "title": item.get("title"),
+        "itemType": item.get("itemType"),
+    }
+
+
+def _item_doi(zotero_key: str) -> str | None:
+    z = zotero_client()
+    item = z.item(zotero_key)
+    if not item:
+        return None
+    data = item.get("data", {})
+    doi = data.get("DOI")
+    if doi:
+        return doi.strip()
+    extra = data.get("extra") or ""
+    for line in extra.splitlines():
+        if line.strip().lower().startswith("doi:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def attach_pdf(
+    zotero_key: str,
+    pdf_url: str,
+    source_note: str | None = None,
+) -> dict[str, Any]:
+    """OA-policy-gated PDF attach.
+
+    Refuses to download pdf_url unless that URL appears in a recent oa_locate
+    cache entry for the parent item's DOI. Cache TTL 15 minutes.
+    """
+    try:
+        parent_doi = _item_doi(zotero_key)
+    except Exception as e:
+        return {"error": f"could not look up parent item: {type(e).__name__}: {e}"}
+    if not parent_doi:
+        return {"error": f"parent Zotero item {zotero_key} has no DOI; OA policy cannot be applied"}
+
+    allowed = _allowed_oa_urls(parent_doi)
+    if allowed is None:
+        # Try a live oa_locate now.
+        oa = oa_module.unpaywall_lookup(parent_doi)
+        if "error" in oa:
+            return {"error": "could not establish OA whitelist for parent item", "oa_lookup_error": oa}
+        remember_oa_urls(parent_doi, oa.get("locations", []))
+        allowed = _allowed_oa_urls(parent_doi) or set()
+    if pdf_url not in allowed:
+        return {
+            "error": "pdf_url not in OA whitelist for this DOI",
+            "doi": parent_doi,
+            "hint": "Call oa_locate(doi) first; only URLs Unpaywall identifies as OA may be attached.",
+            "allowed_urls_count": len(allowed),
+        }
+
+    # Download
+    try:
+        with http.client(timeout=60.0) as c:
+            resp = c.get(pdf_url)
+    except Exception as e:
+        return {"error": f"download failed: {type(e).__name__}: {e}", "url": pdf_url}
+    if resp.status_code >= 400:
+        return {"error": f"download HTTP {resp.status_code}", "url": pdf_url}
+    content = resp.content
+    if not content.startswith(b"%PDF"):
+        return {
+            "error": "downloaded content is not a PDF",
+            "url": pdf_url,
+            "content_type": resp.headers.get("content-type"),
+            "first_bytes": content[:16].hex(),
+        }
+
+    fd, tmp_path = tempfile.mkstemp(suffix=".pdf", prefix="citation-mcp-")
+    try:
+        os.write(fd, content)
+    finally:
+        os.close(fd)
+
+    try:
+        z = zotero_client()
+        result = z.attachment_simple([tmp_path], zotero_key)
+    except Exception as e:
+        return {"error": f"Zotero attach failed: {type(e).__name__}: {e}"}
+    finally:
+        try:
+            Path(tmp_path).unlink()
+        except FileNotFoundError:
+            pass
+
+    # pyzotero's attachment_simple returns various shapes; the response's
+    # `success`/`successful` map is sometimes empty on success and the actual
+    # attachment key only appears via the parent-children listing. We treat a
+    # non-empty `failure`/`failed` map as a definite failure and otherwise
+    # confirm by re-fetching the parent's children and finding the most recent
+    # PDF attachment.
+    success_map = result.get("success") or result.get("successful") or {}
+    failure_map = result.get("failure") or result.get("failed") or {}
+    if failure_map:
+        return {
+            "success": False,
+            "parent_zotero_key": zotero_key,
+            "doi": parent_doi,
+            "source_url": pdf_url,
+            "error": "Zotero attach reported failures",
+            "failure": failure_map,
+        }
+
+    attachment_key: str | None = None
+    if success_map:
+        first = next(iter(success_map.values()))
+        if isinstance(first, str):
+            attachment_key = first
+        elif isinstance(first, dict):
+            attachment_key = first.get("key") or first.get("data", {}).get("key")
+
+    # If pyzotero didn't surface the key directly, scan the parent's children
+    # for a recently-added PDF attachment.
+    if not attachment_key:
+        try:
+            children = z.children(zotero_key)
+            pdf_children = [
+                c for c in children
+                if c.get("data", {}).get("itemType") == "attachment"
+                and c.get("data", {}).get("contentType") == "application/pdf"
+            ]
+            if pdf_children:
+                pdf_children.sort(
+                    key=lambda c: c.get("data", {}).get("dateAdded", ""),
+                    reverse=True,
+                )
+                attachment_key = pdf_children[0]["key"]
+        except Exception:
+            pass
+
+    return {
+        "success": bool(attachment_key),
+        "attachment_key": attachment_key,
+        "parent_zotero_key": zotero_key,
+        "doi": parent_doi,
+        "source_url": pdf_url,
+        "source_note": source_note,
+        "bytes": len(content),
+        "raw_response": result,
+    }

--- a/mcp/citation/pyproject.toml
+++ b/mcp/citation/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "citation-mcp"
+version = "0.1.0"
+description = "Deterministic citation resolution and Zotero ingest MCP for Ground Control research workflows"
+requires-python = ">=3.11"
+dependencies = [
+    "mcp[cli]>=1.2",
+    "httpx>=0.27",
+    "pyzotero>=1.5",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["citation_mcp"]

--- a/skills/lit-review-argument/SKILL.md
+++ b/skills/lit-review-argument/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: lit-review-argument
+description: Phase 4 of the literature-review workflow. Takes the phase-3 evidence base and builds the paper's argument architecture — a section outline plus the discussion's load-bearing arguments reconstructed in Argdown and validated with the Argdown CLI. User-invoked after the phase-3 evidence base has been reviewed; it does not auto-chain. The output is the paper's argument structure, not finished prose.
+---
+
+# # Lit-Review Argument Architecture (Phase 4)
+
+This skill turns the phase-3 evidence base into the paper's argument architecture: a section outline, and the discussion's load-bearing arguments reconstructed in Argdown. It does not write prose — phase 5 (`lit-review-draft`) does that.
+
+Phase 3 produced the evidence base — what the review found. This skill decides *what the paper argues, in what order, and on what support* — and makes every argumentative step explicit and checkable before a word of prose is committed.
+
+## What this skill counters
+
+Each item earns its place by what goes wrong when a paper is drafted straight from an evidence base with no argument layer in between.
+
+- **Asserting what the evidence base does not carry.** Phase 3's hallucination danger returns in argument form: the outline, or an Argdown premise, states a finding the charted corpus does not support. Counter: every outline node and every Argdown statement traces to a specific `synthesis.md` section, `evidence-matrix.md` cell, or `decisions.md` entry, recorded as an `{evidence: "..."}` tag. An ungrounded statement fails the grounding pass.
+- **Argumentative leaps.** The discussion's conclusion does not follow from its stated premises. Counter: each load-bearing argument is reconstructed as an explicit premise–conclusion structure (PCS); a step that does not hold is visible as a gap between the numbered premises and the conclusion, or as a hidden premise that has to be written down.
+- **Importing a generic prior.** The agent builds the argument from "what a paper like this usually argues" instead of from this review's findings. Counter: the argument spine is the paper's own primary claim and research questions answered against `synthesis.md`; nothing enters the map that does not trace to this review's evidence base.
+- **Over-claiming past the method's limits.** The method has limits the synthesis already declared (for a scoping review: no severity ranking, no prevalence claim, no causal claim). Counter: a method-limits pass — any Argdown conclusion asserting more than the method licenses is a violation (`synthesis.md` method-limits section; `requirements.md` §7).
+- **Taxonomy-validity objections left implicit.** A taxonomy paper invites objections about category separability, unit-of-analysis stability, source-role bias, ending-condition satisfaction, and evaluation utility. Counter: for taxonomy-development evidence bases, model those as explicit objections or limitations before drafting.
+- **Drifting from the paper's declared claim.** The outline argues something other than the stanza's primary claim and RQs, or quietly argues a declared non-claim. Counter: the outline's spine is the primary claim and the RQs; each declared non-claim gets an explicit "not argued here" placement.
+- **Unexamined objections.** The discussion ignores objections the protocol already identified — unresolved gate tensions, declared validity threats, the cumulative-deviation question. Counter: known objections enter the Argdown map as explicit attacks; the paper's response is the support attached to each. A discussion with no modelled objections is incomplete, not clean.
+- **Structurally loose argument maps.** The Argdown does not parse; a premise is asserted from nowhere; a support argument is wired in but never reconstructed; an objection is raised and left hanging; a statement supports itself. Counter: `validate-argument-map.sh` — it parses the map with the Argdown CLI and runs `check-argument-structure.mjs` over the model, which mechanically flags ungrounded premises, unreconstructed support arguments, unanswered objections, and circular support. What the tooling cannot check — whether the premises entail the conclusion — is named explicitly so it is not mistaken for done.
+
+## The discipline (what the output IS)
+
+An argument architecture: a section outline plus a validated Argdown argument map, critiqueable by a reviewer who has read the evidence base and the paper's stanza.
+
+Allowed in the output: outline nodes and arguments traceable to the evidence base; known objections modelled as attacks; the method limits stated as explicit boundary statements; the paper's declared non-claims placed as exclusions.
+
+Not allowed: claims not traceable to the charted corpus; prose paragraphs; findings the synthesis does not contain; severity / prevalence / causal conclusions a descriptive review cannot support; citations to sources outside the phase-3 included set; relitigation of the synthesis.
+
+## Argdown conventions for this skill
+
+- Reconstruct each load-bearing argument as a **premise–conclusion structure**: numbered premises, an inference line, then the conclusion.
+- Every premise must be grounded one of two ways: it carries evidence provenance as Argdown metadata — `{evidence: "synthesis.md §3.3"}` — *or* it is itself the conclusion of another argument in the map (grounded by derivation). A premise that is neither is ungrounded, and `validate-argument-map.sh` flags it.
+- A premise that is deliberately the paper's own analytic frame rather than an evidence-base finding is tagged `{evidence: "paper-contribution: ..."}`. The checker lists these separately — they are not failures, but they must be defended in the paper's prose, not cited.
+- Connect nodes with Argdown relations: `<+` / `<-` are incoming support / attack; `+>` / `->` are outgoing.
+- Model an objection as a statement that **attacks** a load-bearing claim (or, if the objector's reasoning is itself worth reconstructing, a full argument). Model the paper's reply as a **counter-attack on the objection**. Every modelled objection must have a reply — a rebuttal, or an explicit concession — or `validate-argument-map.sh` flags it unanswered.
+- One file: `argument-map.argdown` in the workspace.
+
+## Workflow
+
+1. **Read the inputs.** From the workspace: `synthesis.md`, `evidence-matrix.md`, `charting-data.md`, `coding-scheme.md`, `decisions.md`, `requirements.md`, `lit-review-plan.md`. And the paper's stanza in `program/` (primary claim, RQs, non-claims, venue posture, evidence-needed). If `synthesis.md` does not exist, phase 3 has not run — stop and run `lit-review-search` first.
+
+2. **Fix the spine.** The primary claim (verbatim from the stanza / `requirements.md` §2) and the research questions are the argument's spine. List the declared non-claims — these are explicit exclusions the argument must not drift into.
+
+3. **Build the outline.** Write `paper-outline.md`: the section structure, tracing the method's reporting standard (for a scoping review, PRISMA-ScR-shaped — background/rationale, objectives, methods, results, discussion, limitations, conclusions; for another method, trace the contract's equivalent). Each node names what it argues or reports and cites the evidence-base source(s) it draws on. Mark the **load-bearing discussion nodes** — the ones that make an argumentative claim, not just report a count — for Argdown reconstruction.
+
+   For taxonomy-development papers, the outline must foreground the taxonomy artifact and its method-bounded contribution: construction rationale, final dimensions/characteristics, evaluation, utility, limits, and non-claims. Do not present a taxonomy paper as a flat scoping-review results catalogue unless the phase-1 contract chose a review method for that role.
+
+4. **Reconstruct the arguments in Argdown.** In `argument-map.argdown`, reconstruct each load-bearing discussion node as a PCS. At minimum: a central argument for the primary claim; one argument per research question; one per implication the synthesis draws; and a method-adequacy argument that confronts the cumulative-deviation question. Every premise carries its `{evidence: ...}` tag. Connect the arguments with support relations. Model every objection the protocol already identified — declared validity threats and unresolved gate tensions in `decisions.md` — as an explicit attack, with the paper's response attached.
+
+5. **Validate.** Run `validate-argument-map.sh` (in this skill's base directory). It runs two checks: the Argdown CLI parse (syntax), and `check-argument-structure.mjs` over the parsed model — flagging ungrounded premises, unreconstructed support arguments (an argument wired in as support but given no premise-conclusion structure), unanswered objections, and circular support. Fix every failure it reports. Then do the part the tooling *cannot* do — **material validity**: read each PCS and confirm the premises actually entail the conclusion (a structurally clean argument can still be a non-sequitur), and confirm each `{evidence: ...}` pointer genuinely says what the premise claims. Also check no conclusion exceeds the method's declared limits. The script's "OK" means structurally sound, not valid — do not mistake it for done.
+
+6. **Self-review.** Apply the angles in `argument-self-review.md`.
+
+7. **Record decisions.** Extend `decisions.md` with argument-phase decisions: what was promoted to a load-bearing argument, which objections were modelled and how each was answered, any claim deliberately scoped down to stay inside the method's limits.
+
+**Gates** are raised as in earlier phases: a decision that is genuinely the user's (a claim the evidence base will not carry; an objection with no good answer) is surfaced immediately with a recommendation and reasoning, resolved, logged, and the work continues. No end-of-document backlog.
+
+This skill **does not auto-chain into phase 5.** The argument architecture is a checkpoint: the user reviews `paper-outline.md` and `argument-map.argdown`, then invokes `lit-review-draft`.
+
+## Output structure
+
+In the workspace:
+
+- **`paper-outline.md`** — the section structure; each node cites the evidence-base source it draws on; load-bearing discussion nodes marked.
+- **`argument-map.argdown`** — the discussion's load-bearing arguments as validated Argdown PCS, with grounded premises and modelled objections.
+- **`argument-self-review.md`** — the self-review.
+- **`decisions.md`** — extended.
+
+The paper's prose is *not* an output of this skill.
+
+## Self-review angles
+
+### Grounding angles
+
+- **Every-node-grounded pass.** Does every outline node and every Argdown statement trace to a specific evidence-base source? Any premise with no `{evidence: ...}` tag is ungrounded — ground it or cut it.
+- **Argument-completeness pass.** Does every load-bearing discussion node have a reconstructed PCS? Any conclusion resting on a premise that was never stated?
+- **Objection pass.** Is every protocol-identified objection — each declared validity threat, each unresolved gate tension — modelled as an attack with a response or an explicit concession? An unmodelled objection is a discussion gap.
+- **Spine-fidelity pass.** Does the outline argue the stanza's primary claim and RQs, and only those? Has a declared non-claim crept in as an argument?
+
+### Sharpness angles
+
+- **Inference pass.** For each PCS, do the premises actually entail the conclusion, or is there a hidden premise doing silent work? Write the hidden premise down — then it is either defensible or the leap is exposed.
+- **Method-limits pass.** Does any conclusion assert severity, prevalence, causation, or anything else the method's declared limits forbid?
+- **Taxonomy-validity pass.** For taxonomy-development papers, are the strongest objections modelled: category overlap, unstable unit of analysis, unsupported meta-characteristic, weak ending-condition evidence, source-selection bias, and overclaiming recurrence or coverage from background/framing sources?
+- **Claim-term pass.** Does the argument honour the operational definitions set in phase 2 (e.g. what "recurring" was defined to require)? An argument that claims more than the definition licenses is over-reach.
+- **Load-bearing-objection pass.** Is the *strongest* objection to the primary claim actually modelled — or only the weak ones that are easy to rebut?
+- **Contribution-shape pass.** Does the architecture foreground the paper's strongest, most original claim — or does it lay out every research question and finding co-equally, as a catalogue or a flat list? A review still has a *point*. The most original finding should be the spine the outline and the argument map are built around, not item N of a parallel series. If the sharpest claim is buried — the last of three co-equal results sections, one of six co-equal implications — the architecture is competent but not pointed. Re-spine it: make the lead the lead, and re-role the rest as the machinery that earns it. But re-spining can change what the paper claims relative to its stanza and its place on the program's claim ladder — and if it does, that is a stanza / claim-ladder reconciliation, not a phase-4 call: raise it as a gate and settle it with the user *before* restructuring, never as a side-effect inside the restructure. *(Observed: a fourteen-code instrument-problem catalogue presented as the contribution, with the one genuine insight — that pre-backend addressability is a conditional, (problem, mitigation)-pair structure — buried as the third research question and one of six co-equal implications.)*
+
+## What this skill is NOT
+
+- It is not phase 3. If `synthesis.md` does not exist, stop and run `lit-review-search`.
+- It is not phase 5. It builds the argument architecture; it does not write prose.
+- It is not a place to introduce findings. Every claim traces to the phase-3 evidence base; a claim the evidence base will not carry is surfaced to the user, not argued anyway.
+- It is not a place to relitigate the synthesis. If the synthesis is genuinely wrong, stop and surface that — do not quietly argue around it.

--- a/skills/lit-review-argument/check-argument-structure.mjs
+++ b/skills/lit-review-argument/check-argument-structure.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// # phase-4 Argdown structural checker.
+//
+// Reads an Argdown JSON model (produced by `argdown json`) and runs structural
+// checks that mechanically catch argument-construction failure modes an LLM
+// does not reliably self-police:
+//
+//   A  ungrounded premise       — a PCS premise with no {evidence:} tag that is
+//                                 also not derived as a conclusion elsewhere in
+//                                 the map. (A premise tagged "paper-contribution"
+//                                 is the paper's own analytic frame: listed,
+//                                 not failed.)
+//   B  unreconstructed support  — an argument wired in as support for a claim
+//                                 but given no premise-conclusion structure.
+//                                 Argdown exists to make logical structure
+//                                 explicit; claimed support with no PCS is a
+//                                 direct failure to do that. (A no-PCS argument
+//                                 that only ATTACKS is a bare-stated objection
+//                                 — acceptable, reported as info.)
+//   C  unanswered objection     — a node that attacks a load-bearing claim and
+//                                 has no response (no incoming attack on it).
+//   D  circular support         — a statement that transitively supports itself.
+//
+// It does NOT check material validity — whether the premises actually entail
+// the conclusion — or the truth of a premise. Those stay the agent's judgement
+// (see lit-review-argument/SKILL.md, step 5).
+//
+// A malformed PCS (the inference line present but a premise or conclusion
+// missing) is rejected by the Argdown parser at the syntax layer, before this
+// checker runs — so it needs no check here.
+//
+// Usage: check-argument-structure.mjs <model.json>
+// Exit:  0 clean · 1 one or more hard failures · 2 bad input
+
+import { readFileSync } from 'node:fs';
+
+const jf = process.argv[2];
+if (!jf) {
+  console.error('usage: check-argument-structure.mjs <model.json>');
+  process.exit(2);
+}
+let m;
+try {
+  m = JSON.parse(readFileSync(jf, 'utf8'));
+} catch (e) {
+  console.error('FAIL [input]: cannot read JSON model: ' + e.message);
+  process.exit(2);
+}
+
+const args = m.arguments || {};
+const rels = m.relations || [];
+const CONC = new Set(['main-conclusion', 'preliminary-conclusion']);
+const pcsOf = (a) => ((a.members || []).find((x) => x.pcs && x.pcs.length) || {}).pcs || [];
+const snip = (p) => (p.text || p.title || '?').trim().replace(/\s+/g, ' ').slice(0, 72);
+
+const fails = [];
+const info = [];
+
+// statements derived inside the map (conclusions of some argument)
+const conclusionTitles = new Set();
+for (const a of Object.values(args))
+  for (const p of pcsOf(a)) if (CONC.has(p.role) && p.title) conclusionTitles.add(p.title);
+
+// ---- A: ungrounded premises ----
+let premiseCount = 0;
+let analyticFrame = 0;
+for (const [name, a] of Object.entries(args)) {
+  for (const p of pcsOf(a)) {
+    if (p.role !== 'premise') continue;
+    premiseCount++;
+    const ev = p.data && p.data.evidence;
+    if (typeof ev === 'string' && /paper-contribution/i.test(ev)) {
+      analyticFrame++;
+      info.push(`analytic-frame premise (defend in prose, not cited) — <${name}>: "${snip(p)}…"`);
+    } else if (ev) {
+      // grounded in the evidence base
+    } else if (p.title && conclusionTitles.has(p.title)) {
+      // grounded by derivation: it is a conclusion elsewhere in the map
+    } else {
+      fails.push(`A ungrounded premise — <${name}>: "${snip(p)}…" has no {evidence:} tag and is not derived in the map.`);
+    }
+  }
+}
+
+// ---- B: unreconstructed support arguments ----
+// A no-PCS argument that is claimed to SUPPORT a claim (stands as the 'from' of
+// a support relation) is hand-waved — it should be reconstructed. A no-PCS
+// argument that only attacks is a bare-stated objection, which is acceptable.
+const supportFrom = new Set(
+  rels.filter((r) => r.relationType === 'support').map((r) => r.from)
+);
+for (const [name, a] of Object.entries(args)) {
+  if (pcsOf(a).length > 0) continue;
+  if (supportFrom.has(name))
+    fails.push(`B unreconstructed support — <${name}> is wired in as support for a claim but has no premise-conclusion reconstruction.`);
+  else
+    info.push(`argument stated without a reconstruction (no PCS) — <${name}>`);
+}
+
+// ---- C: unanswered objections ----
+// positive seed = every statement that participates in a PCS (premise/conclusion)
+const positive = new Set();
+for (const a of Object.values(args))
+  for (const p of pcsOf(a)) if (p.title) positive.add(p.title);
+const attacks = rels.filter((r) => r.relationType === 'attack');
+const attacked = new Set(attacks.map((r) => r.to));
+const objections = new Set();
+for (const r of attacks) if (positive.has(r.to)) objections.add(r.from);
+for (const o of objections) {
+  if (!attacked.has(o))
+    fails.push(`C unanswered objection — "${o}" attacks a load-bearing claim and has no response (no incoming attack).`);
+}
+
+// ---- D: circular support ----
+const adj = new Map();
+const edge = (u, v) => {
+  if (!adj.has(u)) adj.set(u, []);
+  adj.get(u).push(v);
+};
+for (const [name, a] of Object.entries(args)) {
+  for (const p of pcsOf(a)) {
+    if (p.role === 'premise' && p.title) edge(p.title, name);
+    if (CONC.has(p.role) && p.title) edge(name, p.title);
+  }
+}
+const color = new Map(); // 1 = on stack, 2 = done
+let cycle = null;
+const dfs = (u, path) => {
+  color.set(u, 1);
+  for (const v of adj.get(u) || []) {
+    if (color.get(v) === 1) {
+      cycle = [...path, u, v];
+      return true;
+    }
+    if (!color.get(v) && dfs(v, [...path, u])) return true;
+  }
+  color.set(u, 2);
+  return false;
+};
+for (const u of adj.keys()) {
+  if (!color.get(u) && dfs(u, [])) break;
+}
+if (cycle) fails.push(`D circular support — ${cycle.join(' -> ')}`);
+
+// ---- report ----
+for (const i of info) console.log('  info: ' + i);
+console.log(
+  `  checked: ${Object.keys(args).length} arguments, ${premiseCount} premises, ` +
+    `${attacks.length} attack relations, ${objections.size} objections.`
+);
+if (fails.length === 0) {
+  console.log('  STRUCTURE OK — grounding, support-reconstruction, objection-closure, non-circularity all pass.');
+  if (analyticFrame)
+    console.log(`  (${analyticFrame} analytic-frame premise(s) listed above — the paper's frame, defended in prose, not a failure.)`);
+  console.log('  NOTE: material validity — do the premises entail the conclusion — is NOT checked here; that is the agent pass.');
+  process.exit(0);
+} else {
+  for (const f of fails) console.log('  FAIL: ' + f);
+  console.log(`  STRUCTURE FAIL — ${fails.length} issue(s) above.`);
+  process.exit(1);
+}

--- a/skills/lit-review-argument/package-lock.json
+++ b/skills/lit-review-argument/package-lock.json
@@ -1,0 +1,1593 @@
+{
+  "name": "lit-review-argument-validator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lit-review-argument-validator",
+      "version": "0.1.0",
+      "dependencies": {
+        "@argdown/cli": "2.0.0"
+      }
+    },
+    "node_modules/@argdown/cli": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@argdown/cli/-/cli-2.0.0.tgz",
+      "integrity": "sha512-V0Tw144t7u1NABk1PX2bY9is4vDm7JbeYdT50rI2vjtiAREG3FneNHLe+Li5AVvqVy+oChLitLDLdTUB/KpZQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@argdown/core": "^2.0.1",
+        "@argdown/markdown-it-plugin": "^2.0.0",
+        "@argdown/node": "^2.0.1",
+        "import-global": "^1.1.1",
+        "markdown-it": "^14.1.0",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "argdown": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">= 22.11.0"
+      }
+    },
+    "node_modules/@argdown/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@argdown/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-IXqpZD8KCVzZb113XvXdMjyPmEbcyuGeh2YGQy4Rsir5JNNXZetqAw55r5yIhEPxzA9reG/6ZLD7yIG7UgoJNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@argdown/highlightjs": "^2.0.0",
+        "@hpcc-js/wasm-graphviz": "^1.16.0",
+        "chevrotain": "^11.0.3",
+        "eventemitter3": "^5.0.1",
+        "highlight.js": "11.11.1",
+        "js-yaml": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.defaultsdeep": "^4.6.1",
+        "lodash.last": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.partialright": "^4.2.1",
+        "lodash.union": "^4.6.0",
+        "mdurl": "^2.0.0",
+        "punycode": "^2.3.1",
+        "string-pixel-width": "^1.10.0",
+        "xmlbuilder": "^15.1.0"
+      },
+      "engines": {
+        "node": ">= 22.11.0"
+      }
+    },
+    "node_modules/@argdown/highlightjs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@argdown/highlightjs/-/highlightjs-2.0.0.tgz",
+      "integrity": "sha512-E8Zd+VdLb7rr/xFpsiqkeLEi97kNWATH/k9mU15kFdFfuZGR7xpc19CwNSkIeM2k1oQ7/Jk8GhVJmAZGib1c6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/@argdown/markdown-it-plugin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@argdown/markdown-it-plugin/-/markdown-it-plugin-2.0.0.tgz",
+      "integrity": "sha512-S8oY6HCDvvv8O1qz6//mnDuV/2uPVIOm35Al3U7eWufZlc05/2ELqTbrMP7+Yzpn40nW3BfZ8aWXD9lJOHFJrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@argdown/core": "^2.0.1",
+        "lodash.defaultsdeep": "^4.6.1",
+        "markdown-it": "^14.1.0"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/@argdown/node": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@argdown/node/-/node-2.0.3.tgz",
+      "integrity": "sha512-TFDcOXBaOXm3Xqk58F7xsPPfXCNYI58771tkFz0I9oo/V77QIH+zJxhiqw5GILIfFdSVtJPqQ8UyuZbAedkteQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@argdown/core": "^2.0.1",
+        "@hpcc-js/wasm-graphviz": "^1.18.0",
+        "axios": "^1.8.2",
+        "chokidar": "^5.0.0",
+        "glob": "^13.0.6",
+        "image-size": "^2.0.0",
+        "image-type": "^5.2.0",
+        "import-fresh": "^3.3.1",
+        "is-svg": "^5.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.defaultsdeep": "^4.6.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isobject": "^3.0.2",
+        "lodash.isstring": "^4.0.1",
+        "mkdirp": "^2.1.6",
+        "pdfkit": "^0.17.2",
+        "svg-to-pdfkit": "^0.1.8"
+      },
+      "engines": {
+        "node": ">= 22.11.0"
+      }
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.2.0.tgz",
+      "integrity": "sha512-ssJFvn/UXhQQeICw3SR/fZPmYVj+JM2mP+Lx7bZ51cOeHaMWOKp3AUMuyM3QR82aFFXTfcAp67P5GpPjGmbZWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "11.2.0",
+        "@chevrotain/types": "11.2.0",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.2.0.tgz",
+      "integrity": "sha512-c+KoD6eSI1xjAZZoNUW+V0l13UEn+a4ShmUrjIKs1BeEWCji0Kwhmqn5FSx1K4BhWL7IQKlV7wLR4r8lLArORQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "11.2.0",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.2.0.tgz",
+      "integrity": "sha512-lG73pBFqbXODTbXhdZwv0oyUaI+3Irm+uOv5/W79lI3g5hasYaJnVJOm3H2NkhA0Ef4XLBU4Scr7TJDJwgFkAw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.2.0.tgz",
+      "integrity": "sha512-vBMSj/lz/LqolbGQEHB0tlpW5BnljHVtp+kzjQfQU+5BtGMTuZCPVgaAjtKvQYXnHb/8i/02Kii00y0tsuwfsw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.2.0.tgz",
+      "integrity": "sha512-+7whECg4yNWHottjvr2To2BRxL4XJVjIyyv5J4+bJ0iMOVU8j/8n1qPDLZS/90W/BObDR8VNL46lFbzY/Hosmw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@hpcc-js/wasm-graphviz": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm-graphviz/-/wasm-graphviz-1.21.7.tgz",
+      "integrity": "sha512-7AGe3P9DoJs1eyS41rfNKq1iR9GSCcTSMdOr2DN5vetJEiwCYxI6rnz5bSyaolF1EDmy8X5zdFugY+t8+KO+CQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.2.0.tgz",
+      "integrity": "sha512-mHCHTxM51nCklUw9RzRVc0DLjAh/SAUPM4k/zMInlTIo25ldWXOZoPt7XEIk/LwoT4lFVmJcu9g5MHtx371x3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "11.2.0",
+        "@chevrotain/gast": "11.2.0",
+        "@chevrotain/regexp-to-ast": "11.2.0",
+        "@chevrotain/types": "11.2.0",
+        "@chevrotain/utils": "11.2.0",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "18.7.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.7.0.tgz",
+      "integrity": "sha512-ihHtXRzXEziMrQ56VSgU7wkxh55iNchFkosu7Y9/S+tXHdKyrGjVK0ujbqNnsxzea+78MaLhN6PGmfYSAv1ACw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/image-type": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-5.2.0.tgz",
+      "integrity": "sha512-f0+6qHeGfyEh1HhFGPUWZb+Dqqm6raKeeAR6Opt01wBBIQL32/1wpZkPQm8gcliB/Ws6oiX2ofFYXB57+CV0iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^18.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-global": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/import-global/-/import-global-1.1.1.tgz",
+      "integrity": "sha512-xQ61Xy5435eLQUNYJoOS8bKBB1NP1K1HvurKNrQ8tcQolj5mGVxMaKYX+c8zoDiX2v1YjTlj3RgnBx3tPe5t7w==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-global": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-svg": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-5.1.0.tgz",
+      "integrity": "sha512-uVg5yifaTxHoefNf5Jcx+i9RZe2OBYd/UStp1umx+EERa4xGRa3LLGXjoEph43qUORC0qkafUgrXZ6zzK89yGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.deburr": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
+      "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaultsdeep": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.last": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.partialright": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+      "integrity": "sha512-yebmPMQZH7i4El6SdJTW9rn8irWl8VTcsmiWqm/I4sY8/ZjbSo0Z512HL6soeAu3mh5rhx5uIIo6kYJOQXbCxw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pdfkit": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.2.tgz",
+      "integrity": "sha512-UnwF5fXy08f0dnp4jchFYAROKMNTaPqb/xgR8GtCzIcqoTnbOqtp3bwKvO4688oHI6vzEEs8Q6vqqEnC5IUELw==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
+    "node_modules/peek-readable": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
+      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-global": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-2.0.0.tgz",
+      "integrity": "sha512-gnAQ0Q/KkupGkuiMyX4L0GaBV8iFwlmoXsMtOz+DFTaKmHhOO/dSlP1RMKhpvHv/dh6K/IQkowGJBqUG0NfBUw==",
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-pixel-width": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/string-pixel-width/-/string-pixel-width-1.11.0.tgz",
+      "integrity": "sha512-GeKuNcCza7Gf3tlMJiZY8SF1LtbFGeMUEpHifncgJn+ZcUpnoPyE69HEyb0rXrJ3bejY/M/kBylu7IDlPJD9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.deburr": "^4.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/strtok3": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.1.1.tgz",
+      "integrity": "sha512-mKX8HA/cdBqMKUr0MMZAFssCkIGoZeSCMXgnt79yKxNFguMLVFgRe6wB+fsL0NmoHDbeyZXczy7vEPSoo3rkzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/svg-to-pdfkit": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/svg-to-pdfkit/-/svg-to-pdfkit-0.1.8.tgz",
+      "integrity": "sha512-QItiGZBy5TstGy+q8mjQTMGRlDDOARXLxH+sgVm1n/LYeo0zFcQlcCh8m4zi8QxctrxB9Kue/lStc/RD5iLadQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pdfkit": ">=0.8.1"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    }
+  }
+}

--- a/skills/lit-review-argument/package.json
+++ b/skills/lit-review-argument/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "lit-review-argument-validator",
+  "private": true,
+  "description": "Pinned Argdown CLI for validate-argument-map.sh — the phase-4 skill's structural-check helper. Pinned to defeat dependency-confusion / compromised-package supply-chain attacks at validation time (see codex security review on PR #1032).",
+  "version": "0.1.0",
+  "dependencies": {
+    "@argdown/cli": "2.0.0"
+  }
+}

--- a/skills/lit-review-argument/tests/clean-map.argdown
+++ b/skills/lit-review-argument/tests/clean-map.argdown
@@ -1,0 +1,26 @@
+===
+title: "Clean map — phase-4 structural-checker test fixture"
+===
+
+// A minimal well-formed map: every premise grounded, every objection answered,
+// no support argument left unreconstructed, no circular support. The structural
+// checker must pass it.
+
+[Thesis]: The fixture thesis.
+    <- <Objection>
+
+<Support Argument>
+
+(1) A grounded premise. {evidence: "synthesis.md §1"}
+(2) Another grounded premise. {evidence: "synthesis.md §2"}
+-----
+(3) [Thesis]
+
+<Objection>: A stated objection to the thesis.
+
+<Response>
+
+(1) A grounded reason the objection does not hold. {evidence: "synthesis.md §3"}
+-----
+(2) [Rebuttal]: The objection does not hold.
+    -> <Objection>

--- a/skills/lit-review-argument/tests/dirty-map.argdown
+++ b/skills/lit-review-argument/tests/dirty-map.argdown
@@ -1,0 +1,37 @@
+===
+title: "Dirty map — phase-4 structural-checker test fixture"
+===
+
+// Deliberately broken. This file is SYNTACTICALLY VALID Argdown, so the parser
+// accepts it and hands it to check-argument-structure.mjs — which must then
+// fail every structural check: A, B, C, and D.
+
+[Thesis]: The fixture thesis.
+    <- <Dangling Objection>
+    <+ <Hand-Wave>
+
+<Main Argument>
+
+(1) A properly grounded premise. {evidence: "synthesis.md §1"}
+(2) An ungrounded premise: no evidence tag, and not derived anywhere in the map.
+-----
+(3) [Thesis]
+
+// B: an argument wired in as support for the thesis but never reconstructed.
+<Hand-Wave>: Asserted to support the thesis, but given no premise-conclusion structure.
+
+// C: an objection that attacks the thesis with nothing answering it.
+<Dangling Objection>: Nothing in the map answers this objection.
+
+// D: circular support — each argument's conclusion is the other's premise.
+<Loop One>
+
+(1) [Loop Claim Two]
+-----
+(2) [Loop Claim One]
+
+<Loop Two>
+
+(1) [Loop Claim One]
+-----
+(2) [Loop Claim Two]

--- a/skills/lit-review-argument/tests/run-tests.sh
+++ b/skills/lit-review-argument/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# # phase-4 argument-tooling unit tests.
+#
+# Exercises validate-argument-map.sh (Argdown CLI parse + structural checker)
+# against two fixtures:
+#   clean-map.argdown — well-formed; must pass.
+#   dirty-map.argdown — deliberately broken; must fail structural checks A, B,
+#                       C, and D. It is syntactically valid, so the failures are
+#                       structural, not parse errors — which is the point: it
+#                       exercises check-argument-structure.mjs, not the parser.
+#
+# Run: tests/run-tests.sh   (exit 0 = all tests pass, 1 = a test failed)
+
+set -u
+TDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATE="$TDIR/../validate-argument-map.sh"
+PASS=0
+FAIL=0
+check() {
+  if [ "$1" = ok ]; then
+    PASS=$((PASS + 1))
+    echo "  ok   — $2"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL — $2"
+  fi
+}
+
+echo "clean-map.argdown — expect: passes, exit 0"
+OUT="$("$VALIDATE" "$TDIR/clean-map.argdown" 2>&1)"
+RC=$?
+[ "$RC" -eq 0 ] && check ok "clean map exits 0" || check no "clean map exit $RC (expected 0)"
+grep -q "STRUCTURE OK" <<<"$OUT" && check ok "clean map reports STRUCTURE OK" || check no "clean map missing STRUCTURE OK"
+
+echo "dirty-map.argdown — expect: fails structural checks A, B, C, D, exit 1"
+OUT="$("$VALIDATE" "$TDIR/dirty-map.argdown" 2>&1)"
+RC=$?
+[ "$RC" -eq 1 ] && check ok "dirty map exits 1" || check no "dirty map exit $RC (expected 1)"
+for c in A B C D; do
+  grep -q "FAIL: $c " <<<"$OUT" && check ok "dirty map triggers check $c" || check no "dirty map did not trigger check $c"
+done
+
+echo
+echo "result: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/skills/lit-review-argument/validate-argument-map.sh
+++ b/skills/lit-review-argument/validate-argument-map.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# # phase-4 Argdown validation tooling.
+#
+# Two checks over an argument map:
+#   1. SYNTAX    — the Argdown CLI parses the file.
+#   2. STRUCTURE — check-argument-structure.mjs flags, from the parsed model:
+#        - ungrounded premises      (no {evidence:} tag, not derived elsewhere)
+#        - unreconstructed support  (a support argument given no PCS)
+#        - unanswered objections    (an attack on a load-bearing claim, no reply)
+#        - circular support         (a statement that transitively supports itself)
+#
+# What this tooling does NOT check: material validity — whether the premises
+# actually entail the conclusion — and the truth of each premise. Those stay the
+# agent's job (see lit-review-argument/SKILL.md, workflow step 5).
+#
+# Requires: Node.js >= 20 (no other globals). The Argdown CLI is pinned in
+# package.json + package-lock.json next to this script; on first run, the
+# script installs the lockfile-resolved version into a local node_modules and
+# every subsequent invocation reuses it offline. Pinning + offline reuse closes
+# the supply-chain RCE path that ad-hoc `npx --yes` would open (see codex
+# security review on PR #1032).
+#
+# Exit codes: 0 OK · 1 syntax OR structural failure in the MAP · 2 bad input ·
+#             3 environment/tooling problem (NOT a problem with the map).
+#
+# Usage: validate-argument-map.sh [path-to-.argdown]   (default: argument-map.argdown)
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAP="${1:-argument-map.argdown}"
+
+if [ ! -f "$MAP" ]; then
+  echo "FAIL [input]: argument map not found: $MAP" >&2
+  exit 2
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL [environment]: node not found — install Node.js (>= 20) to run the Argdown CLI." >&2
+  exit 3
+fi
+
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+if [ "${NODE_MAJOR:-0}" -lt 20 ]; then
+  echo "FAIL [environment]: Node $(node --version 2>/dev/null) detected; the Argdown CLI needs Node >= 20." >&2
+  echo "This is a tooling/environment problem, not a problem with $MAP." >&2
+  exit 3
+fi
+
+ARGDOWN_BIN="$SCRIPT_DIR/node_modules/.bin/argdown"
+if [ ! -x "$ARGDOWN_BIN" ]; then
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "FAIL [environment]: npm not found and Argdown CLI not installed at $ARGDOWN_BIN — install Node.js (>= 20) so npm can install the pinned CLI." >&2
+    exit 3
+  fi
+  echo "[validate-argument-map] installing pinned Argdown CLI (one-time, offline reuse after)..." >&2
+  ( cd "$SCRIPT_DIR" && npm ci --silent --no-audit --no-fund ) >&2
+  if [ ! -x "$ARGDOWN_BIN" ]; then
+    echo "FAIL [environment]: npm ci did not produce $ARGDOWN_BIN — see the install log above." >&2
+    exit 3
+  fi
+fi
+
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+# --- 1. syntax: compile forces a full parse and model build ---
+LOG="$OUT/argdown.log"
+"$ARGDOWN_BIN" compile "$MAP" "$OUT" >"$LOG" 2>&1
+STATUS=$?
+cat "$LOG"
+
+if grep -qE 'node:internal|Cannot find module|^[[:space:]]+at .+:[0-9]+:[0-9]+' "$LOG"; then
+  echo "FAIL [environment]: the Argdown CLI failed to execute — see the trace above." >&2
+  echo "This is a tooling/environment problem, not a problem with $MAP." >&2
+  exit 3
+fi
+if [ "$STATUS" -ne 0 ]; then
+  echo "FAIL [syntax]: Argdown reported problems parsing $MAP — fix the errors above." >&2
+  exit 1
+fi
+echo "syntax OK — $MAP parses."
+
+# --- 2. structure: export the JSON model, run the structural checker ---
+"$ARGDOWN_BIN" json "$MAP" "$OUT" >"$OUT/json.log" 2>&1
+JSON="$(ls "$OUT"/*.json 2>/dev/null | head -1)"
+if [ -z "$JSON" ]; then
+  echo "FAIL [environment]: Argdown JSON export produced no model file." >&2
+  cat "$OUT/json.log" >&2
+  exit 3
+fi
+
+echo "--- structural checks ---"
+node "$SCRIPT_DIR/check-argument-structure.mjs" "$JSON"
+CHECK=$?
+if [ "$CHECK" -eq 2 ]; then
+  echo "FAIL [environment]: the structural checker could not read the model." >&2
+  exit 3
+fi
+if [ "$CHECK" -ne 0 ]; then
+  echo "FAIL [structure]: fix the structural issues above." >&2
+  exit 1
+fi
+
+echo
+echo "OK: $MAP passes syntax and structural checks."
+echo "Reminder: material validity (do the premises entail the conclusion) and the"
+echo "truth of each premise are checked by the agent against the evidence base."

--- a/skills/lit-review-draft/SKILL.md
+++ b/skills/lit-review-draft/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: lit-review-draft
+description: Phase 5 of the literature-review workflow. Takes the phase-4 argument architecture and the phase-3 evidence base and drafts the paper as a submission-shaped IEEE-format manuscript — prose plus a visible evidence surface (inline citations from a Zotero-generated reference list, a PRISMA-ScR flow, a coding-scheme table, source examples). User-invoked after the argument architecture has been reviewed. Output is the manuscript in LaTeX with a markdown rendering. Final phase of the workflow.
+---
+
+# # Lit-Review Draft (Phase 5)
+
+This skill drafts the paper from the phase-4 argument architecture, applying `writing-style.md`. It is the last phase of the literature-review workflow.
+
+Phase 4 fixed what the paper argues, in what order, on what support. This skill writes it — as a manuscript a journal or conference reviewer reads cold, knowing nothing of Ground Control, the workflow, or its internal files. That is the test the output must pass.
+
+The skill is built around three dangers. Two are about the argument: prose that drifts from the validated argument, and prose that papers over an inference gap. The third is the one this phase most reliably produces if unchecked — **a manuscript that reads as an internal synthesis memo**: it carries meta headers, names workflow artifacts the reader cannot see, and asserts findings by gesturing at charting and coding work it never shows. A scoping review's credibility is its visible evidence surface. A memo promoted into paper prose has none.
+
+## What this skill counters
+
+- **Prose that drifts from the argument.** The draft improvises claims not in the phase-4 argument map, or drops arguments that are. Counter: each section realizes specific `paper-outline.md` nodes and `argument-map.argdown` arguments; a paragraph that makes a load-bearing claim absent from the argument map is a violation — either the map was wrong (stop, return to phase 4) or the paragraph is.
+- **Prose that papers over an inference gap.** Fluent connective prose — "therefore", "it follows that" — can smooth a step the premises do not license, hiding a non-sequitur or an unstated premise behind good writing. Counter: writing each load-bearing paragraph *is* the entailment test — the bridge from premises to conclusion must be written out, not gestured at; if it cannot be written without an unstated assumption, the phase-4 PCS has a hidden premise or a non-sequitur, fixed in phase 4 rather than smoothed over in prose.
+- **A manuscript that reads as a workflow memo.** The draft carries text that belongs to the workflow, not the paper: a header noting the phase or the draft status; references to internal artifacts by their internal names — `paper-outline.md`, `argument-map.argdown`, "the evidence matrix", "charted cells", "the phase-2 cumulative-deviation assessment", "a dedicated report". A reader outside Ground Control can see none of these; naming them turns the manuscript into a memo about a process. Counter: the manuscript body carries no meta header, no phase or workflow vocabulary, and no reference to any artifact the reader cannot see. An internal artifact either becomes a visible element of the paper — a numbered table, a figure, an appendix — and is referenced as that, or it is not mentioned. Draft provenance and run-status go in `draft-self-review.md`, never in the manuscript.
+- **Claims asserted, not demonstrated.** The draft makes a load-bearing empirical claim and backs it only by gesturing at unseen work — "an independent verification pass found", "the evidence matrix shows", "the coding scheme groups". The reader is asked to *trust* charting they never see. Counter: every load-bearing empirical claim is *demonstrated* on the page — by an inline citation to a specific source, by a numbered table the reader can inspect, or by a concrete example quoted or closely paraphrased from a source. A paper that asks for trust instead of showing the work fails review. Each procedure named in the methods is attributed to who performed it, and LLM assistance is disclosed where it occurred.
+- **Citation hallucination, and a hand-built reference list.** A cited source does not exist, was never in the review, or its reference-list entry is typed from memory and wrong. Counter: `references.bib` is *generated* from the paper's Zotero collection via the citation MCP — `mcp__citation__zotero_search` enumerates the collection, `mcp__citation__cite_resolve` supplies canonical metadata — never authored by hand. Inline citations key into that generated file; the draft cites only sources in the phase-3 included set.
+- **Inventing findings.** The draft states an empirical result the evidence base does not contain, or restates a charted count as a stronger claim than a count. Counter: every empirical claim traces to `synthesis.md`; frequencies are charted counts, worded as charted counts.
+- **Over-claiming past the method.** Severity, prevalence, causation — the method's declared limits, at risk in prose. Counter: the method-limits language from `synthesis.md` is carried, in substance, into the limitations section; no sentence claims more than the method licenses.
+- **Language-model writing tells.** Generic model prose: hedging cadence, the reflexive tricolon, decorative vocabulary, throat-clearing openers, metadiscourse that narrates the paper's own speech acts. Counter: `writing-style.md` — a voice profile plus an explicit blocklist; the style pass checks the draft against both.
+
+## The discipline (what the output IS)
+
+The output is a submission-shaped manuscript: a paper in IEEE format (LaTeX, the `IEEEtran` document class) with a Zotero-generated BibTeX reference list and a markdown rendering for review. It must be critiqueable by a reviewer who has never heard of # that is the bar.
+
+Allowed: prose for every outline node; the validated arguments rendered as paragraphs; inline citations into the Zotero-generated `references.bib`; numbered tables and figures the reader can inspect (at minimum a PRISMA-ScR flow and a coding-scheme summary table; others the evidence warrants); concrete source examples; the method's limits stated plainly; procedures attributed to who performed them.
+
+Not allowed: a meta header or any phase/workflow vocabulary in the manuscript body; a reference to an internal artifact the reader cannot see; a load-bearing empirical claim with no visible citation, table, or example behind it; a load-bearing claim not in the argument map; a finding not in `synthesis.md`; a citation or reference entry not generated from the Zotero collection; the tells in `writing-style.md`'s blocklist; a new argument invented at drafting time.
+
+## Workflow
+
+1. **Read the inputs.** From the workspace: `paper-outline.md`, `argument-map.argdown`, `synthesis.md`, `evidence-matrix.md`, `charting-data.md`, `search-log.md`, `decisions.md`. From this skill's base directory: `writing-style.md`. And the paper's stanza in `program/`. If `paper-outline.md` or `argument-map.argdown` is absent, phase 4 has not run — stop and run `lit-review-argument` first.
+
+2. **Internalize the style.** Read `writing-style.md` in full before drafting. It is voice, tone, and vocabulary — not paper structure, not a licence to alter findings.
+
+3. **Generate the reference list.** Enumerate the paper's Zotero collection (the phase-3 collection / tag) via `mcp__citation__zotero_search`; obtain canonical metadata via `mcp__citation__cite_resolve` where needed; emit `references.bib`. Every source the manuscript will cite gets a real, generated entry — not one reference is hand-typed. Doing this before drafting means every inline citation keys into a real entry from the start.
+
+4. **Draft the manuscript** in IEEE format (LaTeX). Follow `paper-outline.md`; each section realizes its outline nodes, each load-bearing discussion paragraph a specific `argument-map.argdown` argument — the PCS is the paragraph's logical spine. Three disciplines hold throughout:
+   - **Entailment.** Writing the paragraph is the entailment test — write the inference out, premises to conclusion. If the bridge needs an unstated assumption, the PCS has a gap; stop (see Gates).
+   - **Manuscript hygiene.** The manuscript reads as a paper, not a memo: no meta header, no phase or workflow vocabulary, no internal-artifact names. Every procedure in the methods is attributed to who performed it; LLM assistance is disclosed where true.
+   - **Demonstrate, don't assert.** Every load-bearing empirical claim is carried by something the reader can see. Build the evidence-surface elements the paper needs: a PRISMA-ScR flow (numbers screened / excluded-with-reasons / included); a summary table of the coding scheme (each code with its counts, strata, and recurrence status); a concrete example — quoted or closely paraphrased, with citation — for each major recurring code. Cite only included-set sources, keyed into `references.bib`.
+
+5. **Style pass.** Check the prose against `writing-style.md` — voice-profile conformance, zero blocklist hits — section by section.
+
+6. **Self-review.** Apply the angles in `draft-self-review.md`.
+
+7. **Record decisions.** Extend `decisions.md` with drafting decisions: any phase-4 argument gap surfaced (and whether phase 4 was revisited), any claim scoped down in wording.
+
+**Gates:** if drafting reveals a genuine flaw in the phase-4 argument — a missing premise, an unmodelled objection, a conclusion the evidence base will not carry — stop and surface it; fix it in phase 4, then resume. Do not paper over an argument flaw with prose.
+
+This is the final phase. No auto-chain onward.
+
+## Output structure
+
+In the workspace:
+
+- **`manuscript.tex`** — the paper in IEEE format (`IEEEtran`). Conference or journal variant follows the target venue.
+- **`references.bib`** — the reference list, generated from the paper's Zotero collection.
+- **`manuscript.md`** — a markdown rendering of the manuscript, for review.
+- **`draft-self-review.md`** — the self-review. Draft provenance, the warm/cold-run note, and any workflow commentary live here — never in the manuscript.
+- **`decisions.md`** — extended.
+
+## Self-review angles
+
+### Grounding angles
+
+- **Argument-fidelity pass.** Does every load-bearing paragraph trace to an argument in `argument-map.argdown`? Any paragraph making a claim with no argument behind it is either an argument-map gap (return to phase 4) or an over-reach (cut it).
+- **Entailment pass.** For each load-bearing paragraph, does the prose articulate the inference — premises to conclusion — or set the conclusion beside the premises and rely on adjacency? If the inference cannot be stated in a clean bridge sentence, the PCS it renders has a gap: a phase-4 fix. This is still the drafter checking its own inference; a robust independent re-derivation is a future enhancement of this skill.
+- **Manuscript-not-memo pass.** Read the manuscript as a reviewer who has never heard of Ground Control. Is there a meta header, a phase number, or any workflow vocabulary in the body? Does any sentence name an artifact the reader cannot see — `paper-outline.md`, the argument map, "the evidence matrix", "charted cells", a "phase-N assessment", a "dedicated report"? Every hit is a violation: cut it, or turn the artifact into a visible table or appendix and reference that.
+- **Demonstrated-not-asserted pass.** For each load-bearing empirical claim, is there something on the page the reader can check — an inline citation, a numbered table, a quoted example — or only a gesture at unseen work? A claim backed only by "a verification pass found" or "the evidence matrix shows" is asserted, not demonstrated. Add the citation, table, or example, or cut the claim.
+- **Citation pass.** Is every inline citation keyed to a real entry in `references.bib`, and was `references.bib` generated from the Zotero collection rather than hand-authored? Is every cited source in the phase-3 included set? Any entry not traceable to the Zotero collection is removed.
+- **Findings pass.** Does every empirical claim trace to `synthesis.md`? Are frequencies worded as charted counts, not as prevalence?
+- **Method-limits pass.** Does any sentence claim severity, prevalence, causation, or exhaustiveness the method cannot support?
+
+### Style angles
+
+- **Voice pass.** Does the draft match the `writing-style.md` voice profile — sentence rhythm, contrast-driven argument, concreteness, active voice, claims stated flat?
+- **Blocklist pass.** Zero hits on the model-tell blocklist, including the metadiscourse entry? Run the list literally against the text.
+- **Hedge pass.** Is uncertainty *located* — named as a specific open question — rather than *hedged* — smeared with "may", "could", "arguably"?
+
+## What this skill is NOT
+
+- It is not phase 4. If the argument architecture is absent, stop and run `lit-review-argument`.
+- It is not a place to invent argument. The argument is phase 4's; this skill renders it.
+- It is not a place to add sources. The corpus was frozen at phase 3.
+- It is not a place to relax the method's limits because prose wants a stronger sentence.
+- It is not an internal memo. The manuscript stands alone for a reader who knows nothing of the workflow that produced it — meta commentary, phase vocabulary, and internal-artifact names belong to `draft-self-review.md`, not the paper.

--- a/skills/lit-review-draft/writing-style.md
+++ b/skills/lit-review-draft/writing-style.md
@@ -1,0 +1,119 @@
+# Writing-style guide — phase-5 drafting
+
+This guide is the voice contract for `lit-review-draft`. It exists to make the
+draft read like the author wrote it, not like a language model produced it.
+
+**Derived from:** `tir-adan/raw/aces-research-docs/aces/aces-paper.tex` — Edwards et al.,
+*ACES: Toward a Common Architecture for Agentic Cyber Environments* (2026). Examples
+below are quoted from that paper. To widen the profile, add more samples by the same
+author and re-derive.
+
+**Scope.** This guide governs *voice* — sentence rhythm, vocabulary, stance toward
+uncertainty, paragraph shape. It does **not** govern paper *structure* (that is the
+phase-4 outline) and is **not** a licence to alter findings. ACES is an architecture
+paper; the review being drafted may be a different paper type — the voice transfers,
+the section structure does not.
+
+---
+
+## Part A — Voice profile (write like this)
+
+**A1. Short declarative sentences land the point.** After a long, clause-heavy
+sentence, a short one delivers the conclusion. *"These are not projections. They are
+operational realities..."* / *"The pattern works. What is missing is an open
+implementation."* / *"The components exist in fragments. The integration does not."*
+Use this — but only when there is a real point to land. A short sentence with nothing
+behind it is just choppy.
+
+**A2. The argument advances by contrast.** Set up a distinction, then name which side
+is right. *"Where Garg's taxonomy follows the content lifecycle, ACES decomposes by
+architectural responsibility."* / *"The challenge is integration and scale, not
+invention."* The `not X, but Y` and `X. But Y.` patterns are the engine of the prose —
+each paragraph should move by drawing a line, not by accumulating adjacent facts.
+
+**A3. Concrete and specific.** Real numbers, names, versions, amounts: *"EUR 3.3M",
+"version 0.0.2", "16 EU member states", "4,000 participants from 41 nations defending
+8,000 virtualized systems", "145 organizations"*. When a specific count exists, use it.
+
+**A4. Claims stated flat; uncertainty located, not hedged.** Assertions are made
+directly: *"OCR SDL's semantic model is the strongest available foundation." "The
+limitations are real."* When something is genuinely unknown, it is *named* as a
+specific open question — *"an open design question", "an empirical question that
+requires the architecture to exist before it can be studied"* — not smeared across the
+sentence with "may", "could", "arguably". Locate the uncertainty; do not hedge it.
+
+**A5. Active, agent-forward.** Sentences have actors. *"We introduce... We survey... We
+characterize... We evaluate."* The paper does things; prefer the active construction
+that says who does what.
+
+**A6. The precise term, repeated — not elegant variation.** Use the exact domain term
+consistently (*"instantiation", "backend-agnostic", "semantic model"*). Do not swap in
+synonyms to avoid repeating a word; in technical prose the repetition is clarity, the
+variation is noise.
+
+**A7. Em-dashes carry content.** Dashes are for appositive elaboration and embedded
+lists — *"two open-source foundations---the OCR SDL and OCSF---that provide..."* — not
+for rhythmic decoration. Test: if a dash pair can be deleted with no loss of meaning,
+delete it.
+
+**A8. Paragraphs end on a point, not a summary.** The closing sentence sharpens, turns,
+or draws the consequence. It does not restate the topic sentence. *"All four validate
+the same pattern... The pattern works. What is missing is an open implementation."*
+
+**A9. Weakness is addressed head-on.** Name the objection and answer it or concede it.
+*"The limitations are real." "The honest position is that..."* A discussion that hides
+its soft spots reads as evasive; one that names them reads as credible.
+
+**A10. Openers orient briefly, then move.** A section or paragraph may open with one
+short orienting sentence that states its job — *"A specification language, however
+rich, is half the architecture."* — then it gets to work. No throat-clearing.
+
+---
+
+## Part B — Blocklist (never this)
+
+Run this list literally against the draft in the phase-5 blocklist pass. Zero hits.
+
+- **Connective filler as a reflexive opener.** "Moreover,", "Furthermore,",
+  "Additionally,", "Notably,", "Importantly," beginning a sentence that carries no
+  actual escalation or contrast. (A connective is fine when it marks a real turn; it
+  is a tell when it is reflexive.)
+- **Throat-clearing phrases.** "It is worth noting that", "It is important to note",
+  "It should be noted that", "It is interesting that".
+- **Throat-clearing openers.** "In recent years,", "In today's world,", "As technology
+  advances,", "With the rapid development of".
+- **Hedge stacks.** "may potentially", "could arguably", "it could be argued that",
+  "to some extent", "in many ways", and filler "relatively" / "somewhat". (See A4 —
+  locate uncertainty instead.)
+- **Decorative adjectives.** "robust", "crucial", "vital", "pivotal", "seamless",
+  "powerful", "cutting-edge", "state-of-the-art", "comprehensive", "significant" used
+  as decoration rather than to carry a specific, defended meaning.
+- **Inflated diction.** "delve", "leverage" as a verb-of-all-work (use "use"),
+  "utilize" (use "use"), "tapestry", "realm", and "landscape" used decoratively
+  ("ever-evolving landscape").
+- **The reflexive tricolon.** Three-item lists "X, Y, and Z" used as decoration in
+  sentence after sentence. Lists are fine when the three items are load-bearing; the
+  tell is the rhythm applied regardless of content.
+- **"Not only... but also"** as a reflexive construction.
+- **Empty summary sentences.** "In conclusion, X remains a complex and multifaceted
+  challenge." "Ultimately, the importance of X cannot be overstated."
+- **Metadiscourse — narrating the paper's own speech acts.** "The review states",
+  "this review finds", "the paper argues that", "carried as a declared limitation",
+  "it should be emphasized that". Make the claim; do not narrate the paper making it.
+  Ordinary framing — "We surveyed 52 sources", "This paper introduces" — is fine; the
+  tell is *recurrent* narration of the review's own assertions standing in for the
+  assertions.
+- **Vague "this".** "This shows that..." with no referent noun — write "This
+  separation shows...", name the thing.
+- **Vague quantifiers where a count exists.** "various", "numerous", "a number of",
+  "several" when the evidence base gives a specific number (see A3).
+- **Symmetrical paragraph closers** that restate the topic sentence (see A8).
+
+---
+
+## How the phase-5 style pass uses this
+
+After each section: read it once for **Part A conformance** (does it have the rhythm,
+the contrast structure, the concreteness, the flat claims?) and once for **Part B
+hits** (search the text for each blocklist item). Revise until Part A holds and Part B
+is empty. A draft that is grounded and correct but fails this guide is not done.

--- a/skills/lit-review-plan/SKILL.md
+++ b/skills/lit-review-plan/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: lit-review-plan
+description: Phase 2 of the literature-review workflow. Fills the phase-1 methodology+requirements contract with domain content to produce an executable literature-review plan. Normally chained from `lit-review` automatically — the user invokes the workflow once and this skill takes over at the end of phase 1. Can also be invoked standalone when phase 1 was completed in a previous session (a `requirements.md` already exists in the workspace). The output is a lit-review plan an executor can run; it does not run the search.
+---
+
+# # Lit-Review Plan (Phase 2)
+
+This skill's job is one thing: take the phase-1 methodology+requirements contract (`requirements.md`) and fill every requirement with domain content for the specific paper, producing an executable literature-review plan.
+
+The plan is the protocol the search phase (phase 3) will run. It does not run the search itself.
+
+The phase-1 skill (`lit-review`) decided the method and listed the requirements. This skill decides *how this paper meets each requirement*.
+
+## What this skill counters
+
+Each item earns its place by what we have actually seen go wrong, in phase 1 or in earlier walkthroughs.
+
+- **Re-deriving phase 1.** You re-argue the method choice, re-list the requirements, re-justify the rejections. Counter: phase 1's `requirements.md` is the contract. Read it. Reference it. Do not relitigate it. If a phase-1 decision turns out to be wrong, stop and surface that to the user.
+- **Procedural invention.** You fill the search-decision plan (databases, terms, time span, language) with content the agent made up. Counter: every concrete procedure — specific databases, specific date ranges, specific search strings — must come from (a) the paper context (RQs, claim, venue posture, dependencies, current basis named in the program stanza), (b) the user via a gate, or (c) what the methodology source explicitly authorises. Where none of those supply it, surface as a user gate. Do not invent.
+- **Coding-scheme / charting hallucination.** For scoping or critical or narrative reviews, the data-charting fields and any coding scheme can be domain-flavoured. You invent codes from training memory. Counter: the charting form's fields can be drafted, but any *coded categories* should be declared as either (i) taken from a citable source the agent has read via `mcp__citation__cite_resolve`, (ii) supplied by the user, or (iii) **emergent** — pilot reading on a small sample (typically 5–10 included sources) refines the codes, per Levac §Stage 4 recommendation 1c. Mark which.
+- **Source-finding hallucination.** When the plan needs to name seed papers, exemplars, or citable evidence (e.g., for the rationale in PRISMA-ScR item 3, or to justify a date range), you cite from memory. Counter: every cited paper must come from `mcp__citation__cite_resolve` or a Zotero record you have opened. Use `mcp__citation__cite_search` (OpenAlex / Crossref) or `mcp__citation__zotero_search` (the user's library) when you need to find a candidate. Never type a citation from memory.
+- **Search-result-shaped sentences.** "The literature shows", "most papers", "we identified N studies" — phase 2 is the protocol, not the search. Counter: the plan describes *what will be done*; it does not summarise what the search will find. If a section asserts what the literature contains, it has drifted into phase 3.
+- **Drifting from the requirements contract.** Phase 1 named requirements; you skip some or merge them into vagueness. Counter: the plan's organisation traces the contract one-to-one. Every requirement is answered or its deviation is declared with rationale.
+- **Forgetting non-claims and method limits.** The paper context names non-claims; the methodology source names method limits. The plan must respect both. Counter: dedicated sections in the plan for the paper's declared non-claims (so the protocol does not over-collect for them) and the method's declared limits.
+- **Taxonomy source-role collapse.** A taxonomy paper uses different source roles: construction/stress-test corpus, background/framing literature, methodology literature, and validation/evaluation material. You flatten them into one "literature" bucket, then background sources become fake evidence for recurrence or coverage. Counter: for taxonomy-development contracts, assign every source role explicitly and state which claims each role can and cannot support.
+- **Punting user gates as "declared defaults" at the end of the plan.** *Observed failure.* You draft the whole plan with defaults you picked silently, then list 9 "open user gates" in a §11 backlog at the end of the document. That makes the user read the whole plan to find what they are being asked, and provides no audit trail of what was decided. Counter: bring each gate up *as it arises during drafting*, one at a time, with a recommendation and reasoning. Discuss. Resolve. Log to `decisions.md`. Then continue. By the end of drafting there should be no open-gates backlog — only `deferred` gates that the user explicitly chose to set later (e.g., "pilot will set", "decide at write-up"), each named in the plan with that label.
+
+## The discipline (what the output IS)
+
+The output is a literature-review plan that fills the phase-1 contract for a specific paper. Critiqueable against the contract by a reviewer who has read both `requirements.md` and the paper's stanza.
+
+Allowed in the output:
+
+- Concrete domain content where the paper context supplies it (RQs verbatim, declared non-claims, evidence-needed deliverables, venue posture, dependencies, current basis).
+- Concrete decisions where the methodology source authorises them and the agent can justify from sources read (e.g., reporting standard = PRISMA-ScR, since the contract names it).
+- User-resolved decisions where genuine user judgement is required.
+- Cited papers and seed sources only when obtained via the citation MCP or read from Zotero.
+
+Not allowed in the output:
+
+- Renegotiation of the methodology or the requirements contract. If the contract is wrong, stop and surface it.
+- Specific databases, dates, depths, or caps that the agent invented with no rationale.
+- Coded category lists derived from agent training memory.
+- Characterisations of specific literature ("X paper does Y", "the literature shows Z") — search-phase content.
+- Citations not grounded in the citation MCP or Zotero.
+
+## Workflow
+
+1. **Read the contract.** Locate the workspace's `requirements.md` (from phase 1). If it does not exist, the user has not run phase 1 yet — stop and run that first, or ask the user to.
+
+2. **Read the paper context.** Re-read the paper's stanza in `program/`. Note the working title, primary claim, RQs, current basis, evidence-needed deliverables, non-claims, venue posture, dependencies. These are inputs the plan must reflect.
+
+3. **For each requirement in the contract, draft the answer.** Work through the contract in order, requirement by requirement. For each, decide where the answer comes from:
+
+   - *Direct from the paper context* (e.g., RQs, declared non-claims, evidence-needed) — transcribe.
+   - *Direct from the methodology source* (e.g., PRISMA-ScR is the reporting standard for scoping) — restate with citation.
+   - *Defensible domain decision* (e.g., a search-database choice with a clear justification from the paper's domain) — make it, justify it, cite supporting evidence via the citation MCP if any is named.
+   - *User judgement* — surface as a user gate; do not invent.
+   - *Pilot/emergent* — declare it explicitly (e.g., "coding categories emerge from pilot reading of the first 5–10 included sources per Levac §Stage 4 recommendation 1c").
+
+4. **Resolve user gates one at a time, as they arise during drafting, with recommendation + reasoning.** When you hit a section that depends on a user-decision (reviewer count, consultation feasibility, critical-appraisal, database list, date range, workshop target, scope feasibility, taxonomy meta-characteristic, unit of analysis, ending-condition strictness, evaluation audience, anything similar), stop drafting that section, bring the gate to the user *with your recommended option and the reasoning behind it*, discuss if they push back, settle the decision, write the resolution to `decisions.md` immediately with rationale, then continue drafting. Use `AskUserQuestion` for structured choices; use a direct chat question when the gate benefits from open discussion. The final plan should contain no end-of-document "open user gates" backlog — only `deferred` decisions the user explicitly chose to set later (e.g., "pilot will set", "decide at write-up"), labelled inline in the relevant section.
+
+5. **Cite via MCP.** Any specific paper, dataset, standard, or source cited in the plan — for a date-range justification, a venue-posture rationale, an "existing basis" reference, or anything else — must come from `mcp__citation__cite_resolve` (canonical metadata via DOI / arXiv / PMID), `mcp__citation__cite_search` (when you have title or keywords but no identifier), or a Zotero record you have opened. Never from training memory. Tags or labels referring to such sources without prior MCP grounding fail the citation-grounding self-review pass.
+
+6. **Self-review.** Apply the angles below in `self-review.md`.
+
+7. **`decisions.md` is required, not optional.** Every non-obvious choice made during this phase — every user-gate resolution, every default declared with confirmation, every deferral — is logged with: the gate or question, the agent's recommendation and reasoning, what was discussed, what the user decided, the requirement it answers. This is the audit trail. If no non-obvious choices were made, the file may be brief or skipped — but if any gate was raised, `decisions.md` must exist.
+
+8. **Chain into phase 3.** Once `lit-review-plan.md` and `self-review.md` are written, the self-review passes (discipline and sharpness) applied, and `decisions.md` recorded, **immediately invoke the `lit-review-search` skill via the Skill tool** with the same paper_id (or workspace path). The user does not re-invoke; the lit-review workflow runs end-to-end through the search. Phase 2's plan is the input to phase 3; phase 3 raises any search-phase gates with recommendation + reasoning as they arise.
+
+## Output structure
+
+Write `lit-review-plan.md` in the workspace. The structure traces the phase-1 contract so an executor can verify coverage by section.
+
+Required top-matter:
+- **Paper:** working title from the program stanza.
+- **Methodology** (link to phase 1): name of method, link/reference to `requirements.md`.
+- **Status:** which requirements are filled, which are open user gates, which are deferred to pilot.
+
+Body sections, one per requirement group in the contract. For a scoping protocol this typically means:
+
+1. **Research question and scope** (R-Stage1) — RQ verbatim, scope of inquiry with PCC-or-equivalent framing, scoping-study purpose(s), envisioned outcome, rationale.
+2. **Sources and search plan** (R-Stage2 / PRISMA-ScR items 6, 7, 8) — eligibility criteria with rationale, named information sources, search strategy for at least one database with limits.
+3. **Study selection** (R-Stage3 / PRISMA-ScR item 9) — screening procedure, reviewer arrangement, disagreement handling, iterative process.
+4. **Charting** (R-Stage4 / PRISMA-ScR items 10, 11) — data-charting form (field list with rationale per field), pilot plan, codes' provenance (citable / user-supplied / emergent).
+5. **Synthesis and reporting** (R-Stage5 / PRISMA-ScR items 14, 17–21, 24) — numerical summary plan, thematic-analysis plan, envisioned-outcome plan, implications-for-practice plan.
+6. **Consultation** (R-Stage6) — included with stakeholders + integration plan, OR declared absent with limitation.
+7. **Critical appraisal decision** (PRISMA-ScR items 12, 19) — yes/no + rationale; scoping default is no.
+8. **Funding and protocol registration** (PRISMA-ScR items 5, 27) — declaration where applicable.
+9. **Declared non-claims** (from paper context) — what the lit review will *not* be used to support.
+10. **Method-choice limitations** (from contract §7, transcribed) — inherent limits acknowledged.
+11. **Deferred decisions** — only decisions the user explicitly chose to defer (e.g., "pilot will set", "set at write-up"). Each named in its relevant body section with the `deferred` label. If no deferrals exist, this section is omitted. **There should be no "open user gates" backlog here** — gates must be resolved as they arise during drafting (see Workflow step 4).
+
+Drop irrelevant sections for non-scoping methods (e.g., a critical review wouldn't have R-Stage6 consultation). The skeleton above is for scoping; for other methods, trace the contract's actual sections.
+
+For a `taxonomy_development` contract, the plan normally needs sections for:
+
+1. **Taxonomy contribution and limits** — the taxonomy's purpose, intended contribution, declared non-claims, and the claims the method can and cannot support.
+2. **Meta-characteristic and unit of analysis** — the taxonomy's organizing principle and what counts as one classified object.
+3. **Source roles** — separate procedures for taxonomy-instance corpus, background/framing literature, methodology literature, and validation/evaluation material. Background/framing sources are not evidence for recurrence, prevalence, coverage, or exhaustiveness unless the plan explicitly assigns that role and explains the supporting design.
+4. **Starting concepts** — any initial dimensions, categories, or seed concepts, labelled `citable`, `user-supplied`, `paper-context`, `empirical`, or `author-constructed`.
+5. **Construction procedure** — conceptual-to-empirical, empirical-to-conceptual, or iterative steps, with how candidate dimensions and characteristics are generated and checked.
+6. **Iteration log protocol** — what changes are recorded per iteration, including split/merge/add/drop rationale and source or evaluation trigger.
+7. **Ending conditions** — objective and subjective ending conditions from the methodology contract, filled only as far as the paper context and user decisions support.
+8. **Evaluation plan** — criteria such as concision, robustness, comprehensiveness, extensibility, explanatory value, and utility when the contract names them, plus who or what supplies evaluation evidence.
+9. **Validity threats** — source-selection bias, author-imposed categories, coding subjectivity, category overlap, unstable unit of analysis, and overclaiming coverage or recurrence.
+10. **Hybrid integration** — if a review method is also used, which outputs feed taxonomy construction/evaluation and which claims remain out of scope.
+
+`decisions.md` is required (see Workflow step 7) — log every user-gate resolution with recommendation, reasoning, discussion, and the settled rationale.
+
+## Self-review angles
+
+Two kinds. **Discipline angles** check that the plan stays inside its lane (no invention, no leakage, contract fidelity). **Sharpness angles** check that the plan is a *good* protocol, not merely a disciplined one — a disciplined plan can still be analytically loose, and that looseness has been observed repeatedly (the "competent but not tight" pattern). Apply both sets.
+
+### Discipline angles
+
+- **Requirement-coverage pass.** For every requirement in phase 1's `requirements.md`, has the plan answered it (filled / pending user gate / explicit deviation with rationale)? Or has a requirement been skipped, paraphrased, or merged into vagueness?
+- **Procedural-invention pass.** For each concrete procedure named (specific database, date range, search string, coding category, reviewer count, etc.), can you trace where it came from — paper context, source, user, pilot, or invention? Anything sourced as "invention" must move to a user gate or be dropped.
+- **Coding-scheme-provenance pass.** Any coded category, charting-form field, or inclusion criterion: is it labelled `citable` (with source), `user-supplied`, `paper-context` (from stanza), or `emergent` (pilot-driven, per Levac)? Unlabelled categories are unsupported assumptions.
+- **Domain-overreach pass.** Did any sentence in the plan summarise or characterise the literature, name specific competitor papers, or say "we identified" / "the literature shows" / "most studies"? Those are search-phase output. Remove.
+- **Method-limits-respected pass.** Does the plan respect the limits the methodology source named (transcribed in contract §7)? E.g., no quality-weighted gap claims in a scoping plan, no exhaustive-coverage claims, no meta-analytic synthesis.
+- **Citation-grounding pass.** For every specific paper, dataset, or standard cited in the plan, was the citation obtained from `mcp__citation__cite_resolve`, `mcp__citation__cite_search`, or a Zotero record you opened — never typed from training memory? Any unverified citation must be removed or grounded.
+- **Contract-fidelity pass.** Compared to phase 1's `requirements.md`: has the plan stayed within the contract, or has it added requirements the contract did not impose, or skipped requirements the contract did impose?
+
+### Sharpness angles
+
+Each earns its place against an observed failure: across multiple walkthroughs the skill reliably produced a *disciplined* plan and reliably did *not* produce a *tight* one. These angles target that.
+
+- **Claim-term operationalisation pass.** For each load-bearing term in the paper's primary claim and research questions (the words the paper's contribution actually turns on), does the plan either give an operational definition / evidence threshold, or surface it as a user gate / explicit `deferred` decision? A claim term the plan neither operationalises nor flags is a silent gap — the most damaging kind, because the search and synthesis proceed without knowing what would count as evidence for the paper's own claim. *(Observed: a paper claiming problems "recur" with no definition of what recurrence requires — appears in ≥N sources? across ≥M streams?)*
+- **Classification-separability pass** (when the plan builds a coding scheme, classification facets, or a charting taxonomy). Are the top-level categories mutually separable, or do some plausibly overlap? Overlapping top-level categories produce ambiguous charting and uninterpretable cells. If overlap is plausible, the plan must either justify the overlap, commit to a pilot check that the categories are separable, or flag it as a threat to validity. Do not silently pass a coding scheme whose top-level structure has not been examined for separability. *(Observed: an 8-dimension starter scheme with several plausibly-overlapping dimensions, never examined.)*
+- **Taxonomy-source-role pass** (for taxonomy development). Are taxonomy-instance corpus sources, background/framing sources, methodology sources, and validation/evaluation material separated? Does the plan explicitly prevent background/framing sources from supporting recurrence, prevalence, coverage, or exhaustiveness claims unless they were assigned an evidence role?
+- **RQ-dependency pass.** For each research question, trace what the protocol's answer to it depends on — which charting field, which synthesis step, which judgement call. If an RQ's answer hinges on a single judgement-call field or one fragile step, the plan must address *that field's or step's* reliability specifically — a general calibration step is not enough. The most analytically ambitious RQ deserves the most scrutiny here. *(Observed: the hardest of three RQs resting entirely on one uncalibrated high/medium/low single-screener field.)*
+- **Cumulative-deviation pass.** Count the plan's declared deviations and omissions relative to the methodology source's ideal (single- vs dual-screener, consultation absent, quality appraisal skipped, search strategy deferred, registration skipped, etc.). Each may be individually defensible. If several stack up, the plan must confront the cumulative question directly — *with all of these declared away, is the method still recognisably itself?* — and either state plainly why the cumulative deviation is acceptable, or reconsider. Do not let defensible-individually accumulate into indefensible-together without comment. *(Observed: four declared deviations from the scoping-review ideal, never addressed as a set.)*
+
+When a sharpness pass surfaces a gap, the fix is the same as for any gate: bring it to the user with a recommendation and reasoning, resolve, log in `decisions.md`. A sharpness gap caught in self-review is a gate that should have been raised during drafting; raise it now rather than shipping the plan with the gap.
+
+## What this skill is NOT
+
+- It is not phase 1 (methodology + requirements). If `requirements.md` does not exist, stop and ask the user to run `lit-review` first.
+- It is not the search. After this skill produces `lit-review-plan.md`, the next phase is paper-specific Zotero / online source search executing the plan.
+- It is not paper writing. The plan is the protocol; the review prose is later.
+- It is not a place to relitigate the method choice. The contract decides the method.
+- It is not a place to fabricate procedural detail. Where the answer is genuinely unknown, surface a user gate.

--- a/skills/lit-review-search/SKILL.md
+++ b/skills/lit-review-search/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: lit-review-search
+description: Phase 3 of the literature-review workflow. Executes the phase-2 lit-review plan — runs the search, screens candidates, charts included sources, synthesises. Normally chained from `lit-review-plan` automatically. Can be invoked standalone when a `lit-review-plan.md` already exists in the workspace. The output is the review's evidence base (source set, charting data, coding scheme, evidence matrix, synthesis), not paper prose.
+---
+
+# # Lit-Review Search (Phase 3)
+
+This skill executes the protocol in `lit-review-plan.md`: it runs the search, screens candidates, charts the included sources, and synthesises. Output is the review's evidence base — not the paper's prose.
+
+Phase 1 chose the method and listed the requirements. Phase 2 filled them into an executable plan. This skill *runs* that plan.
+
+## What this skill counters
+
+Phase 3 is where hallucination does the most damage: this is the phase that pulls sources into the review. The whole skill is built around one danger — **the agent pulling things that are not real** — and the citation MCP is the counter to every form of it.
+
+- **Source does not exist.** Hallucinated DOI, fabricated title or authors. Counter: every source enters the review *only* via `mcp__citation__cite_search`, `mcp__citation__cite_forward`, or `mcp__citation__cite_resolve` (real OpenAlex / Crossref records), or `mcp__citation__zotero_search` (the user's library). A source the agent typed from memory does not enter. Ever.
+- **Source exists but its content is misremembered.** Charting what the paper "probably says." Counter: a source is charted *only after its full text has been read* — a Zotero attachment, or an OA PDF obtained via `mcp__citation__oa_locate` + `mcp__citation__zotero_attach_pdf`. No charting from an abstract. No charting from training-memory of what the paper contains.
+- **Backward-snowball reference is wrong.** Citing a reference a paper did not actually cite. Counter: backward snowballing uses the `reference` array returned by `cite_resolve` (Crossref's actually-deposited reference list) — never the agent's recollection of what a paper cites.
+- **Forward-citation fabrication.** Inventing "cited by" papers. Counter: forward snowballing uses `mcp__citation__cite_forward` (OpenAlex `cites:` query) — never a hand-search reconstructed from memory.
+- **Synthesis asserts patterns not in the data.** "The literature shows X" where X is not in what was charted. Counter: the numerical summary is literally counts of charted cells; every thematic claim traces to specific charted, included sources. The synthesis cannot reference a source not in the charting form.
+
+## The discipline — the two-state rule
+
+Every source is in exactly one of two states. There is no third state.
+
+- **(a) Fully in the review.** Resolved via the citation MCP → added to the paper's Zotero collection → full text obtained → full text *read* → charted.
+- **(b) Access gap.** Resolved via the citation MCP → added to the paper's Zotero collection → full text *not* obtainable through any legitimate route → recorded as an access gap → **not charted**.
+
+A source is never "charted from its abstract", never "charted from what the agent recalls of it", never "included in the synthesis without being charted". If the full text cannot be read, the source is an access gap and the synthesis treats it as one. The aggregate access-gap count is reported (it bounds the review's coverage claims).
+
+The protocol in `lit-review-plan.md` is the contract. Do not relitigate it. If executing it surfaces a genuine flaw in the plan, stop and surface that to the user — do not silently deviate.
+
+For taxonomy-development plans, the same two-state rule applies inside each source role. A source may be fully in or an access gap for the taxonomy-instance corpus, the background/framing set, the methodology set, or the validation/evaluation set. Do not move a source between roles just because it is convenient. In particular, background/framing sources do not become evidence for recurrence, prevalence, coverage, or exhaustiveness unless the plan explicitly assigned them that evidentiary role.
+
+## Workflow
+
+1. **Read the plan.** Load `lit-review-plan.md` (and `requirements.md`, `decisions.md`) from the workspace. If `lit-review-plan.md` does not exist, phase 2 has not run — stop and run `lit-review-plan` first.
+
+2. **Confirm the paper's Zotero collection.** The citation MCP does not create Zotero collections — that is a user action, deliberately kept outside the agent's privileged surface. Resolve the `paper_collection_key` for this run via a gate (use `AskUserQuestion`): either reuse an existing collection the user names (the user can verify the key via Zotero's UI, or the agent can list candidates with `mcp__citation__zotero_search` filtered by a tag the user assigns to research collections), or pause while the user creates a new collection in Zotero and supplies the key. Cache the resolved `paper_collection_key`. Every source that enters the review — fully-in or access-gap — is added to it via `zotero_add` with that collection key.
+
+3. **Search.** Run the plan's search strategy:
+   - Query-based search via `cite_search` against the databases/facets the plan names.
+   - Backward snowballing from seed papers via the `reference` arrays of `cite_resolve`.
+   - Forward snowballing via `cite_forward`.
+   Every candidate is a real record. Record the queries run and the date, for PRISMA-ScR item 7/8 reporting.
+
+   For taxonomy-development plans, record candidates by role: taxonomy-instance corpus, background/framing, methodology, and validation/evaluation. The plan may use different search procedures for each role; execute the role-specific procedure rather than collapsing everything into one review corpus.
+
+4. **Screen.** Apply the plan's eligibility criteria, three-pass per the plan (title → abstract → full-text). Title/abstract from `cite_resolve` metadata. Full-text screening needs the PDF (Zotero attachment, or `oa_locate` + `zotero_attach_pdf`). Log a reason for every exclusion (the plan's single-screener discipline requires this). Selection is iterative — refine and re-screen per the plan.
+
+5. **Chart.** For every included source, apply the two-state rule. Fully-in sources are charted from their read full text into the plan's charting form; every load-bearing charted value is traceable to a section of the source. Access-gap sources are recorded as gaps, not charted. Develop emergent sub-codes per the plan's coding scheme; run the plan's form-calibration step.
+
+   For taxonomy-development plans, chart taxonomy-instance sources into the taxonomy construction form, not into a generic scoping-review table unless the plan says so. Record iteration triggers and category changes exactly as the plan requires. Background/framing sources may motivate the problem or context, but they are not charted as evidence for category recurrence or coverage unless the plan explicitly licenses that use.
+
+6. **Synthesise.** Numerical summary = counts over the charted cells. Thematic analysis = the plan's QCA approach over the charted data. Assemble the evidence matrix. Every synthesis claim traces to charted cells; nothing is asserted that the charted data does not support.
+
+   For taxonomy-development plans, synthesis includes the final taxonomy, the iteration/change rationale, evaluation results, source-role-specific limitations, and non-claims. A taxonomy can claim construct/evaluation support only from the roles that the plan assigned to those claims.
+
+7. **Self-review.** Apply the angles below in `search-self-review.md`.
+
+8. **Record decisions.** Extend `decisions.md` with every search-phase decision — search-strategy refinements, post-hoc criteria changes, access-gap escalations, calibration-threshold setting, sub-code additions. Same format as earlier phases.
+
+**Gates** are raised the same way as in phase 2: when a decision is genuinely the user's (e.g., a load-bearing access gap the user might obtain through institutional channels; an eligibility-criterion ambiguity that materially changes the corpus), bring it up immediately with a recommendation and reasoning, resolve, log, continue. No end-of-document backlog.
+
+## Output structure
+
+In the workspace:
+
+- **`charting-data.csv`** (or `.md` table) — one row per included source, the plan's charting-form fields. Access gaps listed separately with their gap reason.
+- **`coding-scheme.md`** — the finalised coding scheme: starter codes plus emergent sub-codes, with definitions and source-grounded examples.
+- **`evidence-matrix.md`** — sources × instrument-problem-codes (or the plan's equivalent), cells filled from the charting data.
+- **`synthesis.md`** — numerical summary + thematic analysis + the plan's "applying meaning" section. Every claim traceable.
+- **`search-log.md`** — queries run, dates, candidate counts, PRISMA-ScR flow numbers (screened / excluded with reasons / included), access-gap list.
+- **`search-self-review.md`** — the self-review.
+- **`decisions.md`** — extended.
+
+For taxonomy-development plans, also include taxonomy-specific evidence artifacts when the plan requires them:
+
+- **`taxonomy.md`** — final dimensions, characteristics, definitions, and unit-of-analysis notes.
+- **`taxonomy-iterations.md`** — iteration-by-iteration changes and rationale.
+- **`taxonomy-evaluation.md`** — evaluation criteria, evidence, results, and limitations.
+
+The paper's prose is *not* an output of this skill.
+
+## Self-review angles
+
+### Grounding angles (the not-real danger)
+
+- **Every-source-grounded pass.** Is every source in the review — fully-in and access-gap alike — traceable to a `cite_search` / `cite_forward` / `cite_resolve` / `zotero_search` result? Any source whose provenance is "the agent knew of it" must be re-grounded through the MCP or removed.
+- **Two-state pass.** Is every source either fully-in (resolved + added + full text read + charted) or access-gap (resolved + added + not charted)? Any source charted without its full text read is a violation — fix it or demote it to access-gap.
+- **Snowball-completeness pass.** Did backward snowballing (`cite_resolve` reference arrays) and forward snowballing (`cite_forward`) actually run per the plan, or was a direction silently skipped?
+- **Synthesis-traceability pass.** Does every claim in `synthesis.md` trace to charted cells? Any "the literature shows" / "most studies" sentence that does not resolve to specific charted, included sources is fabrication — remove or ground it.
+- **Exclusion-log pass.** Does every excluded source have a logged reason? PRISMA-ScR item 17 requires it; the plan's single-screener discipline requires it.
+- **Taxonomy-role pass.** For taxonomy development, did each source stay in its assigned role, and does every taxonomy construction, evaluation, recurrence, coverage, or exhaustiveness claim trace only to sources whose role supports that claim?
+
+### Sharpness angles (carried from phase 2 — a disciplined search can still be a loose one)
+
+- **Claim-term pass.** Does the synthesis honour the operational definition of the paper's key claim terms set in phase 2 (e.g., what "recurring" requires)? A synthesis that claims more than the operational definition licenses is over-reach.
+- **Coding-separability pass.** Did the emergent sub-codes and any new top-level codes stay separable, or did charting produce ambiguous multi-coded cells that signal an overlapping scheme? Report it.
+- **Method-limits pass.** Does the synthesis respect the method limits (no quality-weighted claims for a scoping review, no prevalence claims, no effect estimates)?
+
+## What this skill is NOT
+
+- It is not phase 1 or phase 2. If `lit-review-plan.md` does not exist, stop and run the earlier phases.
+- It is not paper writing. The output is the evidence base; the prose is built downstream by phases 4 and 5 (`lit-review-argument`, then `lit-review-draft`), which the user invokes after reviewing the evidence base. This skill does not auto-chain into them — the evidence base is a checkpoint.
+- It is not a place to pull sources from memory. Every source routes through the citation MCP.
+- It is not a place to relitigate the plan. The plan is the contract; a genuine flaw is surfaced to the user, not silently worked around.

--- a/skills/lit-review/SKILL.md
+++ b/skills/lit-review/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: lit-review
+description: Run the literature-review workflow for a research paper. This skill is the user-facing entry point; internally it executes phase 1 (methodology selection + requirements extraction), chains into phase 2 (`lit-review-plan`, fills the requirements into an executable plan), which chains into phase 3 (`lit-review-search`, runs the search and produces the evidence base). The user invokes this once; the workflow runs end-to-end with gates raised mid-flow as needed. Paper prose is downstream and out of scope.
+---
+
+# # Methodology Selection and Requirements Extraction
+
+This skill's job is two things and only these two:
+
+1. **Pick** the methodology that fits this paper's review or taxonomy-construction contribution.
+2. **Extract** the formal requirements that methodology imposes on the downstream plan, from the methodology's own primary sources.
+
+The output is a methodology selection plus a requirements specification — the contract the next phase has to satisfy. The next phase, domain-aware literature-review planning, fills the requirements with content. The phase after that is the search.
+
+Without this skill, agents skip ahead. They invent a procedure ("query ACM, IEEE, arXiv"), they paraphrase methodology sources from memory, they hallucinate citations (88 partially hallucinated references in one recent round of drafting), and they produce something that looks like a plan but is not grounded in any methodology's formal requirements. The skill is a forcing function: select method, read the canonical sources, list the requirements, then stop.
+
+## What this skill counters
+
+Each item earns its place by what we have actually seen go wrong.
+
+- **Citation hallucination.** Real and expensive — 88 partially hallucinated references thrown out. Counter: cite only methodology sources you have actually read. Every citation of a methodology source must come from a deterministic tool — `mcp__citation__cite_resolve` for canonical CSL-JSON, or a Zotero record you have opened — never from training memory. The citation MCP exists to make this enforceable; use it.
+- **Invented procedural detail.** Real — earlier walkthroughs filled outputs with database lists, date ranges, snowballing depths, and source-set caps the agent invented to fill fields. None of it was grounded. Counter: this skill produces *requirements the next phase must meet*, not the answers. If the methodology source does not name a specific database, neither does this skill's output.
+- **Domain content in a methodology output.** Real — earlier walkthroughs included concept definitions, scope narrowings, claim categories, and named systems that belong to the domain-aware planning phase. Counter: this skill's output is the methodology choice and the requirements that the methodology imposes. Domain content goes in the next phase.
+- **Imported framing without provenance.** Real — a four-tier taxonomy used as the spine of a critique with no source given. Counter: every user- or paper-supplied stance, taxonomy, or framework that affects method choice is labeled `citable` (with source) or `paper-contribution` (the paper itself must defend it). Concept definitions the skill does not introduce — concept definitions are the next phase's work.
+- **Proceeding without source grounding.** Real — earlier walkthroughs proceeded with partial source coverage when sources were unavailable. Counter: if any primary source the catalog lists for the chosen method cannot be obtained, fail out. Do not produce a requirements spec grounded in partial sources.
+
+## The discipline (what the output IS)
+
+The output is a methodology selection and a requirements specification. Critiqueable on its own methodological merits by a reviewer who does not know the paper's field.
+
+Allowed in the output:
+- The paper's research questions and claims, transcribed verbatim from user / paper context.
+- The chosen methodology and justification against the rejected alternatives.
+- The primary sources for the chosen method, with citations grounded in actual reading.
+- The formal requirements the methodology imposes, extracted from those sources, in the source's own terms.
+- User gates that materially affect method choice.
+- For taxonomy-development papers, the source-role distinctions the chosen method requires: taxonomy-instance corpus, background/framing literature, methodology literature, and validation/evaluation material. These are role requirements, not domain answers.
+
+Not allowed in the output:
+- Concept definitions the source does not supply. Those are next-phase.
+- Search procedures (databases, terms, date ranges, depths, caps). Those are next-phase.
+- Inclusion / exclusion criteria as logic. Next-phase.
+- Domain narrowings or sub-area weightings. Next-phase.
+- Characterisations of specific literature. Next-phase, then search-phase.
+- Anticipated synthesis dimensions, named claim categories, charting-form fields. Next-phase.
+
+## Workflow
+
+1. **Get paper context.** If a paper ID is supplied, read the relevant stream document in the workspace's `program/` directory. If only a question or topic is supplied, restate it back to the user and confirm before proceeding. Names of literature anchors in the program's framing are context for you, not protocol content for the output.
+
+2. **Pick the method.** Read `methodology/catalog.yaml` to see which methods exist and which primary sources back them.
+
+   When the paper's primary contribution is a taxonomy, classification scheme, typology, framework, design-space analysis, or category system, explicitly consider `taxonomy_development` before defaulting to scoping or mapping. Taxonomy development is the right fit when the plan must construct, iterate, evaluate, and bound a taxonomy. Scoping or mapping is the right fit only when the primary contribution is a literature-review evidence map rather than the taxonomy artifact itself.
+
+   Candidate outcomes include taxonomy development, scoping review, systematic mapping review, systematic review, critical/integrative review, targeted related-work review, or a hybrid. A hybrid is allowed only when the roles of each component are separated: what the taxonomy method constructs/evaluates, what any review method searches/charts/synthesises, and which claims each component can support. Do not let a scoping corpus silently carry taxonomy-construction or taxonomy-validity claims.
+
+3. **Read every primary source for the chosen method.** Open every Zotero item the catalog lists for the chosen method — all of them, not the first one, not your preference. The catalog defines the canonical-source set. Partial coverage is not method-formal grounding.
+
+   For each listed Zotero key, in order:
+
+   a. **Read the Zotero attachment if present.** Call `mcp__citation__cite_resolve` with `doi:<the source's DOI>` to confirm the canonical metadata, then fetch the attached PDF from Zotero (env vars `PERSONAL_ZOTERO_ID` / `PERSONAL_ZOTERO_KEY` are set). Read it.
+
+   b. **If no PDF is attached but the DOI is reachable:** call `mcp__citation__oa_locate` on the DOI. If an OA location exists, download to a local working file (a publisher-direct URL is preferred) and read it. **Use `mcp__citation__zotero_attach_pdf` to attach the OA PDF to the existing Zotero item** — this is the OA-policy-gated path; arbitrary URLs are rejected. If the user has a preference about whether to attach, ask; default is attach so future runs do not have to refetch.
+
+   c. **If the catalog Zotero key is missing from the library entirely (stale catalog):** the source still has to be reached. Call `mcp__citation__cite_resolve` to obtain the canonical citation, `mcp__citation__oa_locate` to identify any OA copy, and download from a publisher-direct or institutional-repository OA URL to a local working file. Alert the user that the catalog points to a key not in the library; name the source you obtained, where it came from, and ask whether to (a) add the source to Zotero via `mcp__citation__zotero_add`, (b) update the catalog with a different Zotero key, or (c) keep the local copy only. **Do not call `mcp__citation__zotero_add` without the user's permission** — Zotero state is theirs to manage.
+
+   **If any required source for the chosen method cannot be obtained through these deterministic paths, fail out.** Do not produce a requirements spec. Do not paraphrase the missing source from memory. Stop the workflow and report: which source was needed, which retrieval paths were tried (Zotero attachment, `oa_locate`, OA download), what failed, and what is required from the user to unblock — typically (a) provide a local PDF, (b) add the source to Zotero, or (c) point to a substitute canonical source that is reachable.
+
+4. **Extract the formal requirements.** For each formal requirement the methodology sources impose on a literature-review plan, list it. Use the sources' own terms. Cite the source and the section where the requirement is named. Where the sources disagree or where one source extends another (e.g., Levac extending Arksey & O'Malley), record that explicitly.
+
+   A requirement names *what the lit-review plan must specify* — not the answer. *"The plan must define the key concepts and the target population"* is a requirement (extracted from a scoping source). *"Define calibration as X"* is not — that is the next-phase decision.
+
+   For taxonomy development, extract requirements for the taxonomy-development plan in the same way: purpose and meta-characteristic, unit of analysis, starting concepts and their provenance, conceptual-to-empirical / empirical-to-conceptual / iterative construction steps, iteration documentation, ending conditions, evaluation criteria, source-role separation, validity threats, and explicit limits on recurrence, prevalence, coverage, or exhaustiveness claims. Do not fill any of those with domain content in phase 1.
+
+5. **Self-review.** Apply the angles below in `self-review.md`.
+
+6. **Record decisions.** Write `decisions.md` for every non-obvious choice made during this phase — at minimum the method choice and any user-gate resolutions. For each entry: the gate / decision, the agent's recommendation with reasoning, what the user decided (if asked), the rationale that was settled on. This is the audit trail; it is not optional.
+
+7. **Chain into phase 2.** Once `requirements.md`, `self-review.md`, and `decisions.md` are written and phase 1's self-review passes have been applied, **immediately invoke the `lit-review-plan` skill via the Skill tool** with the same paper_id (or workspace path). The user does not re-invoke; the lit-review workflow runs end-to-end. Phase 1's output is the input to phase 2; phase 2 raises any user-decision gates with recommendation + reasoning as they arise.
+
+**When a gate must be resolved by the user, bring it up immediately, with a recommendation and reasoning.** Do not collect gates into an end-of-document backlog. Do not punt as "declared defaults". Use `AskUserQuestion` for structured choices, or a direct chat question for ones that benefit from discussion. State your recommended option, state why, name the trade-offs, ask the user to confirm or override. When resolved, log the decision in `decisions.md`, then continue. The phase-1 output's §6 "user gates affecting method choice" lists forward-looking decisions for phase 2 to surface; it is *not* a list of phase-1 gates the agent left open.
+
+## Output structure
+
+Write `requirements.md` in the workspace. Sections:
+
+1. **Research questions** — verbatim from user / paper context.
+2. **Candidate claims** — verbatim from user / paper context, if supplied. Otherwise note as a next-phase input.
+3. **Chosen methodology** — named method + justification against rejected alternatives + explicit method limits as the sources name them. For hybrids, name each component's role and supported claim types separately.
+4. **Primary sources read** — every source the catalog lists for the method, with how it was obtained (Zotero attachment, OA retrieval) and any provenance notes.
+5. **Requirements specification** — every formal requirement the sources impose, with citation to the source(s) and section(s). Grouped by methodology-source stage / phase where the source organizes its requirements that way.
+6. **User gates affecting method choice** — decisions the user must make that determine which method fits or how the requirements get interpreted at the boundary. Not next-phase domain decisions.
+7. **Method-choice limitations declared up front** — what the chosen method, even when executed perfectly, cannot establish.
+
+Optional `decisions.md` for non-obvious choices.
+
+## Self-review angles
+
+Methodology-level. The reviewer in your head does not know the paper's field.
+
+- **Source-completeness pass.** Did I read every primary source the catalog lists for the chosen method, or did I shortcut on one? If any required source was not obtained, I should have failed out, not proceeded.
+- **Requirements-coverage pass.** For each formal requirement the methodology sources name, has the output captured it with citation? Or has a requirement been skipped, paraphrased, or merged with another in a way that loses what the source actually said?
+- **Procedural-invention pass.** Does the output name any requirement the sources do not actually impose? Invented requirements are as harmful as missing ones — they push fake commitments into the next phase.
+- **Domain-leakage pass.** Did any concept definition, scope narrowing, named claim category, named system, characterisation of specific literature, or "what the literature contains" sentence appear in the output? Those belong to the next phase. Remove them.
+- **Method-fit pass.** Is the chosen method the right shape for the paper's category, RQs, and (where supplied) claims? Are the rejected alternatives rejected for real reasons, not aesthetic ones? Are the method's limits (what it cannot support) stated honestly?
+- **Taxonomy-fit pass.** If the paper proposes a taxonomy, classification scheme, typology, framework, or design-space analysis, did I consider `taxonomy_development` and reject/accept scoping, mapping, or systematic review for source-grounded reasons? If I chose a hybrid, are component roles separated rather than blended?
+- **Imported-framing pass.** For each user- or paper-supplied stance, taxonomy, or framework that affects method choice: is it labeled `citable` (with source) or `paper-contribution` (defence plan named)? Unlabeled framings are unsupported assumptions even at the method-selection phase.
+
+## What this skill is NOT
+
+- It is not the lit-review plan. The output is a requirements spec the next phase fills with content.
+- It is not the search. Two phases away.
+- It is not a place for concept definitions. Those are next-phase decisions about what the methodology's requirements mean for this paper.
+- It is not a place for invented procedural details. If the methodology source does not say it, this skill does not say it either.
+- It is not paper writing.

--- a/skills/lit-review/methodology/catalog.yaml
+++ b/skills/lit-review/methodology/catalog.yaml
@@ -1,0 +1,80 @@
+# Methodology lookup
+#
+# Method key → primary methodology sources (Zotero keys + titles + PDF status).
+# The agent reads the source PDFs in Zotero to ground its protocol decisions.
+# This file is a lookup, not a paraphrase: do not put method descriptions here.
+
+methods:
+
+  - key: scoping
+    label: Scoping review
+    primary_sources:
+      - zotero_key: UNMJUBXU
+        title: "Scoping studies: towards a methodological framework"
+        pdf_available: true
+      - zotero_key: 4ZZU62K6
+        title: "Scoping studies: advancing the methodology"
+        pdf_available: true
+      - zotero_key: W4HIAEIK
+        title: "PRISMA Extension for Scoping Reviews (PRISMA-ScR): Checklist and Explanation"
+        pdf_available: true
+
+  - key: systematic
+    label: Systematic review
+    primary_sources:
+      - zotero_key: FRM9HPNG
+        title: "Guidelines for performing Systematic Literature Reviews in Software Engineering"
+        pdf_available: false
+      - zotero_key: MJX3HCT5
+        title: "The PRISMA 2020 statement: an updated guideline for reporting systematic reviews"
+        pdf_available: true
+
+  - key: mapping
+    label: Systematic mapping review
+    primary_sources:
+      - zotero_key: 7H3MVIUS
+        title: "Systematic Mapping Studies in Software Engineering"
+        pdf_available: false
+      - zotero_key: SIA2M3JX
+        title: "Guidelines for conducting systematic mapping studies in software engineering: An update"
+        pdf_available: false
+
+  - key: critical
+    label: Critical review
+    primary_sources:
+      - zotero_key: WM8CQC62
+        title: "A typology of reviews: an analysis of 14 review types and associated methodologies"
+        pdf_available: false
+      - zotero_key: KKQZZZ85
+        title: "Literature review as a research methodology: An overview and guidelines"
+        pdf_available: false
+
+  - key: narrative_conceptual
+    label: Narrative / conceptual review
+    primary_sources:
+      - zotero_key: XVR4XPMQ
+        title: "The integrative review: updated methodology"
+        pdf_available: false
+      - zotero_key: MK62GIH3
+        title: "Writing Integrative Literature Reviews: Guidelines and Examples"
+        pdf_available: false
+
+  - key: targeted_related_work
+    label: Targeted related-work review
+    primary_sources:
+      - zotero_key: PJBMHN3N
+        title: "Guidelines for snowballing in systematic literature studies and a replication in software engineering"
+        pdf_available: true
+      - zotero_key: FRM9HPNG
+        title: "Guidelines for performing Systematic Literature Reviews in Software Engineering"
+        pdf_available: false
+
+  - key: taxonomy_development
+    label: Taxonomy development
+    primary_sources:
+      - zotero_key: 5IEWQBCY
+        title: "A method for taxonomy development and its application in information systems"
+        pdf_available: false
+      - zotero_key: CZZN2X64
+        title: "An Update for Taxonomy Designers: Methodological Guidance from Information Systems Research"
+        pdf_available: true


### PR DESCRIPTION
## Summary

Add Ground Control's research project type artifact infrastructure: five Claude skills under `skills/lit-review*`, a deterministic Python citation MCP at `mcp/citation/` (registered as `citation` in `.mcp.json`), and a methodology catalog. Content sourced from the retired Reactor repository; layout, naming, and conventions are Ground Control's own.

Pipeline: `lit-review` (methodology selection + requirements extraction) auto-chains into `lit-review-plan` (executable protocol) into `lit-review-search` (search + screening + charting + synthesis). User then invokes `lit-review-argument` (validated Argdown architecture) and `lit-review-draft` (IEEE LaTeX manuscript with Zotero-generated `references.bib`). See ADR-055 for the asset-disposition table satisfying F038's explicit-rationale clause.

## Requirement UIDs

- `GC-RSCH-F005`, `GC-RSCH-F006`, `GC-RSCH-F007`, `GC-RSCH-F008`, `GC-RSCH-F009`
- `GC-RSCH-F012`, `GC-RSCH-F014`, `GC-RSCH-F017`, `GC-RSCH-F019`, `GC-RSCH-F020`, `GC-RSCH-F024`
- `GC-RSCH-F028`, `GC-RSCH-F030`
- `GC-RSCH-F038`

## Related Issues

Closes #1032

## ADR Impact

- ADR-055 (new — research workflow skills and citation MCP)

## Changes

- Add 5 phase skills under `skills/lit-review*` (~670 lines of skill prose + workflow contracts).
- Add deterministic citation MCP under `mcp/citation/` (Python FastMCP; `cite_resolve`, `cite_search`, `cite_forward`, `oa_locate`, `zotero_search`, `zotero_add`, `zotero_attach_pdf`).
- Add methodology catalog at `skills/lit-review/methodology/catalog.yaml` (7 methods: `scoping`, `systematic`, `mapping`, `critical`, `narrative_conceptual`, `targeted_related_work`, `taxonomy_development`).
- Add Argdown validation tooling (`validate-argument-map.sh` + `check-argument-structure.mjs` + tests) with pinned `@argdown/cli@2.0.0` via `package-lock.json` (codex security review fix: defeats supply-chain RCE path that ad-hoc `npx --yes` would open).
- Register `citation` MCP server in `.mcp.json` via repo-relative bootstrap launcher (`mcp/citation/bin/citation-mcp.sh` — no hard-coded paths; auto-bootstraps venv on first run).
- Adjust `lit-review-search` SKILL §2 to confirm the paper's Zotero collection key via user gate (citation MCP does not create collections — codex review finding).
- Add `docs/research/RESEARCH_WORKFLOW.md` (Ground Control-native research workflow overview).
- Add `docs/knowledge/research-workflow/auto-research-requirements-and-oss-assessment.md` (FR/NFR catalog + OSS landscape build-vs-adopt assessment as knowledge-base reference).
- Add ADR-055 with the asset-disposition table satisfying F038's explicit-rationale clause.
- Add `changelog.d/1032.added.md`.
- Exclude `skills/**` and `docs/knowledge/**` from Vale (ported skill prose carries its own writing-style contract per `skills/lit-review-draft/writing-style.md` Part A7).

## Documentation

Added: `architecture/adrs/055-research-workflow-skills-and-citation-mcp.md`, `docs/research/RESEARCH_WORKFLOW.md`, `docs/knowledge/research-workflow/auto-research-requirements-and-oss-assessment.md`, `mcp/citation/README.md`. Vale style applied to all newly-authored docs (em-dash spacing, Latin substitutions); ported skill prose excluded via `.vale.ini` per-glob blocks since the skills carry their own writing-style contract (`skills/lit-review-draft/writing-style.md` Part A7 explicitly endorses em-dashes for embedded lists).

## Test Plan

- [x] Citation MCP offline self-test passes: `mcp/citation/bin/citation-mcp.sh --self-test` (7 tools register)
- [x] Argdown structural-check tests pass: `bash skills/lit-review-argument/tests/run-tests.sh` (7 passed, 0 failed)
- [x] `make policy` passes (vale on newly-authored docs clean; ported content excluded via per-glob blocks)
- [x] `make rapid` passes (no Java touched; format check trivially green)
- [ ] No Java backend changes → no new `@WebMvcTest` controller slices or integration tests required for this PR

## Ground Control Checks

- [x] `make policy` passes
- [x] Traceability links created via `gc_create_traceability_link` (14 IMPLEMENTS links, see below)
- [x] All 14 requirements transitioned `DRAFT → ACTIVE`
- [x] Codex pre-push review cycle 1/1 — 3 findings (2 one-off, 1 class), all fixed in-tree
- [x] Test-quality pre-push review cycle 1/1 — clean (0 findings; no new tests added in this port)
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GC-RSCH-F005 ← skills/lit-review/SKILL.md, GC-RSCH-F006 ← skills/lit-review/SKILL.md, GC-RSCH-F007 ← skills/lit-review/SKILL.md, GC-RSCH-F008 ← skills/lit-review-plan/SKILL.md, GC-RSCH-F009 ← skills/lit-review/methodology/catalog.yaml, GC-RSCH-F012 ← mcp/citation/citation_mcp/resolve.py, GC-RSCH-F014 ← mcp/citation/citation_mcp/search.py, GC-RSCH-F017 ← skills/lit-review-search/SKILL.md, GC-RSCH-F019 ← skills/lit-review-search/SKILL.md, GC-RSCH-F020 ← skills/lit-review-plan/SKILL.md, GC-RSCH-F024 ← skills/lit-review-search/SKILL.md, GC-RSCH-F028 ← skills/lit-review-argument/SKILL.md, GC-RSCH-F030 ← skills/lit-review-draft/SKILL.md, GC-RSCH-F038 ← architecture/adrs/055-research-workflow-skills-and-citation-mcp.md
- TESTS: GC-RSCH-F028 ← skills/lit-review-argument/tests/run-tests.sh (Argdown structural checker)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer (no API changes)
- [x] Domain layer has no framework imports (no domain changes)
- [x] Envers `@Audited` on new entities (no new entities)
- [x] Changelog fragment added at `changelog.d/1032.added.md`
- [x] Architectural docs updated (ADR-055, `docs/research/RESEARCH_WORKFLOW.md`)
