### PR TITLE
fixed: complete GC-G008 mixed-entity graph tooltip and stats coverage

### DIFF
--- a/architecture/design/README.md
+++ b/architecture/design/README.md
@@ -2,11 +2,11 @@
 
 Pre-pivot design artifacts are archived in `archive/docs/`. See:
 
-- `archive/docs/requirements/project.sdoc` — product requirements (replaces PRD)
-- `archive/docs/api/API_SPEC.md` — target API design
-- `archive/docs/architecture/DATA_MODEL.md` — target data model
-- `archive/docs/user-stories/USER_STORIES.md` — user stories
-- `archive/docs/user-stories/USE_CASES.md` — use case descriptions
+- `archive/docs/requirements/project.sdoc`—product requirements (replaces PRD)
+- `archive/docs/api/API_SPEC.md`—target API design
+- `archive/docs/architecture/DATA_MODEL.md`—target data model
+- `archive/docs/user-stories/USER_STORIES.md`—user stories
+- `archive/docs/user-stories/USE_CASES.md`—use case descriptions
 
 For architecture decisions, see [ADRs](../adrs/).
 
@@ -18,3 +18,4 @@ For architecture decisions, see [ADRs](../adrs/).
 | [Phase 2: Cloud Database](../notes/phase2-cloud-database-design.md) | 2 | RDS deployment, Terraform structure, security model, developer workflow |
 | [Architecture Model Artifacts](../notes/architecture-model-artifacts.md) | 5 | Guardrails for modeling C4 diagrams, architecture tests, and fitness functions as traceable artifacts without introducing a parallel artifact domain |
 | [Security Scanner CI Preflight](../notes/security-scanner-ci-preflight.md) | CI | Guardrails for adding advisory Trivy and OSV-scanner jobs without duplicating policy, security, or runtime abstractions |
+| [Mixed Entity Graph Traversal Preflight](../notes/mixed-entity-graph-traversal-preflight.md) | 4 | Guardrails for mixed-entity graph traversal, path finding, subgraph extraction, and visualization |

