### PR TITLE
docs: document CI re-trigger after PR-body failures in implement CI-monitor step

### DIFF
--- a/skills/implement/steps/step-10-ci-monitor.md
+++ b/skills/implement/steps/step-10-ci-monitor.md
@@ -19,7 +19,11 @@ Replaces the previous "poll `gh run view` every 15 seconds for up to 45 minutes"
    - `conclusion: "timed_out"` → run did not finish within 45 minutes. STOP and surface the run URL to the user.
    - `conclusion: "failure"` (or `"cancelled"` / `"action_required"` / `"startup_failure"`) → CI failed. The envelope's `failed_steps[]` and `log_summary` (bounded UTF-8, from the tail of `gh run view --log-failed`) tell you which step + what to look at. Raw logs stay server-side; if you need to drill in, the `run_id` lets a separate `gh run view --log-failed` call retrieve them later.
 
-3. On failure, diagnose and fix, then `git add`, `git commit`, `git push`. After the new commit lands, re-invoke `gc_watch_ci_run` to watch the new run.
+3. On failure, diagnose and fix. For a **code** failure: `git add`, `git commit`, `git push`. Pushing a new commit to an open PR re-runs CI through the `pull_request` `synchronize` event; after it lands, re-invoke `gc_watch_ci_run` to watch the new run.
+
+   **PR-body failures recover differently — a body edit alone does not re-run CI.** The `policy` job re-runs the full `bin/policy` against the *live PR*, including the PR-body checks the local `make policy` skips (it passes `--skip-pr-body`): `check_pr_body`, `pr-ground-control-checks` (wants the verbatim `gc_evaluate_quality_gates` / `gc_run_sweep` checklist lines), and `pr-traceability-summary` (wants explicit `IMPLEMENTS:` / `TESTS:` lines). These surface only in CI, never locally. When one fails, the fix is the PR **description**, not the diff: re-render with `gc_render_pr_body` (it emits exactly the markers these checks require) and apply it via `gh pr edit <n> --body-file <file>`. But `ci.yml`'s `pull_request` trigger fires on `opened` / `reopened` / `synchronize` (GitHub's defaults) and **never on `edited`**, so a body-only change triggers nothing. To re-validate it, **close and reopen the PR** (`gh pr close <n> && gh pr reopen <n>`) — that fires a fresh `reopened` event against the unchanged head commit.
+
+   **A branch push only runs CI through an open PR.** `ci.yml` runs `push` builds for `main` / `dev` only; a feature-branch push runs CI solely through that branch's open PR's `synchronize`. If the PR has already merged or closed, pushing the branch triggers nothing — open a new PR for the follow-up commit instead of expecting the push alone to re-run CI.
 
 ## Return contract
 


### PR DESCRIPTION
## Summary

Documents the CI re-trigger behavior an agent hits when a PR's `policy` job fails on a PR-body check. A body edit alone does not re-run CI — the `pull_request` workflow fires on `opened` / `reopened` / `synchronize`, never `edited` — so a body-only fix must be re-validated by closing and reopening the PR. Added to the `/implement` CI-monitor step's failure-handling guidance. Documentation-only change under `skills/`.

## Requirement UIDs

- (none; workflow documentation, see ADR Impact)

## ADR Impact

- ADR-021 (Gated Agentic Development Loop; this clarifies the CI-monitor step of the loop)
- ADR-029 (durable workflow record and PR-body contract; the body checks this note explains enforce ADR-029)

## Changes

- `skills/implement/steps/step-10-ci-monitor.md`: expand failure-handling (step 3) with three points: code failures re-run via the `pull_request` `synchronize` event; PR-body checks (`check_pr_body`, `pr-ground-control-checks`, `pr-traceability-summary`) surface only in CI (the local `make policy` runs `--skip-pr-body`) and are fixed in the PR description, but a body edit needs a close+reopen to re-run; and a branch push only runs CI through an open PR.

## Test Plan

- [x] Documentation-only diff under `skills/` (Vale-exempt per `.vale.ini`; no changelog fragment required per the path policy)
- [x] `make policy` passes locally

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

Documentation-only change; no requirement artifacts are implemented or tested.

- IMPLEMENTS: (none; workflow documentation only)
- TESTS: (none; documentation-only change, exercised by the existing policy and CI gates)

## Documentation

Updated: `skills/implement/steps/step-10-ci-monitor.md`. No REST, MCP, ADR, or Vale-scoped surface changes.
