### PR TITLE
fix(ci): align SonarCloud analysis for dev

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -24,8 +24,13 @@ version = "0.20.1"
 
 sonar {
     properties {
-        property("sonar.projectKey", "KeplerOps_Ground-Control")
-        property("sonar.organization", "keplerops")
+        property("sonar.projectKey", "Brad-Edwards_Ground-Control")
+        property("sonar.organization", "brad-edwards")
+        property("sonar.sources", "src/main/java")
+        property("sonar.tests", "src/test/java")
+        property("sonar.exclusions", "**/node_modules/**,**/.gradle/**,**/build/**,**/dist/**,**/coverage/**,**/*.min.js,bin/**,backend/bin/**,../workflow/releases/**,workflow/releases/**")
+        property("sonar.java.binaries", "build/classes")
+        property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
     }
 }
 

--- a/changelog.d/1095.fixed.md
+++ b/changelog.d/1095.fixed.md
@@ -1,0 +1,1 @@
+Repointed the Gradle SonarCloud analysis to the Brad-Edwards project and made the CI scanner scope explicit so the dev branch is evaluated by the configured backend analysis instead of broad automatic analysis.

--- a/tools/tests/test_sonar_config.py
+++ b/tools/tests/test_sonar_config.py
@@ -1,0 +1,36 @@
+import pathlib
+import re
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKEND_GRADLE = REPO_ROOT / "backend" / "build.gradle.kts"
+SONAR_PROJECT = REPO_ROOT / "sonar-project.properties"
+
+
+class SonarConfigTest(unittest.TestCase):
+    def test_gradle_sonar_targets_active_brad_edwards_project(self) -> None:
+        gradle_config = BACKEND_GRADLE.read_text(encoding="utf-8")
+
+        self.assertIn('property("sonar.projectKey", "Brad-Edwards_Ground-Control")', gradle_config)
+        self.assertIn('property("sonar.organization", "brad-edwards")', gradle_config)
+        self.assertNotIn("KeplerOps_Ground-Control", gradle_config)
+        self.assertNotIn('property("sonar.organization", "keplerops")', gradle_config)
+
+    def test_gradle_sonar_scope_is_explicit(self) -> None:
+        gradle_config = BACKEND_GRADLE.read_text(encoding="utf-8")
+
+        self.assertRegex(gradle_config, re.compile(r'property\("sonar\.sources",\s*"[^"]+"\)'))
+        self.assertRegex(gradle_config, re.compile(r'property\("sonar\.tests",\s*"[^"]+"\)'))
+        self.assertIn("backend/bin/**", gradle_config)
+        self.assertIn("workflow/releases/**", gradle_config)
+
+    def test_repo_sonar_properties_match_gradle_project_identity(self) -> None:
+        properties = SONAR_PROJECT.read_text(encoding="utf-8")
+
+        self.assertIn("sonar.projectKey=Brad-Edwards_Ground-Control", properties)
+        self.assertIn("sonar.organization=brad-edwards", properties)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix SonarCloud configuration drift so dev uses the configured Brad-Edwards CI scanner instead of broad automatic analysis.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1095

## ADR Impact

- ADR-054

## Changes

- Repoint Gradle Sonar analysis to Brad-Edwards_Ground-Control / brad-edwards.
- Make Gradle scanner scope explicit for backend Java sources/tests and generated-output exclusions.
- Add a policy regression test for SonarCloud project identity and explicit scanner scope.
- Add a changelog fragment for issue #1095.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

python3 -m unittest tools.tests.test_sonar_config initially failed, then passed after the config fix; python3 -m unittest discover -s tools/tests -p 'test_*.py'; make policy with Java 21; backend ./gradlew spotlessCheck; backend ./gradlew build sonar -Dsonar.qualitygate.wait=true passed after disabling automatic analysis on the Brad-Edwards SonarCloud project.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: backend/build.gradle.kts, changelog.d/1095.fixed.md
- TESTS: tools/tests/test_sonar_config.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/1095.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.