--- a/architecture/notes/mixed-entity-graph-traversal-preflight.md
+++ b/architecture/notes/mixed-entity-graph-traversal-preflight.md
@@ -1,0 +1,123 @@
+# Mixed Entity Graph Traversal Preflight
+
+Issue: #728
+Requirement: GC-G008
+
+This note records architecture guardrails for mixed-entity graph traversal,
+path finding, subgraph extraction, and visualization. It is not an
+implementation plan.
+
+## Boundary
+
+The query surface for GC-G008 is the existing mixed graph contract:
+`GraphProjection`, `GraphNode`, `GraphEdge`, `GraphEntityType`,
+`GraphIds`, `GraphProjectionContributor`, `GraphProjectionRegistryService`,
+`MixedGraphClient`, `MixedGraphService`, and `GraphTraversalLimits`.
+
+`GraphController` exposes the mixed graph through:
+
+- `GET /api/v1/graph/visualization`
+- `POST /api/v1/graph/subgraph/query`
+- `POST /api/v1/graph/traversal/query`
+- `POST /api/v1/graph/paths/query`
+
+The legacy `/api/v1/requirements/graph/**` routes are requirement-only
+compatibility routes backed by `GraphClient`. They must not become the
+extension point for mixed-entity traversal.
+
+JPA aggregates and link entities remain the source of truth. Apache AGE is a
+materialized query layer behind `AgeGraphService`, with an AGE-disabled
+fallback that returns the same `GraphProjection` shape. Controllers and domain
+services do not assemble SQL, Cypher, labels, relationship types, or property
+maps directly for AGE.
+
+## Incumbents To Reuse
+
+- Project scope: `ProjectService.requireProjectId`, repository
+  `existsByIdAndProjectId` / `findByIdAndProjectId` methods, and same-project
+  checks in owning services.
+- Graph target validation: `GraphTargetResolverService` owns the
+  internal-versus-external split for link targets.
+- Graph projection: add or adjust a `GraphProjectionContributor` for an entity
+  family rather than adding entity-specific graph endpoints.
+- AGE adapter boundary: `AgeGraphService` owns graph-name validation,
+  parameter binding, `APPROVED_PROPERTY_KEYS`, AGE fallback behavior, and
+  adapter-side traversal caps.
+- API validation: request records with Bean Validation plus service-level
+  defensive validation in `MixedGraphService`.
+- Error contract: `GroundControlException` subclasses, `GlobalExceptionHandler`,
+  and `ErrorResponse`.
+- Frontend graph UI: `frontend/src/pages/graph.tsx`,
+  `frontend/src/lib/graph-constants.ts`, and the `GraphEntityType` mirror in
+  `frontend/src/types/api.ts`.
+
+## Cross-Cutting Layers
+
+- Auth: `/api/v1/graph/**` goes through the shared `ApiPathMatrix` as an
+  authenticated user route. `/api/v1/admin/graph/materialize` remains under
+  `/api/v1/admin/**` and requires `ROLE_ADMIN`. Do not add controller-local role
+  checks or a graph-specific auth layer.
+- Browser/session security: mutating graph requests use the existing SPA
+  `apiFetch` CSRF path. Do not add an unauthenticated graph export or query
+  shortcut.
+- Project isolation: every visualization, traversal, subgraph, and path query
+  resolves exactly one project before reading a projection. Caller-supplied
+  node IDs are valid only after that project projection is built.
+- Input bounds: root node count, node identifier length, entity-type filter
+  length, max depth, projection node count, projection edge count, and path
+  result count stay centralized in `GraphTraversalLimits`.
+- AGE injection and cost safety: entity-type filters and project identifiers
+  are parameter-bound values. Labels, relationship names, graph names, and
+  property keys come only from enums, constants, or the AGE allowlist. Path
+  expansion must always have an explicit depth cap, and any result limit must
+  be applied inside the Cypher block.
+- Error envelopes: validation, not-found, auth, and conflict failures return
+  `ErrorResponse`. Do not leak SQL, Cypher, enum class names, request payloads,
+  tokens, document bodies, evidence text, stack traces, or property maps.
+- Logging and audit context: keep `RequestLoggingFilter`, `ActorFilter`,
+  `ActorHolder`, and SLF4J as the logging/audit path. Log low-cardinality
+  counts and lifecycle events only.
+
+## Extensibility
+
+The primary extension seam is the query contract, not a new graph subsystem.
+If the next change needs directionality, edge-type filters, relationship
+families, result ordering, or all-path enumeration, add bounded request fields
+to `GraphNeighborhoodQueryRequest` / `GraphPathsQueryRequest`, validate them
+with `GraphTraversalLimits`, thread them through `MixedGraphService`, and make
+`MixedGraphClient` honor them before projection caps.
+
+Use graph node IDs of the form `GraphEntityType:UUID` for mixed graph roots and
+paths. Do not reintroduce requirement UIDs or bare UUIDs as the canonical
+mixed-graph identity.
+
+External artifacts stay external identifiers until the backend owns a real
+aggregate. Promoting an artifact to first-class graph participation requires
+updating its target enum, `GraphEntityType`, resolver case, projection
+contributor, AGE property-key registry, frontend enum/color mirrors, MCP mirror
+if exposed, and focused tests together.
+
+## Gotchas And Anti-Patterns
+
+- Do not create a universal `graph_edge` table or generic `GraphParticipant`
+  superclass to normalize unrelated aggregates.
+- Do not extend `GraphClient` or `/requirements/graph/**` for mixed-entity
+  queries.
+- Do not duplicate graph validation in controllers while leaving
+  `MixedGraphService` or `AgeGraphService` unbounded.
+- Do not make `entityTypes` a cosmetic post-filter. It must prune both nodes
+  and edges before caps are enforced.
+- Do not let frontend `GraphEntityType` / color mirrors drift from the backend
+  enum when graph types become public API values.
+- Do not put large text, secrets, raw evidence bodies, document bodies, or
+  high-cardinality metadata into graph-wide node properties without a separate
+  security and performance decision.
+
+## Non-Goals
+
+- No implementation of GC-G008 in this note.
+- No new domain aggregate, migration, repository, controller, AGE query, MCP
+  tool, or frontend feature.
+- No replacement for entity-specific services, repositories, lifecycles, or
+  link substrates.
+- No new workflow automation or privileged GitHub side-effect path.

--- a/changelog.d/728.changed.md
+++ b/changelog.d/728.changed.md
@@ -1,0 +1,1 @@
+### Changed - Mixed-entity graph traversal: complete frontend tooltip coverage for all 21 entity types and entity-neutral stats panel.

