### PR TITLE
feat(projects): add Research project type + intake metadata (#999)

### DIFF
--- a/architecture/adrs/054-documentation-coverage-gate.md
+++ b/architecture/adrs/054-documentation-coverage-gate.md
@@ -95,6 +95,15 @@ A new MCP tool `gc_documentation_coverage` exposes the classifier to agents:
 input `{ repo_path, changed_paths[] }`, output
 `{ ok, classifications[], outcome_required, suggested_doc_targets[] }`.
 
+**MCP-surface additions are classified `mcp_tool`.** New `gc_admin` actions
+(for example `replace_research_intake` in issue #999) or any future
+`gc_*` tool registered in `mcp/ground-control/index.js` inherit the existing
+`mcp_tool` classification on path basis; the closed-vocabulary classifier
+does not need an update per-action. The gate-sync rule
+(`doc-coverage-gate-sync` in `architecture/policies/adr-policy.json`) fires
+whenever the listed trigger paths change so this ADR and `DOC_STYLE.md` stay
+current with the actual classifier surface.
+
 ## Consequences
 
 - PRs that modify a classified surface must supply `documentation_outcome` or

--- a/architecture/adrs/056-research-project-type-and-intake.md
+++ b/architecture/adrs/056-research-project-type-and-intake.md
@@ -1,0 +1,97 @@
+# ADR-056: Research project type and intake metadata
+
+## Status
+
+accepted
+
+## Date
+
+2026-05-26
+
+## Context
+
+Ground Control projects are the top-level workspace abstraction. Until now the `project` entity carried only `identifier`, `name`, and `description`—software, GRC, and (after ADR-055) research workspaces were distinguished by convention, not by schema. The acceptance criteria for issue #999 require:
+
+- a user can create or update a project as type Research,
+- research intake fields are persisted and returned through the API,
+- research projects appear in list/detail responses with their project type,
+- non-research projects require no new research-only fields to remain valid.
+
+Five requirements scope the work: `GC-RSCH-F001` (intake fields: research goal, paper context, target contribution type, intended output, autonomy level, allowed tools, privacy constraints, cost/compute budget), `GC-RSCH-R007` (distinguish literature-based work from experiment-running auto-research), and three forward-looking ones (`GC-RSCH-R001` workflow phases, `GC-RSCH-F002` task classification, `GC-RSCH-N011` observability) that describe research workflow internals which assume the intake foundation this ADR delivers exists. The three forward-looking requirements remain DRAFT after this PR; subsequent issues implement the workflow on top of the foundation.
+
+ADR-055 (research workflow skills + citation MCP) shipped the agent-side workflow but explicitly deferred the Java-domain project-type registration to a separate ADR when a typed enum is later wanted. This is that ADR.
+
+## Decision
+
+### 1. `ProjectType` as a closed enum
+
+Add a `type` column to `project` typed as a closed `ProjectType` enum with three values: `SOFTWARE`, `GRC`, `RESEARCH`. The column is `NOT NULL`. Migration V126 backfills existing rows to `SOFTWARE` (the implicit historical default before this PR). New types require an ADR + migration; the enum is closed at the API boundary (invalid values produce 422 with `validation_error`).
+
+`SOFTWARE` is the default for new projects when the client omits `type`, preserving backward compatibility with API clients that do not set the field.
+
+### 2. `ResearchIntake` is a separate aggregate, 1:1 with `Project`
+
+Research intake metadata (~10 fields) lives in a new `ResearchIntake` entity at `domain/research/model/ResearchIntake.java`, joined 1:1 with `Project` by `project_id`. The intake row exists if and only if `Project.type = RESEARCH`. Rejected alternatives:
+
+- **Nullable columns on `Project`.** Adding 10 research-only nullable columns to `Project` makes the entity a junk-drawer that mixes type-agnostic identity (`identifier`, `name`, `description`) with type-specific intake. Every read of `Project` would need to branch on `type` to know which columns are meaningful. Validation would split across the boundary.
+- **JPA Single Table Inheritance (`SoftwareProject`, `GrcProject`, `ResearchProject`).** Ground Control's domain pattern is flat aggregates inheriting `BaseEntity` with explicit references (for example, `TreatmentPlan` is a sibling of `RiskScenario`, not a subclass of `Project`). STI would be net-new architecture for a single type-specific extension.
+- **JSON `intake` column on `Project`.** Defeats Bean Validation on the structured intake fields and loses Envers history per field. The codebase only uses JSON columns for fundamentally polymorphic collections (for example, `action_items` on `TreatmentPlan`), not for structured records.
+
+A separate aggregate keeps `Project` flat, keeps research-only validation localised, and lets `ResearchIntake` carry its own Envers history.
+
+### 3. `ResearchIntake` is `@Audited`; `Project` stays non-audited
+
+Changes to research intake matter for provenance once the workflow phases run on top (per `GC-RSCH-N011`'s observability requirement). `Project` itself remains non-audited (unchanged from current state). The `@ManyToOne` reference from `ResearchIntake` to `Project` is `@NotAudited`, matching the plan rule and the existing `TreatmentPlan → Project` pattern. Migration V127 creates `research_intake_audit` via the standard Envers shadow-table pattern.
+
+### 4. Enums for closed vocabularies under `ResearchIntake`
+
+- `ContributionType`: `TAXONOMY`, `REVIEW`, `EMPIRICAL_STUDY`, `METHODOLOGY`, `POSITION`, `OTHER`.
+- `IntendedOutput`: `SCOPING_REVIEW`, `SYSTEMATIC_REVIEW`, `SYSTEMATIC_MAP`, `CRITICAL_REVIEW`, `NARRATIVE_REVIEW`, `TARGETED_RELATED_WORK`, `TAXONOMY_PAPER`, `OTHER`. The seven non-`OTHER` values mirror the seven method keys in `skills/lit-review/methodology/catalog.yaml` so the downstream `lit-review` phase-1 skill can derive a methodology choice from the intake. `OTHER` keeps the enum open at the edges without making the field free-form.
+- `AutonomyLevel`: `COPILOT`, `AUTONOMOUS`. Matches the user-gate vocabulary in the lit-review skills.
+
+Closed enums match how the codebase represents `TreatmentStrategy`, `TreatmentPlanStatus`, `ActionItemStatus`—invalid values are 422 at the API boundary with a `validValues` hint, the existing `ErrorResponse` envelope shape.
+
+### 5. `allowedTools` as a typed `Set<String>`
+
+Tool identifiers (for example, `cite_resolve`, `python`, `web_search`) are operator-extensible and not a fixed vocabulary, so they cannot be an enum. Stored as a Jackson-converted `Set<String>` on a TEXT column using the existing `JacksonTextCollectionConverters.StringListConverter` pattern. Set semantics (uniqueness, no order) match the meaning of the tools the operator has authorised. An empty set means no tools authorised (the run is read-only and has no side effects); a `null` set is rejected by Bean Validation when `type = RESEARCH`.
+
+### 6. Budget fields are typed and optional
+
+- `budgetTokens BIGINT` (nullable)—token cap; `null` means unbounded.
+- `budgetWallClockMinutes INTEGER` (nullable)—wall-clock cap; `null` means unbounded.
+- `budgetCostUsdMicros BIGINT` (nullable)—cost cap in USD micros (1 USD = 1,000,000 micros). `BIGINT` micros avoid `DECIMAL` round-trips in Jackson and Postgres-driver edge cases; conversion to USD for display is the API/UI's job.
+
+Each is individually optional. Service-layer logging records when an intake is created with no caps (`research_intake_created: no_budget_caps=true`) so operators can audit unbounded runs.
+
+### 7. "Intake required iff type = RESEARCH" enforcement
+
+Two layers:
+
+- **Bean Validation at the API boundary** (`ProjectRequest`, `UpdateProjectRequest`). A custom class-level constraint `@ResearchIntakeRequired` rejects payloads where `type = RESEARCH` and `researchIntake` is null, or where `type != RESEARCH` and `researchIntake` is non-null. 422 with the existing `validation_error` envelope shape.
+- **Service-layer guard** (`ProjectService.validateIntakeAgainstType`). Mirrors the same rule for bypass writes that skip API validation (programmatic creates from tests, migrations, or future intra-backend callers). This is the same defence-in-depth pattern PR #997 used for typed action items: API constraint + service guard.
+
+`update` allows `type` to change only via an explicit `changeProjectType` operation (out of scope for this PR—no AC requires it). Updating intake fields on an existing RESEARCH project goes through `PUT /api/v1/projects/{identifier}/research-intake`, decoupled from project name/description updates so each field has clean change tracking.
+
+### 8. API shape
+
+- `POST /api/v1/projects`—accepts `{identifier, name, description, type?, researchIntake?}`. `type` defaults to `SOFTWARE` if omitted.
+- `GET /api/v1/projects` and `GET /api/v1/projects/{identifier}`—include `type` always; `researchIntake` is present when `type = RESEARCH`, absent otherwise.
+- `PUT /api/v1/projects/{identifier}`—name/description updates (unchanged plus the validation guard).
+- `PUT /api/v1/projects/{identifier}/research-intake`—full replacement of the intake row for a RESEARCH project; 422 if the project is not RESEARCH (semantic validation error, not a resource-state conflict); 404 if the project doesn't exist or has no intake; 422 on field-level validation errors.
+
+Per the plan rules, every new endpoint ships with `@WebMvcTest` controller slice tests (the sonar CI job does not run Testcontainers).
+
+## Consequences
+
+- Existing rows in `project` get `type = SOFTWARE` via V126. Existing API clients that omit `type` continue to get `SOFTWARE`. No breaking change for non-research callers.
+- `GC-RSCH-F001` and `GC-RSCH-R007` transition DRAFT → ACTIVE with this PR. `GC-RSCH-R001`, `GC-RSCH-F002`, `GC-RSCH-N011` stay DRAFT with `DOCUMENTS` links to issue #999; subsequent issues materialise the workflow phases, task classification, and observability on top of the intake foundation this ADR delivers.
+- Future work—phase state machine, task classification per phase, observability of gates and cost—extends `ResearchIntake` and adds sibling aggregates (for example, `ResearchRun`, `PhaseGate`) rather than re-shaping `Project`.
+- The frontend gets the project type in every list/detail response and can route to research-specific intake forms. Frontend work is out of scope for this PR (no UI is required for backend AC); the React side picks this up in a separate issue.
+
+## Alternatives considered
+
+**Allow `type` to change post-creation via plain `PUT /api/v1/projects/{id}`.** Rejected: changing a project's type after creation has cascading effects on adjacent data (a RESEARCH→SOFTWARE flip would orphan the intake row; a SOFTWARE→RESEARCH flip would require synthesising an intake from nothing). Out of scope for this PR; if a use case appears, a dedicated `changeProjectType` operation with explicit operator authorisation is the right shape.
+
+**Make `type` part of the `identifier` (`research/foo`, `software/bar`).** Rejected: identifier is currently a single segment; restructuring it would break every external reference (Linear, dashboards, URLs, traceability links—the `project_identifier` field in every requirement currently carries the unsegmented form). The schema column `type` is the right tool.
+
+**Store the seven `IntendedOutput` values by reference to `skills/lit-review/methodology/catalog.yaml`.** Rejected: the backend should not load + parse a skill-side YAML at runtime; the enum is the contract, the catalog is the agent-side method-source mapping that consumes the enum's choices. If the catalog adds an eighth method, that's an enum addition (ADR + migration) plus a catalog entry—both are deliberate decisions.

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/projects/ProjectController.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/projects/ProjectController.java
@@ -1,8 +1,11 @@
 package com.keplerops.groundcontrol.api.projects;
 
+import com.keplerops.groundcontrol.api.research.ResearchIntakeRequest;
+import com.keplerops.groundcontrol.api.research.ResearchIntakeResponse;
 import com.keplerops.groundcontrol.domain.projects.service.CreateProjectCommand;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.projects.service.UpdateProjectCommand;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeService;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -20,31 +23,57 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProjectController {
 
     private final ProjectService projectService;
+    private final ResearchIntakeService researchIntakeService;
 
-    public ProjectController(ProjectService projectService) {
+    public ProjectController(ProjectService projectService, ResearchIntakeService researchIntakeService) {
         this.projectService = projectService;
+        this.researchIntakeService = researchIntakeService;
     }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ProjectResponse create(@Valid @RequestBody ProjectRequest request) {
-        var command = new CreateProjectCommand(request.identifier(), request.name(), request.description());
-        return ProjectResponse.from(projectService.create(command));
+        var command = new CreateProjectCommand(
+                request.identifier(),
+                request.name(),
+                request.description(),
+                request.type(),
+                request.researchIntake() == null
+                        ? null
+                        : request.researchIntake().toCommand());
+        var project = projectService.create(command);
+        return ProjectResponse.from(
+                project, researchIntakeService.findByProject(project).orElse(null));
     }
 
     @GetMapping
     public List<ProjectResponse> list() {
-        return projectService.list().stream().map(ProjectResponse::from).toList();
+        return projectService.list().stream()
+                .map(p -> ProjectResponse.from(
+                        p, researchIntakeService.findByProject(p).orElse(null)))
+                .toList();
     }
 
     @GetMapping("/{identifier}")
     public ProjectResponse getByIdentifier(@PathVariable String identifier) {
-        return ProjectResponse.from(projectService.getByIdentifier(identifier));
+        var project = projectService.getByIdentifier(identifier);
+        return ProjectResponse.from(
+                project, researchIntakeService.findByProject(project).orElse(null));
     }
 
     @PutMapping("/{identifier}")
     public ProjectResponse update(@PathVariable String identifier, @Valid @RequestBody UpdateProjectRequest request) {
         var command = new UpdateProjectCommand(request.name(), request.description());
-        return ProjectResponse.from(projectService.updateByIdentifier(identifier, command));
+        var project = projectService.updateByIdentifier(identifier, command);
+        return ProjectResponse.from(
+                project, researchIntakeService.findByProject(project).orElse(null));
+    }
+
+    @PutMapping("/{identifier}/research-intake")
+    public ResearchIntakeResponse replaceResearchIntake(
+            @PathVariable String identifier, @Valid @RequestBody ResearchIntakeRequest request) {
+        var project = projectService.getByIdentifier(identifier);
+        var saved = researchIntakeService.replace(project, request.toCommand());
+        return ResearchIntakeResponse.from(saved);
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/projects/ProjectRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/projects/ProjectRequest.java
@@ -1,10 +1,29 @@
 package com.keplerops.groundcontrol.api.projects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.keplerops.groundcontrol.api.research.ResearchIntakeRequest;
+import com.keplerops.groundcontrol.domain.projects.model.ProjectType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+/**
+ * Create-project request. {@code type} defaults to {@link ProjectType#SOFTWARE}
+ * if omitted (preserves backward compatibility for pre-ADR-056 clients).
+ * {@code researchIntake} must be present iff {@code type == RESEARCH};
+ * enforced by the service layer so the rule is uniform across bypass writes
+ * (the API and service guard agree).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ProjectRequest(
         @NotBlank @Size(max = 50) @Pattern(regexp = "[a-z0-9-]+") String identifier,
         @NotBlank @Size(max = 255) String name,
-        String description) {}
+        String description,
+        ProjectType type,
+        @Valid ResearchIntakeRequest researchIntake) {
+
+    public ProjectRequest(String identifier, String name, String description) {
+        this(identifier, name, description, null, null);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/projects/ProjectResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/projects/ProjectResponse.java
@@ -1,14 +1,37 @@
 package com.keplerops.groundcontrol.api.projects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.keplerops.groundcontrol.api.research.ResearchIntakeResponse;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.model.ProjectType;
+import com.keplerops.groundcontrol.domain.research.model.ResearchIntake;
 import java.time.Instant;
 import java.util.UUID;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ProjectResponse(
-        UUID id, String identifier, String name, String description, Instant createdAt, Instant updatedAt) {
+        UUID id,
+        String identifier,
+        String name,
+        String description,
+        ProjectType type,
+        Instant createdAt,
+        Instant updatedAt,
+        ResearchIntakeResponse researchIntake) {
 
     public static ProjectResponse from(Project p) {
+        return from(p, null);
+    }
+
+    public static ProjectResponse from(Project p, ResearchIntake intake) {
         return new ProjectResponse(
-                p.getId(), p.getIdentifier(), p.getName(), p.getDescription(), p.getCreatedAt(), p.getUpdatedAt());
+                p.getId(),
+                p.getIdentifier(),
+                p.getName(),
+                p.getDescription(),
+                p.getType(),
+                p.getCreatedAt(),
+                p.getUpdatedAt(),
+                intake == null ? null : ResearchIntakeResponse.from(intake));
     }
 }

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/research/ResearchIntakeRequest.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/research/ResearchIntakeRequest.java
@@ -1,0 +1,45 @@
+package com.keplerops.groundcontrol.api.research;
+
+import com.keplerops.groundcontrol.domain.research.model.AutonomyLevel;
+import com.keplerops.groundcontrol.domain.research.model.ContributionType;
+import com.keplerops.groundcontrol.domain.research.model.IntendedOutput;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * REST input shape for ResearchIntake. Used both nested inside ProjectRequest
+ * on create and as the body of {@code PUT /research-intake/{identifier}} on
+ * full-replacement updates. Required fields are enforced by Bean Validation
+ * here and re-checked at the service layer for bypass writes. See ADR-056.
+ */
+public record ResearchIntakeRequest(
+        @NotBlank @Size(max = 4000) String goal,
+        @Size(max = 8000) String paperContext,
+        @NotNull ContributionType contributionType,
+        @NotNull IntendedOutput intendedOutput,
+        @NotNull AutonomyLevel autonomyLevel,
+        @NotNull List<@NotBlank @Size(max = 100) String> allowedTools,
+        @Size(max = 4000) String privacyConstraints,
+        @PositiveOrZero Long budgetTokens,
+        @PositiveOrZero Integer budgetWallClockMinutes,
+        @PositiveOrZero Long budgetCostUsdMicros) {
+
+    public ResearchIntakeCommand toCommand() {
+        return new ResearchIntakeCommand(
+                goal,
+                paperContext,
+                contributionType,
+                intendedOutput,
+                autonomyLevel,
+                allowedTools == null ? new ArrayList<>() : new ArrayList<>(allowedTools),
+                privacyConstraints,
+                budgetTokens,
+                budgetWallClockMinutes,
+                budgetCostUsdMicros);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/api/research/ResearchIntakeResponse.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/api/research/ResearchIntakeResponse.java
@@ -1,0 +1,49 @@
+package com.keplerops.groundcontrol.api.research;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.keplerops.groundcontrol.domain.research.model.AutonomyLevel;
+import com.keplerops.groundcontrol.domain.research.model.ContributionType;
+import com.keplerops.groundcontrol.domain.research.model.IntendedOutput;
+import com.keplerops.groundcontrol.domain.research.model.ResearchIntake;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * REST output shape for ResearchIntake. Returned nested inside
+ * {@code ProjectResponse} for RESEARCH projects and as the body of
+ * {@code PUT /research-intake/{identifier}}.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ResearchIntakeResponse(
+        UUID id,
+        String goal,
+        String paperContext,
+        ContributionType contributionType,
+        IntendedOutput intendedOutput,
+        AutonomyLevel autonomyLevel,
+        List<String> allowedTools,
+        String privacyConstraints,
+        Long budgetTokens,
+        Integer budgetWallClockMinutes,
+        Long budgetCostUsdMicros,
+        Instant createdAt,
+        Instant updatedAt) {
+
+    public static ResearchIntakeResponse from(ResearchIntake intake) {
+        return new ResearchIntakeResponse(
+                intake.getId(),
+                intake.getGoal(),
+                intake.getPaperContext(),
+                intake.getContributionType(),
+                intake.getIntendedOutput(),
+                intake.getAutonomyLevel(),
+                List.copyOf(intake.getAllowedTools()),
+                intake.getPrivacyConstraints(),
+                intake.getBudgetTokens(),
+                intake.getBudgetWallClockMinutes(),
+                intake.getBudgetCostUsdMicros(),
+                intake.getCreatedAt(),
+                intake.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/projects/model/Project.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/projects/model/Project.java
@@ -3,6 +3,8 @@ package com.keplerops.groundcontrol.domain.projects.model;
 import com.keplerops.groundcontrol.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 
 @Entity
@@ -18,13 +20,22 @@ public class Project extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String description;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ProjectType type = ProjectType.SOFTWARE;
+
     protected Project() {
         // JPA
     }
 
     public Project(String identifier, String name) {
+        this(identifier, name, ProjectType.SOFTWARE);
+    }
+
+    public Project(String identifier, String name, ProjectType type) {
         this.identifier = identifier;
         this.name = name;
+        this.type = type == null ? ProjectType.SOFTWARE : type;
     }
 
     public String getIdentifier() {
@@ -45,6 +56,10 @@ public class Project extends BaseEntity {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public ProjectType getType() {
+        return type;
     }
 
     @Override

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/projects/model/ProjectType.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/projects/model/ProjectType.java
@@ -1,0 +1,14 @@
+package com.keplerops.groundcontrol.domain.projects.model;
+
+/**
+ * Closed enum of Ground Control project types. See ADR-056.
+ *
+ * <p>Adding a new type is an ADR + migration decision; the enum is closed at
+ * the API boundary. SOFTWARE is the default for clients that omit `type` on
+ * create, preserving backward compatibility for pre-ADR-056 callers.
+ */
+public enum ProjectType {
+    SOFTWARE,
+    GRC,
+    RESEARCH
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/projects/service/CreateProjectCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/projects/service/CreateProjectCommand.java
@@ -1,3 +1,19 @@
 package com.keplerops.groundcontrol.domain.projects.service;
 
-public record CreateProjectCommand(String identifier, String name, String description) {}
+import com.keplerops.groundcontrol.domain.projects.model.ProjectType;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeCommand;
+
+/**
+ * Command DTO for creating a Project. {@code type} defaults to
+ * {@link ProjectType#SOFTWARE} when null; {@code researchIntake} must be
+ * present iff {@code type == RESEARCH}. The service enforces the
+ * intake-vs-type invariant; the API also enforces it at the validation layer.
+ */
+public record CreateProjectCommand(
+        String identifier, String name, String description, ProjectType type, ResearchIntakeCommand researchIntake) {
+
+    /** Backward-compatible constructor for callers that don't supply a type. */
+    public CreateProjectCommand(String identifier, String name, String description) {
+        this(identifier, name, description, ProjectType.SOFTWARE, null);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/projects/service/ProjectService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/projects/service/ProjectService.java
@@ -4,7 +4,9 @@ import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.model.ProjectType;
 import com.keplerops.groundcontrol.domain.projects.repository.ProjectRepository;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeService;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -20,22 +22,45 @@ public class ProjectService {
     private static final Logger log = LoggerFactory.getLogger(ProjectService.class);
 
     private final ProjectRepository projectRepository;
+    private final ResearchIntakeService researchIntakeService;
 
-    public ProjectService(ProjectRepository projectRepository) {
+    public ProjectService(ProjectRepository projectRepository, ResearchIntakeService researchIntakeService) {
         this.projectRepository = projectRepository;
+        this.researchIntakeService = researchIntakeService;
     }
 
     public Project create(CreateProjectCommand command) {
         if (projectRepository.existsByIdentifier(command.identifier())) {
             throw new ConflictException("Project with identifier '" + command.identifier() + "' already exists");
         }
-        var project = new Project(command.identifier(), command.name());
+        var resolvedType = command.type() == null ? ProjectType.SOFTWARE : command.type();
+        validateIntakeAgainstType(resolvedType, command.researchIntake());
+        var project = new Project(command.identifier(), command.name(), resolvedType);
         if (command.description() != null) {
             project.setDescription(command.description());
         }
         var saved = projectRepository.save(project);
-        log.info("project_created: identifier={} id={}", saved.getIdentifier(), saved.getId());
+        log.info("project_created: identifier={} id={} type={}", saved.getIdentifier(), saved.getId(), saved.getType());
+        if (resolvedType == ProjectType.RESEARCH && command.researchIntake() != null) {
+            researchIntakeService.create(saved, command.researchIntake());
+        }
         return saved;
+    }
+
+    private void validateIntakeAgainstType(
+            ProjectType type, com.keplerops.groundcontrol.domain.research.service.ResearchIntakeCommand intake) {
+        if (type == ProjectType.RESEARCH && intake == null) {
+            throw new DomainValidationException(
+                    "type=RESEARCH requires researchIntake to be present",
+                    "research_intake_required",
+                    Map.of("type", type.name()));
+        }
+        if (type != ProjectType.RESEARCH && intake != null) {
+            throw new DomainValidationException(
+                    "researchIntake is only allowed when type=RESEARCH",
+                    "research_intake_not_allowed",
+                    Map.of("type", type.name()));
+        }
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/research/model/AutonomyLevel.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/research/model/AutonomyLevel.java
@@ -1,0 +1,12 @@
+package com.keplerops.groundcontrol.domain.research.model;
+
+/**
+ * How autonomously the research run executes. COPILOT gates more user
+ * decisions; AUTONOMOUS proceeds with declared defaults unless a gate is
+ * marked mandatory. Matches the user-gate vocabulary in the lit-review
+ * skills. See ADR-056.
+ */
+public enum AutonomyLevel {
+    COPILOT,
+    AUTONOMOUS
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/research/model/ContributionType.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/research/model/ContributionType.java
@@ -1,0 +1,11 @@
+package com.keplerops.groundcontrol.domain.research.model;
+
+/** What kind of contribution the research paper is making. See ADR-056. */
+public enum ContributionType {
+    TAXONOMY,
+    REVIEW,
+    EMPIRICAL_STUDY,
+    METHODOLOGY,
+    POSITION,
+    OTHER
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/research/model/IntendedOutput.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/research/model/IntendedOutput.java
@@ -1,0 +1,18 @@
+package com.keplerops.groundcontrol.domain.research.model;
+
+/**
+ * Intended output shape of the research run. Non-OTHER values mirror the
+ * method keys in {@code skills/lit-review/methodology/catalog.yaml} so the
+ * phase-1 lit-review skill can derive a methodology choice from the intake.
+ * See ADR-056.
+ */
+public enum IntendedOutput {
+    SCOPING_REVIEW,
+    SYSTEMATIC_REVIEW,
+    SYSTEMATIC_MAP,
+    CRITICAL_REVIEW,
+    NARRATIVE_REVIEW,
+    TARGETED_RELATED_WORK,
+    TAXONOMY_PAPER,
+    OTHER
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/research/model/ResearchIntake.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/research/model/ResearchIntake.java
@@ -1,0 +1,178 @@
+package com.keplerops.groundcontrol.domain.research.model;
+
+import com.keplerops.groundcontrol.domain.BaseEntity;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.shared.persistence.JacksonTextCollectionConverters;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.ArrayList;
+import java.util.List;
+import org.hibernate.envers.Audited;
+import org.hibernate.envers.NotAudited;
+
+/**
+ * Research-specific intake metadata captured at project create-or-update time.
+ * One row per {@link Project} when {@code project.type = RESEARCH}; absent for
+ * other types. See ADR-056.
+ *
+ * <p>The 1:1 invariant is enforced by the UNIQUE constraint on
+ * {@code project_id} (declared on the {@code @ManyToOne} {@code @JoinColumn}
+ * and reinforced by the DB-level UNIQUE on the migration). The "intake
+ * required iff type=RESEARCH" invariant is enforced by Bean Validation at the
+ * API boundary and a service-layer guard for bypass writes.
+ */
+@Entity
+@Audited
+@Table(name = "research_intake", uniqueConstraints = @UniqueConstraint(columnNames = {"project_id"}))
+public class ResearchIntake extends BaseEntity {
+
+    @NotAudited
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "project_id", nullable = false, unique = true)
+    private Project project;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String goal;
+
+    @Column(name = "paper_context", columnDefinition = "TEXT")
+    private String paperContext;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "contribution_type", nullable = false, length = 40)
+    private ContributionType contributionType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "intended_output", nullable = false, length = 40)
+    private IntendedOutput intendedOutput;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "autonomy_level", nullable = false, length = 20)
+    private AutonomyLevel autonomyLevel;
+
+    @Convert(converter = JacksonTextCollectionConverters.StringListConverter.class)
+    @Column(name = "allowed_tools", nullable = false, columnDefinition = "TEXT")
+    private List<String> allowedTools = new ArrayList<>();
+
+    @Column(name = "privacy_constraints", columnDefinition = "TEXT")
+    private String privacyConstraints;
+
+    @Column(name = "budget_tokens")
+    private Long budgetTokens;
+
+    @Column(name = "budget_wall_clock_minutes")
+    private Integer budgetWallClockMinutes;
+
+    @Column(name = "budget_cost_usd_micros")
+    private Long budgetCostUsdMicros;
+
+    protected ResearchIntake() {
+        // JPA
+    }
+
+    public ResearchIntake(
+            Project project,
+            String goal,
+            ContributionType contributionType,
+            IntendedOutput intendedOutput,
+            AutonomyLevel autonomyLevel,
+            List<String> allowedTools) {
+        this.project = project;
+        this.goal = goal;
+        this.contributionType = contributionType;
+        this.intendedOutput = intendedOutput;
+        this.autonomyLevel = autonomyLevel;
+        this.allowedTools = allowedTools == null ? new ArrayList<>() : new ArrayList<>(allowedTools);
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public String getGoal() {
+        return goal;
+    }
+
+    public void setGoal(String goal) {
+        this.goal = goal;
+    }
+
+    public String getPaperContext() {
+        return paperContext;
+    }
+
+    public void setPaperContext(String paperContext) {
+        this.paperContext = paperContext;
+    }
+
+    public ContributionType getContributionType() {
+        return contributionType;
+    }
+
+    public void setContributionType(ContributionType contributionType) {
+        this.contributionType = contributionType;
+    }
+
+    public IntendedOutput getIntendedOutput() {
+        return intendedOutput;
+    }
+
+    public void setIntendedOutput(IntendedOutput intendedOutput) {
+        this.intendedOutput = intendedOutput;
+    }
+
+    public AutonomyLevel getAutonomyLevel() {
+        return autonomyLevel;
+    }
+
+    public void setAutonomyLevel(AutonomyLevel autonomyLevel) {
+        this.autonomyLevel = autonomyLevel;
+    }
+
+    public List<String> getAllowedTools() {
+        return allowedTools;
+    }
+
+    public void setAllowedTools(List<String> allowedTools) {
+        this.allowedTools = allowedTools == null ? new ArrayList<>() : new ArrayList<>(allowedTools);
+    }
+
+    public String getPrivacyConstraints() {
+        return privacyConstraints;
+    }
+
+    public void setPrivacyConstraints(String privacyConstraints) {
+        this.privacyConstraints = privacyConstraints;
+    }
+
+    public Long getBudgetTokens() {
+        return budgetTokens;
+    }
+
+    public void setBudgetTokens(Long budgetTokens) {
+        this.budgetTokens = budgetTokens;
+    }
+
+    public Integer getBudgetWallClockMinutes() {
+        return budgetWallClockMinutes;
+    }
+
+    public void setBudgetWallClockMinutes(Integer budgetWallClockMinutes) {
+        this.budgetWallClockMinutes = budgetWallClockMinutes;
+    }
+
+    public Long getBudgetCostUsdMicros() {
+        return budgetCostUsdMicros;
+    }
+
+    public void setBudgetCostUsdMicros(Long budgetCostUsdMicros) {
+        this.budgetCostUsdMicros = budgetCostUsdMicros;
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/research/repository/ResearchIntakeRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/research/repository/ResearchIntakeRepository.java
@@ -1,0 +1,13 @@
+package com.keplerops.groundcontrol.domain.research.repository;
+
+import com.keplerops.groundcontrol.domain.research.model.ResearchIntake;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResearchIntakeRepository extends JpaRepository<ResearchIntake, UUID> {
+
+    Optional<ResearchIntake> findByProjectId(UUID projectId);
+
+    boolean existsByProjectId(UUID projectId);
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/research/service/ResearchIntakeCommand.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/research/service/ResearchIntakeCommand.java
@@ -1,0 +1,25 @@
+package com.keplerops.groundcontrol.domain.research.service;
+
+import com.keplerops.groundcontrol.domain.research.model.AutonomyLevel;
+import com.keplerops.groundcontrol.domain.research.model.ContributionType;
+import com.keplerops.groundcontrol.domain.research.model.IntendedOutput;
+import java.util.List;
+
+/**
+ * Service-layer command for creating or fully replacing a ResearchIntake.
+ * All fields are required when present at the service boundary; the API layer
+ * normalises optional vs required per field, and the Bean Validation +
+ * service-layer guard enforces the "intake required iff project.type=RESEARCH"
+ * invariant. See ADR-056.
+ */
+public record ResearchIntakeCommand(
+        String goal,
+        String paperContext,
+        ContributionType contributionType,
+        IntendedOutput intendedOutput,
+        AutonomyLevel autonomyLevel,
+        List<String> allowedTools,
+        String privacyConstraints,
+        Long budgetTokens,
+        Integer budgetWallClockMinutes,
+        Long budgetCostUsdMicros) {}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/research/service/ResearchIntakeService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/research/service/ResearchIntakeService.java
@@ -1,0 +1,224 @@
+package com.keplerops.groundcontrol.domain.research.service;
+
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.model.ProjectType;
+import com.keplerops.groundcontrol.domain.research.model.ResearchIntake;
+import com.keplerops.groundcontrol.domain.research.repository.ResearchIntakeRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns ResearchIntake lifecycle. Composed by ProjectService for the
+ * project-create / project-update flows; also exposes a standalone
+ * {@link #replace} for the dedicated {@code PUT /research-intake} endpoint.
+ *
+ * <p>The "intake required iff Project.type = RESEARCH" invariant is enforced
+ * here and by Bean Validation at the API boundary (defence in depth).
+ */
+@Service
+@Transactional
+public class ResearchIntakeService {
+
+    private static final Logger log = LoggerFactory.getLogger(ResearchIntakeService.class);
+
+    private static final int GOAL_MAX = 4000;
+    private static final int PAPER_CONTEXT_MAX = 8000;
+    private static final int PRIVACY_CONSTRAINTS_MAX = 4000;
+    private static final int ALLOWED_TOOL_MAX = 100;
+    private static final int ALLOWED_TOOLS_MAX_COUNT = 100;
+
+    private final ResearchIntakeRepository intakeRepository;
+
+    public ResearchIntakeService(ResearchIntakeRepository intakeRepository) {
+        this.intakeRepository = intakeRepository;
+    }
+
+    /**
+     * Create the initial ResearchIntake for a freshly-created RESEARCH project.
+     * Throws ConflictException if an intake already exists for the project.
+     */
+    public ResearchIntake create(Project project, ResearchIntakeCommand command) {
+        if (project.getType() != ProjectType.RESEARCH) {
+            throw new DomainValidationException(
+                    "ResearchIntake can only be created for RESEARCH projects",
+                    "research_intake_type_mismatch",
+                    Map.of("project_type", project.getType().name()));
+        }
+        if (intakeRepository.existsByProjectId(project.getId())) {
+            throw new ConflictException("ResearchIntake already exists for project " + project.getIdentifier());
+        }
+        validate(command);
+        var intake = new ResearchIntake(
+                project,
+                command.goal().trim(),
+                command.contributionType(),
+                command.intendedOutput(),
+                command.autonomyLevel(),
+                normaliseTools(command.allowedTools()));
+        intake.setPaperContext(emptyToNull(command.paperContext()));
+        intake.setPrivacyConstraints(emptyToNull(command.privacyConstraints()));
+        intake.setBudgetTokens(command.budgetTokens());
+        intake.setBudgetWallClockMinutes(command.budgetWallClockMinutes());
+        intake.setBudgetCostUsdMicros(command.budgetCostUsdMicros());
+        var saved = intakeRepository.save(intake);
+        log.info(
+                "research_intake_created: project={} id={} no_budget_caps={}",
+                project.getIdentifier(),
+                saved.getId(),
+                command.budgetTokens() == null
+                        && command.budgetWallClockMinutes() == null
+                        && command.budgetCostUsdMicros() == null);
+        return saved;
+    }
+
+    /**
+     * Full replacement of an existing intake. 404 if the project has no intake.
+     * The project must still be RESEARCH; otherwise 422.
+     */
+    public ResearchIntake replace(Project project, ResearchIntakeCommand command) {
+        if (project.getType() != ProjectType.RESEARCH) {
+            throw new DomainValidationException(
+                    "ResearchIntake can only be replaced on RESEARCH projects",
+                    "research_intake_type_mismatch",
+                    Map.of("project_type", project.getType().name()));
+        }
+        var intake = intakeRepository
+                .findByProjectId(project.getId())
+                .orElseThrow(
+                        () -> new NotFoundException("ResearchIntake not found for project " + project.getIdentifier()));
+        validate(command);
+        intake.setGoal(command.goal().trim());
+        intake.setPaperContext(emptyToNull(command.paperContext()));
+        intake.setContributionType(command.contributionType());
+        intake.setIntendedOutput(command.intendedOutput());
+        intake.setAutonomyLevel(command.autonomyLevel());
+        intake.setAllowedTools(normaliseTools(command.allowedTools()));
+        intake.setPrivacyConstraints(emptyToNull(command.privacyConstraints()));
+        intake.setBudgetTokens(command.budgetTokens());
+        intake.setBudgetWallClockMinutes(command.budgetWallClockMinutes());
+        intake.setBudgetCostUsdMicros(command.budgetCostUsdMicros());
+        var saved = intakeRepository.save(intake);
+        log.info("research_intake_replaced: project={} id={}", project.getIdentifier(), saved.getId());
+        return saved;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ResearchIntake> findByProject(Project project) {
+        return intakeRepository.findByProjectId(project.getId());
+    }
+
+    private void validate(ResearchIntakeCommand command) {
+        if (command == null) {
+            throw new DomainValidationException(
+                    "ResearchIntake command must not be null", "research_intake_required", Map.of());
+        }
+        if (command.goal() == null || command.goal().trim().isEmpty()) {
+            throw new DomainValidationException(
+                    "ResearchIntake.goal must not be blank", "research_intake_invalid", Map.of("field", "goal"));
+        }
+        requireUnder(command.goal(), GOAL_MAX, "goal");
+        requireUnder(command.paperContext(), PAPER_CONTEXT_MAX, "paperContext");
+        requireUnder(command.privacyConstraints(), PRIVACY_CONSTRAINTS_MAX, "privacyConstraints");
+        if (command.contributionType() == null) {
+            throw new DomainValidationException(
+                    "ResearchIntake.contributionType must not be null",
+                    "research_intake_invalid",
+                    Map.of("field", "contributionType"));
+        }
+        if (command.intendedOutput() == null) {
+            throw new DomainValidationException(
+                    "ResearchIntake.intendedOutput must not be null",
+                    "research_intake_invalid",
+                    Map.of("field", "intendedOutput"));
+        }
+        if (command.autonomyLevel() == null) {
+            throw new DomainValidationException(
+                    "ResearchIntake.autonomyLevel must not be null",
+                    "research_intake_invalid",
+                    Map.of("field", "autonomyLevel"));
+        }
+        if (command.allowedTools() == null) {
+            throw new DomainValidationException(
+                    "ResearchIntake.allowedTools must not be null (use an empty list for 'no tools')",
+                    "research_intake_invalid",
+                    Map.of("field", "allowedTools"));
+        }
+        if (command.allowedTools().size() > ALLOWED_TOOLS_MAX_COUNT) {
+            throw new DomainValidationException(
+                    "ResearchIntake.allowedTools has too many entries",
+                    "research_intake_invalid",
+                    Map.of("field", "allowedTools", "max", ALLOWED_TOOLS_MAX_COUNT));
+        }
+        for (var tool : command.allowedTools()) {
+            if (tool == null || tool.trim().isEmpty()) {
+                throw new DomainValidationException(
+                        "ResearchIntake.allowedTools must not contain blank entries",
+                        "research_intake_invalid",
+                        Map.of("field", "allowedTools"));
+            }
+            if (tool.length() > ALLOWED_TOOL_MAX) {
+                throw new DomainValidationException(
+                        "ResearchIntake.allowedTools entry too long",
+                        "research_intake_invalid",
+                        Map.of("field", "allowedTools", "max", ALLOWED_TOOL_MAX));
+            }
+        }
+        rejectNegative(command.budgetTokens(), "budgetTokens");
+        rejectNegative(command.budgetWallClockMinutes(), "budgetWallClockMinutes");
+        rejectNegative(command.budgetCostUsdMicros(), "budgetCostUsdMicros");
+    }
+
+    private void requireUnder(String value, int max, String field) {
+        if (value != null && value.length() > max) {
+            throw new DomainValidationException(
+                    "ResearchIntake." + field + " exceeds max length",
+                    "research_intake_invalid",
+                    Map.of("field", field, "max", max));
+        }
+    }
+
+    private void rejectNegative(Number value, String field) {
+        if (value != null && value.longValue() < 0) {
+            throw new DomainValidationException(
+                    "ResearchIntake." + field + " must not be negative",
+                    "research_intake_invalid",
+                    Map.of("field", field));
+        }
+    }
+
+    /** Strip blanks, dedupe (set semantics), preserve insertion order of first occurrence. */
+    private List<String> normaliseTools(List<String> tools) {
+        if (tools == null) {
+            return new ArrayList<>();
+        }
+        var seen = new LinkedHashSet<String>();
+        for (var t : tools) {
+            if (t == null) {
+                continue;
+            }
+            var trimmed = t.trim();
+            if (!trimmed.isEmpty()) {
+                seen.add(trimmed);
+            }
+        }
+        return new ArrayList<>(seen);
+    }
+
+    private String emptyToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        var trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/research/service/ResearchIntakeService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/research/service/ResearchIntakeService.java
@@ -37,6 +37,10 @@ public class ResearchIntakeService {
     private static final int ALLOWED_TOOL_MAX = 100;
     private static final int ALLOWED_TOOLS_MAX_COUNT = 100;
 
+    private static final String FIELD = "field";
+    private static final String ALLOWED_TOOLS = "allowedTools";
+    private static final String INVALID_CODE = "research_intake_invalid";
+
     private final ResearchIntakeRepository intakeRepository;
 
     public ResearchIntakeService(ResearchIntakeRepository intakeRepository) {
@@ -124,7 +128,7 @@ public class ResearchIntakeService {
         }
         if (command.goal() == null || command.goal().trim().isEmpty()) {
             throw new DomainValidationException(
-                    "ResearchIntake.goal must not be blank", "research_intake_invalid", Map.of("field", "goal"));
+                    "ResearchIntake.goal must not be blank", INVALID_CODE, Map.of(FIELD, "goal"));
         }
         requireUnder(command.goal(), GOAL_MAX, "goal");
         requireUnder(command.paperContext(), PAPER_CONTEXT_MAX, "paperContext");
@@ -132,45 +136,41 @@ public class ResearchIntakeService {
         if (command.contributionType() == null) {
             throw new DomainValidationException(
                     "ResearchIntake.contributionType must not be null",
-                    "research_intake_invalid",
-                    Map.of("field", "contributionType"));
+                    INVALID_CODE,
+                    Map.of(FIELD, "contributionType"));
         }
         if (command.intendedOutput() == null) {
             throw new DomainValidationException(
-                    "ResearchIntake.intendedOutput must not be null",
-                    "research_intake_invalid",
-                    Map.of("field", "intendedOutput"));
+                    "ResearchIntake.intendedOutput must not be null", INVALID_CODE, Map.of(FIELD, "intendedOutput"));
         }
         if (command.autonomyLevel() == null) {
             throw new DomainValidationException(
-                    "ResearchIntake.autonomyLevel must not be null",
-                    "research_intake_invalid",
-                    Map.of("field", "autonomyLevel"));
+                    "ResearchIntake.autonomyLevel must not be null", INVALID_CODE, Map.of(FIELD, "autonomyLevel"));
         }
         if (command.allowedTools() == null) {
             throw new DomainValidationException(
                     "ResearchIntake.allowedTools must not be null (use an empty list for 'no tools')",
-                    "research_intake_invalid",
-                    Map.of("field", "allowedTools"));
+                    INVALID_CODE,
+                    Map.of(FIELD, ALLOWED_TOOLS));
         }
         if (command.allowedTools().size() > ALLOWED_TOOLS_MAX_COUNT) {
             throw new DomainValidationException(
                     "ResearchIntake.allowedTools has too many entries",
-                    "research_intake_invalid",
-                    Map.of("field", "allowedTools", "max", ALLOWED_TOOLS_MAX_COUNT));
+                    INVALID_CODE,
+                    Map.of(FIELD, ALLOWED_TOOLS, "max", ALLOWED_TOOLS_MAX_COUNT));
         }
         for (var tool : command.allowedTools()) {
             if (tool == null || tool.trim().isEmpty()) {
                 throw new DomainValidationException(
                         "ResearchIntake.allowedTools must not contain blank entries",
-                        "research_intake_invalid",
-                        Map.of("field", "allowedTools"));
+                        INVALID_CODE,
+                        Map.of(FIELD, ALLOWED_TOOLS));
             }
             if (tool.length() > ALLOWED_TOOL_MAX) {
                 throw new DomainValidationException(
                         "ResearchIntake.allowedTools entry too long",
-                        "research_intake_invalid",
-                        Map.of("field", "allowedTools", "max", ALLOWED_TOOL_MAX));
+                        INVALID_CODE,
+                        Map.of(FIELD, ALLOWED_TOOLS, "max", ALLOWED_TOOL_MAX));
             }
         }
         rejectNegative(command.budgetTokens(), "budgetTokens");
@@ -181,18 +181,14 @@ public class ResearchIntakeService {
     private void requireUnder(String value, int max, String field) {
         if (value != null && value.length() > max) {
             throw new DomainValidationException(
-                    "ResearchIntake." + field + " exceeds max length",
-                    "research_intake_invalid",
-                    Map.of("field", field, "max", max));
+                    "ResearchIntake." + field + " exceeds max length", INVALID_CODE, Map.of(FIELD, field, "max", max));
         }
     }
 
     private void rejectNegative(Number value, String field) {
         if (value != null && value.longValue() < 0) {
             throw new DomainValidationException(
-                    "ResearchIntake." + field + " must not be negative",
-                    "research_intake_invalid",
-                    Map.of("field", field));
+                    "ResearchIntake." + field + " must not be negative", INVALID_CODE, Map.of(FIELD, field));
         }
     }
 

--- a/backend/src/main/resources/db/migration/V131__add_project_type_and_research_intake.sql
+++ b/backend/src/main/resources/db/migration/V131__add_project_type_and_research_intake.sql
@@ -1,0 +1,39 @@
+-- GC-RSCH-F001, GC-RSCH-R007: research project type + intake aggregate.
+-- See ADR-056.
+--
+-- 1. Add `type` to `project`. Existing rows default to SOFTWARE (the implicit
+--    historical default before this PR). Column is NOT NULL going forward;
+--    API + service layers enforce the closed enum (SOFTWARE | GRC | RESEARCH).
+-- 2. Create `research_intake` 1:1 with `project` (only present when
+--    project.type = RESEARCH). Bean Validation + service guard enforce the
+--    "intake required iff type = RESEARCH" invariant; the DB carries the
+--    1:1 shape via UNIQUE on project_id.
+
+ALTER TABLE project
+    ADD COLUMN type VARCHAR(20) NOT NULL DEFAULT 'SOFTWARE';
+
+-- Drop the DEFAULT after backfill so every new project row must declare type
+-- explicitly at the application layer (the API surface enforces a closed enum;
+-- a silent DB default would hide validation gaps).
+ALTER TABLE project
+    ALTER COLUMN type DROP DEFAULT;
+
+CREATE TABLE research_intake (
+    id                          UUID                     PRIMARY KEY,
+    project_id                  UUID                     NOT NULL UNIQUE
+                                                         REFERENCES project(id) ON DELETE CASCADE,
+    goal                        TEXT                     NOT NULL,
+    paper_context               TEXT,
+    contribution_type           VARCHAR(40)              NOT NULL,
+    intended_output             VARCHAR(40)              NOT NULL,
+    autonomy_level              VARCHAR(20)              NOT NULL,
+    allowed_tools               TEXT                     NOT NULL,
+    privacy_constraints         TEXT,
+    budget_tokens               BIGINT,
+    budget_wall_clock_minutes   INTEGER,
+    budget_cost_usd_micros      BIGINT,
+    created_at                  TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at                  TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX idx_research_intake_project_id ON research_intake(project_id);

--- a/backend/src/main/resources/db/migration/V132__create_research_intake_audit.sql
+++ b/backend/src/main/resources/db/migration/V132__create_research_intake_audit.sql
@@ -1,0 +1,26 @@
+-- GC-RSCH-F001, GC-RSCH-N011: Hibernate Envers audit table for research_intake.
+-- See ADR-056.
+--
+-- @NotAudited on the project FK (matches the codebase pattern for Project
+-- back-refs from audited aggregates; Project itself is not audited). All
+-- other columns are tracked.
+
+CREATE TABLE research_intake_audit (
+    id                          UUID         NOT NULL,
+    rev                         INTEGER      NOT NULL REFERENCES revinfo(rev),
+    revtype                     SMALLINT,
+    goal                        TEXT,
+    paper_context               TEXT,
+    contribution_type           VARCHAR(40),
+    intended_output             VARCHAR(40),
+    autonomy_level              VARCHAR(20),
+    allowed_tools               TEXT,
+    privacy_constraints         TEXT,
+    budget_tokens               BIGINT,
+    budget_wall_clock_minutes   INTEGER,
+    budget_cost_usd_micros      BIGINT,
+    created_at                  TIMESTAMPTZ,
+    updated_at                  TIMESTAMPTZ,
+
+    CONSTRAINT pk_research_intake_audit PRIMARY KEY (id, rev)
+);

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
@@ -53,7 +53,7 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         "079", "080", "081", "082", "083", "084", "085", "086", "087", "088", "089", "090", "091",
                         "092", "093", "094", "095", "096", "097", "098", "099", "100", "101", "102", "103", "104",
                         "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122",
-                        "123", "124", "125", "126", "127", "128", "129", "130");
+                        "123", "124", "125", "126", "127", "128", "129", "130", "131", "132");
     }
 
     @Test
@@ -1025,6 +1025,39 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                 .getSingleResult();
         org.assertj.core.api.Assertions.assertThatCode(() -> entityManager
                         .createNativeQuery("SELECT reassessment_required_at FROM risk_assessment_result_audit LIMIT 1")
+                        .getResultList())
+                .doesNotThrowAnyException();
+        // V131-V132: project.type + research_intake (ADR-056, #999). Pin the
+        // type column on project, the live research_intake shape, and the
+        // _audit shadow column set. Without explicit column probes a copy-paste
+        // regression in V132 that dropped goal / autonomy_level / allowed_tools
+        // would silently create a wrong-shape shadow that passes at boot but
+        // fails on the first Envers flush at runtime.
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns"
+                        + " WHERE table_name = 'project'"
+                        + " AND column_name = 'type' AND is_nullable = 'NO'")
+                .getSingleResult();
+        entityManager.createNativeQuery("SELECT 1 FROM research_intake LIMIT 1").getResultList();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM research_intake_audit LIMIT 1")
+                .getResultList();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns"
+                        + " WHERE table_name = 'research_intake'"
+                        + " AND column_name = 'goal' AND is_nullable = 'NO'")
+                .getSingleResult();
+        entityManager
+                .createNativeQuery("SELECT 1 FROM information_schema.columns"
+                        + " WHERE table_name = 'research_intake'"
+                        + " AND column_name = 'project_id' AND is_nullable = 'NO'")
+                .getSingleResult();
+        org.assertj.core.api.Assertions.assertThatCode(() -> entityManager
+                        .createNativeQuery("SELECT goal, paper_context, contribution_type, intended_output,"
+                                + " autonomy_level, allowed_tools, privacy_constraints,"
+                                + " budget_tokens, budget_wall_clock_minutes, budget_cost_usd_micros,"
+                                + " created_at, updated_at"
+                                + " FROM research_intake_audit LIMIT 1")
                         .getResultList())
                 .doesNotThrowAnyException();
     }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -523,6 +523,8 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
                         "127", // V127: FAIR-CRST rename risk_scenario axes + drop vulnerability (GC-T013)
                         "128", // V128: expand seeded NIST SP 800-30 Rev. 1 profile schema (GC-T014)
                         "129", // V129: add methodology_profile crosswalk_entries column (GC-T012)
-                        "130"); // V130: add methodology_profile_aud crosswalk_entries column (GC-T012 audit parity)
+                        "130", // V130: add methodology_profile_aud crosswalk_entries column (GC-T012 audit parity)
+                        "131", // V131: add project.type + create research_intake (ADR-056, #999)
+                        "132"); // V132: create research_intake_audit (ADR-056, #999)
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ProjectControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ProjectControllerTest.java
@@ -1,9 +1,12 @@
 package com.keplerops.groundcontrol.unit.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -14,15 +17,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.keplerops.groundcontrol.TestUtil;
 import com.keplerops.groundcontrol.api.projects.ProjectController;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.model.ProjectType;
 import com.keplerops.groundcontrol.domain.projects.service.CreateProjectCommand;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.projects.service.UpdateProjectCommand;
+import com.keplerops.groundcontrol.domain.research.model.AutonomyLevel;
+import com.keplerops.groundcontrol.domain.research.model.ContributionType;
+import com.keplerops.groundcontrol.domain.research.model.IntendedOutput;
+import com.keplerops.groundcontrol.domain.research.model.ResearchIntake;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeCommand;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeService;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -40,10 +55,34 @@ class ProjectControllerTest {
     @MockitoBean
     private ProjectService projectService;
 
+    @MockitoBean
+    private ResearchIntakeService researchIntakeService;
+
+    @BeforeEach
+    void defaultStubs() {
+        when(researchIntakeService.findByProject(any())).thenReturn(Optional.empty());
+    }
+
     private Project makeProject(String identifier, String name) {
-        var project = new Project(identifier, name);
+        return makeProject(identifier, name, ProjectType.SOFTWARE);
+    }
+
+    private Project makeProject(String identifier, String name, ProjectType type) {
+        var project = new Project(identifier, name, type);
         TestUtil.setField(project, "id", UUID.randomUUID());
         return project;
+    }
+
+    private ResearchIntake makeIntake(Project project) {
+        var intake = new ResearchIntake(
+                project,
+                "Investigate research goal",
+                ContributionType.REVIEW,
+                IntendedOutput.SCOPING_REVIEW,
+                AutonomyLevel.COPILOT,
+                List.of("cite_resolve", "zotero_search"));
+        TestUtil.setField(intake, "id", UUID.randomUUID());
+        return intake;
     }
 
     @Nested
@@ -66,7 +105,8 @@ class ProjectControllerTest {
                             """))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.identifier", is("my-project")))
-                    .andExpect(jsonPath("$.name", is("My Project")));
+                    .andExpect(jsonPath("$.name", is("My Project")))
+                    .andExpect(jsonPath("$.type", is("SOFTWARE")));
         }
 
         @Test
@@ -116,6 +156,175 @@ class ProjectControllerTest {
                             """))
                     .andExpect(status().isConflict());
         }
+
+        @Test
+        void researchType_withIntake_returns201() throws Exception {
+            var project = makeProject("research-project", "Research Project", ProjectType.RESEARCH);
+            when(projectService.create(any(CreateProjectCommand.class))).thenReturn(project);
+            when(researchIntakeService.findByProject(eq(project))).thenReturn(Optional.of(makeIntake(project)));
+
+            mockMvc.perform(
+                            post("/api/v1/projects")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "identifier": "research-project",
+                              "name": "Research Project",
+                              "type": "RESEARCH",
+                              "researchIntake": {
+                                "goal": "Investigate citation hallucination",
+                                "contributionType": "REVIEW",
+                                "intendedOutput": "SCOPING_REVIEW",
+                                "autonomyLevel": "COPILOT",
+                                "allowedTools": ["cite_resolve", "zotero_search"]
+                              }
+                            }
+                            """))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.type", is("RESEARCH")))
+                    .andExpect(jsonPath("$.researchIntake.goal", is("Investigate research goal")))
+                    .andExpect(jsonPath("$.researchIntake.contributionType", is("REVIEW")))
+                    .andExpect(jsonPath("$.researchIntake.intendedOutput", is("SCOPING_REVIEW")))
+                    .andExpect(jsonPath("$.researchIntake.autonomyLevel", is("COPILOT")))
+                    .andExpect(jsonPath(
+                            "$.researchIntake.allowedTools", containsInAnyOrder("cite_resolve", "zotero_search")));
+
+            // Verify the controller actually forwards the request-body intake
+            // into the CreateProjectCommand (closes Step 6.6 test-quality
+            // finding #3): any() would let a controller bug that drops
+            // request.researchIntake() pass undetected.
+            var captor = ArgumentCaptor.forClass(CreateProjectCommand.class);
+            verify(projectService).create(captor.capture());
+            var cmd = captor.getValue();
+            assertThat(cmd.identifier()).isEqualTo("research-project");
+            assertThat(cmd.type()).isEqualTo(ProjectType.RESEARCH);
+            assertThat(cmd.researchIntake()).isNotNull();
+            assertThat(cmd.researchIntake().goal()).isEqualTo("Investigate citation hallucination");
+            assertThat(cmd.researchIntake().contributionType().name()).isEqualTo("REVIEW");
+            assertThat(cmd.researchIntake().intendedOutput().name()).isEqualTo("SCOPING_REVIEW");
+            assertThat(cmd.researchIntake().autonomyLevel().name()).isEqualTo("COPILOT");
+            assertThat(cmd.researchIntake().allowedTools()).containsExactlyInAnyOrder("cite_resolve", "zotero_search");
+        }
+
+        @Test
+        void researchType_missingIntake_returns422() throws Exception {
+            when(projectService.create(any(CreateProjectCommand.class)))
+                    .thenThrow(new DomainValidationException(
+                            "type=RESEARCH requires researchIntake to be present",
+                            "research_intake_required",
+                            Map.of("type", "RESEARCH")));
+
+            mockMvc.perform(
+                            post("/api/v1/projects")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "identifier": "research-project",
+                              "name": "Research Project",
+                              "type": "RESEARCH"
+                            }
+                            """))
+                    .andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        void softwareType_withIntake_returns422() throws Exception {
+            when(projectService.create(any(CreateProjectCommand.class)))
+                    .thenThrow(new DomainValidationException(
+                            "researchIntake is only allowed when type=RESEARCH",
+                            "research_intake_not_allowed",
+                            Map.of("type", "SOFTWARE")));
+
+            mockMvc.perform(
+                            post("/api/v1/projects")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "identifier": "sw-project",
+                              "name": "SW Project",
+                              "type": "SOFTWARE",
+                              "researchIntake": {
+                                "goal": "x",
+                                "contributionType": "REVIEW",
+                                "intendedOutput": "SCOPING_REVIEW",
+                                "autonomyLevel": "COPILOT",
+                                "allowedTools": []
+                              }
+                            }
+                            """))
+                    .andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        void researchType_blankGoal_returns422() throws Exception {
+            mockMvc.perform(
+                            post("/api/v1/projects")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "identifier": "research-project",
+                              "name": "Research Project",
+                              "type": "RESEARCH",
+                              "researchIntake": {
+                                "goal": "",
+                                "contributionType": "REVIEW",
+                                "intendedOutput": "SCOPING_REVIEW",
+                                "autonomyLevel": "COPILOT",
+                                "allowedTools": []
+                              }
+                            }
+                            """))
+                    .andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        void researchType_invalidEnum_returns422() throws Exception {
+            mockMvc.perform(
+                            post("/api/v1/projects")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "identifier": "research-project",
+                              "name": "Research Project",
+                              "type": "RESEARCH",
+                              "researchIntake": {
+                                "goal": "x",
+                                "contributionType": "BOGUS",
+                                "intendedOutput": "SCOPING_REVIEW",
+                                "autonomyLevel": "COPILOT",
+                                "allowedTools": []
+                              }
+                            }
+                            """))
+                    .andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        void researchType_missingAllowedTools_returns422() throws Exception {
+            mockMvc.perform(
+                            post("/api/v1/projects")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "identifier": "research-project",
+                              "name": "Research Project",
+                              "type": "RESEARCH",
+                              "researchIntake": {
+                                "goal": "x",
+                                "contributionType": "REVIEW",
+                                "intendedOutput": "SCOPING_REVIEW",
+                                "autonomyLevel": "COPILOT"
+                              }
+                            }
+                            """))
+                    .andExpect(status().isUnprocessableEntity());
+        }
     }
 
     @Nested
@@ -128,7 +337,8 @@ class ProjectControllerTest {
             mockMvc.perform(get("/api/v1/projects"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", hasSize(2)))
-                    .andExpect(jsonPath("$[0].identifier", is("p1")));
+                    .andExpect(jsonPath("$[0].identifier", is("p1")))
+                    .andExpect(jsonPath("$[0].type", is("SOFTWARE")));
         }
     }
 
@@ -141,7 +351,20 @@ class ProjectControllerTest {
 
             mockMvc.perform(get("/api/v1/projects/my-project"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.identifier", is("my-project")));
+                    .andExpect(jsonPath("$.identifier", is("my-project")))
+                    .andExpect(jsonPath("$.type", is("SOFTWARE")));
+        }
+
+        @Test
+        void researchProject_includesIntake() throws Exception {
+            var project = makeProject("research-p", "Research", ProjectType.RESEARCH);
+            when(projectService.getByIdentifier("research-p")).thenReturn(project);
+            when(researchIntakeService.findByProject(eq(project))).thenReturn(Optional.of(makeIntake(project)));
+
+            mockMvc.perform(get("/api/v1/projects/research-p"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.type", is("RESEARCH")))
+                    .andExpect(jsonPath("$.researchIntake.goal", is("Investigate research goal")));
         }
 
         @Test
@@ -173,6 +396,105 @@ class ProjectControllerTest {
                             """))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.name", is("Updated Name")));
+        }
+    }
+
+    @Nested
+    class ReplaceResearchIntake {
+
+        @Test
+        void returns200() throws Exception {
+            var project = makeProject("research-p", "Research", ProjectType.RESEARCH);
+            var intake = makeIntake(project);
+            when(projectService.getByIdentifier("research-p")).thenReturn(project);
+            when(researchIntakeService.replace(eq(project), any(ResearchIntakeCommand.class)))
+                    .thenReturn(intake);
+
+            mockMvc.perform(
+                            put("/api/v1/projects/research-p/research-intake")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "goal": "Updated goal",
+                              "contributionType": "TAXONOMY",
+                              "intendedOutput": "TAXONOMY_PAPER",
+                              "autonomyLevel": "AUTONOMOUS",
+                              "allowedTools": ["cite_resolve"]
+                            }
+                            """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.goal", is("Investigate research goal")));
+        }
+
+        @Test
+        void notResearchType_returns422() throws Exception {
+            var project = makeProject("sw-p", "SW", ProjectType.SOFTWARE);
+            when(projectService.getByIdentifier("sw-p")).thenReturn(project);
+            when(researchIntakeService.replace(eq(project), any(ResearchIntakeCommand.class)))
+                    .thenThrow(new DomainValidationException(
+                            "ResearchIntake can only be replaced on RESEARCH projects",
+                            "research_intake_type_mismatch",
+                            Map.of("project_type", "SOFTWARE")));
+
+            mockMvc.perform(
+                            put("/api/v1/projects/sw-p/research-intake")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "goal": "x",
+                              "contributionType": "REVIEW",
+                              "intendedOutput": "SCOPING_REVIEW",
+                              "autonomyLevel": "COPILOT",
+                              "allowedTools": []
+                            }
+                            """))
+                    .andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        void noIntakeExists_returns404() throws Exception {
+            var project = makeProject("research-p", "Research", ProjectType.RESEARCH);
+            when(projectService.getByIdentifier("research-p")).thenReturn(project);
+            when(researchIntakeService.replace(eq(project), any(ResearchIntakeCommand.class)))
+                    .thenThrow(new NotFoundException("ResearchIntake not found for project research-p"));
+
+            mockMvc.perform(
+                            put("/api/v1/projects/research-p/research-intake")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "goal": "x",
+                              "contributionType": "REVIEW",
+                              "intendedOutput": "SCOPING_REVIEW",
+                              "autonomyLevel": "COPILOT",
+                              "allowedTools": []
+                            }
+                            """))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void projectNotFound_returns404() throws Exception {
+            when(projectService.getByIdentifier("nonexistent"))
+                    .thenThrow(new NotFoundException("Project not found: nonexistent"));
+
+            mockMvc.perform(
+                            put("/api/v1/projects/nonexistent/research-intake")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                            {
+                              "goal": "x",
+                              "contributionType": "REVIEW",
+                              "intendedOutput": "SCOPING_REVIEW",
+                              "autonomyLevel": "COPILOT",
+                              "allowedTools": []
+                            }
+                            """))
+                    .andExpect(status().isNotFound());
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ProjectControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ProjectControllerTest.java
@@ -161,7 +161,7 @@ class ProjectControllerTest {
         void researchType_withIntake_returns201() throws Exception {
             var project = makeProject("research-project", "Research Project", ProjectType.RESEARCH);
             when(projectService.create(any(CreateProjectCommand.class))).thenReturn(project);
-            when(researchIntakeService.findByProject(eq(project))).thenReturn(Optional.of(makeIntake(project)));
+            when(researchIntakeService.findByProject(project)).thenReturn(Optional.of(makeIntake(project)));
 
             mockMvc.perform(
                             post("/api/v1/projects")
@@ -359,7 +359,7 @@ class ProjectControllerTest {
         void researchProject_includesIntake() throws Exception {
             var project = makeProject("research-p", "Research", ProjectType.RESEARCH);
             when(projectService.getByIdentifier("research-p")).thenReturn(project);
-            when(researchIntakeService.findByProject(eq(project))).thenReturn(Optional.of(makeIntake(project)));
+            when(researchIntakeService.findByProject(project)).thenReturn(Optional.of(makeIntake(project)));
 
             mockMvc.perform(get("/api/v1/projects/research-p"))
                     .andExpect(status().isOk())

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ProjectServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ProjectServiceTest.java
@@ -3,6 +3,9 @@ package com.keplerops.groundcontrol.unit.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.keplerops.groundcontrol.TestUtil;
@@ -10,10 +13,16 @@ import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.model.ProjectType;
 import com.keplerops.groundcontrol.domain.projects.repository.ProjectRepository;
 import com.keplerops.groundcontrol.domain.projects.service.CreateProjectCommand;
 import com.keplerops.groundcontrol.domain.projects.service.ProjectService;
 import com.keplerops.groundcontrol.domain.projects.service.UpdateProjectCommand;
+import com.keplerops.groundcontrol.domain.research.model.AutonomyLevel;
+import com.keplerops.groundcontrol.domain.research.model.ContributionType;
+import com.keplerops.groundcontrol.domain.research.model.IntendedOutput;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeCommand;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeService;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,11 +41,14 @@ class ProjectServiceTest {
     @Mock
     private ProjectRepository projectRepository;
 
+    @Mock
+    private ResearchIntakeService researchIntakeService;
+
     private ProjectService service;
 
     @BeforeEach
     void setUp() {
-        service = new ProjectService(projectRepository);
+        service = new ProjectService(projectRepository, researchIntakeService);
     }
 
     private Project makeProject(String identifier, String name) {
@@ -82,6 +94,63 @@ class ProjectServiceTest {
             when(projectRepository.existsByIdentifier("existing")).thenReturn(true);
 
             assertThatThrownBy(() -> service.create(command)).isInstanceOf(ConflictException.class);
+        }
+
+        @Test
+        void researchType_withIntake_delegatesToIntakeService() {
+            var intakeCmd = new ResearchIntakeCommand(
+                    "Investigate research goal",
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    List.of("cite_resolve"),
+                    null,
+                    null,
+                    null,
+                    null);
+            var command = new CreateProjectCommand(
+                    "research-project", "Research Project", "desc", ProjectType.RESEARCH, intakeCmd);
+            when(projectRepository.existsByIdentifier("research-project")).thenReturn(false);
+            when(projectRepository.save(any(Project.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = service.create(command);
+            assertThat(result.getType()).isEqualTo(ProjectType.RESEARCH);
+            verify(researchIntakeService, times(1)).create(result, intakeCmd);
+        }
+
+        @Test
+        void researchType_missingIntake_throwsValidation() {
+            var command =
+                    new CreateProjectCommand("research-project", "Research Project", null, ProjectType.RESEARCH, null);
+            when(projectRepository.existsByIdentifier("research-project")).thenReturn(false);
+
+            assertThatThrownBy(() -> service.create(command))
+                    .isInstanceOf(com.keplerops.groundcontrol.domain.exception.DomainValidationException.class)
+                    .hasMessageContaining("researchIntake");
+            verify(researchIntakeService, never()).create(any(), any());
+        }
+
+        @Test
+        void softwareType_withIntake_throwsValidation() {
+            var intakeCmd = new ResearchIntakeCommand(
+                    "x",
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    List.of(),
+                    null,
+                    null,
+                    null,
+                    null);
+            var command = new CreateProjectCommand("sw-project", "SW Project", null, ProjectType.SOFTWARE, intakeCmd);
+            when(projectRepository.existsByIdentifier("sw-project")).thenReturn(false);
+
+            assertThatThrownBy(() -> service.create(command))
+                    .isInstanceOf(com.keplerops.groundcontrol.domain.exception.DomainValidationException.class)
+                    .hasMessageContaining("researchIntake");
+            verify(researchIntakeService, never()).create(any(), any());
         }
     }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ResearchIntakeServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ResearchIntakeServiceTest.java
@@ -92,8 +92,9 @@ class ResearchIntakeServiceTest {
         @Test
         void nonResearchProject_throwsValidation() {
             var project = makeProject(ProjectType.SOFTWARE);
+            var cmd = validCommand();
 
-            assertThatThrownBy(() -> service.create(project, validCommand()))
+            assertThatThrownBy(() -> service.create(project, cmd))
                     .isInstanceOf(DomainValidationException.class)
                     .hasMessageContaining("RESEARCH");
         }
@@ -102,8 +103,9 @@ class ResearchIntakeServiceTest {
         void existingIntake_throwsConflict() {
             var project = makeProject(ProjectType.RESEARCH);
             when(intakeRepository.existsByProjectId(project.getId())).thenReturn(true);
+            var cmd = validCommand();
 
-            assertThatThrownBy(() -> service.create(project, validCommand())).isInstanceOf(ConflictException.class);
+            assertThatThrownBy(() -> service.create(project, cmd)).isInstanceOf(ConflictException.class);
         }
 
         @Test
@@ -362,17 +364,18 @@ class ResearchIntakeServiceTest {
         @Test
         void nonResearchProject_throwsValidation() {
             var project = makeProject(ProjectType.GRC);
+            var cmd = validCommand();
 
-            assertThatThrownBy(() -> service.replace(project, validCommand()))
-                    .isInstanceOf(DomainValidationException.class);
+            assertThatThrownBy(() -> service.replace(project, cmd)).isInstanceOf(DomainValidationException.class);
         }
 
         @Test
         void noExistingIntake_throwsNotFound() {
             var project = makeProject(ProjectType.RESEARCH);
             when(intakeRepository.findByProjectId(project.getId())).thenReturn(Optional.empty());
+            var cmd = validCommand();
 
-            assertThatThrownBy(() -> service.replace(project, validCommand())).isInstanceOf(NotFoundException.class);
+            assertThatThrownBy(() -> service.replace(project, cmd)).isInstanceOf(NotFoundException.class);
         }
     }
 

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ResearchIntakeServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ResearchIntakeServiceTest.java
@@ -1,0 +1,409 @@
+package com.keplerops.groundcontrol.unit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.keplerops.groundcontrol.TestUtil;
+import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import com.keplerops.groundcontrol.domain.exception.NotFoundException;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.model.ProjectType;
+import com.keplerops.groundcontrol.domain.research.model.AutonomyLevel;
+import com.keplerops.groundcontrol.domain.research.model.ContributionType;
+import com.keplerops.groundcontrol.domain.research.model.IntendedOutput;
+import com.keplerops.groundcontrol.domain.research.model.ResearchIntake;
+import com.keplerops.groundcontrol.domain.research.repository.ResearchIntakeRepository;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeCommand;
+import com.keplerops.groundcontrol.domain.research.service.ResearchIntakeService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResearchIntakeServiceTest {
+
+    @Mock
+    private ResearchIntakeRepository intakeRepository;
+
+    private ResearchIntakeService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ResearchIntakeService(intakeRepository);
+    }
+
+    private Project makeProject(ProjectType type) {
+        var project = new Project("research-p", "Research Project", type);
+        TestUtil.setField(project, "id", UUID.randomUUID());
+        return project;
+    }
+
+    /**
+     * Build a valid command. validate() iterates raw allowed-tool entries
+     * before normaliseTools() runs, so the input list cannot contain blank
+     * entries; the with-spaces and duplicate entries exercise the trim +
+     * dedup paths in normaliseTools().
+     */
+    private ResearchIntakeCommand validCommand() {
+        return new ResearchIntakeCommand(
+                "  Investigate research goal  ",
+                "  Paper context  ",
+                ContributionType.REVIEW,
+                IntendedOutput.SCOPING_REVIEW,
+                AutonomyLevel.COPILOT,
+                List.of("cite_resolve", "  zotero_search  ", "cite_resolve"),
+                "  Privacy note  ",
+                1000L,
+                60,
+                500_000L);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void happyPath_persistsTrimmedNormalisedIntake() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            when(intakeRepository.save(any(ResearchIntake.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var saved = service.create(project, validCommand());
+
+            assertThat(saved.getGoal()).isEqualTo("Investigate research goal");
+            assertThat(saved.getPaperContext()).isEqualTo("Paper context");
+            assertThat(saved.getPrivacyConstraints()).isEqualTo("Privacy note");
+            assertThat(saved.getAllowedTools()).containsExactly("cite_resolve", "zotero_search");
+            assertThat(saved.getBudgetTokens()).isEqualTo(1000L);
+            assertThat(saved.getContributionType()).isEqualTo(ContributionType.REVIEW);
+            assertThat(saved.getIntendedOutput()).isEqualTo(IntendedOutput.SCOPING_REVIEW);
+            assertThat(saved.getAutonomyLevel()).isEqualTo(AutonomyLevel.COPILOT);
+        }
+
+        @Test
+        void nonResearchProject_throwsValidation() {
+            var project = makeProject(ProjectType.SOFTWARE);
+
+            assertThatThrownBy(() -> service.create(project, validCommand()))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("RESEARCH");
+        }
+
+        @Test
+        void existingIntake_throwsConflict() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(true);
+
+            assertThatThrownBy(() -> service.create(project, validCommand())).isInstanceOf(ConflictException.class);
+        }
+
+        @Test
+        void nullCommand_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+
+            assertThatThrownBy(() -> service.create(project, null)).isInstanceOf(DomainValidationException.class);
+        }
+
+        @Test
+        void blankGoal_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            var bad = new ResearchIntakeCommand(
+                    "  ",
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    List.of(),
+                    null,
+                    null,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("goal");
+        }
+
+        @Test
+        void nullContributionType_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            var bad = new ResearchIntakeCommand(
+                    "goal",
+                    null,
+                    null,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    List.of(),
+                    null,
+                    null,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("contributionType");
+        }
+
+        @Test
+        void nullIntendedOutput_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            var bad = new ResearchIntakeCommand(
+                    "goal",
+                    null,
+                    ContributionType.REVIEW,
+                    null,
+                    AutonomyLevel.COPILOT,
+                    List.of(),
+                    null,
+                    null,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("intendedOutput");
+        }
+
+        @Test
+        void nullAutonomyLevel_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            var bad = new ResearchIntakeCommand(
+                    "goal",
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    null,
+                    List.of(),
+                    null,
+                    null,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("autonomyLevel");
+        }
+
+        @Test
+        void nullAllowedTools_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            var bad = new ResearchIntakeCommand(
+                    "goal",
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("allowedTools");
+        }
+
+        @Test
+        void blankAllowedToolEntry_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            // Pre-trimmed-empty entries are stripped by normaliseTools; raw null/empty after
+            // normaliseTools won't trigger this. Use a list that bypasses normalisation: the
+            // validate() function runs on the command-as-passed before normalisation.
+            var tools = new ArrayList<String>();
+            tools.add("valid");
+            tools.add(null);
+            var bad = new ResearchIntakeCommand(
+                    "goal",
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    tools,
+                    null,
+                    null,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("allowedTools");
+        }
+
+        @Test
+        void tooManyAllowedTools_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            var tools = new ArrayList<String>();
+            for (int i = 0; i < 101; i++) {
+                tools.add("t" + i);
+            }
+            var bad = new ResearchIntakeCommand(
+                    "goal",
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    tools,
+                    null,
+                    null,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("allowedTools");
+        }
+
+        @Test
+        void overlongAllowedToolEntry_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            var bad = new ResearchIntakeCommand(
+                    "goal",
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    List.of("x".repeat(101)),
+                    null,
+                    null,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("allowedTools");
+        }
+
+        @Test
+        void negativeBudget_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            var bad = new ResearchIntakeCommand(
+                    "goal",
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    List.of(),
+                    null,
+                    -1L,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("budgetTokens");
+        }
+
+        @Test
+        void overlongGoal_throwsValidation() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.existsByProjectId(project.getId())).thenReturn(false);
+            var bad = new ResearchIntakeCommand(
+                    "x".repeat(4001),
+                    null,
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    List.of(),
+                    null,
+                    null,
+                    null,
+                    null);
+
+            assertThatThrownBy(() -> service.create(project, bad))
+                    .isInstanceOf(DomainValidationException.class)
+                    .hasMessageContaining("goal");
+        }
+    }
+
+    @Nested
+    class Replace {
+
+        @Test
+        void happyPath_updatesFields() {
+            var project = makeProject(ProjectType.RESEARCH);
+            var existing = new ResearchIntake(
+                    project,
+                    "old",
+                    ContributionType.OTHER,
+                    IntendedOutput.OTHER,
+                    AutonomyLevel.AUTONOMOUS,
+                    List.of("old-tool"));
+            TestUtil.setField(existing, "id", UUID.randomUUID());
+            when(intakeRepository.findByProjectId(project.getId())).thenReturn(Optional.of(existing));
+            when(intakeRepository.save(any(ResearchIntake.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var updated = service.replace(project, validCommand());
+
+            assertThat(updated.getGoal()).isEqualTo("Investigate research goal");
+            assertThat(updated.getContributionType()).isEqualTo(ContributionType.REVIEW);
+            assertThat(updated.getAllowedTools()).containsExactly("cite_resolve", "zotero_search");
+        }
+
+        @Test
+        void nonResearchProject_throwsValidation() {
+            var project = makeProject(ProjectType.GRC);
+
+            assertThatThrownBy(() -> service.replace(project, validCommand()))
+                    .isInstanceOf(DomainValidationException.class);
+        }
+
+        @Test
+        void noExistingIntake_throwsNotFound() {
+            var project = makeProject(ProjectType.RESEARCH);
+            when(intakeRepository.findByProjectId(project.getId())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.replace(project, validCommand())).isInstanceOf(NotFoundException.class);
+        }
+    }
+
+    @Nested
+    class FindByProject {
+
+        @Test
+        void returnsIntakeWhenPresent() {
+            var project = makeProject(ProjectType.RESEARCH);
+            var intake = new ResearchIntake(
+                    project,
+                    "g",
+                    ContributionType.REVIEW,
+                    IntendedOutput.SCOPING_REVIEW,
+                    AutonomyLevel.COPILOT,
+                    List.of());
+            when(intakeRepository.findByProjectId(project.getId())).thenReturn(Optional.of(intake));
+
+            var found = service.findByProject(project);
+
+            assertThat(found).contains(intake);
+        }
+
+        @Test
+        void returnsEmptyWhenAbsent() {
+            var project = makeProject(ProjectType.SOFTWARE);
+            when(intakeRepository.findByProjectId(project.getId())).thenReturn(Optional.empty());
+
+            var found = service.findByProject(project);
+
+            assertThat(found).isEmpty();
+        }
+    }
+}

--- a/changelog.d/999.added.md
+++ b/changelog.d/999.added.md
@@ -1,0 +1,25 @@
+### Added
+
+- **Research as a first-class project type (ADR-056)**: `project.type` column
+  with closed enum `SOFTWARE | GRC | RESEARCH` (existing rows backfill to
+  `SOFTWARE`; non-research callers see no breaking change).
+- **`ResearchIntake` aggregate** at `domain/research/`: 1:1 with `Project` when
+  `type=RESEARCH`, captures research goal, paper context, contribution type,
+  intended output, autonomy level, allowed tools (typed list with dedup),
+  privacy constraints, and typed token / wall-clock / cost budgets. `@Audited`
+  via Envers with the standard `_audit` shadow table.
+- **`POST /api/v1/projects`** accepts optional `type` (default `SOFTWARE`) and
+  optional nested `researchIntake`; service enforces "intake required iff
+  type=RESEARCH" with a 422 `validation_error` envelope.
+- **`PUT /api/v1/projects/{identifier}/research-intake`** for full intake
+  replacement on a RESEARCH project (404 if no intake; 422 if not RESEARCH).
+- **`GET /api/v1/projects` and `GET /api/v1/projects/{identifier}`** now
+  return `type` always and `researchIntake` when present.
+- Flyway migrations `V126` (project.type + research_intake) and `V127`
+  (research_intake_audit); both wired into the `MigrationSmokeTest` and
+  `RequirementsE2EIntegrationTest` hardcoded version lists per plan rules.
+
+Satisfies GC-RSCH-F001 (intake fields) and GC-RSCH-R007 (RESEARCH literal
+distinguishes literature work). GC-RSCH-R001 / F002 / N011 are forward-looking
+workflow internals that stay DRAFT until subsequent issues materialise the
+research workflow phases on top of this foundation; see ADR-056.

--- a/changelog.d/999.fixed.md
+++ b/changelog.d/999.fixed.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Internal:** extract `FIELD` / `ALLOWED_TOOLS` / `INVALID_CODE` constants
+  in `ResearchIntakeService` to satisfy Sonar `S1192` (literal duplication),
+  and drop redundant `eq(project)` matchers in `ProjectControllerTest`
+  (Sonar `S6068`). Behaviour-preserving cleanup of code shipped in this PR.

--- a/changelog.d/999.fixed.md
+++ b/changelog.d/999.fixed.md
@@ -8,3 +8,5 @@
   findByProject and every validate() error path to satisfy the SonarCloud
   new-code coverage gate (80% threshold). The sonar CI job runs unit tests
   only (no Testcontainers), so this test contributes to the gate.
+- **Internal:** extract `cmd` locals before `assertThatThrownBy` lambdas to
+  satisfy Sonar `S5778` (one possibly throwing invocation per lambda body).

--- a/changelog.d/999.fixed.md
+++ b/changelog.d/999.fixed.md
@@ -4,3 +4,7 @@
   in `ResearchIntakeService` to satisfy Sonar `S1192` (literal duplication),
   and drop redundant `eq(project)` matchers in `ProjectControllerTest`
   (Sonar `S6068`). Behaviour-preserving cleanup of code shipped in this PR.
+- **Internal:** add `ResearchIntakeServiceTest` covering create / replace /
+  findByProject and every validate() error path to satisfy the SonarCloud
+  new-code coverage gate (80% threshold). The sonar CI job runs unit tests
+  only (no Testcontainers), so this test contributes to the gate.

--- a/docs/API.md
+++ b/docs/API.md
@@ -34,6 +34,45 @@ http://localhost:8000/api/v1/
 
 ## Endpoints
 
+### Projects
+
+| Method | Path | Body | Status | Purpose |
+|--------|------|------|--------|---------|
+| POST | `/projects` | ProjectRequest | 201 | Create a project (optional `type` + nested `researchIntake`) |
+| GET | `/projects` |—| 200 | List projects (includes `type` and `researchIntake` when present) |
+| GET | `/projects/{identifier}` |—| 200 | Get a project by identifier |
+| PUT | `/projects/{identifier}` | UpdateProjectRequest | 200 | Update name / description |
+| PUT | `/projects/{identifier}/research-intake` | ResearchIntakeRequest | 200 | Replace the research intake on a RESEARCH project (404 if no intake exists; 422 if not RESEARCH) |
+
+`ProjectRequest` fields (ADR-056):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `identifier` | string (`[a-z0-9-]+`, ≤ 50) | yes | Unique, immutable |
+| `name` | string (≤ 255) | yes | |
+| `description` | string | no | TEXT |
+| `type` | enum `SOFTWARE` \| `GRC` \| `RESEARCH` | no | Defaults to `SOFTWARE` |
+| `researchIntake` | `ResearchIntakeRequest` | required iff `type=RESEARCH` | 422 if mismatched |
+
+`ResearchIntakeRequest` fields (issue #999):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `goal` | string (≤ 4000) | yes | Research goal narrative |
+| `paperContext` | string (≤ 8000) | no | Paper / project context |
+| `contributionType` | enum | yes | `TAXONOMY` \| `REVIEW` \| `EMPIRICAL_STUDY` \| `METHODOLOGY` \| `POSITION` \| `OTHER` |
+| `intendedOutput` | enum | yes | `SCOPING_REVIEW` \| `SYSTEMATIC_REVIEW` \| `SYSTEMATIC_MAP` \| `CRITICAL_REVIEW` \| `NARRATIVE_REVIEW` \| `TARGETED_RELATED_WORK` \| `TAXONOMY_PAPER` \| `OTHER` |
+| `autonomyLevel` | enum | yes | `COPILOT` \| `AUTONOMOUS` |
+| `allowedTools` | array of string (≤ 100 each, ≤ 100 entries) | yes | Empty list means no tools authorised; null is rejected |
+| `privacyConstraints` | string (≤ 4000) | no | Free-form |
+| `budgetTokens` | integer ≥ 0 | no | Token cap; null = unbounded |
+| `budgetWallClockMinutes` | integer ≥ 0 | no | Wall-clock cap; null = unbounded |
+| `budgetCostUsdMicros` | integer ≥ 0 | no | Cost cap in USD micros (1 USD = 1,000,000); null = unbounded |
+
+The seven non-`OTHER` `intendedOutput` values mirror the method keys in
+`skills/lit-review/methodology/catalog.yaml` so the phase-1 lit-review skill
+can derive a methodology choice from the intake (ADR-055).
+
 ### Requirements
 
 | Method | Path | Body | Status | Purpose |

--- a/docs/DOC_STYLE.md
+++ b/docs/DOC_STYLE.md
@@ -27,7 +27,7 @@ semicolon cannot carry.
 Soft budget: at most one em-dash per paragraph, typically zero. If a paragraph
 has two, rewrite one.
 
-Em-dash chains (`X — Y — Z`) should almost always be reordered into separate
+Em-dash chains (`X—Y—Z`) should almost always be reordered into separate
 clauses.
 
 This pattern was surfaced in shifter #704, where agent-written prose accumulated
@@ -50,6 +50,14 @@ Vale with the `errata-ai/Google` package runs on docs touched in the current
 diff via `make policy`, the CI `policy` job, and the pre-commit `vale-prose-lint`
 hook. The hook installs Vale via `tools/install-vale.sh` on first need; no
 manual `make vale-install` step is required.
+
+MCP-surface changes (`mcp/ground-control/index.js`, `mcp/ground-control/lib.js`)
+also trigger the `doc-coverage-gate-sync` rule per ADR-054, which requires this
+file and ADR-054 to stay current with the classifier surface they describe.
+Adding a new MCP tool or `gc_admin` action does not require new style rules
+here unless the action introduces a new doc-shape (a new request/response
+schema, for example)—in that case document the schema under the relevant
+service section in `docs/API.md`, which Vale lints on touch.
 
 ## Scope: whole file on first touch
 

--- a/mcp/ground-control/index.js
+++ b/mcp/ground-control/index.js
@@ -47,7 +47,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import {
   // ---- project/requirement/relation/traceability ----
-  listProjects, createProject,
+  listProjects, createProject, replaceResearchIntake,
   getRequirementByUid, listRequirements, createRequirement, updateRequirement,
   transitionStatus, bulkTransitionStatus, archiveRequirement, cloneRequirement,
   createRelation, getRelations, deleteRelation,
@@ -2706,6 +2706,7 @@ const ADMIN_ACTIONS = [
   "import_strictdoc", "import_reqif", "sync_github", "sync_github_prs",
   "embed_requirement", "embed_project", "embedding_status",
   "materialize_graph", "create_project", "list_projects",
+  "replace_research_intake",
   "run_sweep", "run_sweep_all",
   "export_audit_timeline", "export_requirements", "export_sweep_report", "export_document",
 ];
@@ -2731,6 +2732,25 @@ if (ADMIN_TOOLS_ENABLED) {
       format: z.string().optional(),
       from: z.string().optional(),
       to: z.string().optional(),
+      // Project type + research intake (ADR-056, issue #999).
+      type: z.enum(["SOFTWARE", "GRC", "RESEARCH"]).optional(),
+      research_intake: z.object({
+        goal: z.string(),
+        paperContext: z.string().optional(),
+        contributionType: z.enum([
+          "TAXONOMY", "REVIEW", "EMPIRICAL_STUDY", "METHODOLOGY", "POSITION", "OTHER",
+        ]),
+        intendedOutput: z.enum([
+          "SCOPING_REVIEW", "SYSTEMATIC_REVIEW", "SYSTEMATIC_MAP", "CRITICAL_REVIEW",
+          "NARRATIVE_REVIEW", "TARGETED_RELATED_WORK", "TAXONOMY_PAPER", "OTHER",
+        ]),
+        autonomyLevel: z.enum(["COPILOT", "AUTONOMOUS"]),
+        allowedTools: z.array(z.string()),
+        privacyConstraints: z.string().optional(),
+        budgetTokens: z.number().int().nonnegative().optional(),
+        budgetWallClockMinutes: z.number().int().nonnegative().optional(),
+        budgetCostUsdMicros: z.number().int().nonnegative().optional(),
+      }).optional(),
     },
     async (args) => {
       try {
@@ -2746,7 +2766,21 @@ if (ADMIN_TOOLS_ENABLED) {
           case "list_projects": return ok(JSON.stringify(await listProjects(), null, 2));
           case "create_project": {
             reqArg(args, "identifier", "create_project"); reqArg(args, "name", "create_project");
-            return ok(JSON.stringify(await createProject({ identifier: args.identifier, name: args.name, description: args.description }), null, 2));
+            // type + researchIntake are optional (ADR-056); the backend defaults
+            // type to SOFTWARE and enforces "researchIntake iff type=RESEARCH".
+            const body = {
+              identifier: args.identifier,
+              name: args.name,
+              description: args.description,
+            };
+            if (args.type) body.type = args.type;
+            if (args.research_intake) body.researchIntake = args.research_intake;
+            return ok(JSON.stringify(await createProject(body), null, 2));
+          }
+          case "replace_research_intake": {
+            reqArg(args, "identifier", "replace_research_intake");
+            reqArg(args, "research_intake", "replace_research_intake");
+            return ok(JSON.stringify(await replaceResearchIntake(args.identifier, args.research_intake), null, 2));
           }
           case "run_sweep": return ok(JSON.stringify(await runSweep(args.project), null, 2));
           case "run_sweep_all": return ok(JSON.stringify(await runSweepAll(), null, 2));

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -1009,12 +1009,28 @@ export async function getProject(identifier) {
   return request("GET", `/api/v1/projects/${encodeURIComponent(identifier)}`);
 }
 
+/**
+ * Create a project. {@code data} accepts {@code identifier}, {@code name},
+ * {@code description}, and (since ADR-056 / issue #999) optional
+ * {@code type} (SOFTWARE | GRC | RESEARCH; defaults to SOFTWARE backend-side)
+ * and optional {@code researchIntake} nested object. The backend enforces
+ * "researchIntake required iff type=RESEARCH" with a 422 if mismatched.
+ */
 export async function createProject(data) {
   return request("POST", "/api/v1/projects", { body: data });
 }
 
 export async function updateProject(identifier, data) {
   return request("PUT", `/api/v1/projects/${encodeURIComponent(identifier)}`, { body: data });
+}
+
+/**
+ * Replace the research-intake metadata for a RESEARCH project. The backend
+ * returns 404 if no intake exists, 422 if the project is not RESEARCH.
+ * See ADR-056.
+ */
+export async function replaceResearchIntake(identifier, data) {
+  return request("PUT", `/api/v1/projects/${encodeURIComponent(identifier)}/research-intake`, { body: data });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add Research as a first-class Ground Control project type with the intake metadata called out in `GC-RSCH-F001`. Adds a `ProjectType` enum (`SOFTWARE` | `GRC` | `RESEARCH`) on `Project` and a sibling `ResearchIntake` aggregate (1:1 with Project when `type=RESEARCH`, `@Audited`) capturing research goal, paper context, contribution type, intended output, autonomy level, allowed tools (typed list with dedup), privacy constraints, and typed token / wall-clock / cost budgets. Validation enforces "intake required iff `type=RESEARCH`" at the API boundary and at a service-layer guard (defence in depth, mirrors PR #997's typed-action-item pattern). See ADR-056 for the architecture decision and for the rationale recording why R001 / F002 / N011 remain DRAFT.

## Requirement UIDs

- `GC-RSCH-F001`
- `GC-RSCH-R007`
- `GC-RSCH-R001` (forward-looking, stays DRAFT, `DOCUMENTS` link to ADR-056)
- `GC-RSCH-F002` (forward-looking, stays DRAFT, `DOCUMENTS` link to ADR-056)
- `GC-RSCH-N011` (forward-looking, stays DRAFT, `DOCUMENTS` link to ADR-056)

## Related Issues

Closes #999

## ADR Impact

- ADR-056 (new — Research project type + intake metadata)
- ADR-054 (touched — gate-sync rule acknowledges the new MCP `gc_admin` action)

## Changes

- Add `ProjectType` enum (`SOFTWARE` | `GRC` | `RESEARCH`) on `Project`. Existing rows backfill to `SOFTWARE` (V126); the column is `NOT NULL` with no DB default after backfill so callers must declare type explicitly.
- New `domain/research/` package: `ResearchIntake` `@Audited` aggregate, `ContributionType` / `IntendedOutput` / `AutonomyLevel` enums, `ResearchIntakeRepository`, `ResearchIntakeService` (creation + full replacement + lookup).
- Extend `ProjectService.create()` to orchestrate Project + ResearchIntake atomically; new `validateIntakeAgainstType()` guard for bypass writes.
- Extend DTOs (`ProjectRequest` / `UpdateProjectRequest` / `ProjectResponse`); add `ResearchIntakeRequest` / `ResearchIntakeResponse`.
- Extend `ProjectController`: type-aware create / get / list now include `researchIntake` when present; new `PUT /api/v1/projects/{identifier}/research-intake` for full-replacement updates (404 / 422 envelopes per ADR-056 §8).
- Flyway migrations `V126` (project.type + research_intake table) and `V127` (research_intake_audit Envers shadow). Both wired into the `MigrationSmokeTest` + `RequirementsE2EIntegrationTest` hardcoded version lists per plan rules.
- MCP `gc_admin`: extend `create_project` action to accept `type` + `research_intake`; add `replace_research_intake` action. New `replaceResearchIntake` function in `mcp/ground-control/lib.js`.
- `docs/API.md` gains a Projects section documenting `ProjectRequest` + `ResearchIntakeRequest` shapes.
- `MigrationSmokeTest` gains explicit column-existence probes for `research_intake` + `research_intake_audit` so a copy-paste regression that drops a payload column fails at boot rather than at first Envers flush.
- `ProjectServiceTest` gains 3 tests covering the intake guard + delegation paths; `ProjectControllerTest` gains 8 cases for research-flavoured create / get / replace-intake, with `ArgumentCaptor` verifying intake forwarding into `CreateProjectCommand` (Step 6.6 test-quality review).

## Documentation

Added: `architecture/adrs/056-research-project-type-and-intake.md`, `docs/API.md` Projects section. Touched: `architecture/adrs/054-documentation-coverage-gate.md` and `docs/DOC_STYLE.md` per the `doc-coverage-gate-sync` rule. Vale style applied to all touched docs (em-dash spacing, Latin substitutions). `documentation_outcome: updated`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass (`make check`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (controller-parity, gate-sync, changelog-fragment)
- [x] No coverage regression
- [x] `MigrationSmokeTest::allFlywayMigrationsRan` includes `126` + `127`
- [x] `MigrationSmokeTest::auditTablesExist` probes `research_intake` + `research_intake_audit` column shape

## Ground Control Checks

- [x] `make policy` passes
- [x] Traceability links created via `gc_create_traceability_link` (2 IMPLEMENTS for F001/R007 → primary artifacts; 5 DOCUMENTS to ADR-056 covering all 5 in-scope requirements)
- [x] F001 + R007 transitioned `DRAFT → ACTIVE`; R001 / F002 / N011 explicitly stay DRAFT (forward-looking per ADR-056)
- [x] Codex pre-push review cycle 1/1 — 1 class finding (ADR/impl status-code drift), fixed in-tree
- [x] Test-quality pre-push review cycle 1/1 — 3 one-off findings (smoke-test probes + service-test coverage + ArgumentCaptor on controller test), all fixed in-tree
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GC-RSCH-F001 ← backend/src/main/java/com/keplerops/groundcontrol/domain/research/model/ResearchIntake.java, GC-RSCH-R007 ← backend/src/main/java/com/keplerops/groundcontrol/domain/projects/model/ProjectType.java
- DOCUMENTS: GC-RSCH-F001 ← architecture/adrs/056-research-project-type-and-intake.md, GC-RSCH-R007 ← architecture/adrs/056-research-project-type-and-intake.md, GC-RSCH-R001 ← architecture/adrs/056-research-project-type-and-intake.md, GC-RSCH-F002 ← architecture/adrs/056-research-project-type-and-intake.md, GC-RSCH-N011 ← architecture/adrs/056-research-project-type-and-intake.md
- TESTS: GC-RSCH-F001 ← backend/src/test/java/com/keplerops/groundcontrol/unit/api/ProjectControllerTest.java, GC-RSCH-F001 ← backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ProjectServiceTest.java

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer (validation only; orchestration in ProjectService)
- [x] Domain layer has no framework imports (only `jakarta.persistence` + `org.hibernate.envers`)
- [x] Envers `@Audited` on the new ResearchIntake entity with `@NotAudited` on the Project back-ref (plan rule)
- [x] Changelog fragment added at `changelog.d/999.added.md`
- [x] Architectural docs updated (ADR-056; `docs/API.md` Projects section)