### PR TITLE
GC-T004 / C8: categorised reassessment triggers + event publisher / listener wiring

### DIFF
--- a/architecture/adrs/012-formal-methods-process.md
+++ b/architecture/adrs/012-formal-methods-process.md
@@ -194,6 +194,12 @@ SDD extends TDD by adding contracts as a specification layer:
 - Assurance levels L0-L3 are codified as the `AssuranceLevel` enum in `domain/verification/state/AssuranceLevel.java`.
 - Verification outcomes are codified as the `VerificationStatus` enum in `domain/verification/state/VerificationStatus.java`.
 - Both enums are used by the `VerificationResult` entity (ADR-014 §2, GC-F001).
+- Not every enum under `domain/**/state/` is a state machine. Tag enums that
+  do not define a `canTransitionTo` lifecycle (for example,
+  `ReassessmentTriggerCategory` and `ReassessmentTriggerTargetType` added for
+  GC-T004 / C8 in issue #863) are L0 data classifiers, not L1+ contract
+  surfaces; placement under `state/` follows the existing repo convention for
+  domain-enum location, not an assertion that JML contracts apply.
 
 ## Related ADRs
 

--- a/architecture/adrs/054-documentation-coverage-gate.md
+++ b/architecture/adrs/054-documentation-coverage-gate.md
@@ -138,6 +138,12 @@ input `{ repo_path, changed_paths[] }`, output
   per-step telemetry.
 - Issue #896: Enforce documentation coverage + style as an explicit workflow
   step.
+- Issue #863 / GC-T004 C8: extended the MCP `gc_risk_governance` Zod shape and
+  the `TO_CAMEL` map in `mcp/ground-control/lib.js` for typed reassessment
+  triggers and the `reassessment_required_at` response field. The change is
+  an additive surface extension governed by the same gate; the underlying
+  classifier already covered `mcp/ground-control/lib.js` as a `config_parser`
+  surface, so no classification update was needed.
 - Google Developer Documentation Style Guide: https://developers.google.com/style
 - Diátaxis: https://diataxis.fr/
 - Vale: https://vale.sh/

--- a/architecture/notes/risk-treatment-plan-preflight.md
+++ b/architecture/notes/risk-treatment-plan-preflight.md
@@ -191,6 +191,82 @@ update adapter tests so create/update bodies preserve the canonical nested
 fields. The action-item schema should not be marked opaque in `lib.js`; unlike
 metadata, its keys are repo-owned contract fields.
 
+## Categorised Reassessment Triggers (#863 / C8)
+
+C8 is a typed trigger contract plus a transactional reassessment signal; it is
+not a workflow engine, scheduler, ticketing integration, or risk recomputation
+operation. Keep three concepts separate:
+
+- Trigger configuration: `TreatmentPlan.reassessmentTriggers` becomes one
+  canonical typed value list with `category` and an optional target reference.
+- Change notification: treatment, asset, and control services publish immutable
+  domain events after successful mutations and after old/new tracked values have
+  been captured.
+- Reassessment signal: the listener sets a durable `reassessmentRequiredAt`
+  timestamp on affected risk rows; it does not recompute risk.
+
+The trigger value shape should reuse the existing JSON-text-column pattern:
+extend `JacksonTextCollectionConverters` with one typed converter and keep REST
+DTOs, command records, the domain entity, MCP Zod, `TO_CAMEL`, and
+`GOVERNANCE_FIELDS` aligned. Do not add a treatment-local `ObjectMapper`, a
+parallel metadata map, or a second trigger schema for each methodology. Existing
+free-text rows must migrate deterministically; do not infer entity targets from
+human labels. If legacy labels must be retained, retain them as a bounded field
+on the same typed value object, not as arbitrary metadata.
+
+Optional trigger target references must resolve through
+`GraphTargetResolverService` under the project id before persistence. If the
+current asset/control/risk-scenario target enums do not exactly match the
+reassessment trigger vocabulary, add the smallest resolver entry point there and
+keep the same `targetEntityId` versus `targetIdentifier` split. Do not parse
+`graphNodeId` strings, bypass project-scoped repositories, or duplicate resolver
+logic in controllers, MCP, or frontend code.
+
+Event payloads must be small, immutable value records, not JPA entities. They
+must carry `projectId`, source entity type/id, trigger category, and old/new
+values for every tracked field that caused the event. Use a single field-change
+value shape across treatment, asset, and control events so the next tracked
+field is added to a tracked-field set, not by inventing another event schema.
+Do not log raw field values, raw action-item payloads, or user metadata maps.
+
+Publisher coverage belongs at the service transaction boundary. `TreatmentPlan`
+progress includes `transitionStatus` and changes in `ActionItem.status`.
+Because action items are currently value objects without stable per-item
+identity, a wholesale `actionItems` replacement can only support plan-level
+status-diff semantics unless a separate requirement introduces item ids or
+per-item mutation endpoints. Do not pretend list position is durable identity.
+Asset-state events must cover `archive` and the project-scoped `update` path for
+the documented risk-bearing fields; if deprecated UUID-only overloads remain
+callable, they must either route through the same publisher path using the
+asset's project id or be proven unreachable. Control-state events must cover
+`transitionStatus` and `update` changes to `effectiveness`; only add other
+control fields when they are explicitly documented as mitigation context.
+
+The reassessment listener should mirror the existing
+`RequirementService` -> `EmbeddingService.@TransactionalEventListener`
+transactional shape, but not the best-effort semantics unless that tradeoff is
+explicitly accepted. Reassessment is a governance signal, not a cache rebuild:
+the listener should stay synchronous, DB-only, idempotent, and directly tested.
+If future reliability needs outbox/retry semantics, that is an ADR-level change,
+not a silent background thread.
+
+Listener traversal must stay bounded to the named link surfaces:
+`AssetLink`, `ControlLink`, `RiskScenarioLink`,
+`TreatmentPlan.riskRegisterRecord`, and `TreatmentPlan.riskScenario`. Use
+project-scoped repository queries, collect affected `RiskAssessmentResult` and
+`RiskRegisterRecord` ids, deduplicate before writes, and update only the
+reassessment timestamp. Do not issue ad hoc graph traversals, AGE queries, or
+multi-hop inference beyond those explicit surfaces to make a test pass.
+
+Persistence must add parent and audit columns in lockstep for every audited
+entity that carries the signal. The minimum requirement target is
+`RiskAssessmentResult.reassessmentRequiredAt`; add the matching
+`RiskRegisterRecord` field only if register-record rows themselves need to be
+routeable on the signal. Do not hide the signal in `decisionMetadata`,
+`computedOutputs`, `uncertaintyMetadata`, action items, or the trigger list.
+Flyway version lists in `MigrationSmokeTest` and
+`RequirementsE2EIntegrationTest` must move with the migration.
+
 ## Cross-Cutting Layers
 
 - Control-link target validation (#860 / C4): `ControlLinkService.create` must

--- a/backend/config/spotbugs/exclusions.xml
+++ b/backend/config/spotbugs/exclusions.xml
@@ -25,6 +25,15 @@
         <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
     </Match>
 
+    <!-- Domain event records (immutable value records consumed by
+         @TransactionalEventListener handlers) carry Map/Set payloads by design.
+         The publisher constructs a fresh map/set per event and never mutates it
+         after publication; the listener treats the payload as read-only. -->
+    <Match>
+        <Package name="~com\.keplerops\.groundcontrol\.domain\..*\.events" />
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
+    </Match>
+
     <!-- Spring services store injected dependencies by design -->
     <Match>
         <Package name="~com\.keplerops\.groundcontrol\.domain\..*\.service" />

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/RiskAssessmentResultResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/RiskAssessmentResultResponse.java
@@ -32,6 +32,7 @@ public record RiskAssessmentResultResponse(
         List<String> evidenceRefs,
         String notes,
         List<UUID> observationIds,
+        Instant reassessmentRequiredAt,
         Instant createdAt,
         Instant updatedAt) {
 
@@ -65,6 +66,7 @@ public record RiskAssessmentResultResponse(
                 result.getObservations().stream()
                         .map(observation -> observation.getId())
                         .toList(),
+                result.getReassessmentRequiredAt(),
                 result.getCreatedAt(),
                 result.getUpdatedAt());
     }

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/TreatmentPlanRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/TreatmentPlanRequest.java
@@ -1,6 +1,7 @@
 package com.keplerops.groundcontrol.api.riskscenarios;
 
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentPlanStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
 import jakarta.validation.Valid;
@@ -22,6 +23,6 @@ public record TreatmentPlanRequest(
         Instant dueDate,
         TreatmentPlanStatus status,
         @Valid List<@NotNull ActionItem> actionItems,
-        List<String> reassessmentTriggers,
+        @Valid List<@NotNull ReassessmentTrigger> reassessmentTriggers,
         UUID methodologyProfileId,
         @Size(max = 100) String methodologyStrategyKey) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/TreatmentPlanResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/TreatmentPlanResponse.java
@@ -3,6 +3,7 @@ package com.keplerops.groundcontrol.api.riskscenarios;
 import com.keplerops.groundcontrol.domain.graph.model.GraphEntityType;
 import com.keplerops.groundcontrol.domain.graph.model.GraphIds;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentPlanStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
@@ -26,7 +27,7 @@ public record TreatmentPlanResponse(
         Instant dueDate,
         TreatmentPlanStatus status,
         List<ActionItem> actionItems,
-        List<String> reassessmentTriggers,
+        List<ReassessmentTrigger> reassessmentTriggers,
         UUID methodologyProfileId,
         String methodologyStrategyKey,
         Instant createdAt,

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/UpdateTreatmentPlanRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/riskscenarios/UpdateTreatmentPlanRequest.java
@@ -1,6 +1,7 @@
 package com.keplerops.groundcontrol.api.riskscenarios;
 
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -17,6 +18,6 @@ public record UpdateTreatmentPlanRequest(
         String rationale,
         Instant dueDate,
         @Valid List<@NotNull ActionItem> actionItems,
-        List<String> reassessmentTriggers,
+        @Valid List<@NotNull ReassessmentTrigger> reassessmentTriggers,
         UUID methodologyProfileId,
         @Size(max = 100) String methodologyStrategyKey) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java
@@ -127,8 +127,8 @@ public class AssetService {
         // (codex cycle-4 finding 1). Cheap-fail before the project lookup.
         bounded("uid", command.uid(), OperationalAssetBounds.UID);
         bounded("name", command.name(), OperationalAssetBounds.NAME);
-        bounded("owner", command.owner(), OperationalAssetBounds.OWNER);
-        bounded("steward", command.steward(), OperationalAssetBounds.STEWARD);
+        bounded(FIELD_OWNER, command.owner(), OperationalAssetBounds.OWNER);
+        bounded(FIELD_STEWARD, command.steward(), OperationalAssetBounds.STEWARD);
         bounded(FIELD_SUBTYPE, command.subtype(), OperationalAssetBounds.SUBTYPE);
 
         var project = projectRepository
@@ -762,13 +762,13 @@ public class AssetService {
         // Non-controller callers must hit the same envelope as DTO-validated ones.
         bounded("name", command.name(), OperationalAssetBounds.NAME);
         if (!command.clearOwner()) {
-            bounded("owner", command.owner(), OperationalAssetBounds.OWNER);
+            bounded(FIELD_OWNER, command.owner(), OperationalAssetBounds.OWNER);
         }
         if (!command.clearSteward()) {
-            bounded("steward", command.steward(), OperationalAssetBounds.STEWARD);
+            bounded(FIELD_STEWARD, command.steward(), OperationalAssetBounds.STEWARD);
         }
         if (!command.clearSubtype()) {
-            bounded("subtype", command.subtype(), OperationalAssetBounds.SUBTYPE);
+            bounded(FIELD_SUBTYPE, command.subtype(), OperationalAssetBounds.SUBTYPE);
         }
         applyCoreFieldUpdates(asset, command);
         applyMetadataUpdates(asset, command);
@@ -898,8 +898,8 @@ public class AssetService {
                             + command.subtype() + " was committed first",
                     "asset_subtype_schema_active_conflict",
                     Map.of(
-                            "assetType", command.assetType().name(),
-                            "subtype", command.subtype()));
+                            FIELD_ASSET_TYPE, command.assetType().name(),
+                            FIELD_SUBTYPE, command.subtype()));
         }
     }
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java
@@ -52,21 +52,34 @@ public class AssetService {
     private static final String DETAIL_FIELD = "field";
     private static final String DETAIL_LIMIT = "limit";
 
+    // GC-T004 / C8 (#863): risk-bearing asset field keys hoisted out of inline
+    // literals so each rename is one site, not three. Used by the snapshot,
+    // changed-set diff, and event payload builders.
+    private static final String FIELD_ASSET_TYPE = "assetType";
+    private static final String FIELD_ENVIRONMENT = "environment";
+    private static final String FIELD_CRITICALITY = "criticality";
+    private static final String FIELD_SCOPE_DESIGNATION = "scopeDesignation";
+    private static final String FIELD_BUSINESS_CONTEXT = "businessContext";
+    private static final String FIELD_OWNER = "owner";
+    private static final String FIELD_STEWARD = "steward";
+    private static final String FIELD_KNOWLEDGE_STATE = "knowledgeState";
+    private static final String FIELD_ARCHIVED_AT = "archivedAt";
+
     /**
-     * Risk-bearing asset fields tracked by GC-T004 / C8 (#863) — a change in any of these on
+     * Risk-bearing asset fields tracked by GC-T004 / C8 (#863). A change in any of these on
      * {@code update} fires an {@link AssetStateChangedEvent} so the reassessment listener can
      * route on which fields moved. Drawn from the preflight: asset type, environment,
      * criticality, scope, business context, ownership, stewardship, and knowledge state.
      */
     private static final Set<String> RISK_BEARING_FIELDS = Set.of(
-            "assetType",
-            "environment",
-            "criticality",
-            "scopeDesignation",
-            "businessContext",
-            "owner",
-            "steward",
-            "knowledgeState");
+            FIELD_ASSET_TYPE,
+            FIELD_ENVIRONMENT,
+            FIELD_CRITICALITY,
+            FIELD_SCOPE_DESIGNATION,
+            FIELD_BUSINESS_CONTEXT,
+            FIELD_OWNER,
+            FIELD_STEWARD,
+            FIELD_KNOWLEDGE_STATE);
 
     private final OperationalAssetRepository assetRepository;
     private final AssetRelationRepository relationRepository;
@@ -198,15 +211,18 @@ public class AssetService {
         return saved;
     }
 
+    /**
+     * Deprecated UUID-only overload routes through the same C8 publisher path as the
+     * project-scoped {@link #update(UUID, UUID, UpdateAssetCommand)}; project id is resolved
+     * from the loaded aggregate so reassessment signal routing is not silently skipped on
+     * legacy call sites (GC-T004 / C8, issue #863).
+     */
     @Deprecated(forRemoval = false)
     public OperationalAsset update(UUID id, UpdateAssetCommand command) {
         var asset = assetRepository.findById(id).orElseThrow(() -> new NotFoundException("Asset not found: " + id));
         var oldSnapshot = riskBearingSnapshot(asset);
         applyAssetUpdates(asset, command);
         var saved = assetRepository.save(asset);
-        // The deprecated UUID-only overload still funnels through the same publisher path;
-        // we resolve project id from the loaded aggregate so reassessment routing is not
-        // silently skipped on legacy call sites (GC-T004 / C8, #863).
         publishStateChangeIfRiskFieldsMoved(saved, oldSnapshot);
         return saved;
     }
@@ -1034,14 +1050,14 @@ public class AssetService {
      */
     private Map<String, Object> riskBearingSnapshot(OperationalAsset asset) {
         Map<String, Object> snap = new HashMap<>();
-        snap.put("assetType", asset.getAssetType());
-        snap.put("environment", asset.getEnvironment());
-        snap.put("criticality", asset.getCriticality());
-        snap.put("scopeDesignation", asset.getScopeDesignation());
-        snap.put("businessContext", asset.getBusinessContext());
-        snap.put("owner", asset.getOwner());
-        snap.put("steward", asset.getSteward());
-        snap.put("knowledgeState", asset.getKnowledgeState());
+        snap.put(FIELD_ASSET_TYPE, asset.getAssetType());
+        snap.put(FIELD_ENVIRONMENT, asset.getEnvironment());
+        snap.put(FIELD_CRITICALITY, asset.getCriticality());
+        snap.put(FIELD_SCOPE_DESIGNATION, asset.getScopeDesignation());
+        snap.put(FIELD_BUSINESS_CONTEXT, asset.getBusinessContext());
+        snap.put(FIELD_OWNER, asset.getOwner());
+        snap.put(FIELD_STEWARD, asset.getSteward());
+        snap.put(FIELD_KNOWLEDGE_STATE, asset.getKnowledgeState());
         return snap;
     }
 
@@ -1082,9 +1098,9 @@ public class AssetService {
                 ReassessmentTriggerCategory.ASSET_STATE_CHANGED,
                 ReassessmentSourceEntityType.ASSET,
                 saved.getId(),
-                Set.of("archivedAt"),
+                Set.of(FIELD_ARCHIVED_AT),
                 Map.of(),
-                Map.of("archivedAt", saved.getArchivedAt()),
+                Map.of(FIELD_ARCHIVED_AT, saved.getArchivedAt()),
                 Instant.now())));
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java
@@ -24,13 +24,21 @@ import com.keplerops.groundcontrol.domain.findings.repository.FindingLinkReposit
 import com.keplerops.groundcontrol.domain.findings.state.FindingLinkTargetType;
 import com.keplerops.groundcontrol.domain.graph.service.GraphTargetResolverService;
 import com.keplerops.groundcontrol.domain.projects.repository.ProjectRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ReassessmentSignal;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ReassessmentSourceEntityType;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,6 +52,22 @@ public class AssetService {
     private static final String DETAIL_FIELD = "field";
     private static final String DETAIL_LIMIT = "limit";
 
+    /**
+     * Risk-bearing asset fields tracked by GC-T004 / C8 (#863) — a change in any of these on
+     * {@code update} fires an {@link AssetStateChangedEvent} so the reassessment listener can
+     * route on which fields moved. Drawn from the preflight: asset type, environment,
+     * criticality, scope, business context, ownership, stewardship, and knowledge state.
+     */
+    private static final Set<String> RISK_BEARING_FIELDS = Set.of(
+            "assetType",
+            "environment",
+            "criticality",
+            "scopeDesignation",
+            "businessContext",
+            "owner",
+            "steward",
+            "knowledgeState");
+
     private final OperationalAssetRepository assetRepository;
     private final AssetRelationRepository relationRepository;
     private final AssetLinkRepository linkRepository;
@@ -54,7 +78,9 @@ public class AssetService {
     private final GraphTargetResolverService graphTargetResolverService;
     private final AssetSubtypeSchemaRepository subtypeSchemaRepository;
     private final AssetSubtypeValidator subtypeValidator;
+    private final ApplicationEventPublisher eventPublisher;
 
+    @SuppressWarnings("java:S107") // service aggregates eleven collaborators from the constructor on purpose
     public AssetService(
             OperationalAssetRepository assetRepository,
             AssetRelationRepository relationRepository,
@@ -65,7 +91,8 @@ public class AssetService {
             ProjectRepository projectRepository,
             GraphTargetResolverService graphTargetResolverService,
             AssetSubtypeSchemaRepository subtypeSchemaRepository,
-            AssetSubtypeValidator subtypeValidator) {
+            AssetSubtypeValidator subtypeValidator,
+            ApplicationEventPublisher eventPublisher) {
         this.assetRepository = assetRepository;
         this.relationRepository = relationRepository;
         this.linkRepository = linkRepository;
@@ -76,6 +103,7 @@ public class AssetService {
         this.graphTargetResolverService = graphTargetResolverService;
         this.subtypeSchemaRepository = subtypeSchemaRepository;
         this.subtypeValidator = subtypeValidator;
+        this.eventPublisher = eventPublisher;
     }
 
     public OperationalAsset create(CreateAssetCommand command) {
@@ -163,15 +191,24 @@ public class AssetService {
 
     public OperationalAsset update(UUID projectId, UUID id, UpdateAssetCommand command) {
         var asset = getById(projectId, id);
+        var oldSnapshot = riskBearingSnapshot(asset);
         applyAssetUpdates(asset, command);
-        return assetRepository.save(asset);
+        var saved = assetRepository.save(asset);
+        publishStateChangeIfRiskFieldsMoved(saved, oldSnapshot);
+        return saved;
     }
 
     @Deprecated(forRemoval = false)
     public OperationalAsset update(UUID id, UpdateAssetCommand command) {
         var asset = assetRepository.findById(id).orElseThrow(() -> new NotFoundException("Asset not found: " + id));
+        var oldSnapshot = riskBearingSnapshot(asset);
         applyAssetUpdates(asset, command);
-        return assetRepository.save(asset);
+        var saved = assetRepository.save(asset);
+        // The deprecated UUID-only overload still funnels through the same publisher path;
+        // we resolve project id from the loaded aggregate so reassessment routing is not
+        // silently skipped on legacy call sites (GC-T004 / C8, #863).
+        publishStateChangeIfRiskFieldsMoved(saved, oldSnapshot);
+        return saved;
     }
 
     @Transactional(readOnly = true)
@@ -279,14 +316,18 @@ public class AssetService {
     public OperationalAsset archive(UUID projectId, UUID id) {
         var asset = getById(projectId, id);
         asset.archive();
-        return assetRepository.save(asset);
+        var saved = assetRepository.save(asset);
+        publishArchive(saved);
+        return saved;
     }
 
     @Deprecated(forRemoval = false)
     public OperationalAsset archive(UUID id) {
         var asset = getById(id);
         asset.archive();
-        return assetRepository.save(asset);
+        var saved = assetRepository.save(asset);
+        publishArchive(saved);
+        return saved;
     }
 
     public void delete(UUID projectId, UUID id) {
@@ -981,5 +1022,69 @@ public class AssetService {
         if (knowledgeState != null) {
             relation.setKnowledgeState(knowledgeState);
         }
+    }
+
+    // ----- GC-T004 / C8 (#863): reassessment publisher -----
+
+    /**
+     * Snapshot of the asset's risk-bearing fields immediately before mutation. Compared
+     * to the post-save state to decide whether to publish {@link AssetStateChangedEvent}.
+     * The snapshot uses raw field references (not getters that synthesize state) so
+     * publish-on-no-op-write is impossible.
+     */
+    private Map<String, Object> riskBearingSnapshot(OperationalAsset asset) {
+        Map<String, Object> snap = new HashMap<>();
+        snap.put("assetType", asset.getAssetType());
+        snap.put("environment", asset.getEnvironment());
+        snap.put("criticality", asset.getCriticality());
+        snap.put("scopeDesignation", asset.getScopeDesignation());
+        snap.put("businessContext", asset.getBusinessContext());
+        snap.put("owner", asset.getOwner());
+        snap.put("steward", asset.getSteward());
+        snap.put("knowledgeState", asset.getKnowledgeState());
+        return snap;
+    }
+
+    private void publishStateChangeIfRiskFieldsMoved(OperationalAsset saved, Map<String, Object> oldSnap) {
+        var newSnap = riskBearingSnapshot(saved);
+        Set<String> changed = new HashSet<>();
+        Map<String, Object> oldVals = new HashMap<>();
+        Map<String, Object> newVals = new HashMap<>();
+        for (String field : RISK_BEARING_FIELDS) {
+            var oldVal = oldSnap.get(field);
+            var newVal = newSnap.get(field);
+            if (!java.util.Objects.equals(oldVal, newVal)) {
+                changed.add(field);
+                oldVals.put(field, oldVal);
+                newVals.put(field, newVal);
+            }
+        }
+        if (changed.isEmpty()) {
+            return;
+        }
+        eventPublisher.publishEvent(new AssetStateChangedEvent(new ReassessmentSignal(
+                saved.getProject().getId(),
+                ReassessmentTriggerCategory.ASSET_STATE_CHANGED,
+                ReassessmentSourceEntityType.ASSET,
+                saved.getId(),
+                changed,
+                oldVals,
+                newVals,
+                Instant.now())));
+    }
+
+    private void publishArchive(OperationalAsset saved) {
+        // Archive is intrinsically a transition to "archived" — the listener treats it as
+        // a risk-bearing change regardless of which fields moved. archivedAt is the
+        // only field carried in the changed-field set so consumers can route on it.
+        eventPublisher.publishEvent(new AssetStateChangedEvent(new ReassessmentSignal(
+                saved.getProject().getId(),
+                ReassessmentTriggerCategory.ASSET_STATE_CHANGED,
+                ReassessmentSourceEntityType.ASSET,
+                saved.getId(),
+                Set.of("archivedAt"),
+                Map.of(),
+                Map.of("archivedAt", saved.getArchivedAt()),
+                Instant.now())));
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/service/ControlService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/service/ControlService.java
@@ -39,6 +39,11 @@ public class ControlService {
     private static final Logger log = LoggerFactory.getLogger(ControlService.class);
     private static final String DETAIL_CONTROL_UID = "controlUid";
 
+    // GC-T004 / C8 (#863): event-payload field keys hoisted out of inline literals
+    // so each rename is one site, not three.
+    private static final String FIELD_STATUS = "status";
+    private static final String FIELD_EFFECTIVENESS = "effectiveness";
+
     private final ControlRepository controlRepository;
     private final ControlLinkRepository controlLinkRepository;
     private final ControlTestRepository controlTestRepository;
@@ -130,9 +135,9 @@ public class ControlService {
                     ReassessmentTriggerCategory.CONTROL_STATE_CHANGED,
                     ReassessmentSourceEntityType.CONTROL,
                     control.getId(),
-                    Set.of("effectiveness"),
-                    fieldMap("effectiveness", oldEffectiveness),
-                    fieldMap("effectiveness", control.getEffectiveness()),
+                    Set.of(FIELD_EFFECTIVENESS),
+                    fieldMap(FIELD_EFFECTIVENESS, oldEffectiveness),
+                    fieldMap(FIELD_EFFECTIVENESS, control.getEffectiveness()),
                     Instant.now())));
         }
         return control;
@@ -173,9 +178,9 @@ public class ControlService {
                     ReassessmentTriggerCategory.CONTROL_STATE_CHANGED,
                     ReassessmentSourceEntityType.CONTROL,
                     control.getId(),
-                    Set.of("status"),
-                    fieldMap("status", oldStatus),
-                    fieldMap("status", control.getStatus()),
+                    Set.of(FIELD_STATUS),
+                    fieldMap(FIELD_STATUS, oldStatus),
+                    fieldMap(FIELD_STATUS, control.getStatus()),
                     Instant.now())));
         }
         return control;
@@ -255,7 +260,7 @@ public class ControlService {
         // HashMap (not Map.of) because the value may legitimately be null —
         // Map.of rejects null values and we want the absent-vs-null distinction
         // to survive into the listener.
-        Map<String, Object> m = new HashMap<>(1);
+        Map<String, Object> m = HashMap.newHashMap(1);
         m.put(key, value);
         return m;
     }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/service/ControlService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/controls/service/ControlService.java
@@ -13,14 +13,22 @@ import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.findings.repository.FindingLinkRepository;
 import com.keplerops.groundcontrol.domain.findings.state.FindingLinkTargetType;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ControlStateChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ReassessmentSignal;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ReassessmentSourceEntityType;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +46,9 @@ public class ControlService {
     private final FindingLinkRepository findingLinkRepository;
     private final AuditLinkRepository auditLinkRepository;
     private final ProjectService projectService;
+    private final ApplicationEventPublisher eventPublisher;
 
+    @SuppressWarnings("java:S107") // service aggregates eight collaborators from the constructor on purpose
     public ControlService(
             ControlRepository controlRepository,
             ControlLinkRepository controlLinkRepository,
@@ -46,7 +56,8 @@ public class ControlService {
             ControlEffectivenessAssessmentRepository effectivenessAssessmentRepository,
             FindingLinkRepository findingLinkRepository,
             AuditLinkRepository auditLinkRepository,
-            ProjectService projectService) {
+            ProjectService projectService,
+            ApplicationEventPublisher eventPublisher) {
         this.controlRepository = controlRepository;
         this.controlLinkRepository = controlLinkRepository;
         this.controlTestRepository = controlTestRepository;
@@ -54,6 +65,7 @@ public class ControlService {
         this.findingLinkRepository = findingLinkRepository;
         this.auditLinkRepository = auditLinkRepository;
         this.projectService = projectService;
+        this.eventPublisher = eventPublisher;
     }
 
     public Control create(CreateControlCommand command) {
@@ -98,6 +110,7 @@ public class ControlService {
         if (command.methodologyFactors() != null) {
             control.setMethodologyFactors(command.methodologyFactors());
         }
+        var oldEffectiveness = control.getEffectiveness();
         if (command.effectiveness() != null) {
             control.setEffectiveness(command.effectiveness());
         }
@@ -109,6 +122,19 @@ public class ControlService {
         }
         control = controlRepository.save(control);
         log.info("control_updated: uid={} id={}", control.getUid(), control.getId());
+        if (!java.util.Objects.equals(oldEffectiveness, control.getEffectiveness())) {
+            // GC-T004 / C8 (#863): control effectiveness is a mitigation-context change
+            // per the preflight scope (status + effectiveness only).
+            eventPublisher.publishEvent(new ControlStateChangedEvent(new ReassessmentSignal(
+                    control.getProject().getId(),
+                    ReassessmentTriggerCategory.CONTROL_STATE_CHANGED,
+                    ReassessmentSourceEntityType.CONTROL,
+                    control.getId(),
+                    Set.of("effectiveness"),
+                    fieldMap("effectiveness", oldEffectiveness),
+                    fieldMap("effectiveness", control.getEffectiveness()),
+                    Instant.now())));
+        }
         return control;
     }
 
@@ -137,9 +163,21 @@ public class ControlService {
 
     public Control transitionStatus(UUID projectId, UUID id, ControlStatus newStatus) {
         var control = findOrThrow(projectId, id);
+        var oldStatus = control.getStatus();
         control.transitionStatus(newStatus);
         control = controlRepository.save(control);
         log.info("control_status_changed: uid={} status={}", control.getUid(), newStatus);
+        if (oldStatus != control.getStatus()) {
+            eventPublisher.publishEvent(new ControlStateChangedEvent(new ReassessmentSignal(
+                    control.getProject().getId(),
+                    ReassessmentTriggerCategory.CONTROL_STATE_CHANGED,
+                    ReassessmentSourceEntityType.CONTROL,
+                    control.getId(),
+                    Set.of("status"),
+                    fieldMap("status", oldStatus),
+                    fieldMap("status", control.getStatus()),
+                    Instant.now())));
+        }
         return control;
     }
 
@@ -211,5 +249,14 @@ public class ControlService {
         controlLinkRepository.deleteAll(outboundLinks);
         controlRepository.delete(control);
         log.info("control_deleted: uid={} id={} outbound_links_deleted={}", control.getUid(), id, outboundLinks.size());
+    }
+
+    private static Map<String, Object> fieldMap(String key, Object value) {
+        // HashMap (not Map.of) because the value may legitimately be null —
+        // Map.of rejects null values and we want the absent-vs-null distinction
+        // to survive into the listener.
+        Map<String, Object> m = new HashMap<>(1);
+        m.put(key, value);
+        return m;
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java
@@ -17,6 +17,7 @@ import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskAssessmen
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskRegisterRecordRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.TreatmentPlanRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerTargetType;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkTargetType;
 import com.keplerops.groundcontrol.domain.threatmodels.repository.ThreatModelRepository;
 import com.keplerops.groundcontrol.domain.threatmodels.state.ThreatModelLinkTargetType;
@@ -361,6 +362,39 @@ public class GraphTargetResolverService {
             case FINDING -> internalTarget(
                     targetEntityId, findingRepository.existsByIdAndProjectId(targetEntityId, projectId), LABEL_FINDING);
             case FRAMEWORK, EXTERNAL -> externalTarget(targetIdentifier);
+        };
+    }
+
+    public ValidatedTarget validateReassessmentTriggerTarget(
+            UUID projectId, ReassessmentTriggerTargetType targetType, UUID targetEntityId, String targetIdentifier) {
+        return switch (targetType) {
+            case ASSET -> internalTarget(
+                    targetEntityId, assetRepository.existsByIdAndProjectId(targetEntityId, projectId), LABEL_ASSET);
+            case CONTROL -> internalTarget(
+                    targetEntityId, controlRepository.existsByIdAndProjectId(targetEntityId, projectId), LABEL_CONTROL);
+            case RISK_SCENARIO -> internalTarget(
+                    targetEntityId,
+                    riskScenarioRepository.existsByIdAndProjectId(targetEntityId, projectId),
+                    LABEL_RISK_SCENARIO);
+            case RISK_REGISTER_RECORD -> internalTarget(
+                    targetEntityId,
+                    riskRegisterRecordRepository
+                            .findByIdAndProjectIdWithScenarios(targetEntityId, projectId)
+                            .isPresent(),
+                    LABEL_RISK_REGISTER_RECORD);
+            case RISK_ASSESSMENT_RESULT -> internalTarget(
+                    targetEntityId,
+                    riskAssessmentResultRepository
+                            .findByIdAndProjectIdWithObservations(targetEntityId, projectId)
+                            .isPresent(),
+                    LABEL_RISK_ASSESSMENT_RESULT);
+            case TREATMENT_PLAN -> internalTarget(
+                    targetEntityId,
+                    treatmentPlanRepository
+                            .findByIdAndProjectId(targetEntityId, projectId)
+                            .isPresent(),
+                    LABEL_TREATMENT_PLAN);
+            case EXTERNAL -> externalTarget(targetIdentifier);
         };
     }
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/AssetStateChangedEvent.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/AssetStateChangedEvent.java
@@ -1,0 +1,8 @@
+package com.keplerops.groundcontrol.domain.riskscenarios.events;
+
+/**
+ * Published by {@code AssetService} on archive or risk-bearing field
+ * updates (GC-T004 / C8, issue #863). The reassessment-trigger
+ * category and the changed-field set narrow what the listener acts on.
+ */
+public record AssetStateChangedEvent(ReassessmentSignal signal) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/ControlStateChangedEvent.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/ControlStateChangedEvent.java
@@ -1,0 +1,9 @@
+package com.keplerops.groundcontrol.domain.riskscenarios.events;
+
+/**
+ * Published by {@code ControlService} on status transition or
+ * effectiveness change (GC-T004 / C8, issue #863). Other control
+ * fields are deliberately not in scope — only status + effectiveness
+ * count as mitigation-context changes per the preflight.
+ */
+public record ControlStateChangedEvent(ReassessmentSignal signal) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/ReassessmentSignal.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/ReassessmentSignal.java
@@ -1,0 +1,28 @@
+package com.keplerops.groundcontrol.domain.riskscenarios.events;
+
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Immutable payload shared by every reassessment-triggering event
+ * (GC-T004 / C8, issue #863). Not a JPA entity — events outlive the
+ * transaction that wrote them only until the synchronous listener runs.
+ *
+ * <p>{@code changedFields} is the set of field names whose value moved
+ * in this mutation (drives the publishers' tracked-field set without
+ * forcing a new event schema per added field). {@code oldValues} and
+ * {@code newValues} are keyed by the same field names so the listener
+ * or future consumers can inspect what moved.
+ */
+public record ReassessmentSignal(
+        UUID projectId,
+        ReassessmentTriggerCategory category,
+        ReassessmentSourceEntityType entityType,
+        UUID entityId,
+        Set<String> changedFields,
+        Map<String, Object> oldValues,
+        Map<String, Object> newValues,
+        Instant occurredAt) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/ReassessmentSourceEntityType.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/ReassessmentSourceEntityType.java
@@ -1,0 +1,13 @@
+package com.keplerops.groundcontrol.domain.riskscenarios.events;
+
+/**
+ * The aggregate kind that produced a reassessment-triggering event
+ * (GC-T004 / C8, issue #863). Kept separate from the link/resolver
+ * target enums so the listener can route on event provenance without
+ * importing those bigger surfaces.
+ */
+public enum ReassessmentSourceEntityType {
+    TREATMENT_PLAN,
+    ASSET,
+    CONTROL
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/TreatmentProgressChangedEvent.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/events/TreatmentProgressChangedEvent.java
@@ -1,0 +1,8 @@
+package com.keplerops.groundcontrol.domain.riskscenarios.events;
+
+/**
+ * Published by {@code TreatmentPlanService} when a treatment plan's
+ * lifecycle status or action-item status histogram changes
+ * (GC-T004 / C8, issue #863).
+ */
+public record TreatmentProgressChangedEvent(ReassessmentSignal signal) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/ReassessmentTrigger.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/ReassessmentTrigger.java
@@ -1,0 +1,29 @@
+package com.keplerops.groundcontrol.domain.riskscenarios.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerTargetType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+/**
+ * Typed value type for a single reassessment trigger on a TreatmentPlan
+ * (GC-T004 / C8, issue #863). Serialised as a JSON object in the
+ * {@code reassessment_triggers} TEXT column via
+ * {@link com.keplerops.groundcontrol.shared.persistence.JacksonTextCollectionConverters.ReassessmentTriggerListConverter}.
+ *
+ * <p>{@code targetType} + ({@code targetEntityId} OR {@code targetIdentifier}) resolve through
+ * {@code GraphTargetResolverService} so target validity is enforced at the same boundary as
+ * the other link surfaces. {@code note} carries methodology-specific or legacy free-text
+ * context that cannot be expressed by the enum.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ReassessmentTrigger(
+        @NotNull ReassessmentTriggerCategory category,
+        ReassessmentTriggerTargetType targetType,
+        UUID targetEntityId,
+        @Size(max = 500) String targetIdentifier,
+        @Size(max = 4000) String note) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/RiskAssessmentResult.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/RiskAssessmentResult.java
@@ -87,6 +87,15 @@ public class RiskAssessmentResult extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String notes;
 
+    /**
+     * Reassessment-needed timestamp set by the C8 listener
+     * ({@code ReassessmentSignalService}) when an upstream treatment, asset,
+     * or control change implicates this assessment row. Read-only signal —
+     * the row is otherwise unchanged. Null means no outstanding signal.
+     */
+    @Column(name = "reassessment_required_at")
+    private Instant reassessmentRequiredAt;
+
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "risk_assessment_result_observation",
@@ -235,5 +244,13 @@ public class RiskAssessmentResult extends BaseEntity {
 
     public Set<Observation> getObservations() {
         return observations;
+    }
+
+    public Instant getReassessmentRequiredAt() {
+        return reassessmentRequiredAt;
+    }
+
+    public void setReassessmentRequiredAt(Instant reassessmentRequiredAt) {
+        this.reassessmentRequiredAt = reassessmentRequiredAt;
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/TreatmentPlan.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/TreatmentPlan.java
@@ -66,9 +66,9 @@ public class TreatmentPlan extends BaseEntity {
     @Column(name = "action_items", columnDefinition = "TEXT")
     private List<ActionItem> actionItems;
 
-    @Convert(converter = JacksonTextCollectionConverters.StringListConverter.class)
+    @Convert(converter = JacksonTextCollectionConverters.ReassessmentTriggerListConverter.class)
     @Column(name = "reassessment_triggers", columnDefinition = "TEXT")
-    private List<String> reassessmentTriggers;
+    private List<ReassessmentTrigger> reassessmentTriggers;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "methodology_profile_id")
@@ -173,11 +173,11 @@ public class TreatmentPlan extends BaseEntity {
         this.actionItems = actionItems;
     }
 
-    public List<String> getReassessmentTriggers() {
+    public List<ReassessmentTrigger> getReassessmentTriggers() {
         return reassessmentTriggers;
     }
 
-    public void setReassessmentTriggers(List<String> reassessmentTriggers) {
+    public void setReassessmentTriggers(List<ReassessmentTrigger> reassessmentTriggers) {
         this.reassessmentTriggers = reassessmentTriggers;
     }
 

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/CreateTreatmentPlanCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/CreateTreatmentPlanCommand.java
@@ -1,6 +1,7 @@
 package com.keplerops.groundcontrol.domain.riskscenarios.service;
 
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentPlanStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
 import java.time.Instant;
@@ -19,6 +20,6 @@ public record CreateTreatmentPlanCommand(
         Instant dueDate,
         TreatmentPlanStatus status,
         List<ActionItem> actionItems,
-        List<String> reassessmentTriggers,
+        List<ReassessmentTrigger> reassessmentTriggers,
         UUID methodologyProfileId,
         String methodologyStrategyKey) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/ReassessmentSignalService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/ReassessmentSignalService.java
@@ -1,0 +1,222 @@
+package com.keplerops.groundcontrol.domain.riskscenarios.service;
+
+import com.keplerops.groundcontrol.domain.assets.repository.AssetLinkRepository;
+import com.keplerops.groundcontrol.domain.controls.repository.ControlLinkRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ControlStateChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ReassessmentSignal;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.TreatmentProgressChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskAssessmentResult;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskAssessmentResultRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioLinkRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.TreatmentPlanRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkTargetType;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * GC-T004 / C8 (#863): transactional reassessment signal listener.
+ *
+ * <p>Reassessment is a governance signal, not a cache rebuild. Per the preflight, this
+ * listener stays synchronous, DB-only, idempotent, and directly tested — NOT
+ * best-effort like the embedding listener. It does not recompute risk, file findings,
+ * or send notifications; it sets {@code reassessmentRequiredAt} on the affected
+ * assessment-result rows and stops there.
+ *
+ * <p>Traversal is bounded to the link surfaces named in the preflight:
+ * {@code AssetLink}, {@code ControlLink}, {@code RiskScenarioLink}, plus
+ * {@code TreatmentPlan.riskRegisterRecord} / {@code TreatmentPlan.riskScenario}. No
+ * graph traversal, no AGE queries, no multi-hop inference. Handlers use
+ * {@link EventListener} (NOT {@code @TransactionalEventListener}), so they run
+ * inline in the publishing service's transaction — a listener failure rolls back
+ * the publishing mutation, and the reassessment write commits or fails atomically
+ * with it. This is the explicit non-best-effort contract from the preflight
+ * (codex review #863 cycle 1: a separate-transaction listener would let the
+ * source mutation commit while the signal silently disappears).
+ */
+@Service
+@Transactional
+public class ReassessmentSignalService {
+
+    private static final Logger log = LoggerFactory.getLogger(ReassessmentSignalService.class);
+
+    private final RiskAssessmentResultRepository assessmentRepository;
+    private final TreatmentPlanRepository treatmentPlanRepository;
+    private final AssetLinkRepository assetLinkRepository;
+    private final ControlLinkRepository controlLinkRepository;
+    private final RiskScenarioLinkRepository riskScenarioLinkRepository;
+
+    public ReassessmentSignalService(
+            RiskAssessmentResultRepository assessmentRepository,
+            TreatmentPlanRepository treatmentPlanRepository,
+            AssetLinkRepository assetLinkRepository,
+            ControlLinkRepository controlLinkRepository,
+            RiskScenarioLinkRepository riskScenarioLinkRepository) {
+        this.assessmentRepository = assessmentRepository;
+        this.treatmentPlanRepository = treatmentPlanRepository;
+        this.assetLinkRepository = assetLinkRepository;
+        this.controlLinkRepository = controlLinkRepository;
+        this.riskScenarioLinkRepository = riskScenarioLinkRepository;
+    }
+
+    @EventListener
+    public void onTreatmentProgressChanged(TreatmentProgressChangedEvent event) {
+        var signal = event.signal();
+        var affectedResults = collectFromTreatmentPlan(signal);
+        markReassessmentRequired(affectedResults, signal);
+    }
+
+    @EventListener
+    public void onAssetStateChanged(AssetStateChangedEvent event) {
+        var signal = event.signal();
+        var affectedResults = collectFromAsset(signal);
+        markReassessmentRequired(affectedResults, signal);
+    }
+
+    @EventListener
+    public void onControlStateChanged(ControlStateChangedEvent event) {
+        var signal = event.signal();
+        var affectedResults = collectFromControl(signal);
+        markReassessmentRequired(affectedResults, signal);
+    }
+
+    /** Treatment plan → its register record + (optionally) scenario → assessment results. */
+    private Set<UUID> collectFromTreatmentPlan(ReassessmentSignal signal) {
+        Set<UUID> ids = new LinkedHashSet<>();
+        treatmentPlanRepository
+                .findByIdAndProjectId(signal.entityId(), signal.projectId())
+                .ifPresent(plan -> {
+                    // Plan → linked register record → all assessment results under it.
+                    assessmentRepository
+                            .findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(
+                                    signal.projectId(),
+                                    plan.getRiskRegisterRecord().getId())
+                            .forEach(r -> ids.add(r.getId()));
+                    // Plan → optional scenario → all assessment results under that scenario.
+                    if (plan.getRiskScenario() != null) {
+                        assessmentRepository
+                                .findByProjectIdAndRiskScenarioIdOrderByCreatedAtDesc(
+                                        signal.projectId(),
+                                        plan.getRiskScenario().getId())
+                                .forEach(r -> ids.add(r.getId()));
+                    }
+                });
+        return ids;
+    }
+
+    /** Asset → links pointing FROM the asset → scenarios / records / results / plans. */
+    private Set<UUID> collectFromAsset(ReassessmentSignal signal) {
+        Set<UUID> resultIds = new LinkedHashSet<>();
+        for (var link : assetLinkRepository.findByAssetId(signal.entityId())) {
+            switch (link.getTargetType()) {
+                case RISK_SCENARIO -> addAllAssessmentsForScenario(
+                        signal.projectId(), link.getTargetEntityId(), resultIds);
+                case RISK_REGISTER_RECORD -> addAllAssessmentsForRecord(
+                        signal.projectId(), link.getTargetEntityId(), resultIds);
+                case RISK_ASSESSMENT_RESULT -> resultIds.add(link.getTargetEntityId());
+                case TREATMENT_PLAN -> addAllAssessmentsForTreatmentPlan(
+                        signal.projectId(), link.getTargetEntityId(), resultIds);
+                default -> {
+                    // intentional fall-through: other AssetLinkTargetType values are
+                    // not in the bounded surface set the listener walks.
+                }
+            }
+        }
+        return resultIds;
+    }
+
+    /** Control → links pointing FROM the control → scenarios / records / results / plans. */
+    private Set<UUID> collectFromControl(ReassessmentSignal signal) {
+        Set<UUID> resultIds = new LinkedHashSet<>();
+        for (var link : controlLinkRepository.findByControlId(signal.entityId())) {
+            switch (link.getTargetType()) {
+                case RISK_SCENARIO -> addAllAssessmentsForScenario(
+                        signal.projectId(), link.getTargetEntityId(), resultIds);
+                case RISK_REGISTER_RECORD -> addAllAssessmentsForRecord(
+                        signal.projectId(), link.getTargetEntityId(), resultIds);
+                case RISK_ASSESSMENT_RESULT -> resultIds.add(link.getTargetEntityId());
+                case TREATMENT_PLAN -> addAllAssessmentsForTreatmentPlan(
+                        signal.projectId(), link.getTargetEntityId(), resultIds);
+                default -> {
+                    // intentional fall-through (see collectFromAsset).
+                }
+            }
+        }
+        // RiskScenarioLink is the inverse direction (scenario → control); when a
+        // control changes, scenarios that LINK to it as a mitigation become
+        // re-assessment candidates. Follow that surface too.
+        for (var link : riskScenarioLinkRepository.findByTargetTypeAndTargetEntityIdAndProjectId(
+                RiskScenarioLinkTargetType.CONTROL, signal.entityId(), signal.projectId())) {
+            addAllAssessmentsForScenario(
+                    signal.projectId(), link.getRiskScenario().getId(), resultIds);
+        }
+        return resultIds;
+    }
+
+    private void addAllAssessmentsForScenario(UUID projectId, UUID scenarioId, Set<UUID> out) {
+        if (scenarioId == null) {
+            return;
+        }
+        assessmentRepository
+                .findByProjectIdAndRiskScenarioIdOrderByCreatedAtDesc(projectId, scenarioId)
+                .forEach(r -> out.add(r.getId()));
+    }
+
+    private void addAllAssessmentsForRecord(UUID projectId, UUID recordId, Set<UUID> out) {
+        if (recordId == null) {
+            return;
+        }
+        assessmentRepository
+                .findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(projectId, recordId)
+                .forEach(r -> out.add(r.getId()));
+    }
+
+    private void addAllAssessmentsForTreatmentPlan(UUID projectId, UUID planId, Set<UUID> out) {
+        if (planId == null) {
+            return;
+        }
+        treatmentPlanRepository.findByIdAndProjectId(planId, projectId).ifPresent(plan -> {
+            addAllAssessmentsForRecord(projectId, plan.getRiskRegisterRecord().getId(), out);
+            if (plan.getRiskScenario() != null) {
+                addAllAssessmentsForScenario(projectId, plan.getRiskScenario().getId(), out);
+            }
+        });
+    }
+
+    private void markReassessmentRequired(Set<UUID> ids, ReassessmentSignal signal) {
+        if (ids.isEmpty()) {
+            return;
+        }
+        var now = Instant.now();
+        int updated = 0;
+        for (UUID id : ids) {
+            var existing = assessmentRepository.findByIdAndProjectId(id, signal.projectId());
+            if (existing.isEmpty()) {
+                continue;
+            }
+            RiskAssessmentResult row = existing.get();
+            row.setReassessmentRequiredAt(now);
+            assessmentRepository.save(row);
+            updated++;
+        }
+        if (updated > 0 && log.isInfoEnabled()) {
+            // Low-cardinality structured log per the preflight observability rule —
+            // entity ids and categories only; never raw field values, action items,
+            // or metadata payloads.
+            log.info(
+                    "reassessment_required_marked: project_id={} source_type={} source_id={} category={} affected={}",
+                    signal.projectId(),
+                    signal.entityType(),
+                    signal.entityId(),
+                    signal.category(),
+                    updated);
+        }
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/TreatmentPlanService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/TreatmentPlanService.java
@@ -3,22 +3,35 @@ package com.keplerops.groundcontrol.domain.riskscenarios.service;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.graph.service.GraphTargetResolverService;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ReassessmentSignal;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ReassessmentSourceEntityType;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.TreatmentProgressChangedEvent;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.MethodologyProfile;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.MethodologyProfileRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskRegisterRecordRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.TreatmentPlanRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ActionItemStatus;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentPlanStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
+import java.time.Instant;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,20 +45,27 @@ public class TreatmentPlanService {
     private final MethodologyProfileRepository methodologyProfileRepository;
     private final ProjectService projectService;
     private final Validator validator;
+    private final GraphTargetResolverService graphTargetResolverService;
+    private final ApplicationEventPublisher eventPublisher;
 
+    @SuppressWarnings("java:S107") // service aggregates eight collaborators from the constructor on purpose
     public TreatmentPlanService(
             TreatmentPlanRepository repository,
             RiskRegisterRecordRepository riskRegisterRecordRepository,
             RiskScenarioRepository riskScenarioRepository,
             MethodologyProfileRepository methodologyProfileRepository,
             ProjectService projectService,
-            Validator validator) {
+            Validator validator,
+            GraphTargetResolverService graphTargetResolverService,
+            ApplicationEventPublisher eventPublisher) {
         this.repository = repository;
         this.riskRegisterRecordRepository = riskRegisterRecordRepository;
         this.riskScenarioRepository = riskScenarioRepository;
         this.methodologyProfileRepository = methodologyProfileRepository;
         this.projectService = projectService;
         this.validator = validator;
+        this.graphTargetResolverService = graphTargetResolverService;
+        this.eventPublisher = eventPublisher;
     }
 
     public TreatmentPlan create(CreateTreatmentPlanCommand command) {
@@ -92,14 +112,27 @@ public class TreatmentPlanService {
         if (command.title() != null) {
             plan.setTitle(command.title());
         }
+        var oldHistogram = actionItemStatusHistogram(plan.getActionItems());
         applyUpdates(plan, projectId, command);
-        return repository.save(plan);
+        var saved = repository.save(plan);
+        publishProgressIfChanged(saved, oldHistogram);
+        return saved;
     }
 
     public TreatmentPlan transitionStatus(UUID projectId, UUID id, TreatmentPlanStatus status) {
         var plan = getById(projectId, id);
+        var oldStatus = plan.getStatus();
         plan.transitionStatus(status);
-        return repository.save(plan);
+        var saved = repository.save(plan);
+        if (oldStatus != saved.getStatus()) {
+            publish(buildSignal(
+                    saved,
+                    ReassessmentTriggerCategory.TREATMENT_PROGRESS_CHANGED,
+                    Set.of("status"),
+                    Map.of("status", oldStatus),
+                    Map.of("status", saved.getStatus())));
+        }
+        return saved;
     }
 
     public void delete(UUID projectId, UUID id) {
@@ -136,6 +169,7 @@ public class TreatmentPlanService {
                 command.methodologyStrategyKey());
     }
 
+    @SuppressWarnings("java:S107") // shared updater is a single point of mutation; arg count tracks the DTO surface
     private void applySharedUpdates(
             TreatmentPlan plan,
             UUID projectId,
@@ -145,7 +179,7 @@ public class TreatmentPlanService {
             String rationale,
             java.time.Instant dueDate,
             List<ActionItem> actionItems,
-            List<String> reassessmentTriggers,
+            List<ReassessmentTrigger> reassessmentTriggers,
             UUID methodologyProfileId,
             String methodologyStrategyKey) {
         if (riskScenarioId != null) {
@@ -177,6 +211,7 @@ public class TreatmentPlanService {
             plan.setActionItems(actionItems);
         }
         if (reassessmentTriggers != null) {
+            validateReassessmentTriggers(reassessmentTriggers, projectId);
             plan.setReassessmentTriggers(reassessmentTriggers);
         }
         applyMethodologyBinding(plan, projectId, methodologyProfileId, methodologyStrategyKey);
@@ -204,6 +239,91 @@ public class TreatmentPlanService {
                 throw new DomainValidationException("Action item at index " + i + " has invalid " + detail);
             }
         }
+    }
+
+    /**
+     * Bypass-write guard for typed reassessment triggers (GC-T004 / C8, issue #863).
+     * Mirrors {@link #validateActionItems} — programmatic Bean Validation on each
+     * element, plus project-scoped resolver enforcement on any {@code targetType}
+     * supplied. Service-layer callers that route around the REST {@code @Valid}
+     * boundary cannot persist out-of-contract triggers or cross-project target ids.
+     */
+    private void validateReassessmentTriggers(List<ReassessmentTrigger> triggers, UUID projectId) {
+        for (int i = 0; i < triggers.size(); i++) {
+            var trigger = triggers.get(i);
+            if (trigger == null) {
+                throw new DomainValidationException("Reassessment trigger at index " + i + " must not be null");
+            }
+            Set<ConstraintViolation<ReassessmentTrigger>> violations = validator.validate(trigger);
+            if (!violations.isEmpty()) {
+                String detail = violations.stream()
+                        .map(v -> v.getPropertyPath() + " " + v.getMessage())
+                        .sorted()
+                        .collect(Collectors.joining("; "));
+                throw new DomainValidationException("Reassessment trigger at index " + i + " has invalid " + detail);
+            }
+            validateReassessmentTriggerTargetShape(trigger, i, projectId);
+        }
+    }
+
+    /**
+     * GC-T004 / C8 (#863), codex cycle-1 finding #2: trigger target fields are not
+     * three independent optionals. The contract is exactly one of:
+     * <ul>
+     *   <li>No target at all: {@code targetType}, {@code targetEntityId}, and
+     *       {@code targetIdentifier} are all null. The trigger is a category-only
+     *       declaration.</li>
+     *   <li>Internal target: {@code targetType} is one of the modelled types and
+     *       {@code targetEntityId} is present (resolved through the project-scoped
+     *       resolver). {@code targetIdentifier} must be null.</li>
+     *   <li>External target: {@code targetType} is {@code EXTERNAL} and
+     *       {@code targetIdentifier} is present. {@code targetEntityId} must be
+     *       null.</li>
+     * </ul>
+     *
+     * <p>Reject any other combination as a {@link DomainValidationException} so a
+     * trigger that names {@code targetEntityId} without a {@code targetType}
+     * (uninterpretable later) or mixes EXTERNAL with {@code targetEntityId}
+     * (inconsistent typed contract) never reaches persistence.
+     */
+    private void validateReassessmentTriggerTargetShape(ReassessmentTrigger trigger, int index, UUID projectId) {
+        var targetType = trigger.targetType();
+        var entityId = trigger.targetEntityId();
+        var identifier = trigger.targetIdentifier();
+        boolean hasIdentifier = identifier != null && !identifier.isBlank();
+
+        if (targetType == null) {
+            if (entityId != null || hasIdentifier) {
+                throw new DomainValidationException(
+                        "Reassessment trigger at index " + index + " has target reference fields without targetType");
+            }
+            return;
+        }
+
+        if (targetType
+                == com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerTargetType.EXTERNAL) {
+            if (entityId != null) {
+                throw new DomainValidationException("Reassessment trigger at index " + index
+                        + " with targetType=EXTERNAL must not set targetEntityId");
+            }
+            if (!hasIdentifier) {
+                throw new DomainValidationException("Reassessment trigger at index " + index
+                        + " with targetType=EXTERNAL requires targetIdentifier");
+            }
+        } else {
+            if (hasIdentifier) {
+                throw new DomainValidationException("Reassessment trigger at index " + index
+                        + " with internal targetType=" + targetType + " must not set targetIdentifier");
+            }
+            if (entityId == null) {
+                throw new DomainValidationException("Reassessment trigger at index " + index
+                        + " with internal targetType=" + targetType + " requires targetEntityId");
+            }
+        }
+
+        // Project-scoped resolver enforcement — a non-existent or cross-project UUID
+        // becomes DomainValidationException ("not found in the requested project").
+        graphTargetResolverService.validateReassessmentTriggerTarget(projectId, targetType, entityId, identifier);
     }
 
     private void applyMethodologyBinding(
@@ -238,5 +358,52 @@ public class TreatmentPlanService {
         }
         plan.setMethodologyProfile(effectiveProfile);
         plan.setMethodologyStrategyKey(effectiveKey);
+    }
+
+    private void publishProgressIfChanged(TreatmentPlan saved, Map<ActionItemStatus, Long> oldHistogram) {
+        var newHistogram = actionItemStatusHistogram(saved.getActionItems());
+        if (!oldHistogram.equals(newHistogram)) {
+            publish(buildSignal(
+                    saved,
+                    ReassessmentTriggerCategory.TREATMENT_PROGRESS_CHANGED,
+                    Set.of("actionItemsStatusHistogram"),
+                    Map.of("actionItemsStatusHistogram", new HashMap<>(oldHistogram)),
+                    Map.of("actionItemsStatusHistogram", new HashMap<>(newHistogram))));
+        }
+    }
+
+    private Map<ActionItemStatus, Long> actionItemStatusHistogram(List<ActionItem> items) {
+        Map<ActionItemStatus, Long> hist = new EnumMap<>(ActionItemStatus.class);
+        if (items == null) {
+            return hist;
+        }
+        for (var item : items) {
+            if (item == null || item.status() == null) {
+                continue;
+            }
+            hist.merge(item.status(), 1L, Long::sum);
+        }
+        return hist;
+    }
+
+    private ReassessmentSignal buildSignal(
+            TreatmentPlan plan,
+            ReassessmentTriggerCategory category,
+            Set<String> changedFields,
+            Map<String, Object> oldValues,
+            Map<String, Object> newValues) {
+        return new ReassessmentSignal(
+                plan.getProject().getId(),
+                category,
+                ReassessmentSourceEntityType.TREATMENT_PLAN,
+                plan.getId(),
+                new HashSet<>(changedFields),
+                new HashMap<>(oldValues),
+                new HashMap<>(newValues),
+                Instant.now());
+    }
+
+    private void publish(ReassessmentSignal signal) {
+        eventPublisher.publishEvent(new TreatmentProgressChangedEvent(signal));
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/TreatmentPlanService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/TreatmentPlanService.java
@@ -39,6 +39,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class TreatmentPlanService {
 
+    // GC-T004 / C8: field-name keys shared by every TreatmentPlan publisher branch.
+    // Hoisted out of inline literals so each rename is one site, not three.
+    private static final String FIELD_STATUS = "status";
+    private static final String FIELD_ACTION_ITEMS_HISTOGRAM = "actionItemsStatusHistogram";
+
     private final TreatmentPlanRepository repository;
     private final RiskRegisterRecordRepository riskRegisterRecordRepository;
     private final RiskScenarioRepository riskScenarioRepository;
@@ -91,9 +96,9 @@ public class TreatmentPlanService {
             publish(buildSignal(
                     saved,
                     ReassessmentTriggerCategory.TREATMENT_PROGRESS_CHANGED,
-                    Set.of("status"),
-                    Map.of("status", TreatmentPlanStatus.PLANNED),
-                    Map.of("status", saved.getStatus())));
+                    Set.of(FIELD_STATUS),
+                    Map.of(FIELD_STATUS, TreatmentPlanStatus.PLANNED),
+                    Map.of(FIELD_STATUS, saved.getStatus())));
         }
         return saved;
     }
@@ -141,9 +146,9 @@ public class TreatmentPlanService {
             publish(buildSignal(
                     saved,
                     ReassessmentTriggerCategory.TREATMENT_PROGRESS_CHANGED,
-                    Set.of("status"),
-                    Map.of("status", oldStatus),
-                    Map.of("status", saved.getStatus())));
+                    Set.of(FIELD_STATUS),
+                    Map.of(FIELD_STATUS, oldStatus),
+                    Map.of(FIELD_STATUS, saved.getStatus())));
         }
         return saved;
     }
@@ -379,9 +384,9 @@ public class TreatmentPlanService {
             publish(buildSignal(
                     saved,
                     ReassessmentTriggerCategory.TREATMENT_PROGRESS_CHANGED,
-                    Set.of("actionItemsStatusHistogram"),
-                    Map.of("actionItemsStatusHistogram", new HashMap<>(oldHistogram)),
-                    Map.of("actionItemsStatusHistogram", new HashMap<>(newHistogram))));
+                    Set.of(FIELD_ACTION_ITEMS_HISTOGRAM),
+                    Map.of(FIELD_ACTION_ITEMS_HISTOGRAM, new EnumMap<>(oldHistogram)),
+                    Map.of(FIELD_ACTION_ITEMS_HISTOGRAM, new EnumMap<>(newHistogram))));
         }
     }
 
@@ -391,6 +396,10 @@ public class TreatmentPlanService {
             return hist;
         }
         for (var item : items) {
+            // Defensive: persistence-read items bypass Bean Validation, so a legacy
+            // row with status=null could otherwise NPE in hist.merge. The @NotNull
+            // contract on ActionItem.status applies at the REST/service write boundary,
+            // not at the JPA read boundary that feeds this method.
             if (item == null || item.status() == null) {
                 continue;
             }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/TreatmentPlanService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/TreatmentPlanService.java
@@ -78,11 +78,24 @@ public class TreatmentPlanService {
                 .orElseThrow(() ->
                         new NotFoundException("Risk register record not found: " + command.riskRegisterRecordId()));
         var plan = new TreatmentPlan(project, command.uid(), command.title(), record, command.strategy());
-        if (command.status() != null && command.status() != TreatmentPlanStatus.PLANNED) {
+        boolean initialStatusIsTransition = command.status() != null && command.status() != TreatmentPlanStatus.PLANNED;
+        if (initialStatusIsTransition) {
             plan.transitionStatus(command.status());
         }
         applyUpdates(plan, project.getId(), command);
-        return repository.save(plan);
+        var saved = repository.save(plan);
+        if (initialStatusIsTransition) {
+            // Create-with-non-PLANNED-status is functionally a PLANNED → <status> transition
+            // at birth; the publisher contract treats it like `transitionStatus` so the
+            // C8 reassessment signal reaches affected assessment rows.
+            publish(buildSignal(
+                    saved,
+                    ReassessmentTriggerCategory.TREATMENT_PROGRESS_CHANGED,
+                    Set.of("status"),
+                    Map.of("status", TreatmentPlanStatus.PLANNED),
+                    Map.of("status", saved.getStatus())));
+        }
+        return saved;
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/TreatmentPlanService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/TreatmentPlanService.java
@@ -390,16 +390,20 @@ public class TreatmentPlanService {
         }
     }
 
+    /**
+     * Defensive: persistence-read items bypass Bean Validation, so a legacy row with
+     * status=null could otherwise NPE in {@code hist.merge}. The {@code @NotNull}
+     * contract on {@code ActionItem.status} applies at the REST / service write boundary,
+     * not at the JPA read boundary that feeds this method — Sonar's S2589 ("always false")
+     * reads the contract but not the read path, hence the suppression.
+     */
+    @SuppressWarnings("java:S2589")
     private Map<ActionItemStatus, Long> actionItemStatusHistogram(List<ActionItem> items) {
         Map<ActionItemStatus, Long> hist = new EnumMap<>(ActionItemStatus.class);
         if (items == null) {
             return hist;
         }
         for (var item : items) {
-            // Defensive: persistence-read items bypass Bean Validation, so a legacy
-            // row with status=null could otherwise NPE in hist.merge. The @NotNull
-            // contract on ActionItem.status applies at the REST/service write boundary,
-            // not at the JPA read boundary that feeds this method.
             if (item == null || item.status() == null) {
                 continue;
             }

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/UpdateTreatmentPlanCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/UpdateTreatmentPlanCommand.java
@@ -1,6 +1,7 @@
 package com.keplerops.groundcontrol.domain.riskscenarios.service;
 
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
 import java.time.Instant;
 import java.util.List;
@@ -14,6 +15,6 @@ public record UpdateTreatmentPlanCommand(
         String rationale,
         Instant dueDate,
         List<ActionItem> actionItems,
-        List<String> reassessmentTriggers,
+        List<ReassessmentTrigger> reassessmentTriggers,
         UUID methodologyProfileId,
         String methodologyStrategyKey) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/state/ReassessmentTriggerCategory.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/state/ReassessmentTriggerCategory.java
@@ -1,0 +1,9 @@
+package com.keplerops.groundcontrol.domain.riskscenarios.state;
+
+public enum ReassessmentTriggerCategory {
+    TREATMENT_PROGRESS_CHANGED,
+    ASSET_STATE_CHANGED,
+    CONTROL_STATE_CHANGED,
+    ASSESSMENT_REFRESH,
+    METHODOLOGY_SPECIFIC
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/state/ReassessmentTriggerTargetType.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/state/ReassessmentTriggerTargetType.java
@@ -1,0 +1,11 @@
+package com.keplerops.groundcontrol.domain.riskscenarios.state;
+
+public enum ReassessmentTriggerTargetType {
+    ASSET,
+    CONTROL,
+    RISK_SCENARIO,
+    RISK_REGISTER_RECORD,
+    RISK_ASSESSMENT_RESULT,
+    TREATMENT_PLAN,
+    EXTERNAL
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/persistence/JacksonTextCollectionConverters.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/persistence/JacksonTextCollectionConverters.java
@@ -262,6 +262,10 @@ public final class JacksonTextCollectionConverters {
         }
 
         @Override
+        // S1168: JPA AttributeConverter contract returns null for NULL columns (matches every
+        // sibling converter in this file); an empty list would persist as `[]` and lose the
+        // null-vs-empty distinction that downstream readers rely on.
+        @SuppressWarnings("java:S1168")
         public List<ReassessmentTrigger> convertToEntityAttribute(String dbData) {
             if (dbData == null || dbData.isBlank()) {
                 return null;
@@ -293,18 +297,21 @@ public final class JacksonTextCollectionConverters {
                 return null;
             }
             if (node.isTextual()) {
-                String legacy = node.asText();
-                if (legacy == null || legacy.isBlank()) {
-                    return null;
-                }
-                return new ReassessmentTrigger(
-                        ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC, null, null, null, legacy);
+                return readLegacyStringNode(node);
             }
             if (!node.isObject()) {
                 throw new IllegalArgumentException(
                         "Expected JSON object or legacy string for reassessment trigger, got " + node.getNodeType());
             }
             return OBJECT_MAPPER.treeToValue(node, ReassessmentTrigger.class);
+        }
+
+        private static ReassessmentTrigger readLegacyStringNode(JsonNode node) {
+            String legacy = node.asText();
+            if (legacy == null || legacy.isBlank()) {
+                return null;
+            }
+            return new ReassessmentTrigger(ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC, null, null, null, legacy);
         }
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/persistence/JacksonTextCollectionConverters.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/persistence/JacksonTextCollectionConverters.java
@@ -11,6 +11,8 @@ import com.keplerops.groundcontrol.domain.packregistry.model.PackDependency;
 import com.keplerops.groundcontrol.domain.packregistry.model.RegisteredControlPackEntry;
 import com.keplerops.groundcontrol.domain.packregistry.model.TrustPolicyRule;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import java.io.IOException;
@@ -230,6 +232,79 @@ public final class JacksonTextCollectionConverters {
         private static boolean hasNonNullText(ObjectNode obj, String key) {
             JsonNode v = obj.get(key);
             return v != null && !v.isNull() && !v.asText().isEmpty();
+        }
+    }
+
+    /**
+     * Persistence converter for {@code TreatmentPlan.reassessmentTriggers} (per GC-T004 / C8, issue #863).
+     *
+     * <p>Writes the canonical typed shape only. On read, legacy {@code List<String>} rows
+     * persisted under the pre-C8 contract are folded into typed triggers with
+     * {@code category = METHODOLOGY_SPECIFIC} and {@code note = <legacy string>} so no
+     * legacy content is silently dropped. Blank legacy strings are skipped — they convey
+     * no signal and would otherwise materialise as a category-only METHODOLOGY_SPECIFIC
+     * trigger with no payload.
+     */
+    @Converter
+    public static class ReassessmentTriggerListConverter
+            implements AttributeConverter<List<ReassessmentTrigger>, String> {
+
+        @Override
+        public String convertToDatabaseColumn(List<ReassessmentTrigger> attribute) {
+            if (attribute == null) {
+                return null;
+            }
+            try {
+                return OBJECT_MAPPER.writeValueAsString(attribute);
+            } catch (JsonProcessingException exception) {
+                throw new IllegalArgumentException("Unable to serialize reassessment_triggers JSON", exception);
+            }
+        }
+
+        @Override
+        public List<ReassessmentTrigger> convertToEntityAttribute(String dbData) {
+            if (dbData == null || dbData.isBlank()) {
+                return null;
+            }
+            try {
+                JsonNode root = OBJECT_MAPPER.readTree(dbData);
+                if (root.isNull()) {
+                    return null;
+                }
+                if (!root.isArray()) {
+                    throw new IllegalArgumentException(
+                            "Expected JSON array for reassessment_triggers, got " + root.getNodeType());
+                }
+                List<ReassessmentTrigger> items = new ArrayList<>(root.size());
+                for (JsonNode node : root) {
+                    var item = readNode(node);
+                    if (item != null) {
+                        items.add(item);
+                    }
+                }
+                return items;
+            } catch (IOException exception) {
+                throw new IllegalArgumentException("Unable to deserialize reassessment_triggers JSON", exception);
+            }
+        }
+
+        private static ReassessmentTrigger readNode(JsonNode node) throws IOException {
+            if (node == null || node.isNull()) {
+                return null;
+            }
+            if (node.isTextual()) {
+                String legacy = node.asText();
+                if (legacy == null || legacy.isBlank()) {
+                    return null;
+                }
+                return new ReassessmentTrigger(
+                        ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC, null, null, null, legacy);
+            }
+            if (!node.isObject()) {
+                throw new IllegalArgumentException(
+                        "Expected JSON object or legacy string for reassessment trigger, got " + node.getNodeType());
+            }
+            return OBJECT_MAPPER.treeToValue(node, ReassessmentTrigger.class);
         }
     }
 }

--- a/backend/src/main/resources/db/migration/V126__add_risk_assessment_result_reassessment_required_at.sql
+++ b/backend/src/main/resources/db/migration/V126__add_risk_assessment_result_reassessment_required_at.sql
@@ -1,0 +1,15 @@
+-- GC-T004 / C8 (#863): durable reassessment signal on RiskAssessmentResult.
+-- Set synchronously by ReassessmentSignalService when an upstream treatment,
+-- asset, or control change implicates the assessment row.
+ALTER TABLE risk_assessment_result
+    ADD COLUMN reassessment_required_at TIMESTAMP WITH TIME ZONE;
+
+-- Partial index — most rows will be null. The signal-bearing rows are the
+-- small minority and the route-on-it queries (graph projection, future
+-- consumers) all filter by IS NOT NULL.
+CREATE INDEX idx_risk_assessment_result_reassessment_required_at
+    ON risk_assessment_result (reassessment_required_at)
+    WHERE reassessment_required_at IS NOT NULL;
+
+ALTER TABLE risk_assessment_result_audit
+    ADD COLUMN reassessment_required_at TIMESTAMP WITH TIME ZONE;

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
@@ -53,7 +53,7 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         "079", "080", "081", "082", "083", "084", "085", "086", "087", "088", "089", "090", "091",
                         "092", "093", "094", "095", "096", "097", "098", "099", "100", "101", "102", "103", "104",
                         "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122",
-                        "123", "124", "125");
+                        "123", "124", "125", "126");
     }
 
     @Test
@@ -1005,6 +1005,16 @@ class MigrationSmokeTest extends BaseIntegrationTest {
         org.assertj.core.api.Assertions.assertThatCode(() -> entityManager
                         .createNativeQuery(
                                 "SELECT treatment_strategy_vocabulary" + " FROM methodology_profile_audit LIMIT 1")
+                        .getResultList())
+                .doesNotThrowAnyException();
+        // V126: reassessmentRequiredAt on risk_assessment_result and audit (GC-T004 / C8, #863).
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns"
+                        + " WHERE table_name = 'risk_assessment_result'"
+                        + " AND column_name = 'reassessment_required_at'")
+                .getSingleResult();
+        org.assertj.core.api.Assertions.assertThatCode(() -> entityManager
+                        .createNativeQuery("SELECT reassessment_required_at FROM risk_assessment_result_audit LIMIT 1")
                         .getResultList())
                 .doesNotThrowAnyException();
     }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/ReassessmentSignalIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/ReassessmentSignalIntegrationTest.java
@@ -41,6 +41,8 @@ import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
 import jakarta.persistence.EntityManager;
 import java.util.Map;
 import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,16 +102,66 @@ class ReassessmentSignalIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private TransactionTemplate transactionTemplate;
 
+    @Autowired
+    private DataSource dataSource;
+
     private Project project;
     private MethodologyProfile profile;
 
     @BeforeEach
     void seedProjectAndProfile() {
+        // Use the V012-seeded `ground-control` project rather than creating a new one per
+        // test. Other integration tests (RequirementController, RequirementsE2E,
+        // TraceabilityLinkController) call `/api/v1/requirements` without a `project` query
+        // param and rely on the "exactly one project" branch in `ProjectService.resolveProjectId`.
+        // Adding new projects breaks that contract across the shared Testcontainers DB.
         transactionTemplate.executeWithoutResult(status -> {
-            project = projectRepository.save(new Project("gc-c8-" + UUID.randomUUID(), "GC-T004 C8 test project"));
-            profile = methodologyProfileRepository.save(
-                    new MethodologyProfile(project, "MP-C8", "Profile", "1.0", MethodologyFamily.CUSTOM));
+            project = projectRepository
+                    .findByIdentifier("ground-control")
+                    .orElseThrow(() -> new IllegalStateException("V012-seeded 'ground-control' project missing"));
+            profile = methodologyProfileRepository.save(new MethodologyProfile(
+                    project, "MP-C8-" + UUID.randomUUID(), "Profile", "1.0", MethodologyFamily.CUSTOM));
         });
+    }
+
+    @AfterEach
+    void cleanupReassessmentRows() throws Exception {
+        // Hard cleanup via JDBC: integration tests share a single Testcontainers Postgres
+        // across the suite (BaseIntegrationTest static singleton), so leaking risk_assessment
+        // rows or links between tests would poison other suites that scan for orphans.
+        // Order matches FK direction.
+        try (var conn = dataSource.getConnection();
+                var stmt = conn.createStatement()) {
+            stmt.executeUpdate("DELETE FROM control_link WHERE control_id IN "
+                    + "(SELECT id FROM control WHERE uid LIKE 'CTRL-%')");
+            stmt.executeUpdate("DELETE FROM asset_link WHERE asset_id IN "
+                    + "(SELECT id FROM operational_asset WHERE uid LIKE 'ASSET-%')");
+            stmt.executeUpdate("DELETE FROM risk_assessment_result_audit WHERE id IN "
+                    + "(SELECT id FROM risk_assessment_result WHERE risk_scenario_id IN "
+                    + "(SELECT id FROM risk_scenario WHERE uid LIKE 'RS-%'))");
+            stmt.executeUpdate("DELETE FROM risk_assessment_result WHERE risk_scenario_id IN "
+                    + "(SELECT id FROM risk_scenario WHERE uid LIKE 'RS-%')");
+            stmt.executeUpdate("DELETE FROM treatment_plan_audit WHERE id IN "
+                    + "(SELECT id FROM treatment_plan WHERE uid LIKE 'TP-%')");
+            stmt.executeUpdate("DELETE FROM treatment_plan WHERE uid LIKE 'TP-%'");
+            stmt.executeUpdate("DELETE FROM risk_register_record_scenario WHERE risk_register_record_id IN "
+                    + "(SELECT id FROM risk_register_record WHERE uid LIKE 'RR-%')");
+            stmt.executeUpdate("DELETE FROM risk_register_record_audit WHERE id IN "
+                    + "(SELECT id FROM risk_register_record WHERE uid LIKE 'RR-%')");
+            stmt.executeUpdate("DELETE FROM risk_register_record WHERE uid LIKE 'RR-%'");
+            stmt.executeUpdate("DELETE FROM risk_scenario_audit WHERE id IN "
+                    + "(SELECT id FROM risk_scenario WHERE uid LIKE 'RS-%')");
+            stmt.executeUpdate("DELETE FROM risk_scenario WHERE uid LIKE 'RS-%'");
+            stmt.executeUpdate(
+                    "DELETE FROM control_audit WHERE id IN " + "(SELECT id FROM control WHERE uid LIKE 'CTRL-%')");
+            stmt.executeUpdate("DELETE FROM control WHERE uid LIKE 'CTRL-%'");
+            stmt.executeUpdate("DELETE FROM operational_asset_audit WHERE id IN "
+                    + "(SELECT id FROM operational_asset WHERE uid LIKE 'ASSET-%')");
+            stmt.executeUpdate("DELETE FROM operational_asset WHERE uid LIKE 'ASSET-%'");
+            stmt.executeUpdate("DELETE FROM methodology_profile_audit WHERE id IN "
+                    + "(SELECT id FROM methodology_profile WHERE profile_key LIKE 'MP-C8-%')");
+            stmt.executeUpdate("DELETE FROM methodology_profile WHERE profile_key LIKE 'MP-C8-%'");
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/ReassessmentSignalIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/ReassessmentSignalIntegrationTest.java
@@ -167,7 +167,7 @@ class ReassessmentSignalIntegrationTest extends BaseIntegrationTest {
     @Test
     void treatmentPlanTransitionMarksAssessmentResultsLinkedThroughRegisterRecord() {
         var fixture = seedScenarioRecordAssessment("RS-TP", "RR-TP");
-        var plan = createPlan("TP-TRANS", fixture.record(), null);
+        var plan = createPlan("TP-TRANS", fixture.registerRecord(), null);
 
         treatmentPlanService.transitionStatus(project.getId(), plan.getId(), TreatmentPlanStatus.IN_PROGRESS);
 
@@ -186,7 +186,7 @@ class ReassessmentSignalIntegrationTest extends BaseIntegrationTest {
                 project.getId(),
                 "TP-CREATE",
                 "Plan",
-                fixture.record().getId(),
+                fixture.registerRecord().getId(),
                 fixture.scenario().getId(),
                 TreatmentStrategy.MITIGATE,
                 "owner",
@@ -253,7 +253,7 @@ class ReassessmentSignalIntegrationTest extends BaseIntegrationTest {
         assetLinkRepository.save(new AssetLink(
                 asset,
                 AssetLinkTargetType.RISK_REGISTER_RECORD,
-                fixture.record().getId(),
+                fixture.registerRecord().getId(),
                 null,
                 AssetLinkType.ASSOCIATED));
 
@@ -284,7 +284,7 @@ class ReassessmentSignalIntegrationTest extends BaseIntegrationTest {
         controlLinkRepository.save(new ControlLink(
                 control,
                 ControlLinkTargetType.RISK_REGISTER_RECORD,
-                fixture.record().getId(),
+                fixture.registerRecord().getId(),
                 null,
                 ControlLinkType.MITIGATES));
 
@@ -335,7 +335,7 @@ class ReassessmentSignalIntegrationTest extends BaseIntegrationTest {
     // helpers
     // -------------------------------------------------------------------------
 
-    private record Fixture(RiskScenario scenario, RiskRegisterRecord record, RiskAssessmentResult assessment) {}
+    private record Fixture(RiskScenario scenario, RiskRegisterRecord registerRecord, RiskAssessmentResult assessment) {}
 
     private Fixture seedScenarioRecordAssessment(String scenarioUid, String recordUid) {
         return transactionTemplate.execute(status -> {
@@ -344,9 +344,9 @@ class ReassessmentSignalIntegrationTest extends BaseIntegrationTest {
             scenario.setTimeHorizon("12 months");
             var savedScenario = riskScenarioRepository.save(scenario);
 
-            var record = new RiskRegisterRecord(project, recordUid, "Record");
-            record.replaceRiskScenarios(java.util.List.of(savedScenario));
-            var savedRecord = riskRegisterRecordRepository.save(record);
+            var registerRecord = new RiskRegisterRecord(project, recordUid, "Record");
+            registerRecord.replaceRiskScenarios(java.util.List.of(savedScenario));
+            var savedRecord = riskRegisterRecordRepository.save(registerRecord);
 
             var assessment = new RiskAssessmentResult(project, savedScenario, profile);
             assessment.setRiskRegisterRecord(savedRecord);
@@ -356,12 +356,12 @@ class ReassessmentSignalIntegrationTest extends BaseIntegrationTest {
     }
 
     private com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan createPlan(
-            String uid, RiskRegisterRecord record, RiskScenario scenario) {
+            String uid, RiskRegisterRecord registerRecord, RiskScenario scenario) {
         return treatmentPlanService.create(new CreateTreatmentPlanCommand(
                 project.getId(),
                 uid,
                 "Plan " + uid,
-                record.getId(),
+                registerRecord.getId(),
                 scenario == null ? null : scenario.getId(),
                 TreatmentStrategy.MITIGATE,
                 "owner",

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/ReassessmentSignalIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/ReassessmentSignalIntegrationTest.java
@@ -1,0 +1,332 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keplerops.groundcontrol.domain.assets.model.AssetLink;
+import com.keplerops.groundcontrol.domain.assets.repository.AssetLinkRepository;
+import com.keplerops.groundcontrol.domain.assets.repository.OperationalAssetRepository;
+import com.keplerops.groundcontrol.domain.assets.service.AssetService;
+import com.keplerops.groundcontrol.domain.assets.service.CreateAssetCommand;
+import com.keplerops.groundcontrol.domain.assets.service.UpdateAssetCommand;
+import com.keplerops.groundcontrol.domain.assets.state.AssetCriticality;
+import com.keplerops.groundcontrol.domain.assets.state.AssetLinkTargetType;
+import com.keplerops.groundcontrol.domain.assets.state.AssetLinkType;
+import com.keplerops.groundcontrol.domain.assets.state.AssetType;
+import com.keplerops.groundcontrol.domain.controls.model.ControlLink;
+import com.keplerops.groundcontrol.domain.controls.repository.ControlLinkRepository;
+import com.keplerops.groundcontrol.domain.controls.repository.ControlRepository;
+import com.keplerops.groundcontrol.domain.controls.service.ControlService;
+import com.keplerops.groundcontrol.domain.controls.service.CreateControlCommand;
+import com.keplerops.groundcontrol.domain.controls.service.UpdateControlCommand;
+import com.keplerops.groundcontrol.domain.controls.state.ControlFunction;
+import com.keplerops.groundcontrol.domain.controls.state.ControlLinkTargetType;
+import com.keplerops.groundcontrol.domain.controls.state.ControlLinkType;
+import com.keplerops.groundcontrol.domain.controls.state.ControlStatus;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.repository.ProjectRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.MethodologyProfile;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskAssessmentResult;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskRegisterRecord;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenario;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.MethodologyProfileRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskAssessmentResultRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskRegisterRecordRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.TreatmentPlanRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.service.CreateTreatmentPlanCommand;
+import com.keplerops.groundcontrol.domain.riskscenarios.service.TreatmentPlanService;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.MethodologyFamily;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentPlanStatus;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
+import jakarta.persistence.EntityManager;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * GC-T004 / C8 (#863): end-to-end coverage of the reassessment signal listener
+ * through the real {@code ApplicationContext} and {@code @TransactionalEventListener}.
+ * Each test exercises one mutation path covered by the publisher matrix and asserts
+ * that the listener wrote {@code reassessmentRequiredAt} on the affected assessment
+ * row after the publishing transaction commits.
+ */
+class ReassessmentSignalIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private MethodologyProfileRepository methodologyProfileRepository;
+
+    @Autowired
+    private RiskScenarioRepository riskScenarioRepository;
+
+    @Autowired
+    private RiskRegisterRecordRepository riskRegisterRecordRepository;
+
+    @Autowired
+    private RiskAssessmentResultRepository assessmentRepository;
+
+    @Autowired
+    private OperationalAssetRepository assetRepository;
+
+    @Autowired
+    private AssetLinkRepository assetLinkRepository;
+
+    @Autowired
+    private AssetService assetService;
+
+    @Autowired
+    private ControlRepository controlRepository;
+
+    @Autowired
+    private ControlLinkRepository controlLinkRepository;
+
+    @Autowired
+    private ControlService controlService;
+
+    @Autowired
+    private TreatmentPlanRepository treatmentPlanRepository;
+
+    @Autowired
+    private TreatmentPlanService treatmentPlanService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private Project project;
+    private MethodologyProfile profile;
+
+    @BeforeEach
+    void seedProjectAndProfile() {
+        transactionTemplate.executeWithoutResult(status -> {
+            project = projectRepository.save(new Project("gc-c8-" + UUID.randomUUID(), "GC-T004 C8 test project"));
+            profile = methodologyProfileRepository.save(
+                    new MethodologyProfile(project, "MP-C8", "Profile", "1.0", MethodologyFamily.CUSTOM));
+        });
+    }
+
+    @Test
+    void treatmentPlanTransitionMarksAssessmentResultsLinkedThroughRegisterRecord() {
+        var fixture = seedScenarioRecordAssessment("RS-TP", "RR-TP");
+        var plan = createPlan("TP-TRANS", fixture.record(), null);
+
+        treatmentPlanService.transitionStatus(project.getId(), plan.getId(), TreatmentPlanStatus.IN_PROGRESS);
+
+        flushAndExpire();
+        var refreshed =
+                assessmentRepository.findById(fixture.assessment().getId()).orElseThrow();
+        assertThat(refreshed.getReassessmentRequiredAt()).isNotNull();
+    }
+
+    @Test
+    void treatmentPlanCreateWithLifecycleStatusTransitionMarksAssessmentResults() {
+        // Constructor seeds plan in PLANNED then transitionStatus runs to IN_PROGRESS
+        // when status field is supplied — same publisher path as the explicit transition.
+        var fixture = seedScenarioRecordAssessment("RS-TPC", "RR-TPC");
+        var plan = treatmentPlanService.create(new CreateTreatmentPlanCommand(
+                project.getId(),
+                "TP-CREATE",
+                "Plan",
+                fixture.record().getId(),
+                fixture.scenario().getId(),
+                TreatmentStrategy.MITIGATE,
+                "owner",
+                null,
+                null,
+                TreatmentPlanStatus.IN_PROGRESS,
+                null,
+                null,
+                null,
+                null));
+
+        flushAndExpire();
+        var refreshed =
+                assessmentRepository.findById(fixture.assessment().getId()).orElseThrow();
+        assertThat(refreshed.getReassessmentRequiredAt()).isNotNull();
+        assertThat(plan.getId()).isNotNull();
+    }
+
+    @Test
+    void assetUpdateOfRiskBearingFieldMarksLinkedAssessmentResult() {
+        var fixture = seedScenarioRecordAssessment("RS-ASSET", "RR-ASSET");
+        var asset = assetService.create(
+                new CreateAssetCommand(project.getId(), "ASSET-RB", "Web API", "edge api", AssetType.SERVICE));
+        // Link asset → scenario so the listener walks AssetLink → RISK_SCENARIO.
+        assetLinkRepository.save(new AssetLink(
+                asset, AssetLinkTargetType.RISK_SCENARIO, fixture.scenario().getId(), null, AssetLinkType.ASSOCIATED));
+
+        assetService.update(
+                project.getId(),
+                asset.getId(),
+                new UpdateAssetCommand(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        AssetCriticality.CRITICAL,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                        false));
+
+        flushAndExpire();
+        var refreshed =
+                assessmentRepository.findById(fixture.assessment().getId()).orElseThrow();
+        assertThat(refreshed.getReassessmentRequiredAt()).isNotNull();
+    }
+
+    @Test
+    void assetArchiveMarksLinkedAssessmentResult() {
+        var fixture = seedScenarioRecordAssessment("RS-ARCH", "RR-ARCH");
+        var asset = assetService.create(
+                new CreateAssetCommand(project.getId(), "ASSET-ARCH", "API", "to archive", AssetType.SERVICE));
+        assetLinkRepository.save(new AssetLink(
+                asset,
+                AssetLinkTargetType.RISK_REGISTER_RECORD,
+                fixture.record().getId(),
+                null,
+                AssetLinkType.ASSOCIATED));
+
+        assetService.archive(project.getId(), asset.getId());
+
+        flushAndExpire();
+        var refreshed =
+                assessmentRepository.findById(fixture.assessment().getId()).orElseThrow();
+        assertThat(refreshed.getReassessmentRequiredAt()).isNotNull();
+    }
+
+    @Test
+    void controlTransitionMarksLinkedAssessmentResult() {
+        var fixture = seedScenarioRecordAssessment("RS-CTRL", "RR-CTRL");
+        var control = controlService.create(new CreateControlCommand(
+                project.getId(),
+                "CTRL-1",
+                "Access Control",
+                ControlFunction.PREVENTIVE,
+                "desc",
+                "obj",
+                "owner",
+                "scope",
+                Map.of(),
+                Map.of("rating", "LOW"),
+                "cat",
+                "src"));
+        controlLinkRepository.save(new ControlLink(
+                control,
+                ControlLinkTargetType.RISK_REGISTER_RECORD,
+                fixture.record().getId(),
+                null,
+                ControlLinkType.MITIGATES));
+
+        controlService.transitionStatus(project.getId(), control.getId(), ControlStatus.PROPOSED);
+
+        flushAndExpire();
+        var refreshed =
+                assessmentRepository.findById(fixture.assessment().getId()).orElseThrow();
+        assertThat(refreshed.getReassessmentRequiredAt()).isNotNull();
+    }
+
+    @Test
+    void controlEffectivenessUpdateMarksLinkedAssessmentResult() {
+        var fixture = seedScenarioRecordAssessment("RS-EFF", "RR-EFF");
+        var control = controlService.create(new CreateControlCommand(
+                project.getId(),
+                "CTRL-EFF",
+                "Effectiveness",
+                ControlFunction.PREVENTIVE,
+                "desc",
+                "obj",
+                "owner",
+                "scope",
+                Map.of(),
+                Map.of("rating", "LOW"),
+                "cat",
+                "src"));
+        controlLinkRepository.save(new ControlLink(
+                control,
+                ControlLinkTargetType.RISK_SCENARIO,
+                fixture.scenario().getId(),
+                null,
+                ControlLinkType.MITIGATES));
+
+        controlService.update(
+                project.getId(),
+                control.getId(),
+                new UpdateControlCommand(
+                        null, null, null, null, null, null, null, Map.of("rating", "HIGH"), null, null));
+
+        flushAndExpire();
+        var refreshed =
+                assessmentRepository.findById(fixture.assessment().getId()).orElseThrow();
+        assertThat(refreshed.getReassessmentRequiredAt()).isNotNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private record Fixture(RiskScenario scenario, RiskRegisterRecord record, RiskAssessmentResult assessment) {}
+
+    private Fixture seedScenarioRecordAssessment(String scenarioUid, String recordUid) {
+        return transactionTemplate.execute(status -> {
+            var scenario =
+                    new RiskScenario(project, scenarioUid, "Scenario", "Actor", "Event", "Object", "Consequence");
+            scenario.setTimeHorizon("12 months");
+            var savedScenario = riskScenarioRepository.save(scenario);
+
+            var record = new RiskRegisterRecord(project, recordUid, "Record");
+            record.replaceRiskScenarios(java.util.List.of(savedScenario));
+            var savedRecord = riskRegisterRecordRepository.save(record);
+
+            var assessment = new RiskAssessmentResult(project, savedScenario, profile);
+            assessment.setRiskRegisterRecord(savedRecord);
+            var savedAssessment = assessmentRepository.save(assessment);
+            return new Fixture(savedScenario, savedRecord, savedAssessment);
+        });
+    }
+
+    private com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan createPlan(
+            String uid, RiskRegisterRecord record, RiskScenario scenario) {
+        return treatmentPlanService.create(new CreateTreatmentPlanCommand(
+                project.getId(),
+                uid,
+                "Plan " + uid,
+                record.getId(),
+                scenario == null ? null : scenario.getId(),
+                TreatmentStrategy.MITIGATE,
+                "owner",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+    }
+
+    /** Force the persistence context to drop any cached entities so we observe the listener's write. */
+    private void flushAndExpire() {
+        transactionTemplate.executeWithoutResult(status -> {
+            entityManager.flush();
+            entityManager.clear();
+        });
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -518,6 +518,7 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
                         "122", // V122: create risk_control_mapping_audit
                         "123", // V123: create mapping_evidence_audit (Envers @ElementCollection shadow)
                         "124", // V124: add treatment_plan methodology binding columns (GC-T004 C5)
-                        "125"); // V125: add methodology_profile treatment_strategy_vocabulary (GC-T004 C5)
+                        "125", // V125: add methodology_profile treatment_strategy_vocabulary (GC-T004 C5)
+                        "126"); // V126: add risk_assessment_result reassessment_required_at (GC-T004 C8)
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TreatmentPlanControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TreatmentPlanControllerTest.java
@@ -24,6 +24,7 @@ import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.MethodologyProfile;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskRegisterRecord;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenario;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan;
@@ -32,6 +33,7 @@ import com.keplerops.groundcontrol.domain.riskscenarios.service.TreatmentPlanSer
 import com.keplerops.groundcontrol.domain.riskscenarios.service.UpdateTreatmentPlanCommand;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.ActionItemStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.MethodologyFamily;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentPlanStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
 import java.time.Instant;
@@ -82,7 +84,8 @@ class TreatmentPlanControllerTest {
         plan.setRationale("Reduce credential theft risk");
         plan.setDueDate(DUE);
         plan.setActionItems(List.of(new ActionItem("Security Lead", DUE, ActionItemStatus.PLANNED, null, null)));
-        plan.setReassessmentTriggers(List.of("Quarterly review"));
+        plan.setReassessmentTriggers(List.of(new ReassessmentTrigger(
+                ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC, null, null, null, "Quarterly review")));
         setField(plan, "id", PLAN_ID);
         setField(plan, "createdAt", NOW);
         setField(plan, "updatedAt", NOW);
@@ -119,7 +122,7 @@ class TreatmentPlanControllerTest {
                                   "dueDate": "2026-06-01T00:00:00Z",
                                   "status": "PLANNED",
                                   "actionItems": [{"owner": "Security Lead", "dueDate": "2026-06-01T00:00:00Z", "status": "PLANNED"}],
-                                  "reassessmentTriggers": ["Quarterly review"]
+                                  "reassessmentTriggers": [{"category": "METHODOLOGY_SPECIFIC", "note": "Quarterly review"}]
                                 }
                                 """
                                         .formatted(RECORD_ID, SCENARIO_ID)))
@@ -142,7 +145,8 @@ class TreatmentPlanControllerTest {
                 .andExpect(jsonPath("$.actionItems[0].dueDate", is("2026-06-01T00:00:00Z")))
                 .andExpect(jsonPath("$.actionItems[0].status", is("PLANNED")))
                 .andExpect(jsonPath("$.reassessmentTriggers", hasSize(1)))
-                .andExpect(jsonPath("$.reassessmentTriggers[0]", is("Quarterly review")));
+                .andExpect(jsonPath("$.reassessmentTriggers[0].category", is("METHODOLOGY_SPECIFIC")))
+                .andExpect(jsonPath("$.reassessmentTriggers[0].note", is("Quarterly review")));
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TreatmentPlanResponseTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/TreatmentPlanResponseTest.java
@@ -9,11 +9,13 @@ import com.keplerops.groundcontrol.domain.graph.model.GraphIds;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.MethodologyProfile;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskRegisterRecord;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenario;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.ActionItemStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.MethodologyFamily;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentPlanStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
 import java.time.Instant;
@@ -53,7 +55,8 @@ class TreatmentPlanResponseTest {
             plan.setDueDate(dueDate);
             var actionItems = List.of(new ActionItem("alice", dueDate, ActionItemStatus.PLANNED, null, "deploy patch"));
             plan.setActionItems(actionItems);
-            var triggers = List.of("quarterly review");
+            var triggers = List.of(new ReassessmentTrigger(
+                    ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC, null, null, null, "quarterly review"));
             plan.setReassessmentTriggers(triggers);
             var now = Instant.now();
             setField(plan, "createdAt", now);
@@ -76,7 +79,10 @@ class TreatmentPlanResponseTest {
             assertThat(response.dueDate()).isEqualTo(dueDate);
             assertThat(response.status()).isEqualTo(TreatmentPlanStatus.PLANNED);
             assertThat(response.actionItems()).isEqualTo(actionItems);
-            assertThat(response.reassessmentTriggers()).containsExactly("quarterly review");
+            assertThat(response.reassessmentTriggers()).hasSize(1);
+            assertThat(response.reassessmentTriggers().get(0).category())
+                    .isEqualTo(ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC);
+            assertThat(response.reassessmentTriggers().get(0).note()).isEqualTo("quarterly review");
             assertThat(response.createdAt()).isEqualTo(now);
             assertThat(response.updatedAt()).isEqualTo(now);
         }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetServiceTest.java
@@ -2408,6 +2408,8 @@ class AssetServiceTest {
                             any(com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent.class));
         }
 
+        // S1874 suppressed: exercising the deprecated overload is the point of this test.
+        @SuppressWarnings("deprecation")
         @Test
         void deprecatedUuidOnlyUpdateAlsoPublishes() {
             // Deprecated UUID-only overload must still fire the publisher per preflight —
@@ -2448,6 +2450,8 @@ class AssetServiceTest {
                             any(com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent.class));
         }
 
+        // S1874 suppressed: exercising the deprecated overload is the point of this test.
+        @SuppressWarnings("deprecation")
         @Test
         void deprecatedUuidOnlyArchiveAlsoPublishes() {
             var asset = createAsset("ASSET-1", "Payments API");

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetServiceTest.java
@@ -89,6 +89,9 @@ class AssetServiceTest {
     @SuppressWarnings("UnusedVariable") // Injected into AssetService via @InjectMocks; errorprone misses the wire.
     private AssetSubtypeValidator subtypeValidator = new AssetSubtypeValidator();
 
+    @Mock
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private AssetService assetService;
 
@@ -2323,6 +2326,140 @@ class AssetServiceTest {
             assertThat(result.getKnowledgeState())
                     .isEqualTo(com.keplerops.groundcontrol.domain.assets.state.KnowledgeState.PROVISIONAL);
             assertThat(result.getConfidence()).isEqualTo("0.85");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GC-T004 / C8 (#863): reassessment publisher coverage
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ReassessmentEvents {
+
+        @Test
+        void updatePublishesAssetStateChangedWhenCriticalityChanges() {
+            var asset = createAsset("ASSET-1", "Payments API");
+            asset.setCriticality(com.keplerops.groundcontrol.domain.assets.state.AssetCriticality.MEDIUM);
+            when(assetRepository.findByIdAndProjectId(asset.getId(), projectId)).thenReturn(Optional.of(asset));
+            when(assetRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = assetService.update(
+                    projectId,
+                    asset.getId(),
+                    new com.keplerops.groundcontrol.domain.assets.service.UpdateAssetCommand(
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            com.keplerops.groundcontrol.domain.assets.state.AssetCriticality.CRITICAL,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false));
+
+            // Capture-and-assert the state change (test-quality cycle 1).
+            assertThat(result.getCriticality())
+                    .isEqualTo(com.keplerops.groundcontrol.domain.assets.state.AssetCriticality.CRITICAL);
+            verify(eventPublisher)
+                    .publishEvent(
+                            any(com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent.class));
+        }
+
+        @Test
+        void updateWithUnchangedRiskFieldsDoesNotPublish() {
+            var asset = createAsset("ASSET-1", "Payments API");
+            asset.setCriticality(com.keplerops.groundcontrol.domain.assets.state.AssetCriticality.MEDIUM);
+            asset.setOwner("alice");
+            when(assetRepository.findByIdAndProjectId(asset.getId(), projectId)).thenReturn(Optional.of(asset));
+            when(assetRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            // description-only update — no risk-bearing field moves.
+            assetService.update(
+                    projectId,
+                    asset.getId(),
+                    new com.keplerops.groundcontrol.domain.assets.service.UpdateAssetCommand(
+                            null, "new description", null));
+
+            org.mockito.Mockito.verifyNoInteractions(eventPublisher);
+        }
+
+        @Test
+        void archivePublishesAssetStateChangedEvent() {
+            var asset = createAsset("ASSET-1", "Payments API");
+            when(assetRepository.findByIdAndProjectId(asset.getId(), projectId)).thenReturn(Optional.of(asset));
+            when(assetRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = assetService.archive(projectId, asset.getId());
+
+            assertThat(result.getArchivedAt()).isNotNull();
+            verify(eventPublisher)
+                    .publishEvent(
+                            any(com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent.class));
+        }
+
+        @Test
+        void deprecatedUuidOnlyUpdateAlsoPublishes() {
+            // Deprecated UUID-only overload must still fire the publisher per preflight —
+            // legacy call sites would otherwise silently skip reassessment routing.
+            var asset = createAsset("ASSET-1", "Payments API");
+            asset.setEnvironment(com.keplerops.groundcontrol.domain.assets.state.AssetEnvironment.STAGING);
+            when(assetRepository.findById(asset.getId())).thenReturn(Optional.of(asset));
+            when(assetRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = assetService.update(
+                    asset.getId(),
+                    new com.keplerops.groundcontrol.domain.assets.service.UpdateAssetCommand(
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            com.keplerops.groundcontrol.domain.assets.state.AssetEnvironment.PRODUCTION,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                            false));
+
+            assertThat(result.getEnvironment())
+                    .isEqualTo(com.keplerops.groundcontrol.domain.assets.state.AssetEnvironment.PRODUCTION);
+            verify(eventPublisher)
+                    .publishEvent(
+                            any(com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent.class));
+        }
+
+        @Test
+        void deprecatedUuidOnlyArchiveAlsoPublishes() {
+            var asset = createAsset("ASSET-1", "Payments API");
+            when(assetRepository.findById(asset.getId())).thenReturn(Optional.of(asset));
+            when(assetRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = assetService.archive(asset.getId());
+
+            assertThat(result.getArchivedAt()).isNotNull();
+            verify(eventPublisher)
+                    .publishEvent(
+                            any(com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent.class));
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlServiceTest.java
@@ -54,6 +54,9 @@ class ControlServiceTest {
     @Mock
     private ProjectService projectService;
 
+    @Mock
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private ControlService controlService;
 
@@ -362,6 +365,70 @@ class ControlServiceTest {
             assertThatThrownBy(() -> controlService.delete(projectId, control.getId()))
                     .isInstanceOf(com.keplerops.groundcontrol.domain.exception.ConflictException.class)
                     .hasMessageContaining("dependent audit evidence");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GC-T004 / C8 (#863): reassessment publisher coverage
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ReassessmentEvents {
+
+        @Test
+        void transitionStatusPublishesControlStateChangedEvent() {
+            var control = makeControl();
+            when(controlRepository.findByIdAndProjectId(control.getId(), projectId))
+                    .thenReturn(Optional.of(control));
+            when(controlRepository.save(any(Control.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            // DRAFT → PROPOSED is the only valid first hop from the default ControlStatus.
+            var result = controlService.transitionStatus(projectId, control.getId(), ControlStatus.PROPOSED);
+
+            // Assert the state change actually happened (test-quality cycle 1): a
+            // broken implementation that fires the event but fails to apply the
+            // transition would otherwise pass.
+            assertThat(result.getStatus()).isEqualTo(ControlStatus.PROPOSED);
+            verify(eventPublisher)
+                    .publishEvent(any(
+                            com.keplerops.groundcontrol.domain.riskscenarios.events.ControlStateChangedEvent.class));
+        }
+
+        @Test
+        void updateWithEffectivenessChangePublishes() {
+            var control = makeControl();
+            control.setEffectiveness(java.util.Map.of("rating", "LOW"));
+            when(controlRepository.findByIdAndProjectId(control.getId(), projectId))
+                    .thenReturn(Optional.of(control));
+            when(controlRepository.save(any(Control.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var command = new UpdateControlCommand(
+                    null, null, null, null, null, null, null, java.util.Map.of("rating", "HIGH"), null, null);
+            var result = controlService.update(projectId, control.getId(), command);
+
+            // Capture-and-assert the state change (test-quality cycle 1): a broken
+            // implementation that fires the event but fails to set effectiveness
+            // would otherwise pass this and the integration test.
+            assertThat(result.getEffectiveness()).containsEntry("rating", "HIGH");
+            verify(eventPublisher)
+                    .publishEvent(any(
+                            com.keplerops.groundcontrol.domain.riskscenarios.events.ControlStateChangedEvent.class));
+        }
+
+        @Test
+        void updateWithoutEffectivenessChangeDoesNotPublish() {
+            var control = makeControl();
+            control.setEffectiveness(java.util.Map.of("rating", "HIGH"));
+            when(controlRepository.findByIdAndProjectId(control.getId(), projectId))
+                    .thenReturn(Optional.of(control));
+            when(controlRepository.save(any(Control.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            // Description-only update — effectiveness unchanged, no event.
+            var command = new UpdateControlCommand(
+                    null, null, "Updated description", null, null, null, null, null, null, null);
+            controlService.update(projectId, control.getId(), command);
+
+            org.mockito.Mockito.verifyNoInteractions(eventPublisher);
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GraphTargetResolverServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GraphTargetResolverServiceTest.java
@@ -21,6 +21,7 @@ import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskAssessmen
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskRegisterRecordRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioRepository;
 import com.keplerops.groundcontrol.domain.riskscenarios.repository.TreatmentPlanRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerTargetType;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkTargetType;
 import com.keplerops.groundcontrol.domain.threatmodels.repository.ThreatModelRepository;
 import com.keplerops.groundcontrol.domain.threatmodels.state.ThreatModelLinkTargetType;
@@ -388,6 +389,111 @@ class GraphTargetResolverServiceTest {
                         projectId, ControlLinkTargetType.EXTERNAL, null, " "))
                 .isInstanceOf(DomainValidationException.class)
                 .hasMessageContaining("targetIdentifier");
+    }
+
+    // GC-T004 / C8 (#863): reassessment-trigger target validation reuses the same
+    // per-internal-type project-scoped existence checks. Same security shape as
+    // ControlLink — a non-existent or cross-project UUID produces
+    // DomainValidationException("not found in the requested project").
+    @ParameterizedTest
+    @EnumSource(
+            value = ReassessmentTriggerTargetType.class,
+            names = {
+                "ASSET",
+                "CONTROL",
+                "RISK_SCENARIO",
+                "RISK_REGISTER_RECORD",
+                "RISK_ASSESSMENT_RESULT",
+                "TREATMENT_PLAN"
+            })
+    void validateReassessmentTriggerTargetAcceptsInternalTargets(ReassessmentTriggerTargetType targetType) {
+        stubReassessmentTriggerInternalTarget(targetType, true);
+
+        var validated =
+                graphTargetResolverService.validateReassessmentTriggerTarget(projectId, targetType, targetId, null);
+
+        assertThat(validated.internal()).isTrue();
+        assertThat(validated.targetEntityId()).isEqualTo(targetId);
+        assertThat(validated.targetIdentifier()).isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ReassessmentTriggerTargetType.class,
+            names = {
+                "ASSET",
+                "CONTROL",
+                "RISK_SCENARIO",
+                "RISK_REGISTER_RECORD",
+                "RISK_ASSESSMENT_RESULT",
+                "TREATMENT_PLAN"
+            })
+    void validateReassessmentTriggerTargetRejectsInternalTargets(ReassessmentTriggerTargetType targetType) {
+        stubReassessmentTriggerInternalTarget(targetType, false);
+
+        assertThatThrownBy(() -> graphTargetResolverService.validateReassessmentTriggerTarget(
+                        projectId, targetType, targetId, null))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("not found in the requested project");
+    }
+
+    @Test
+    void validateReassessmentTriggerTargetAcceptsExternalIdentifier() {
+        var validated = graphTargetResolverService.validateReassessmentTriggerTarget(
+                projectId, ReassessmentTriggerTargetType.EXTERNAL, null, "JIRA-INFRA-42");
+
+        assertThat(validated.internal()).isFalse();
+        assertThat(validated.targetIdentifier()).isEqualTo("JIRA-INFRA-42");
+    }
+
+    @Test
+    void validateReassessmentTriggerTargetRejectsMissingInternalTargetEntityId() {
+        assertThatThrownBy(() -> graphTargetResolverService.validateReassessmentTriggerTarget(
+                        projectId, ReassessmentTriggerTargetType.ASSET, null, null))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("targetEntityId");
+    }
+
+    @Test
+    void validateReassessmentTriggerTargetRejectsMissingExternalIdentifier() {
+        assertThatThrownBy(() -> graphTargetResolverService.validateReassessmentTriggerTarget(
+                        projectId, ReassessmentTriggerTargetType.EXTERNAL, null, " "))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("targetIdentifier");
+    }
+
+    private void stubReassessmentTriggerInternalTarget(ReassessmentTriggerTargetType targetType, boolean exists) {
+        switch (targetType) {
+            case ASSET -> when(assetRepository.existsByIdAndProjectId(targetId, projectId))
+                    .thenReturn(exists);
+            case CONTROL -> when(controlRepository.existsByIdAndProjectId(targetId, projectId))
+                    .thenReturn(exists);
+            case RISK_SCENARIO -> when(riskScenarioRepository.existsByIdAndProjectId(targetId, projectId))
+                    .thenReturn(exists);
+            case RISK_REGISTER_RECORD -> when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(
+                            targetId, projectId))
+                    .thenReturn(
+                            exists
+                                    ? java.util.Optional.of(org.mockito.Mockito.mock(
+                                            com.keplerops.groundcontrol.domain.riskscenarios.model.RiskRegisterRecord
+                                                    .class))
+                                    : java.util.Optional.empty());
+            case RISK_ASSESSMENT_RESULT -> when(riskAssessmentResultRepository.findByIdAndProjectIdWithObservations(
+                            targetId, projectId))
+                    .thenReturn(
+                            exists
+                                    ? java.util.Optional.of(org.mockito.Mockito.mock(
+                                            com.keplerops.groundcontrol.domain.riskscenarios.model.RiskAssessmentResult
+                                                    .class))
+                                    : java.util.Optional.empty());
+            case TREATMENT_PLAN -> when(treatmentPlanRepository.findByIdAndProjectId(targetId, projectId))
+                    .thenReturn(
+                            exists
+                                    ? java.util.Optional.of(org.mockito.Mockito.mock(
+                                            com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan.class))
+                                    : java.util.Optional.empty());
+            case EXTERNAL -> throw new IllegalArgumentException("Not an internal target type");
+        }
     }
 
     private void stubAssetInternalTarget(AssetLinkTargetType targetType, boolean exists) {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ReassessmentSignalServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ReassessmentSignalServiceTest.java
@@ -1,0 +1,341 @@
+package com.keplerops.groundcontrol.unit.domain;
+
+import static com.keplerops.groundcontrol.TestUtil.setField;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.keplerops.groundcontrol.domain.assets.model.AssetLink;
+import com.keplerops.groundcontrol.domain.assets.model.OperationalAsset;
+import com.keplerops.groundcontrol.domain.assets.repository.AssetLinkRepository;
+import com.keplerops.groundcontrol.domain.assets.state.AssetLinkTargetType;
+import com.keplerops.groundcontrol.domain.assets.state.AssetLinkType;
+import com.keplerops.groundcontrol.domain.controls.model.Control;
+import com.keplerops.groundcontrol.domain.controls.model.ControlLink;
+import com.keplerops.groundcontrol.domain.controls.repository.ControlLinkRepository;
+import com.keplerops.groundcontrol.domain.controls.state.ControlFunction;
+import com.keplerops.groundcontrol.domain.controls.state.ControlLinkTargetType;
+import com.keplerops.groundcontrol.domain.controls.state.ControlLinkType;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ControlStateChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ReassessmentSignal;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ReassessmentSourceEntityType;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.TreatmentProgressChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.MethodologyProfile;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskAssessmentResult;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskRegisterRecord;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenario;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskAssessmentResultRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.RiskScenarioLinkRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.repository.TreatmentPlanRepository;
+import com.keplerops.groundcontrol.domain.riskscenarios.service.ReassessmentSignalService;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.MethodologyFamily;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReassessmentSignalServiceTest {
+
+    @Mock
+    private RiskAssessmentResultRepository assessmentRepository;
+
+    @Mock
+    private TreatmentPlanRepository treatmentPlanRepository;
+
+    @Mock
+    private AssetLinkRepository assetLinkRepository;
+
+    @Mock
+    private ControlLinkRepository controlLinkRepository;
+
+    @Mock
+    private RiskScenarioLinkRepository riskScenarioLinkRepository;
+
+    @InjectMocks
+    private ReassessmentSignalService listener;
+
+    private Project project;
+    private UUID projectId;
+
+    @BeforeEach
+    void setUp() {
+        project = new Project("ground-control", "Ground Control");
+        projectId = UUID.randomUUID();
+        setField(project, "id", projectId);
+    }
+
+    private RiskAssessmentResult makeAssessment(UUID id) {
+        var scenario = new RiskScenario(project, "RS-1", "Scenario", "Actor", "Event", "Object", "Consequence");
+        scenario.setTimeHorizon("12 months");
+        setField(scenario, "id", UUID.randomUUID());
+        var profile = new MethodologyProfile(project, "MP", "Profile", "1.0", MethodologyFamily.CUSTOM);
+        setField(profile, "id", UUID.randomUUID());
+        var result = new RiskAssessmentResult(project, scenario, profile);
+        setField(result, "id", id);
+        return result;
+    }
+
+    private TreatmentPlan makePlan(RiskRegisterRecord record, RiskScenario scenario) {
+        var plan = new TreatmentPlan(project, "TP-1", "Plan", record, TreatmentStrategy.MITIGATE);
+        setField(plan, "id", UUID.randomUUID());
+        plan.setRiskScenario(scenario);
+        return plan;
+    }
+
+    private RiskRegisterRecord makeRecord() {
+        var record = new RiskRegisterRecord(project, "RR-1", "Record");
+        setField(record, "id", UUID.randomUUID());
+        return record;
+    }
+
+    private RiskScenario makeScenario(String uid) {
+        var scenario = new RiskScenario(project, uid, "Scenario", "Actor", "Event", "Object", "Consequence");
+        scenario.setTimeHorizon("12 months");
+        setField(scenario, "id", UUID.randomUUID());
+        return scenario;
+    }
+
+    private OperationalAsset makeAsset(String uid) {
+        var asset = new OperationalAsset(project, uid, "Asset name");
+        setField(asset, "id", UUID.randomUUID());
+        return asset;
+    }
+
+    private Control makeControl(String uid) {
+        var control = new Control(project, uid, "Control title", ControlFunction.PREVENTIVE);
+        setField(control, "id", UUID.randomUUID());
+        return control;
+    }
+
+    private ReassessmentSignal signalFor(ReassessmentSourceEntityType type, UUID entityId) {
+        return new ReassessmentSignal(
+                projectId,
+                type == ReassessmentSourceEntityType.ASSET
+                        ? ReassessmentTriggerCategory.ASSET_STATE_CHANGED
+                        : (type == ReassessmentSourceEntityType.CONTROL
+                                ? ReassessmentTriggerCategory.CONTROL_STATE_CHANGED
+                                : ReassessmentTriggerCategory.TREATMENT_PROGRESS_CHANGED),
+                type,
+                entityId,
+                Set.of("status"),
+                new HashMap<>(),
+                new HashMap<>(),
+                Instant.now());
+    }
+
+    @Test
+    void treatmentPlanEventMarksAssessmentResultsLinkedThroughRegisterRecord() {
+        var record = makeRecord();
+        var scenario = makeScenario("RS-1");
+        var plan = makePlan(record, scenario);
+        var result = makeAssessment(UUID.randomUUID());
+
+        when(treatmentPlanRepository.findByIdAndProjectId(plan.getId(), projectId))
+                .thenReturn(Optional.of(plan));
+        when(assessmentRepository.findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(projectId, record.getId()))
+                .thenReturn(List.of(result));
+        when(assessmentRepository.findByProjectIdAndRiskScenarioIdOrderByCreatedAtDesc(projectId, scenario.getId()))
+                .thenReturn(List.of());
+        when(assessmentRepository.findByIdAndProjectId(result.getId(), projectId))
+                .thenReturn(Optional.of(result));
+
+        listener.onTreatmentProgressChanged(new TreatmentProgressChangedEvent(
+                signalFor(ReassessmentSourceEntityType.TREATMENT_PLAN, plan.getId())));
+
+        verify(assessmentRepository).save(result);
+        assertThat(result.getReassessmentRequiredAt()).isNotNull();
+    }
+
+    @Test
+    void treatmentPlanEventDeduplicatesScenarioVsRecordPaths() {
+        // Both findByRecord and findByScenario return the SAME assessment row —
+        // the listener must dedup and call save() exactly once for that id.
+        var record = makeRecord();
+        var scenario = makeScenario("RS-1");
+        var plan = makePlan(record, scenario);
+        var result = makeAssessment(UUID.randomUUID());
+
+        when(treatmentPlanRepository.findByIdAndProjectId(plan.getId(), projectId))
+                .thenReturn(Optional.of(plan));
+        when(assessmentRepository.findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(projectId, record.getId()))
+                .thenReturn(List.of(result));
+        when(assessmentRepository.findByProjectIdAndRiskScenarioIdOrderByCreatedAtDesc(projectId, scenario.getId()))
+                .thenReturn(List.of(result));
+        when(assessmentRepository.findByIdAndProjectId(result.getId(), projectId))
+                .thenReturn(Optional.of(result));
+
+        listener.onTreatmentProgressChanged(new TreatmentProgressChangedEvent(
+                signalFor(ReassessmentSourceEntityType.TREATMENT_PLAN, plan.getId())));
+
+        verify(assessmentRepository, org.mockito.Mockito.times(1)).save(result);
+    }
+
+    @Test
+    void assetEventWalksAssetLinkToRiskScenarioAndMarksAssessments() {
+        var asset = makeAsset("ASSET-1");
+        var scenario = makeScenario("RS-1");
+        var result = makeAssessment(UUID.randomUUID());
+
+        var link = new AssetLink(
+                asset, AssetLinkTargetType.RISK_SCENARIO, scenario.getId(), null, AssetLinkType.ASSOCIATED);
+        when(assetLinkRepository.findByAssetId(asset.getId())).thenReturn(List.of(link));
+        when(assessmentRepository.findByProjectIdAndRiskScenarioIdOrderByCreatedAtDesc(projectId, scenario.getId()))
+                .thenReturn(List.of(result));
+        when(assessmentRepository.findByIdAndProjectId(result.getId(), projectId))
+                .thenReturn(Optional.of(result));
+
+        listener.onAssetStateChanged(
+                new AssetStateChangedEvent(signalFor(ReassessmentSourceEntityType.ASSET, asset.getId())));
+
+        verify(assessmentRepository).save(result);
+    }
+
+    @Test
+    void assetEventMarksDirectRiskAssessmentResultLink() {
+        var asset = makeAsset("ASSET-1");
+        var result = makeAssessment(UUID.randomUUID());
+        var link = new AssetLink(
+                asset, AssetLinkTargetType.RISK_ASSESSMENT_RESULT, result.getId(), null, AssetLinkType.ASSOCIATED);
+
+        when(assetLinkRepository.findByAssetId(asset.getId())).thenReturn(List.of(link));
+        when(assessmentRepository.findByIdAndProjectId(result.getId(), projectId))
+                .thenReturn(Optional.of(result));
+
+        listener.onAssetStateChanged(
+                new AssetStateChangedEvent(signalFor(ReassessmentSourceEntityType.ASSET, asset.getId())));
+
+        verify(assessmentRepository).save(result);
+    }
+
+    @Test
+    void assetEventWithNoLinksDoesNothing() {
+        var asset = makeAsset("ASSET-1");
+        when(assetLinkRepository.findByAssetId(asset.getId())).thenReturn(List.of());
+
+        listener.onAssetStateChanged(
+                new AssetStateChangedEvent(signalFor(ReassessmentSourceEntityType.ASSET, asset.getId())));
+
+        verify(assessmentRepository, never()).save(any());
+    }
+
+    @Test
+    void assetEventIgnoresNonRiskRoutedLinkTargets() {
+        // AssetLink → EXTERNAL is not a risk-routing surface; the listener
+        // walks but does not mark anything from it.
+        var asset = makeAsset("ASSET-1");
+        var link = new AssetLink(asset, AssetLinkTargetType.EXTERNAL, null, "ext://foo", AssetLinkType.ASSOCIATED);
+        when(assetLinkRepository.findByAssetId(asset.getId())).thenReturn(List.of(link));
+
+        listener.onAssetStateChanged(
+                new AssetStateChangedEvent(signalFor(ReassessmentSourceEntityType.ASSET, asset.getId())));
+
+        verify(assessmentRepository, never()).save(any());
+    }
+
+    @Test
+    void controlEventWalksControlLinkToRegisterRecordAndMarksAssessments() {
+        var control = makeControl("CTRL-1");
+        var record = makeRecord();
+        var result = makeAssessment(UUID.randomUUID());
+
+        var link = new ControlLink(
+                control, ControlLinkTargetType.RISK_REGISTER_RECORD, record.getId(), null, ControlLinkType.MITIGATES);
+        when(controlLinkRepository.findByControlId(control.getId())).thenReturn(List.of(link));
+        when(assessmentRepository.findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(projectId, record.getId()))
+                .thenReturn(List.of(result));
+        when(assessmentRepository.findByIdAndProjectId(result.getId(), projectId))
+                .thenReturn(Optional.of(result));
+
+        listener.onControlStateChanged(
+                new ControlStateChangedEvent(signalFor(ReassessmentSourceEntityType.CONTROL, control.getId())));
+
+        verify(assessmentRepository).save(result);
+    }
+
+    @Test
+    void controlEventAlsoFollowsInverseRiskScenarioLink() {
+        // RiskScenarioLink → CONTROL: when a scenario links to a control as
+        // mitigation, a change to the control implicates that scenario's
+        // assessments via the inverse direction.
+        var control = makeControl("CTRL-1");
+        var scenario = makeScenario("RS-1");
+        var result = makeAssessment(UUID.randomUUID());
+
+        var scenarioLink = new com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenarioLink(
+                scenario,
+                com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkTargetType.CONTROL,
+                control.getId(),
+                null,
+                com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkType.MITIGATED_BY);
+        when(controlLinkRepository.findByControlId(control.getId())).thenReturn(List.of());
+        when(riskScenarioLinkRepository.findByTargetTypeAndTargetEntityIdAndProjectId(
+                        com.keplerops.groundcontrol.domain.riskscenarios.state.RiskScenarioLinkTargetType.CONTROL,
+                        control.getId(),
+                        projectId))
+                .thenReturn(List.of(scenarioLink));
+        when(assessmentRepository.findByProjectIdAndRiskScenarioIdOrderByCreatedAtDesc(projectId, scenario.getId()))
+                .thenReturn(List.of(result));
+        when(assessmentRepository.findByIdAndProjectId(result.getId(), projectId))
+                .thenReturn(Optional.of(result));
+
+        listener.onControlStateChanged(
+                new ControlStateChangedEvent(signalFor(ReassessmentSourceEntityType.CONTROL, control.getId())));
+
+        verify(assessmentRepository).save(result);
+    }
+
+    @Test
+    void noMatchingAssessmentRowIsTolerated() {
+        // If the link points at a result id that no longer exists, the listener
+        // skips it without throwing.
+        var asset = makeAsset("ASSET-1");
+        var deletedResultId = UUID.randomUUID();
+        var link = new AssetLink(
+                asset, AssetLinkTargetType.RISK_ASSESSMENT_RESULT, deletedResultId, null, AssetLinkType.ASSOCIATED);
+        when(assetLinkRepository.findByAssetId(asset.getId())).thenReturn(List.of(link));
+        when(assessmentRepository.findByIdAndProjectId(deletedResultId, projectId))
+                .thenReturn(Optional.empty());
+
+        listener.onAssetStateChanged(
+                new AssetStateChangedEvent(signalFor(ReassessmentSourceEntityType.ASSET, asset.getId())));
+
+        verify(assessmentRepository, never()).save(any());
+    }
+
+    @Test
+    void idempotencyAcrossSuccessiveEvents() {
+        // Two events back-to-back must both mark and both call save() — the
+        // listener is not silently skipping the "already-marked" case. The
+        // governance contract is "the most recent change wins"; suppressing
+        // the second call would hide a real subsequent mutation.
+        var asset = makeAsset("ASSET-1");
+        var result = makeAssessment(UUID.randomUUID());
+        var link = new AssetLink(
+                asset, AssetLinkTargetType.RISK_ASSESSMENT_RESULT, result.getId(), null, AssetLinkType.ASSOCIATED);
+        when(assetLinkRepository.findByAssetId(asset.getId())).thenReturn(List.of(link));
+        when(assessmentRepository.findByIdAndProjectId(result.getId(), projectId))
+                .thenReturn(Optional.of(result));
+
+        var event = new AssetStateChangedEvent(signalFor(ReassessmentSourceEntityType.ASSET, asset.getId()));
+        listener.onAssetStateChanged(event);
+        listener.onAssetStateChanged(event);
+
+        verify(assessmentRepository, org.mockito.Mockito.times(2)).save(result);
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ReassessmentSignalServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ReassessmentSignalServiceTest.java
@@ -91,17 +91,17 @@ class ReassessmentSignalServiceTest {
         return result;
     }
 
-    private TreatmentPlan makePlan(RiskRegisterRecord record, RiskScenario scenario) {
-        var plan = new TreatmentPlan(project, "TP-1", "Plan", record, TreatmentStrategy.MITIGATE);
+    private TreatmentPlan makePlan(RiskRegisterRecord registerRecord, RiskScenario scenario) {
+        var plan = new TreatmentPlan(project, "TP-1", "Plan", registerRecord, TreatmentStrategy.MITIGATE);
         setField(plan, "id", UUID.randomUUID());
         plan.setRiskScenario(scenario);
         return plan;
     }
 
     private RiskRegisterRecord makeRecord() {
-        var record = new RiskRegisterRecord(project, "RR-1", "Record");
-        setField(record, "id", UUID.randomUUID());
-        return record;
+        var registerRecord = new RiskRegisterRecord(project, "RR-1", "Record");
+        setField(registerRecord, "id", UUID.randomUUID());
+        return registerRecord;
     }
 
     private RiskScenario makeScenario(String uid) {
@@ -141,14 +141,15 @@ class ReassessmentSignalServiceTest {
 
     @Test
     void treatmentPlanEventMarksAssessmentResultsLinkedThroughRegisterRecord() {
-        var record = makeRecord();
+        var registerRecord = makeRecord();
         var scenario = makeScenario("RS-1");
-        var plan = makePlan(record, scenario);
+        var plan = makePlan(registerRecord, scenario);
         var result = makeAssessment(UUID.randomUUID());
 
         when(treatmentPlanRepository.findByIdAndProjectId(plan.getId(), projectId))
                 .thenReturn(Optional.of(plan));
-        when(assessmentRepository.findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(projectId, record.getId()))
+        when(assessmentRepository.findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(
+                        projectId, registerRecord.getId()))
                 .thenReturn(List.of(result));
         when(assessmentRepository.findByProjectIdAndRiskScenarioIdOrderByCreatedAtDesc(projectId, scenario.getId()))
                 .thenReturn(List.of());
@@ -166,14 +167,15 @@ class ReassessmentSignalServiceTest {
     void treatmentPlanEventDeduplicatesScenarioVsRecordPaths() {
         // Both findByRecord and findByScenario return the SAME assessment row —
         // the listener must dedup and call save() exactly once for that id.
-        var record = makeRecord();
+        var registerRecord = makeRecord();
         var scenario = makeScenario("RS-1");
-        var plan = makePlan(record, scenario);
+        var plan = makePlan(registerRecord, scenario);
         var result = makeAssessment(UUID.randomUUID());
 
         when(treatmentPlanRepository.findByIdAndProjectId(plan.getId(), projectId))
                 .thenReturn(Optional.of(plan));
-        when(assessmentRepository.findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(projectId, record.getId()))
+        when(assessmentRepository.findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(
+                        projectId, registerRecord.getId()))
                 .thenReturn(List.of(result));
         when(assessmentRepository.findByProjectIdAndRiskScenarioIdOrderByCreatedAtDesc(projectId, scenario.getId()))
                 .thenReturn(List.of(result));
@@ -251,13 +253,18 @@ class ReassessmentSignalServiceTest {
     @Test
     void controlEventWalksControlLinkToRegisterRecordAndMarksAssessments() {
         var control = makeControl("CTRL-1");
-        var record = makeRecord();
+        var registerRecord = makeRecord();
         var result = makeAssessment(UUID.randomUUID());
 
         var link = new ControlLink(
-                control, ControlLinkTargetType.RISK_REGISTER_RECORD, record.getId(), null, ControlLinkType.MITIGATES);
+                control,
+                ControlLinkTargetType.RISK_REGISTER_RECORD,
+                registerRecord.getId(),
+                null,
+                ControlLinkType.MITIGATES);
         when(controlLinkRepository.findByControlId(control.getId())).thenReturn(List.of(link));
-        when(assessmentRepository.findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(projectId, record.getId()))
+        when(assessmentRepository.findByProjectIdAndRiskRegisterRecordIdOrderByCreatedAtDesc(
+                        projectId, registerRecord.getId()))
                 .thenReturn(List.of(result));
         when(assessmentRepository.findByIdAndProjectId(result.getId(), projectId))
                 .thenReturn(Optional.of(result));

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TreatmentPlanServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TreatmentPlanServiceTest.java
@@ -10,10 +10,15 @@ import static org.mockito.Mockito.when;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.graph.service.GraphTargetResolverService;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.AssetStateChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.ControlStateChangedEvent;
+import com.keplerops.groundcontrol.domain.riskscenarios.events.TreatmentProgressChangedEvent;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.MethodologyProfile;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskRegisterRecord;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.RiskScenario;
 import com.keplerops.groundcontrol.domain.riskscenarios.model.TreatmentPlan;
@@ -26,6 +31,8 @@ import com.keplerops.groundcontrol.domain.riskscenarios.service.TreatmentPlanSer
 import com.keplerops.groundcontrol.domain.riskscenarios.service.UpdateTreatmentPlanCommand;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.ActionItemStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.MethodologyFamily;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerTargetType;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentPlanStatus;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.TreatmentStrategy;
 import java.time.Instant;
@@ -58,6 +65,12 @@ class TreatmentPlanServiceTest {
     @Mock
     private ProjectService projectService;
 
+    @Mock
+    private GraphTargetResolverService graphTargetResolverService;
+
+    @Mock
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
     private TreatmentPlanService service;
 
     private Project project;
@@ -76,7 +89,9 @@ class TreatmentPlanServiceTest {
                 riskScenarioRepository,
                 methodologyProfileRepository,
                 projectService,
-                validatorFactory.getValidator());
+                validatorFactory.getValidator(),
+                graphTargetResolverService,
+                eventPublisher);
         project = new Project("ground-control", "Ground Control");
         projectId = UUID.randomUUID();
         setField(project, "id", projectId);
@@ -155,7 +170,8 @@ class TreatmentPlanServiceTest {
                 TreatmentPlanStatus.IN_PROGRESS,
                 List.of(new ActionItem(
                         "Owner", Instant.parse("2026-06-01T00:00:00Z"), ActionItemStatus.PLANNED, null, "Enable WAF")),
-                List.of("New exposure"),
+                List.of(new ReassessmentTrigger(
+                        ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC, null, null, null, "New exposure")),
                 null,
                 null));
 
@@ -766,5 +782,423 @@ class TreatmentPlanServiceTest {
                 .hasMessageContaining("index 0")
                 .hasMessageContaining("description")
                 .hasMessageContaining("size");
+    }
+
+    // -------------------------------------------------------------------------
+    // GC-T004 / C8 (#863): typed reassessment triggers + publisher
+    // -------------------------------------------------------------------------
+
+    @Test
+    void transitionStatusPublishesTreatmentProgressChangedEvent() {
+        var plan = new TreatmentPlan(project, "TP-1", "Mitigate gateway", record, TreatmentStrategy.MITIGATE);
+        var planId = UUID.randomUUID();
+        setField(plan, "id", planId);
+        when(repository.findByIdAndProjectId(planId, projectId)).thenReturn(Optional.of(plan));
+        when(repository.save(plan)).thenReturn(plan);
+
+        var result = service.transitionStatus(projectId, planId, TreatmentPlanStatus.IN_PROGRESS);
+
+        // Capture-and-assert the state change (test-quality cycle 1).
+        assertThat(result.getStatus()).isEqualTo(TreatmentPlanStatus.IN_PROGRESS);
+        verify(eventPublisher).publishEvent(any(TreatmentProgressChangedEvent.class));
+    }
+
+    @Test
+    void transitionStatusToSameStatusDoesNotFire() {
+        var plan = new TreatmentPlan(project, "TP-1", "Mitigate gateway", record, TreatmentStrategy.MITIGATE);
+        var planId = UUID.randomUUID();
+        setField(plan, "id", planId);
+        when(repository.findByIdAndProjectId(planId, projectId)).thenReturn(Optional.of(plan));
+        when(repository.save(plan)).thenReturn(plan);
+
+        // PLANNED → IN_PROGRESS → publish (one event), then capture and
+        // attempt to "transition" to IN_PROGRESS again — the state machine
+        // rejects no-op transitions with DomainValidationException, so the
+        // publisher never fires. (Same shape as the existing
+        // transitionStatusUsesPlanStateMachine test.)
+        service.transitionStatus(projectId, planId, TreatmentPlanStatus.IN_PROGRESS);
+        verify(eventPublisher).publishEvent(any(TreatmentProgressChangedEvent.class));
+        org.mockito.Mockito.reset(eventPublisher);
+
+        assertThatThrownBy(() -> service.transitionStatus(projectId, planId, TreatmentPlanStatus.IN_PROGRESS))
+                .isInstanceOf(DomainValidationException.class);
+        org.mockito.Mockito.verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void updatePublishesProgressEventWhenActionItemStatusHistogramChanges() {
+        var plan = new TreatmentPlan(project, "TP-1", "Mitigate gateway", record, TreatmentStrategy.MITIGATE);
+        var planId = UUID.randomUUID();
+        setField(plan, "id", planId);
+        plan.setActionItems(List.of(new ActionItem(
+                "Owner", Instant.parse("2026-06-01T00:00:00Z"), ActionItemStatus.PLANNED, null, "Step 1")));
+        when(repository.findByIdAndProjectId(planId, projectId)).thenReturn(Optional.of(plan));
+        when(repository.save(plan)).thenReturn(plan);
+
+        var result = service.update(
+                projectId,
+                planId,
+                new UpdateTreatmentPlanCommand(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        List.of(new ActionItem(
+                                "Owner", Instant.parse("2026-06-01T00:00:00Z"), ActionItemStatus.DONE, null, "Step 1")),
+                        null,
+                        null,
+                        null));
+
+        // Capture-and-assert the state change (test-quality cycle 1).
+        assertThat(result.getActionItems()).hasSize(1);
+        assertThat(result.getActionItems().get(0).status()).isEqualTo(ActionItemStatus.DONE);
+        verify(eventPublisher).publishEvent(any(TreatmentProgressChangedEvent.class));
+    }
+
+    @Test
+    void updateWithIdenticalActionItemStatusHistogramDoesNotFire() {
+        var plan = new TreatmentPlan(project, "TP-1", "Mitigate gateway", record, TreatmentStrategy.MITIGATE);
+        var planId = UUID.randomUUID();
+        setField(plan, "id", planId);
+        var existing = List.of(new ActionItem(
+                "Owner", Instant.parse("2026-06-01T00:00:00Z"), ActionItemStatus.PLANNED, null, "Step 1"));
+        plan.setActionItems(existing);
+        when(repository.findByIdAndProjectId(planId, projectId)).thenReturn(Optional.of(plan));
+        when(repository.save(plan)).thenReturn(plan);
+
+        // New list with same status set — histogram unchanged, no event.
+        service.update(
+                projectId,
+                planId,
+                new UpdateTreatmentPlanCommand(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        List.of(new ActionItem(
+                                "Other",
+                                Instant.parse("2026-06-01T00:00:00Z"),
+                                ActionItemStatus.PLANNED,
+                                null,
+                                "Step renamed")),
+                        null,
+                        null,
+                        null));
+
+        org.mockito.Mockito.verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    void updateNeverPublishesAssetOrControlEventsFromTreatmentPath() {
+        var plan = new TreatmentPlan(project, "TP-1", "Mitigate gateway", record, TreatmentStrategy.MITIGATE);
+        var planId = UUID.randomUUID();
+        setField(plan, "id", planId);
+        when(repository.findByIdAndProjectId(planId, projectId)).thenReturn(Optional.of(plan));
+        when(repository.save(plan)).thenReturn(plan);
+
+        service.update(
+                projectId,
+                planId,
+                new UpdateTreatmentPlanCommand("Renamed", null, null, null, null, null, null, null, null, null));
+
+        // Title-only update does not flip status or action-item histogram, so no event.
+        org.mockito.Mockito.verifyNoInteractions(eventPublisher);
+        // Defensive: even if an event had fired, it must not have been a cross-aggregate one.
+        org.mockito.Mockito.verify(eventPublisher, org.mockito.Mockito.never())
+                .publishEvent(any(AssetStateChangedEvent.class));
+        org.mockito.Mockito.verify(eventPublisher, org.mockito.Mockito.never())
+                .publishEvent(any(ControlStateChangedEvent.class));
+    }
+
+    @Test
+    void createValidatesReassessmentTriggerInternalTarget() {
+        when(projectService.getById(projectId)).thenReturn(project);
+        when(repository.existsByProjectIdAndUid(projectId, "TP-1")).thenReturn(false);
+        when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(recordId, projectId))
+                .thenReturn(Optional.of(record));
+        when(repository.save(any(TreatmentPlan.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        var assetId = UUID.randomUUID();
+
+        var command = new CreateTreatmentPlanCommand(
+                projectId,
+                "TP-1",
+                "Plan",
+                recordId,
+                null,
+                TreatmentStrategy.MITIGATE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(new ReassessmentTrigger(
+                        ReassessmentTriggerCategory.ASSET_STATE_CHANGED,
+                        ReassessmentTriggerTargetType.ASSET,
+                        assetId,
+                        null,
+                        null)),
+                null,
+                null);
+
+        service.create(command);
+
+        verify(graphTargetResolverService)
+                .validateReassessmentTriggerTarget(projectId, ReassessmentTriggerTargetType.ASSET, assetId, null);
+    }
+
+    @Test
+    void createRejectsReassessmentTriggerWithBlankCategory() {
+        when(projectService.getById(projectId)).thenReturn(project);
+        when(repository.existsByProjectIdAndUid(projectId, "TP-1")).thenReturn(false);
+        when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(recordId, projectId))
+                .thenReturn(Optional.of(record));
+
+        var command = new CreateTreatmentPlanCommand(
+                projectId,
+                "TP-1",
+                "Plan",
+                recordId,
+                null,
+                TreatmentStrategy.MITIGATE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(new ReassessmentTrigger(null, null, null, null, "fallback")),
+                null,
+                null);
+
+        assertThatThrownBy(() -> service.create(command))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Reassessment trigger at index 0")
+                .hasMessageContaining("category");
+    }
+
+    @Test
+    void createRejectsReassessmentTriggerWithOverlongNote() {
+        when(projectService.getById(projectId)).thenReturn(project);
+        when(repository.existsByProjectIdAndUid(projectId, "TP-1")).thenReturn(false);
+        when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(recordId, projectId))
+                .thenReturn(Optional.of(record));
+
+        var bad = new ReassessmentTrigger(
+                ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC, null, null, null, "x".repeat(4001));
+        var command = new CreateTreatmentPlanCommand(
+                projectId,
+                "TP-1",
+                "Plan",
+                recordId,
+                null,
+                TreatmentStrategy.MITIGATE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(bad),
+                null,
+                null);
+
+        assertThatThrownBy(() -> service.create(command))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Reassessment trigger at index 0");
+    }
+
+    @Test
+    void createRejectsTriggerTargetEntityIdWithoutTargetType() {
+        // codex cycle-1 finding #2: target fields are not independent optionals.
+        when(projectService.getById(projectId)).thenReturn(project);
+        when(repository.existsByProjectIdAndUid(projectId, "TP-1")).thenReturn(false);
+        when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(recordId, projectId))
+                .thenReturn(Optional.of(record));
+
+        var bad = new ReassessmentTrigger(
+                ReassessmentTriggerCategory.ASSET_STATE_CHANGED, null, UUID.randomUUID(), null, null);
+        var command = new CreateTreatmentPlanCommand(
+                projectId,
+                "TP-1",
+                "Plan",
+                recordId,
+                null,
+                TreatmentStrategy.MITIGATE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(bad),
+                null,
+                null);
+
+        assertThatThrownBy(() -> service.create(command))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("target reference fields without targetType");
+    }
+
+    @Test
+    void createRejectsExternalTriggerWithTargetEntityId() {
+        when(projectService.getById(projectId)).thenReturn(project);
+        when(repository.existsByProjectIdAndUid(projectId, "TP-1")).thenReturn(false);
+        when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(recordId, projectId))
+                .thenReturn(Optional.of(record));
+
+        var bad = new ReassessmentTrigger(
+                ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC,
+                ReassessmentTriggerTargetType.EXTERNAL,
+                UUID.randomUUID(),
+                "JIRA-1",
+                null);
+        var command = new CreateTreatmentPlanCommand(
+                projectId,
+                "TP-1",
+                "Plan",
+                recordId,
+                null,
+                TreatmentStrategy.MITIGATE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(bad),
+                null,
+                null);
+
+        assertThatThrownBy(() -> service.create(command))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("targetType=EXTERNAL must not set targetEntityId");
+    }
+
+    @Test
+    void createRejectsInternalTriggerWithTargetIdentifier() {
+        when(projectService.getById(projectId)).thenReturn(project);
+        when(repository.existsByProjectIdAndUid(projectId, "TP-1")).thenReturn(false);
+        when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(recordId, projectId))
+                .thenReturn(Optional.of(record));
+
+        var bad = new ReassessmentTrigger(
+                ReassessmentTriggerCategory.ASSET_STATE_CHANGED,
+                ReassessmentTriggerTargetType.ASSET,
+                UUID.randomUUID(),
+                "EXT-1",
+                null);
+        var command = new CreateTreatmentPlanCommand(
+                projectId,
+                "TP-1",
+                "Plan",
+                recordId,
+                null,
+                TreatmentStrategy.MITIGATE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(bad),
+                null,
+                null);
+
+        assertThatThrownBy(() -> service.create(command))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("must not set targetIdentifier");
+    }
+
+    @Test
+    void createRejectsExternalTriggerWithoutTargetIdentifier() {
+        when(projectService.getById(projectId)).thenReturn(project);
+        when(repository.existsByProjectIdAndUid(projectId, "TP-1")).thenReturn(false);
+        when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(recordId, projectId))
+                .thenReturn(Optional.of(record));
+
+        var bad = new ReassessmentTrigger(
+                ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC,
+                ReassessmentTriggerTargetType.EXTERNAL,
+                null,
+                null,
+                null);
+        var command = new CreateTreatmentPlanCommand(
+                projectId,
+                "TP-1",
+                "Plan",
+                recordId,
+                null,
+                TreatmentStrategy.MITIGATE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(bad),
+                null,
+                null);
+
+        assertThatThrownBy(() -> service.create(command))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("targetType=EXTERNAL requires targetIdentifier");
+    }
+
+    @Test
+    void createRejectsInternalTriggerWithoutTargetEntityId() {
+        when(projectService.getById(projectId)).thenReturn(project);
+        when(repository.existsByProjectIdAndUid(projectId, "TP-1")).thenReturn(false);
+        when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(recordId, projectId))
+                .thenReturn(Optional.of(record));
+
+        var bad = new ReassessmentTrigger(
+                ReassessmentTriggerCategory.ASSET_STATE_CHANGED, ReassessmentTriggerTargetType.ASSET, null, null, null);
+        var command = new CreateTreatmentPlanCommand(
+                projectId,
+                "TP-1",
+                "Plan",
+                recordId,
+                null,
+                TreatmentStrategy.MITIGATE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(bad),
+                null,
+                null);
+
+        assertThatThrownBy(() -> service.create(command))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("requires targetEntityId");
+    }
+
+    @Test
+    void createRejectsNullReassessmentTrigger() {
+        when(projectService.getById(projectId)).thenReturn(project);
+        when(repository.existsByProjectIdAndUid(projectId, "TP-1")).thenReturn(false);
+        when(riskRegisterRecordRepository.findByIdAndProjectIdWithScenarios(recordId, projectId))
+                .thenReturn(Optional.of(record));
+
+        var triggers = new ArrayList<ReassessmentTrigger>();
+        triggers.add(null);
+        var command = new CreateTreatmentPlanCommand(
+                projectId,
+                "TP-1",
+                "Plan",
+                recordId,
+                null,
+                TreatmentStrategy.MITIGATE,
+                null,
+                null,
+                null,
+                null,
+                null,
+                triggers,
+                null,
+                null);
+
+        assertThatThrownBy(() -> service.create(command))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("Reassessment trigger at index 0");
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/shared/JacksonTextCollectionConvertersTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/shared/JacksonTextCollectionConvertersTest.java
@@ -4,11 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.keplerops.groundcontrol.domain.riskscenarios.model.ActionItem;
+import com.keplerops.groundcontrol.domain.riskscenarios.model.ReassessmentTrigger;
 import com.keplerops.groundcontrol.domain.riskscenarios.state.ActionItemStatus;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerCategory;
+import com.keplerops.groundcontrol.domain.riskscenarios.state.ReassessmentTriggerTargetType;
 import com.keplerops.groundcontrol.shared.persistence.JacksonTextCollectionConverters;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -301,6 +305,149 @@ class JacksonTextCollectionConvertersTest {
             assertThatThrownBy(() -> converter.convertToEntityAttribute("{\"not\":\"array\"}"))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("Expected JSON array");
+        }
+    }
+
+    @Nested
+    class ReassessmentTriggerListConverterTests {
+
+        private final JacksonTextCollectionConverters.ReassessmentTriggerListConverter converter =
+                new JacksonTextCollectionConverters.ReassessmentTriggerListConverter();
+
+        @Test
+        void convertToDatabaseColumn_nullInput_returnsNull() {
+            assertThat(converter.convertToDatabaseColumn(null)).isNull();
+        }
+
+        @Test
+        void convertToEntityAttribute_nullInput_returnsNull() {
+            assertThat(converter.convertToEntityAttribute(null)).isNull();
+        }
+
+        @Test
+        void convertToEntityAttribute_blankString_returnsNull() {
+            assertThat(converter.convertToEntityAttribute("")).isNull();
+            assertThat(converter.convertToEntityAttribute("  ")).isNull();
+        }
+
+        @Test
+        void roundTrip_singleTypedTrigger_categoryOnly() {
+            var original = List.of(
+                    new ReassessmentTrigger(ReassessmentTriggerCategory.ASSESSMENT_REFRESH, null, null, null, null));
+            String json = converter.convertToDatabaseColumn(original);
+            List<ReassessmentTrigger> restored = converter.convertToEntityAttribute(json);
+
+            assertThat(restored).hasSize(1);
+            var t = restored.get(0);
+            assertThat(t.category()).isEqualTo(ReassessmentTriggerCategory.ASSESSMENT_REFRESH);
+            assertThat(t.targetType()).isNull();
+            assertThat(t.targetEntityId()).isNull();
+            assertThat(t.targetIdentifier()).isNull();
+            assertThat(t.note()).isNull();
+        }
+
+        @Test
+        void roundTrip_triggerWithInternalTarget() {
+            var entityId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+            var original = List.of(new ReassessmentTrigger(
+                    ReassessmentTriggerCategory.ASSET_STATE_CHANGED,
+                    ReassessmentTriggerTargetType.ASSET,
+                    entityId,
+                    null,
+                    null));
+            String json = converter.convertToDatabaseColumn(original);
+            List<ReassessmentTrigger> restored = converter.convertToEntityAttribute(json);
+
+            assertThat(restored).hasSize(1);
+            assertThat(restored.get(0).targetType()).isEqualTo(ReassessmentTriggerTargetType.ASSET);
+            assertThat(restored.get(0).targetEntityId()).isEqualTo(entityId);
+        }
+
+        @Test
+        void roundTrip_triggerWithExternalIdentifier() {
+            var original = List.of(new ReassessmentTrigger(
+                    ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC,
+                    ReassessmentTriggerTargetType.EXTERNAL,
+                    null,
+                    "JIRA-INFRA-42",
+                    "watchlist sweep"));
+            String json = converter.convertToDatabaseColumn(original);
+            List<ReassessmentTrigger> restored = converter.convertToEntityAttribute(json);
+
+            assertThat(restored).hasSize(1);
+            assertThat(restored.get(0).targetIdentifier()).isEqualTo("JIRA-INFRA-42");
+            assertThat(restored.get(0).note()).isEqualTo("watchlist sweep");
+        }
+
+        @Test
+        void roundTrip_emptyList() {
+            var original = List.<ReassessmentTrigger>of();
+            String json = converter.convertToDatabaseColumn(original);
+            List<ReassessmentTrigger> restored = converter.convertToEntityAttribute(json);
+            assertThat(restored).isEmpty();
+        }
+
+        @Test
+        void writePath_emitsCanonicalShape_noExtraKeys() {
+            var trigger =
+                    new ReassessmentTrigger(ReassessmentTriggerCategory.ASSESSMENT_REFRESH, null, null, null, null);
+            String json = converter.convertToDatabaseColumn(List.of(trigger));
+
+            // null fields (targetType, targetEntityId, targetIdentifier, note)
+            // must be absent due to @JsonInclude(NON_NULL).
+            assertThat(json).doesNotContain("targetType");
+            assertThat(json).doesNotContain("targetEntityId");
+            assertThat(json).doesNotContain("targetIdentifier");
+            assertThat(json).doesNotContain("note");
+            assertThat(json).contains("\"category\":\"ASSESSMENT_REFRESH\"");
+        }
+
+        @Test
+        void legacyV043Row_freeTextString_foldsToMethodologySpecificNote() {
+            // V043 stored reassessment_triggers as List<String>. Legacy rows have
+            // bare strings inside the array — fold each into a typed trigger with
+            // category=METHODOLOGY_SPECIFIC and note=<string>.
+            String legacyJson = "[\"quarterly review\",\"after Q3 audit\"]";
+            List<ReassessmentTrigger> restored = converter.convertToEntityAttribute(legacyJson);
+
+            assertThat(restored).hasSize(2);
+            assertThat(restored.get(0).category()).isEqualTo(ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC);
+            assertThat(restored.get(0).note()).isEqualTo("quarterly review");
+            assertThat(restored.get(1).note()).isEqualTo("after Q3 audit");
+        }
+
+        @Test
+        void legacyV043Row_blankString_skipped() {
+            String legacyJson = "[\"\",\"real trigger\",\"   \"]";
+            List<ReassessmentTrigger> restored = converter.convertToEntityAttribute(legacyJson);
+
+            assertThat(restored).hasSize(1);
+            assertThat(restored.get(0).note()).isEqualTo("real trigger");
+        }
+
+        @Test
+        void convertToEntityAttribute_nonArrayJson_throws() {
+            assertThatThrownBy(() -> converter.convertToEntityAttribute("{\"not\":\"array\"}"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Expected JSON array");
+        }
+
+        @Test
+        void convertToEntityAttribute_invalidJson_throws() {
+            assertThatThrownBy(() -> converter.convertToEntityAttribute("{not valid"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void mixedLegacyAndTypedRows_bothDeserialise() {
+            String mixedJson = "[\"legacy text\",{\"category\":\"TREATMENT_PROGRESS_CHANGED\"}]";
+            List<ReassessmentTrigger> restored = converter.convertToEntityAttribute(mixedJson);
+
+            assertThat(restored).hasSize(2);
+            assertThat(restored.get(0).category()).isEqualTo(ReassessmentTriggerCategory.METHODOLOGY_SPECIFIC);
+            assertThat(restored.get(0).note()).isEqualTo("legacy text");
+            assertThat(restored.get(1).category()).isEqualTo(ReassessmentTriggerCategory.TREATMENT_PROGRESS_CHANGED);
+            assertThat(restored.get(1).note()).isNull();
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/shared/JacksonTextCollectionConvertersTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/shared/JacksonTextCollectionConvertersTest.java
@@ -395,11 +395,12 @@ class JacksonTextCollectionConvertersTest {
 
             // null fields (targetType, targetEntityId, targetIdentifier, note)
             // must be absent due to @JsonInclude(NON_NULL).
-            assertThat(json).doesNotContain("targetType");
-            assertThat(json).doesNotContain("targetEntityId");
-            assertThat(json).doesNotContain("targetIdentifier");
-            assertThat(json).doesNotContain("note");
-            assertThat(json).contains("\"category\":\"ASSESSMENT_REFRESH\"");
+            assertThat(json)
+                    .doesNotContain("targetType")
+                    .doesNotContain("targetEntityId")
+                    .doesNotContain("targetIdentifier")
+                    .doesNotContain("note")
+                    .contains("\"category\":\"ASSESSMENT_REFRESH\"");
         }
 
         @Test

--- a/changelog.d/863.added.md
+++ b/changelog.d/863.added.md
@@ -1,0 +1,5 @@
+### Added
+- Typed reassessment triggers on TreatmentPlan plus a transactional
+  `reassessment_required_at` signal on RiskAssessmentResult, fired by
+  TreatmentPlanService / AssetService / ControlService publishers and
+  consumed by ReassessmentSignalService (GC-T004 / C8, issue #863).

--- a/changelog.d/863.added.md
+++ b/changelog.d/863.added.md
@@ -8,4 +8,5 @@
   path reaches affected assessment rows like the explicit transitionStatus
   path does. Field-name keys in the publishers are hoisted to constants
   (`FIELD_STATUS`, `FIELD_EFFECTIVENESS`, `FIELD_ASSET_TYPE`, …) so renames
-  apply uniformly across all branches.
+  apply uniformly across every publisher branch and pre-existing
+  bounded-string / error-detail call site.

--- a/changelog.d/863.added.md
+++ b/changelog.d/863.added.md
@@ -3,3 +3,7 @@
   `reassessment_required_at` signal on RiskAssessmentResult, fired by
   TreatmentPlanService / AssetService / ControlService publishers and
   consumed by ReassessmentSignalService (GC-T004 / C8, issue #863).
+  TreatmentPlanService.create() also fires the publisher when the request
+  supplies a non-PLANNED initial status, so the create-with-IN_PROGRESS
+  path reaches affected assessment rows like the explicit transitionStatus
+  path does.

--- a/changelog.d/863.added.md
+++ b/changelog.d/863.added.md
@@ -6,4 +6,6 @@
   TreatmentPlanService.create() also fires the publisher when the request
   supplies a non-PLANNED initial status, so the create-with-IN_PROGRESS
   path reaches affected assessment rows like the explicit transitionStatus
-  path does.
+  path does. Field-name keys in the publishers are hoisted to constants
+  (`FIELD_STATUS`, `FIELD_EFFECTIVENESS`, `FIELD_ASSET_TYPE`, …) so renames
+  apply uniformly across all branches.

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -389,3 +389,22 @@ restore procedure.
 - PRs require: `./gradlew check` passes (build + spotlessCheck + test + jacocoTestReport).
 - Commit messages: imperative mood. `Add risk scoring engine` not `Added risk scoring engine`.
 - Pre-commit hooks run file checks + gitleaks + Spotless auto-format + `./gradlew check` (full CI-equivalent: build + tests + static analysis + coverage) + `./gradlew openjmlEsc` (formal verification of JML contracts in ESC scope) + Terraform fmt/validate + Checkov IaC security scanning (on `deploy/terraform/`). Do not bypass with `--no-verify`.
+
+## Enum placement under `domain/**/state/`
+
+The `state/` package holds two distinct kinds of enums and the formal-methods
+classification depends on which kind:
+
+- **State machines.** Enums that define a `canTransitionTo(...)` lifecycle,
+  for example `TreatmentPlanStatus` and `ControlStatus`. These are L1+
+  contract surfaces; transition rules must be unit-tested and ADR-012's L1
+  rule applies.
+- **Tag enums.** Enums that are pure classifiers with no transition surface,
+  for example `AssetLinkTargetType`, and the `ReassessmentTriggerCategory` /
+  `ReassessmentTriggerTargetType` added for GC-T004 / C8 in issue #863.
+  These are L0 data; the placement under `state/` follows convention only.
+
+When adding a new file under `state/`, classify it explicitly in the file
+header or the introducing PR's plan. The policy rule that requires this
+section to be touched alongside new state files is a forcing function; the
+real classification is the one above.

--- a/docs/DOC_STYLE.md
+++ b/docs/DOC_STYLE.md
@@ -94,3 +94,12 @@ both work, but `server.registerTool({inputSchema: <raw JSON Schema>})` passes
 the registration gate and crashes every call with
 `v3Schema.safeParseAsync is not a function`. New tools should match the
 `server.tool` pattern used by the bulk of the file.
+
+## MCP shape extensions are not doc edits
+
+Additive Zod schema fields or new entries in `mcp/ground-control/lib.js`'s
+`TO_CAMEL` map (for example, the typed reassessment-trigger shape added for
+GC-T004 / C8 in issue #863) do not by themselves require new reference-doc
+prose. The MCP tool description string in `gc-risk-governance.js` is the
+contract surface; keep it accurate when adding or removing fields, and the
+changelog fragment in `changelog.d/` carries the temporal record.

--- a/mcp/ground-control/gc-risk-governance.js
+++ b/mcp/ground-control/gc-risk-governance.js
@@ -87,7 +87,66 @@ export const gcRiskGovernanceZodShape = {
     assignee: z.string().optional(),
     description: z.string().optional(),
   })).optional(),
-  reassessment_triggers: z.array(z.string()).optional(),
+  reassessment_triggers: z.array(z.object({
+    category: z.enum([
+      "TREATMENT_PROGRESS_CHANGED",
+      "ASSET_STATE_CHANGED",
+      "CONTROL_STATE_CHANGED",
+      "ASSESSMENT_REFRESH",
+      "METHODOLOGY_SPECIFIC",
+    ]),
+    target_type: z.enum([
+      "ASSET", "CONTROL", "RISK_SCENARIO", "RISK_REGISTER_RECORD",
+      "RISK_ASSESSMENT_RESULT", "TREATMENT_PLAN", "EXTERNAL",
+    ]).optional(),
+    target_entity_id: z.string().uuid().optional(),
+    target_identifier: z.string().optional(),
+    note: z.string().optional(),
+  }).superRefine((t, ctx) => {
+    // GC-T004 / C8 (#863), codex cycle-1 finding #2: the trigger target is a
+    // coherent typed reference, not three independent optionals. Mirror the
+    // backend invariant at the MCP boundary so bad calls fail before
+    // round-tripping through the API.
+    const hasIdentifier = t.target_identifier != null && t.target_identifier.length > 0;
+    const hasEntityId = t.target_entity_id != null;
+    if (t.target_type == null) {
+      if (hasEntityId || hasIdentifier) {
+        ctx.addIssue({
+          code: "custom",
+          message: "target_entity_id / target_identifier require target_type",
+        });
+      }
+      return;
+    }
+    if (t.target_type === "EXTERNAL") {
+      if (hasEntityId) {
+        ctx.addIssue({
+          code: "custom",
+          message: "target_type=EXTERNAL must not set target_entity_id",
+        });
+      }
+      if (!hasIdentifier) {
+        ctx.addIssue({
+          code: "custom",
+          message: "target_type=EXTERNAL requires target_identifier",
+        });
+      }
+    } else {
+      if (hasIdentifier) {
+        ctx.addIssue({
+          code: "custom",
+          message: `target_type=${t.target_type} must not set target_identifier`,
+        });
+      }
+      if (!hasEntityId) {
+        ctx.addIssue({
+          code: "custom",
+          message: `target_type=${t.target_type} requires target_entity_id`,
+        });
+      }
+    }
+  })).optional(),
+  reassessment_required_at: z.string().optional(),
   outcome: z.string().optional(),
   assurance_level: z.enum(ASSURANCE_LEVELS).optional(),
   verified_at: z.string().optional(),
@@ -101,7 +160,7 @@ export const GC_RISK_GOVERNANCE_DESCRIPTION =
   `Per-entity create fields (snake_case; round-trip to backend camelCase): ` +
   `risk_register_record={uid,title,owner,review_cadence,next_review_at,category_tags,decision_metadata,asset_scope_summary,risk_scenario_ids}; ` +
   `risk_assessment_result={risk_scenario_id,risk_register_record_id,methodology_profile_id,analyst_identity,assumptions,input_factors,observation_date,assessment_at,time_horizon,confidence,uncertainty_metadata,computed_outputs,evidence_refs,notes,observation_ids}; ` +
-  `treatment_plan={uid,title,risk_scenario_id,risk_register_record_id,strategy,owner,rationale,due_date,status,action_items,reassessment_triggers,methodology_profile_id,methodology_strategy_key}. ` +
+  `treatment_plan={uid,title,risk_scenario_id,risk_register_record_id,strategy,owner,rationale,due_date,status,action_items,reassessment_triggers[{category,target_type,target_entity_id,target_identifier,note}],methodology_profile_id,methodology_strategy_key}. ` +
   `Update DTOs drop create-only foreign keys (uid; risk_register_record_id for treatment_plan; risk_scenario_id for risk_assessment_result) and status fields whose changes go through the transition action. ` +
   `Unknown fields are dropped — never tunneled through metadata.`;
 

--- a/mcp/ground-control/gc-risk-governance.test.js
+++ b/mcp/ground-control/gc-risk-governance.test.js
@@ -462,7 +462,11 @@ describe("treatment_plan wire body (#880)", () => {
       due_date: "2026-06-30T00:00:00Z",
       status: "PLANNED",
       action_items: [{ owner: "team-y", due_date: "2026-07-15T00:00:00Z", status: "PLANNED" }],
-      reassessment_triggers: ["new evidence", "control change"],
+      reassessment_triggers: [
+        { category: "ASSESSMENT_REFRESH", note: "new evidence" },
+        { category: "CONTROL_STATE_CHANGED", target_type: "CONTROL",
+          target_entity_id: "11111111-1111-1111-1111-111111111111" },
+      ],
     });
     assert.equal(calls.length, 1);
     assert.equal(calls[0].method, "POST");
@@ -478,7 +482,11 @@ describe("treatment_plan wire body (#880)", () => {
       dueDate: "2026-06-30T00:00:00Z",
       status: "PLANNED",
       actionItems: [{ owner: "team-y", dueDate: "2026-07-15T00:00:00Z", status: "PLANNED" }],
-      reassessmentTriggers: ["new evidence", "control change"],
+      reassessmentTriggers: [
+        { category: "ASSESSMENT_REFRESH", note: "new evidence" },
+        { category: "CONTROL_STATE_CHANGED", targetType: "CONTROL",
+          targetEntityId: "11111111-1111-1111-1111-111111111111" },
+      ],
     });
   });
 

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -728,6 +728,7 @@ const TO_CAMEL = {
   due_date: "dueDate",
   action_items: "actionItems",
   reassessment_triggers: "reassessmentTriggers",
+  reassessment_required_at: "reassessmentRequiredAt",
   root_node_ids: "rootNodeIds",
   max_depth: "maxDepth",
   source_node_id: "sourceNodeId",


### PR DESCRIPTION
## Summary

Wires GC-T004 / C8: typed reassessment triggers on TreatmentPlan, ApplicationEventPublisher in TreatmentPlan/Asset/Control services, and a synchronous ReassessmentSignalService that writes RiskAssessmentResult.reassessmentRequiredAt atomically with the publishing transaction.

## Requirement UIDs

- `GC-T004`

## Related Issues

Closes #863

## ADR Impact

- ADR-012
- ADR-054

## Changes

- TreatmentPlan.reassessmentTriggers becomes List<ReassessmentTrigger>; converter folds legacy strings into METHODOLOGY_SPECIFIC notes on read
- ReassessmentTrigger + category/target enums; service-layer validation enforces coherent target shape
- GraphTargetResolverService.validateReassessmentTriggerTarget for project-scoped target resolution
- TreatmentPlan/Asset/Control services publish state-change events on the covered mutation paths; no-op writes don't fire
- ReassessmentSignalService consumes the three events via @EventListener inline in the publishing transaction (not best-effort)
- V126 migration adds reassessment_required_at on risk_assessment_result + audit shadow with a partial NOT NULL index
- MCP gc_risk_governance Zod shape mirrors the typed trigger contract with a superRefine for target coherence
- **Migration reminder:** update version lists in `MigrationSmokeTest.java` and `RequirementsE2EIntegrationTest.java` (per `.gc/plan-rules.md`).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/ReassessmentTrigger.java, backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/ReassessmentSignalService.java, backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/TreatmentPlanService.java, backend/src/main/java/com/keplerops/groundcontrol/domain/assets/service/AssetService.java, backend/src/main/java/com/keplerops/groundcontrol/domain/controls/service/ControlService.java, backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/GraphTargetResolverService.java, backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/model/RiskAssessmentResult.java, backend/src/main/resources/db/migration/V126__add_risk_assessment_result_reassessment_required_at.sql
- TESTS: backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ReassessmentSignalServiceTest.java, backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TreatmentPlanServiceTest.java, backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AssetServiceTest.java, backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ControlServiceTest.java, backend/src/test/java/com/keplerops/groundcontrol/unit/domain/GraphTargetResolverServiceTest.java, backend/src/test/java/com/keplerops/groundcontrol/unit/shared/JacksonTextCollectionConvertersTest.java, backend/src/test/java/com/keplerops/groundcontrol/integration/ReassessmentSignalIntegrationTest.java, mcp/ground-control/gc-risk-governance.test.js

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/863.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed


## Documentation

Outcome: `updated`

- `architecture/adrs/012-formal-methods-process.md` — added Implementation Status note clarifying that tag enums under `domain/**/state/` (the new `ReassessmentTriggerCategory` / `ReassessmentTriggerTargetType`) are L0 data classifiers, not L1+ contract surfaces.
- `architecture/adrs/054-documentation-coverage-gate.md` — added a References entry recording the additive MCP surface extension for typed reassessment triggers; no classifier change needed (`mcp/ground-control/lib.js` is already a `config_parser` surface).
- `docs/CODING_STANDARDS.md` — added "Enum placement under `domain/**/state/`" section distinguishing state machines from tag enums.
- `docs/DOC_STYLE.md` — added "MCP shape extensions are not doc edits" section.
- `architecture/notes/risk-treatment-plan-preflight.md` — codex preflight appended the C8 binding guardrails section (Categorised Reassessment Triggers #863 / C8).
