### PR TITLE
fix(ci): repoint SonarCloud to brad-edwards org project

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -7,8 +7,8 @@ workflow:
   lint_command: cd backend && ./gradlew spotlessCheck
   format_command: cd backend && ./gradlew spotlessApply
 sonarcloud:
-  project_key: KeplerOps_Ground-Control
-  organization: KeplerOps
+  project_key: Brad-Edwards_Ground-Control
+  organization: brad-edwards
 remote_quality:
   tier: zero_overall_issues
 rules:

--- a/.mcp.json
+++ b/.mcp.json
@@ -37,7 +37,7 @@
       ],
       "env": {
         "SONARQUBE_TOKEN": "${SONAR_TOKEN}",
-        "SONARQUBE_ORG": "KeplerOps"
+        "SONARQUBE_ORG": "brad-edwards"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Ground Control
 
 [![CI](https://github.com/KeplerOps/Ground-Control/actions/workflows/ci.yml/badge.svg)](https://github.com/KeplerOps/Ground-Control/actions/workflows/ci.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=KeplerOps_Ground-Control&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=KeplerOps_Ground-Control)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Brad-Edwards_Ground-Control&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Brad-Edwards_Ground-Control)
 
 An automated software factory that connects requirements, code, controls, and
 observability over a single data layer—with traceability throughout.
 
 Ground Control unifies the software lifecycle into one graph-native platform.
-Every artifact—requirement, code file, test, ADR, verification result,
-security control—is a node. Every relationship is an edge. One query can
+Every artifact (requirement, code file, test, ADR, verification result,
+security control) is a node. Every relationship is an edge. One query can
 answer "which security requirements have no formal verification in the last
 30 days?" or "what breaks if this interface changes?" No tool-hopping, no
 stale spreadsheets, no traceability theater.

--- a/changelog.d/+sonarcloud-brad-edwards-org.fixed.md
+++ b/changelog.d/+sonarcloud-brad-edwards-org.fixed.md
@@ -1,0 +1,1 @@
+Repoint SonarCloud analysis to the `brad-edwards` org / `Brad-Edwards_Ground-Control` project so PR decoration (check run + summary comment) returns after the repo moved off the `KeplerOps` GitHub org (#1079).

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
 # SonarCloud Configuration
-# https://sonarcloud.io/project/overview?id=KeplerOps_Ground-Control
+# https://sonarcloud.io/project/overview?id=Brad-Edwards_Ground-Control
 
-sonar.projectKey=KeplerOps_Ground-Control
-sonar.organization=keplerops
+sonar.projectKey=Brad-Edwards_Ground-Control
+sonar.organization=brad-edwards
 
 # Source and test directories
 sonar.sources=backend/src/main/java


### PR DESCRIPTION
## Summary

This repo moved off the `KeplerOps` GitHub org to the `Brad-Edwards` account, so the `keplerops` SonarCloud org could no longer post PR decoration (the check run + summary comment) even though analysis upload and the quality gate still worked. A new SonarCloud org `brad-edwards` / project `Brad-Edwards_Ground-Control` was onboarded for the current owner. This repoints the repo's SonarCloud configuration at the new org/project so the gate signal returns on PRs.

## Requirement UIDs

- `GC-O007` (Gated Agentic Development Loop) — Phase D requires the workflow to "monitor CI, validate the SonarCloud quality gate." This restores the SonarCloud gate decoration on PRs that Phase D consumes. This is operational plumbing for that requirement, not new requirement-implementing code.

## Related Issues

- Closes #1079.

## ADR Impact

- No ADR required — operational configuration change. ADR-051 (SonarCloud gate recalibration) governs the gate and is unchanged.

## Changes

- `sonar-project.properties` — `sonar.projectKey` → `Brad-Edwards_Ground-Control`, `sonar.organization` → `brad-edwards`
- `.ground-control.yaml` — `sonarcloud.project_key` / `sonarcloud.organization`
- `.mcp.json` — `SONARQUBE_ORG` → `brad-edwards`
- `README.md` — quality-gate badge repointed (plus one em-dash-density fix the prose linter required)
- `changelog.d/+sonarcloud-brad-edwards-org.fixed.md`

## Test Plan

- [x] Confirmed the `sonarqubecloud` "SonarCloud Code Analysis" check posts `success` on this PR against the new project
- Backend Java is unchanged, so `make test` / `make check` are not applicable to this config-only change.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: none — operational CI / SonarCloud configuration; no new requirement-implementing code. Restores the gate signal `GC-O007` Phase D consumes.
- TESTS: none — configuration change; verification is the SonarCloud "SonarCloud Code Analysis" check posting `success` on this PR.

## Documentation

- Outcome: updated
- Updated: `changelog.d/+sonarcloud-brad-edwards-org.fixed.md` and the `sonar-project.properties` header comment URL.