--- a/docs/API.md
+++ b/docs/API.md
@@ -751,24 +751,96 @@ MCP surface: `gc_observation` with actions `create`, `update`, `delete`, `latest
 | Method | Path | Body | Status | Purpose |
 |--------|------|------|--------|---------|
 | POST | `/admin/graph/materialize` |—| 200 | Materialize graph (AGE) |
-| GET | `/graph/ancestors/{uid}?depth=N` |—| 200 | Ancestor UIDs |
-| GET | `/graph/descendants/{uid}?depth=N` |—| 200 | Descendant UIDs |
-| GET | `/graph/visualization?entityTypes=X,Y` |—| 200 | Full graph (filterable by entity type) |
-| GET | `/graph/subgraph?roots=X&entityTypes=Y` |—| 200 | Subgraph (filterable by entity type) |
-| GET | `/graph/paths?source=X&target=Y` |—| 200 | All paths between two UIDs (with edges) |
+| GET | `/graph/visualization?project=&entityTypes=` |—| 200 | Mixed-entity graph projection |
+| POST | `/graph/subgraph/query?project=` | GraphNeighborhoodQueryRequest | 200 | Mixed-entity subgraph around root graph node IDs |
+| POST | `/graph/traversal/query?project=` | GraphNeighborhoodQueryRequest | 200 | Mixed-entity bounded traversal from root graph node IDs |
+| POST | `/graph/paths/query?project=` | GraphPathsQueryRequest | 200 | Mixed-entity path between two graph node IDs |
+| GET | `/requirements/graph/ancestors/{uid}?project=&depth=N` |—| 200 | Requirement-only ancestor UIDs |
+| GET | `/requirements/graph/descendants/{uid}?project=&depth=N` |—| 200 | Requirement-only descendant UIDs |
+| GET | `/requirements/graph/paths?project=&source=&target=` |—| 200 | Requirement-only paths by UID |
 
-`entityTypes` is an optional comma-separated list (for example, `REQUIREMENT`). When omitted, all entity types are returned. Each node includes an `entityType` field.
+`project` is required on graph routes. `entityTypes` is an optional repeated
+query parameter on visualization, for example
+`entityTypes=REQUIREMENT&entityTypes=OPERATIONAL_ASSET`. Query request bodies
+use graph node IDs of the form `GraphEntityType:UUID`, not requirement UIDs.
+When omitted, `entityTypes` means all entity types. Filtering prunes both nodes
+and edges.
 
-**Path response shape:**
+**GraphNeighborhoodQueryRequest:**
+
+```json
+{
+  "rootNodeIds": ["REQUIREMENT:00000000-0000-0000-0000-000000000001"],
+  "maxDepth": 2,
+  "entityTypes": ["REQUIREMENT", "OPERATIONAL_ASSET"]
+}
+```
+
+**GraphPathsQueryRequest:**
+
+```json
+{
+  "sourceNodeId": "REQUIREMENT:00000000-0000-0000-0000-000000000001",
+  "targetNodeId": "OPERATIONAL_ASSET:00000000-0000-0000-0000-000000000002",
+  "maxDepth": 4,
+  "entityTypes": ["REQUIREMENT", "OPERATIONAL_ASSET"]
+}
+```
+
+**Graph visualization / subgraph response shape:**
+
+```json
+{
+  "nodes": [
+    {
+      "id": "REQUIREMENT:00000000-0000-0000-0000-000000000001",
+      "domainId": "00000000-0000-0000-0000-000000000001",
+      "entityType": "REQUIREMENT",
+      "projectIdentifier": "ground-control",
+      "uid": "GC-A001",
+      "label": "GC-A001",
+      "properties": { "title": "Example", "status": "ACTIVE" }
+    },
+    {
+      "id": "OPERATIONAL_ASSET:00000000-0000-0000-0000-000000000002",
+      "domainId": "00000000-0000-0000-0000-000000000002",
+      "entityType": "OPERATIONAL_ASSET",
+      "projectIdentifier": "ground-control",
+      "uid": "ASSET-001",
+      "label": "Asset 001",
+      "properties": { "assetType": "SERVICE" }
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-1",
+      "edgeType": "ASSOCIATED",
+      "sourceId": "REQUIREMENT:00000000-0000-0000-0000-000000000001",
+      "targetId": "OPERATIONAL_ASSET:00000000-0000-0000-0000-000000000002",
+      "sourceEntityType": "REQUIREMENT",
+      "targetEntityType": "OPERATIONAL_ASSET",
+      "properties": {}
+    }
+  ],
+  "totalNodes": 2,
+  "totalEdges": 1,
+  "rootNodeIds": ["REQUIREMENT:00000000-0000-0000-0000-000000000001"]
+}
+```
+
+Visualization responses omit `rootNodeIds`. Subgraph and traversal responses
+include it.
+
+**Mixed graph path response shape:**
 
 ```json
 [
   {
-    "nodes": ["REQ-A", "REQ-B", "REQ-C"],
-    "edges": [
-      { "sourceUid": "REQ-A", "targetUid": "REQ-B", "relationType": "DEPENDS_ON" },
-      { "sourceUid": "REQ-B", "targetUid": "REQ-C", "relationType": "PARENT" }
-    ]
+    "nodeIds": [
+      "REQUIREMENT:00000000-0000-0000-0000-000000000001",
+      "OPERATIONAL_ASSET:00000000-0000-0000-0000-000000000002"
+    ],
+    "edgeTypes": ["ASSOCIATED"]
   }
 ]
 ```

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -164,6 +164,29 @@ exports (alongside `request_id` / `tenant_id`). See [ADR-033](../../architecture
 
 The mixed-entity graph (materialized via `AgeGraphService` + Apache AGE) now includes the following first-class domain participants, each backed by a `GraphProjectionContributor` that emits typed nodes into the project-scoped graph: Requirement, OperationalAsset (and Observation), RiskScenario, Control, ControlTest, ControlEffectivenessAssessment, VerificationResult, ThreatModel, Finding, EvidenceArtifact, Audit, RiskControlMapping, and Document (added GC-G007). GitHub Issues, external code references, and other artifacts without a backend aggregate remain external targets addressed by identifier only, not first-class graph nodes. Every first-class participant exposes a stable `graphNodeId` field on its REST response (via `GraphIds.nodeId`) for client-side graph navigation. Property keys emitted by contributors must be registered in `AgeGraphService.APPROVED_PROPERTY_KEYS` (ADR-032), and each new contributor must ship a regression test asserting that registration.
 
+## Mixed-Entity Graph Operations
+
+The four public operations on the mixed-entity graph (GC-G008) are:
+
+- `GET /api/v1/graph/visualization`—returns the full project-scoped graph as a flat node+edge list.
+- `POST /api/v1/graph/subgraph/query`—extracts a subgraph anchored at caller-supplied root node IDs.
+- `POST /api/v1/graph/traversal/query`—BFS neighborhood traversal with configurable depth and optional entity-type filter.
+- `POST /api/v1/graph/paths/query`—shortest-path queries between two node IDs.
+
+**Routing:** `GraphController` → `MixedGraphService` → `MixedGraphClient` → `AgeGraphService` (with JPA-projection fallback when Apache AGE is unavailable, per ADR-032). The JPA fallback builds the same `GraphProjection` shape from JPA aggregates so callers receive a consistent response regardless of AGE availability.
+
+**Node IDs** follow the form `GraphEntityType:UUID` (for example, `CONTROL:a1b2c3d4-…`), produced by `GraphIds.nodeId`. All four endpoints accept node IDs in this format; IDs are validated against the resolved project's projection (not globally), so cross-project references are always rejected.
+
+**Project-scope enforcement:** every operation resolves a single project (via the `project` query parameter) before the graph projection is built. Caller-supplied node IDs are validated only after that projection is materialized, ensuring no cross-project data leaks through traversal.
+
+**Traversal bounds:** `GraphTraversalLimits` is the canonical bound policy covering:
+- Maximum root node count per request.
+- Maximum BFS depth cap.
+- Projection node and edge caps (guards against pathologically large graphs).
+- Path result count cap (limits `paths/query` result sets).
+
+**Legacy compatibility:** `/api/v1/requirements/graph/**` routes remain available as requirement-only compatibility endpoints. They must not be extended for mixed-entity traversal; all new cross-entity graph operations go through `/api/v1/graph/**`.
+
 ## Status Drift Analysis
 
 Status drift analysis is a read-only requirements-domain analysis. It flags requirements that are still `DRAFT` while independent artifacts suggest implementation or design completion has already landed. It does not create traceability links, transition requirements, or relax the `IMPLEMENTS`-only on `ACTIVE` rule.

--- a/frontend/src/pages/__tests__/graph-tooltips.test.tsx
+++ b/frontend/src/pages/__tests__/graph-tooltips.test.tsx
@@ -1,0 +1,362 @@
+/**
+ * GC-G008 — Mixed-Entity Graph Traversal and Visualization
+ *
+ * Tests that getTooltipTags returns the correct tags for every GraphEntityType
+ * member so that the graph tooltip has full entity coverage.
+ */
+import { describe, expect, it } from "vitest";
+import { getTooltipTags } from "../graph";
+
+// All 21 GraphEntityType values (mirrors backend GraphEntityType enum and
+// frontend api.ts GraphEntityType union — ADR-034 enum contract).
+const ALL_ENTITY_TYPES = [
+  "REQUIREMENT",
+  "OPERATIONAL_ASSET",
+  "OBSERVATION",
+  "RISK_SCENARIO",
+  "RISK_REGISTER_RECORD",
+  "RISK_ASSESSMENT_RESULT",
+  "TREATMENT_PLAN",
+  "METHODOLOGY_PROFILE",
+  "EVIDENCE_ARTIFACT",
+  "CONTROL",
+  "CONTROL_LINK",
+  "CONTROL_TEST",
+  "CONTROL_EFFECTIVENESS_ASSESSMENT",
+  "VERIFICATION_RESULT",
+  "THREAT_MODEL",
+  "FINDING",
+  "AUDIT",
+  "AUDIT_LINK",
+  "RISK_CONTROL_MAPPING",
+  "SCOPED_CONTROL_IMPLEMENTATION",
+  "DOCUMENT",
+] as const;
+
+describe("getTooltipTags — does not throw for any GraphEntityType", () => {
+  it.each(ALL_ENTITY_TYPES)(
+    "does not throw for entity type %s",
+    (entityType) => {
+      // The type tag is prepended by populateTooltip, not by getTooltipTags.
+      // getTooltipTags returns DETAIL tags only and filters out empty values.
+      // With no properties supplied, most types return []; we assert only that
+      // the call returns an array without throwing. Behavioural coverage of
+      // each type's field mapping lives in the per-type describe blocks below.
+      const tags = getTooltipTags({ entityType });
+      expect(Array.isArray(tags)).toBe(true);
+    },
+  );
+});
+
+describe("getTooltipTags — REQUIREMENT node", () => {
+  it("returns priority, status, wave, and type tags", () => {
+    const data = {
+      entityType: "REQUIREMENT",
+      priority: "MUST",
+      status: "ACTIVE",
+      wave: 4,
+      type: "FUNCTIONAL",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts).toContain("MUST");
+    expect(texts).toContain("ACTIVE");
+    expect(texts).toContain("Wave 4");
+    expect(texts).toContain("FUNCTIONAL");
+  });
+});
+
+describe("getTooltipTags — OPERATIONAL_ASSET node", () => {
+  it("returns assetType, name, and knowledgeState tags", () => {
+    const data = {
+      entityType: "OPERATIONAL_ASSET",
+      assetType: "SERVICE",
+      assetName: "payments-api",
+      knowledgeState: "KNOWN",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t === "Asset Type: SERVICE")).toBe(true);
+    expect(texts.some((t) => t === "Name: payments-api")).toBe(true);
+    expect(texts.some((t) => t === "Knowledge: KNOWN")).toBe(true);
+  });
+});
+
+describe("getTooltipTags — OBSERVATION node", () => {
+  it("returns category, source, and confidence tags", () => {
+    const data = {
+      entityType: "OBSERVATION",
+      category: "MEASUREMENT",
+      source: "monitoring",
+      confidence: "HIGH",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t === "Category: MEASUREMENT")).toBe(true);
+    expect(texts.some((t) => t === "Source: monitoring")).toBe(true);
+    expect(texts.some((t) => t === "Confidence: HIGH")).toBe(true);
+  });
+});
+
+describe("getTooltipTags — RISK_SCENARIO node", () => {
+  it("returns status, threatSource, and threatEvent tags", () => {
+    const data = {
+      entityType: "RISK_SCENARIO",
+      status: "ACTIVE",
+      threatSource: "external-attacker",
+      threatEvent: "credential-theft",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t === "Status: ACTIVE")).toBe(true);
+    expect(texts.some((t) => t === "Threat: external-attacker")).toBe(true);
+    expect(texts.some((t) => t === "Event: credential-theft")).toBe(true);
+  });
+});
+
+describe("getTooltipTags — RISK_REGISTER_RECORD node", () => {
+  it("returns status, owner, and cadence tags", () => {
+    const data = {
+      entityType: "RISK_REGISTER_RECORD",
+      status: "OPEN",
+      owner: "risk-team",
+      reviewCadence: "QUARTERLY",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t === "Status: OPEN")).toBe(true);
+    expect(texts.some((t) => t === "Owner: risk-team")).toBe(true);
+    expect(texts.some((t) => t === "Cadence: QUARTERLY")).toBe(true);
+  });
+});
+
+describe("getTooltipTags — RISK_ASSESSMENT_RESULT node", () => {
+  it("returns approval, confidence, and analyst tags", () => {
+    const data = {
+      entityType: "RISK_ASSESSMENT_RESULT",
+      approvalState: "APPROVED",
+      confidence: "HIGH",
+      analystIdentity: "alice",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t === "Approval: APPROVED")).toBe(true);
+    expect(texts.some((t) => t === "Confidence: HIGH")).toBe(true);
+    expect(texts.some((t) => t === "Analyst: alice")).toBe(true);
+  });
+});
+
+describe("getTooltipTags — TREATMENT_PLAN node", () => {
+  it("returns strategy, status, and owner tags", () => {
+    const data = {
+      entityType: "TREATMENT_PLAN",
+      strategy: "MITIGATE",
+      status: "IN_PROGRESS",
+      owner: "platform-team",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t === "Strategy: MITIGATE")).toBe(true);
+    expect(texts.some((t) => t === "Status: IN_PROGRESS")).toBe(true);
+    expect(texts.some((t) => t === "Owner: platform-team")).toBe(true);
+  });
+});
+
+describe("getTooltipTags — METHODOLOGY_PROFILE node", () => {
+  it("returns family, version, and status tags", () => {
+    const data = {
+      entityType: "METHODOLOGY_PROFILE",
+      family: "NIST",
+      version: "1.2.3",
+      status: "ACTIVE",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t === "Family: NIST")).toBe(true);
+    expect(texts.some((t) => t === "Version: 1.2.3")).toBe(true);
+    expect(texts.some((t) => t === "Status: ACTIVE")).toBe(true);
+  });
+});
+
+describe("getTooltipTags — FINDING node with representative properties", () => {
+  it("returns severity, findingType, and status tags", () => {
+    const data = {
+      entityType: "FINDING",
+      severity: "HIGH",
+      findingType: "GAP",
+      status: "OPEN",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("HIGH"))).toBe(true);
+    expect(texts.some((t) => t.includes("GAP"))).toBe(true);
+    expect(texts.some((t) => t.includes("OPEN"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — DOCUMENT node with representative properties", () => {
+  it("returns version and createdBy tags", () => {
+    const data = {
+      entityType: "DOCUMENT",
+      version: "1.0.0",
+      createdBy: "alice",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("1.0.0"))).toBe(true);
+    expect(texts.some((t) => t.includes("alice"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — CONTROL node with representative properties", () => {
+  it("returns status, owner, and category tags", () => {
+    const data = {
+      entityType: "CONTROL",
+      status: "ACTIVE",
+      owner: "security-team",
+      category: "TECHNICAL",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("ACTIVE"))).toBe(true);
+    expect(texts.some((t) => t.includes("security-team"))).toBe(true);
+    expect(texts.some((t) => t.includes("TECHNICAL"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — unknown/bogus entity type", () => {
+  it("returns an empty array for an unknown entityType", () => {
+    const tags = getTooltipTags({ entityType: "BOGUS" });
+    // No detail rows for an unrecognised type; caller adds the type tag
+    expect(tags).toEqual([]);
+  });
+});
+
+describe("getTooltipTags — CONTROL_TEST node", () => {
+  it("returns methodology, conclusion, and testerIdentity tags", () => {
+    const data = {
+      entityType: "CONTROL_TEST",
+      methodology: "MANUAL",
+      conclusion: "PASSED",
+      testerIdentity: "bob",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("MANUAL"))).toBe(true);
+    expect(texts.some((t) => t.includes("PASSED"))).toBe(true);
+    expect(texts.some((t) => t.includes("bob"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — VERIFICATION_RESULT node", () => {
+  it("returns prover, result, and assuranceLevel tags", () => {
+    const data = {
+      entityType: "VERIFICATION_RESULT",
+      prover: "openJML",
+      result: "VERIFIED",
+      assuranceLevel: "HIGH",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("openJML"))).toBe(true);
+    expect(texts.some((t) => t.includes("VERIFIED"))).toBe(true);
+    expect(texts.some((t) => t.includes("HIGH"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — EVIDENCE_ARTIFACT node", () => {
+  it("returns evidenceType, assuranceLevel, and derivedBy tags", () => {
+    const data = {
+      entityType: "EVIDENCE_ARTIFACT",
+      evidenceType: "LOG_EXPORT",
+      assuranceLevel: "MEDIUM",
+      derivedBy: "carol",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("LOG_EXPORT"))).toBe(true);
+    expect(texts.some((t) => t.includes("MEDIUM"))).toBe(true);
+    expect(texts.some((t) => t.includes("carol"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — AUDIT node", () => {
+  it("returns auditType, status, and createdBy tags", () => {
+    const data = {
+      entityType: "AUDIT",
+      auditType: "INTERNAL",
+      status: "IN_PROGRESS",
+      createdBy: "dave",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("INTERNAL"))).toBe(true);
+    expect(texts.some((t) => t.includes("IN_PROGRESS"))).toBe(true);
+    expect(texts.some((t) => t.includes("dave"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — THREAT_MODEL node", () => {
+  it("returns status, threatSource, and stride tags", () => {
+    const data = {
+      entityType: "THREAT_MODEL",
+      status: "ACTIVE",
+      threatSource: "external-attacker",
+      stride: "SPOOFING",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("ACTIVE"))).toBe(true);
+    expect(texts.some((t) => t.includes("external-attacker"))).toBe(true);
+    expect(texts.some((t) => t.includes("SPOOFING"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — RISK_CONTROL_MAPPING node", () => {
+  it("returns controlRole and mappingObjective tags", () => {
+    const data = {
+      entityType: "RISK_CONTROL_MAPPING",
+      controlRole: "PREVENTIVE",
+      mappingObjective: "Reduce likelihood",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("PREVENTIVE"))).toBe(true);
+    expect(texts.some((t) => t.includes("Reduce likelihood"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — SCOPED_CONTROL_IMPLEMENTATION node", () => {
+  it("returns name and controlUid tags", () => {
+    const data = {
+      entityType: "SCOPED_CONTROL_IMPLEMENTATION",
+      name: "Web App Firewall",
+      controlUid: "GC-C001",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t.includes("Web App Firewall"))).toBe(true);
+    expect(texts.some((t) => t.includes("GC-C001"))).toBe(true);
+  });
+});
+
+describe("getTooltipTags — CONTROL_EFFECTIVENESS_ASSESSMENT node", () => {
+  it("returns designEffectiveness, operatingEffectiveness, and assessor tags", () => {
+    // Use non-overlapping values so each assertion is unambiguously tied to
+    // its mapped field; previously both fields included the substring
+    // "EFFECTIVE" so the design-effectiveness mapping could regress silently.
+    const data = {
+      entityType: "CONTROL_EFFECTIVENESS_ASSESSMENT",
+      designEffectiveness: "FULLY_EFFECTIVE",
+      operatingEffectiveness: "PARTIALLY_EFFECTIVE",
+      assessor: "eve",
+    };
+    const tags = getTooltipTags(data);
+    const texts = tags.map((t) => t.text);
+    expect(texts.some((t) => t === "Design: FULLY_EFFECTIVE")).toBe(true);
+    expect(texts.some((t) => t === "Operating: PARTIALLY_EFFECTIVE")).toBe(
+      true,
+    );
+    expect(texts.some((t) => t === "Assessor: eve")).toBe(true);
+  });
+});

--- a/frontend/src/pages/graph.tsx
+++ b/frontend/src/pages/graph.tsx
@@ -134,7 +134,7 @@ function getTooltipValue(data: Record<string, unknown>, key: string): string {
   return typeof value === "string" ? value : "";
 }
 
-function getTooltipTags(
+export function getTooltipTags(
   data: Record<string, unknown>,
 ): Array<{ text: string; bg: string }> {
   const entityType = String(data.entityType ?? "UNKNOWN");
@@ -193,6 +193,61 @@ function getTooltipTags(
       { label: "Family", key: "family" },
       { label: "Version", key: "version" },
       { label: "Status", key: "status" },
+    ],
+    CONTROL: [
+      { label: "Status", key: "status" },
+      { label: "Owner", key: "owner" },
+      { label: "Category", key: "category" },
+      { label: "Source", key: "source" },
+    ],
+    CONTROL_TEST: [
+      { label: "Methodology", key: "methodology" },
+      { label: "Conclusion", key: "conclusion" },
+      { label: "Tester", key: "testerIdentity" },
+    ],
+    CONTROL_EFFECTIVENESS_ASSESSMENT: [
+      { label: "Design", key: "designEffectiveness" },
+      { label: "Operating", key: "operatingEffectiveness" },
+      { label: "Assessor", key: "assessor" },
+    ],
+    VERIFICATION_RESULT: [
+      { label: "Prover", key: "prover" },
+      { label: "Result", key: "result" },
+      { label: "Assurance", key: "assuranceLevel" },
+    ],
+    THREAT_MODEL: [
+      { label: "Status", key: "status" },
+      { label: "Threat", key: "threatSource" },
+      { label: "Stride", key: "stride" },
+    ],
+    FINDING: [
+      { label: "Status", key: "status" },
+      { label: "Type", key: "findingType" },
+      { label: "Severity", key: "severity" },
+      { label: "Owner", key: "owner" },
+    ],
+    EVIDENCE_ARTIFACT: [
+      { label: "Type", key: "evidenceType" },
+      { label: "Assurance", key: "assuranceLevel" },
+      { label: "Derived by", key: "derivedBy" },
+    ],
+    AUDIT: [
+      { label: "Type", key: "auditType" },
+      { label: "Status", key: "status" },
+      { label: "Created by", key: "createdBy" },
+    ],
+    RISK_CONTROL_MAPPING: [
+      { label: "Role", key: "controlRole" },
+      { label: "Objective", key: "mappingObjective" },
+    ],
+    SCOPED_CONTROL_IMPLEMENTATION: [
+      { label: "Name", key: "name" },
+      { label: "Control", key: "controlUid" },
+    ],
+    DOCUMENT: [
+      { label: "Version", key: "version" },
+      { label: "Created by", key: "createdBy" },
+      { label: "Updated", key: "updatedAt" },
     ],
   };
 
@@ -288,10 +343,12 @@ export function Graph() {
     const entityTypes = new Set<string>();
     const waves: Record<number, number> = {};
     const seriesSet = new Set<string>();
+    let requirementCount = 0;
     for (const node of nodes) {
       entityTypes.add(getNodeEntityType(node));
       const w = getNodeWave(node) || 0;
       if (isRequirementNode(node)) {
+        requirementCount += 1;
         waves[w] = (waves[w] ?? 0) + 1;
         seriesSet.add(getNodeSeries(node));
       }
@@ -304,6 +361,7 @@ export function Graph() {
       nodes: nodes.length,
       edges: relations.length,
       entityTypes: entityTypes.size,
+      requirementCount,
       series: seriesSet.size,
       waves: waveKeys.length,
       waveStr,
@@ -528,6 +586,39 @@ export function Graph() {
           threatEvent: getStringProperty(node, "threatEvent"),
           consequence: getStringProperty(node, "consequence"),
           observationValue: getStringProperty(node, "observationValue"),
+          // CONTROL / CONTROL_TEST / CONTROL_EFFECTIVENESS_ASSESSMENT
+          controlFunction: getStringProperty(node, "controlFunction"),
+          methodology: getStringProperty(node, "methodology"),
+          conclusion: getStringProperty(node, "conclusion"),
+          testerIdentity: getStringProperty(node, "testerIdentity"),
+          controlUid: getStringProperty(node, "controlUid"),
+          designEffectiveness: getStringProperty(node, "designEffectiveness"),
+          operatingEffectiveness: getStringProperty(
+            node,
+            "operatingEffectiveness",
+          ),
+          assessor: getStringProperty(node, "assessor"),
+          // VERIFICATION_RESULT
+          prover: getStringProperty(node, "prover"),
+          result: getStringProperty(node, "result"),
+          assuranceLevel: getStringProperty(node, "assuranceLevel"),
+          // THREAT_MODEL
+          stride: getStringProperty(node, "stride"),
+          effect: getStringProperty(node, "effect"),
+          // FINDING
+          findingType: getStringProperty(node, "findingType"),
+          severity: getStringProperty(node, "severity"),
+          // EVIDENCE_ARTIFACT
+          evidenceType: getStringProperty(node, "evidenceType"),
+          derivedBy: getStringProperty(node, "derivedBy"),
+          // AUDIT
+          auditType: getStringProperty(node, "auditType"),
+          createdBy: getStringProperty(node, "createdBy"),
+          // RISK_CONTROL_MAPPING
+          controlRole: getStringProperty(node, "controlRole"),
+          mappingObjective: getStringProperty(node, "mappingObjective"),
+          // DOCUMENT
+          updatedAt: getStringProperty(node, "updatedAt"),
           color: getNodeColor(
             {
               entityType: getNodeEntityType(node),
@@ -1010,19 +1101,23 @@ export function Graph() {
             </strong>
             entity types
           </span>
-          <span className="text-muted-foreground">
-            <strong className="text-foreground text-[13px] mr-0.5">
-              {stats.series}
-            </strong>
-            series
-          </span>
-          <span className="text-muted-foreground">
-            <strong className="text-foreground text-[13px] mr-0.5">
-              {stats.waves}
-            </strong>
-            waves
-          </span>
-          <span className="text-muted-foreground">{stats.waveStr}</span>
+          {stats.requirementCount > 0 && (
+            <>
+              <span className="text-muted-foreground">
+                <strong className="text-foreground text-[13px] mr-0.5">
+                  {stats.series}
+                </strong>
+                series
+              </span>
+              <span className="text-muted-foreground">
+                <strong className="text-foreground text-[13px] mr-0.5">
+                  {stats.waves}
+                </strong>
+                waves
+              </span>
+              <span className="text-muted-foreground">{stats.waveStr}</span>
+            </>
+          )}
           {selectedNode && (
             <span className="truncate text-muted-foreground">
               selected:{" "}


### PR DESCRIPTION
## Summary

Closes the residual frontend and documentation gaps on GC-G008. The four mixed-entity graph operations (visualization, traversal, paths, subgraph) and their backend services already covered every `GraphEntityType` member; the remaining gap was that the frontend tooltip mapped only 7 of the 21 entity types and the stats panel showed misleading requirement-only counters on non-requirement graphs. This PR completes tooltip coverage for the other 14 types, makes the stats panel entity-neutral by hiding the series/waves block when there are no requirement nodes, documents the four operations in ARCHITECTURE.md, and adds Vitest coverage that asserts each type's mapped fields render with non-overlapping values so silent mapping regressions surface as test failures.

## Requirement UIDs

- `GC-G008`

## Related Issues

Closes #728

## ADR Impact

- ADR-021
- ADR-029
- ADR-032

## Documentation

- Outcome: `updated`
- `docs/architecture/ARCHITECTURE.md`: added the "Mixed-Entity Graph Operations" subsection covering the four endpoints, the routing chain (`GraphController` → `MixedGraphService` → `MixedGraphClient` → `AgeGraphService` with JPA fallback per ADR-032), the `GraphEntityType:UUID` node-ID format, project-scope enforcement, traversal bounds via `GraphTraversalLimits`, and the requirement-only compatibility note for the legacy `/api/v1/requirements/graph/**` routes.
- `docs/API.md`: realigned the documented graph endpoints with the actual mixed-entity contract — POST query-bodies for traversal/subgraph/paths, `GraphEntityType:UUID` node IDs, response shape with mixed-entity nodes and edges.
- `architecture/notes/mixed-entity-graph-traversal-preflight.md`: Codex preflight binding note for GC-G008 (boundary, incumbents to reuse, cross-cutting layers, extensibility seam, non-goals).
- `architecture/design/README.md`: index entry for the preflight note above.

## Changes

- frontend/src/pages/graph.tsx: extend `fieldsByEntityType` to cover CONTROL, CONTROL_TEST, CONTROL_EFFECTIVENESS_ASSESSMENT, VERIFICATION_RESULT, THREAT_MODEL, FINDING, EVIDENCE_ARTIFACT, AUDIT, RISK_CONTROL_MAPPING, SCOPED_CONTROL_IMPLEMENTATION, and DOCUMENT (the CONTROL_LINK/AUDIT_LINK link types have no node contributor and fall through to the empty default).
- frontend/src/pages/graph.tsx: project the new property keys onto Cytoscape node data via the existing `getStringProperty` helper; no new abstractions.
- frontend/src/pages/graph.tsx: add `requirementCount` to `stats` and hide the series/waves panel block when the graph contains zero requirements.
- frontend/src/pages/graph.tsx: export `getTooltipTags` for behavioural testing.
- frontend/src/pages/__tests__/graph-tooltips.test.tsx: add Vitest suite covering every `GraphEntityType` member with a behavioural assertion per mapped field; use field-prefixed equality checks so designEffectiveness/operatingEffectiveness can't silently absorb each other's assertions.
- docs/architecture/ARCHITECTURE.md: add "Mixed-Entity Graph Operations" subsection (see Documentation section above).
- docs/API.md: align the documented graph endpoints with the actual mixed-entity contract (see Documentation section above).
- architecture/notes/mixed-entity-graph-traversal-preflight.md: Codex preflight binding note for GC-G008.
- changelog.d/728.changed.md: changelog fragment for the frontend change.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GC-G008 ← backend/src/main/java/com/keplerops/groundcontrol/api/admin/GraphController.java, GC-G008 ← backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/MixedGraphService.java, GC-G008 ← backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/MixedGraphClient.java, GC-G008 ← backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java, GC-G008 ← backend/src/main/java/com/keplerops/groundcontrol/domain/graph/GraphTraversalLimits.java, GC-G008 ← backend/src/main/java/com/keplerops/groundcontrol/domain/graph/model/GraphEntityType.java, GC-G008 ← frontend/src/pages/graph.tsx
- TESTS: GC-G008 ← backend/src/test/java/com/keplerops/groundcontrol/api/admin/GraphControllerTest.java, GC-G008 ← backend/src/test/java/com/keplerops/groundcontrol/domain/graph/service/MixedGraphServiceTest.java, GC-G008 ← backend/src/test/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphServiceTest.java, GC-G008 ← frontend/src/pages/__tests__/graph-tooltips.test.tsx

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/728.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
