### PR TITLE
Record tier/model consistency in /implement step telemetry

### DIFF
--- a/architecture/adrs/036-per-step-routing-tool-surfaces-telemetry.md
+++ b/architecture/adrs/036-per-step-routing-tool-surfaces-telemetry.md
@@ -158,13 +158,15 @@ Each routed step writes one JSONL line via `gc_log_step_telemetry` to
 
 ```json
 {
-  "schema": "gc.implement.telemetry/v1",
+  "schema": "gc.implement.telemetry/v2",
   "ts": "2026-05-11T07:00:00Z",
   "issue": 868,
   "branch": "868-route-tools-telem",
   "step": "4.5",
   "tier": "medium",
-  "model": "sonnet",
+  "model": "claude-sonnet-4-6",
+  "expected_model": "claude-sonnet-4-6",
+  "model_matches_expected": true,
   "wall_time_ms": 12480,
   "input_tokens": 8421,
   "output_tokens": 612,
@@ -172,6 +174,19 @@ Each routed step writes one JSONL line via `gc_log_step_telemetry` to
 }
 ```
 
+- `expected_model` and `model_matches_expected` (schema v2, issue #1181) are
+  derived server-side from the step's `tier` via `CLAUDE_MODEL_BY_TIER`. The
+  `model` field itself is self-reported by the orchestrator and was found
+  unreliable in the recorded data (tier/model mismatches, intra-run
+  contradictions, model ids that postdated the config). `model_matches_expected`
+  is a recorded tier/model **consistency assertion**: `false` flags a record
+  whose reported model diverged from the tier's canonical model - routing that
+  did not land where the tier intended, or a mis-report. It is recorded, never
+  gating; telemetry stays operational measurement only. Capturing the *actual*
+  dispatched-subagent model from the harness (rather than the reported value)
+  remains future work tracked in #1181. Note that high-tier `agent: parent`
+  steps run on the parent session model, so the configured `high:` id is
+  advisory for those steps.
 - `wall_time_ms` is mandatory; the agent measures around its delegation calls.
 - `input_tokens` and `output_tokens` are optional; Claude Code's `Agent` tool
   does not surface per-call counts today, so the writer accepts `null`. When

--- a/architecture/adrs/054-documentation-coverage-gate.md
+++ b/architecture/adrs/054-documentation-coverage-gate.md
@@ -285,3 +285,12 @@ This is a one-line routing-default model-id change, not a documentation-coverage
 gate surface: the `run_documentation_coverage_check` classifier, the Vale rule
 set, `tools/install-vale.sh`, and `.vale.ini` are unchanged, and no new
 `docs/DOC_STYLE.md` style rule is established.
+
+**2026-06-18 (issue #1181 telemetry consistency fields).** A second
+`mcp/ground-control/lib.js` change under #1181 adds `expected_model` and
+`model_matches_expected` to the `/implement` step-telemetry record (schema
+bumped to `gc.implement.telemetry/v2`), documented in ADR-036's telemetry
+contract. This is an internal telemetry-record field addition, not a
+documentation-coverage gate surface: the `run_documentation_coverage_check`
+classifier, the Vale rule set, `tools/install-vale.sh`, and `.vale.ini` are
+unchanged, and no new `docs/DOC_STYLE.md` style rule is established.

--- a/changelog.d/1181.added.md
+++ b/changelog.d/1181.added.md
@@ -1,0 +1,9 @@
+### Added
+
+- **`/implement` step telemetry now records a tier/model consistency
+  assertion.** Each record gained `expected_model` (the canonical model for the
+  step's tier, derived server-side from `CLAUDE_MODEL_BY_TIER`) and
+  `model_matches_expected` (a recorded, non-gating flag). The schema version is
+  bumped to `gc.implement.telemetry/v2`. This surfaces routing drift directly in
+  the data - the self-reported `model` field alone could not be trusted to show
+  whether a step ran on its resolved model (issue #1181).

--- a/docs/DOC_STYLE.md
+++ b/docs/DOC_STYLE.md
@@ -218,3 +218,5 @@ the changelog fragment; no new DOC_STYLE.md style rule is established.
 Correcting a `GOVERNANCE_FIELDS` create/update allowlist in `mcp/ground-control/lib.js` to match the backend DTO (issue #1173) is a config-parser fix recorded in an ADR-054 amendment, not a new doc page.
 
 Bumping the `CLAUDE_MODEL_BY_TIER.high` routing-default model id in `mcp/ground-control/lib.js` from `claude-opus-4-7` to `claude-opus-4-8` (issue #1181) is a constant change recorded in an ADR-054 amendment, not a new doc page or style rule.
+
+Adding `expected_model` and `model_matches_expected` to the `/implement` step-telemetry record in `mcp/ground-control/lib.js` (issue #1181, schema `gc.implement.telemetry/v2`) is a telemetry-record field addition documented in ADR-036 and recorded in an ADR-054 amendment, not a new doc page or style rule.

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -15124,7 +15124,14 @@ export function _resetReviewJobsForTest() {
 // to the agent. Path is `.gc/telemetry/<issue>-<sanitized-branch>.jsonl`,
 // repo-relative, validated via `resolveRepoRelativePath` + `assertRealpathInRepo`.
 
-export const TELEMETRY_SCHEMA_VERSION = "gc.implement.telemetry/v1";
+// v2 (issue #1181): records now carry `expected_model` (the canonical model
+// for the step's tier, derived server-side from CLAUDE_MODEL_BY_TIER) and a
+// `model_matches_expected` consistency flag. The caller-supplied `model` is
+// self-reported by the orchestrator and was demonstrably unreliable (tier/model
+// mismatches, intra-run contradictions); the flag surfaces that divergence in
+// the data instead of trusting the reported value. This is recorded, never
+// gating — telemetry stays operational measurement only (ADR-036).
+export const TELEMETRY_SCHEMA_VERSION = "gc.implement.telemetry/v2";
 export const TELEMETRY_TIERS = Object.freeze(["low", "medium", "high"]);
 export const TELEMETRY_OUTCOMES = Object.freeze(["ok", "error", "skipped"]);
 export const ROUTING_TIERS = TELEMETRY_TIERS;
@@ -15204,6 +15211,14 @@ export function buildTelemetryRecord(input) {
     step,
     tier,
     model,
+    // Config-derived ground truth for the step's tier (issue #1181). `tier` is
+    // validated against TELEMETRY_TIERS above, so this lookup is always defined.
+    // `model_matches_expected` is the tier/model consistency assertion: false
+    // means the reported model diverged from the tier's canonical model — the
+    // signal that routing did not land where the tier intended (or the
+    // orchestrator mis-reported). Never gates; analysis-only.
+    expected_model: CLAUDE_MODEL_BY_TIER[tier],
+    model_matches_expected: model === CLAUDE_MODEL_BY_TIER[tier],
     wall_time_ms: wallTimeMs,
     input_tokens: inputTokens,
     output_tokens: outputTokens,

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -6575,6 +6575,25 @@ describe("buildTelemetryRecord", () => {
     assert.match(r.ts, /^\d{4}-\d{2}-\d{2}T/);
   });
 
+  it("records the config-derived expected_model for each tier (issue #1181)", () => {
+    assert.equal(buildTelemetryRecord(baseInput({ tier: "low" })).expected_model, CLAUDE_MODEL_BY_TIER.low);
+    assert.equal(buildTelemetryRecord(baseInput({ tier: "medium" })).expected_model, CLAUDE_MODEL_BY_TIER.medium);
+    assert.equal(buildTelemetryRecord(baseInput({ tier: "high" })).expected_model, CLAUDE_MODEL_BY_TIER.high);
+  });
+
+  it("flags model_matches_expected true when the reported model is the tier's canonical model", () => {
+    const r = buildTelemetryRecord(baseInput({ tier: "medium", model: CLAUDE_MODEL_BY_TIER.medium }));
+    assert.equal(r.model_matches_expected, true);
+  });
+
+  it("flags model_matches_expected false when the reported model diverges from the tier (routing-drift signal)", () => {
+    // A medium step reporting an opus model — the exact divergence seen in the
+    // real .gc/telemetry data that motivated #1181.
+    const r = buildTelemetryRecord(baseInput({ tier: "medium", model: CLAUDE_MODEL_BY_TIER.high }));
+    assert.equal(r.expected_model, CLAUDE_MODEL_BY_TIER.medium);
+    assert.equal(r.model_matches_expected, false);
+  });
+
   it("accepts optional token counts", () => {
     const r = buildTelemetryRecord(baseInput({ inputTokens: 8421, outputTokens: 612 }));
     assert.equal(r.input_tokens, 8421);


### PR DESCRIPTION
## Summary

The `/implement` per-step telemetry (`.gc/telemetry/<issue>-<branch>.jsonl`) could not actually show whether the model routing worked. The `model` field is **self-reported by the orchestrator** — `gc_log_step_telemetry` accepts `model: z.string().min(1)` and `buildTelemetryRecord` validated only that it is a non-empty string, with no cross-check against the tier or the resolved route. The recorded data proved it unreliable: tier/model mismatches (a `medium` step logging an opus model), intra-run contradictions (two `high` steps logging different models in one run), and model ids that postdated the config.

This adds a server-side **tier/model consistency assertion**:

- `expected_model` — the canonical model for the step's `tier`, derived from `CLAUDE_MODEL_BY_TIER`.
- `model_matches_expected` — boolean; `false` flags a record whose reported model diverged from the tier's canonical model (routing that did not land where the tier intended, or a mis-report).
- Schema bumped to `gc.implement.telemetry/v2`.

The flag is **recorded, never gating** — telemetry stays operational measurement only (ADR-036). Capturing the *actual* dispatched-subagent model from the harness (rather than the reported value) is a harness-side limitation and remains tracked in #1181; high-tier `agent: parent` steps run on the parent session model, so the configured `high:` id is advisory for them.

## Requirement UIDs

- `GC-O007` — Gated Agentic Development Loop (per-step routing + telemetry added by ADR-036). This strengthens the telemetry surface defined there; the gate model is unchanged.

## Related Issues

- Refs #1181 — the model-selection refinement tracking issue (left open; the telemetry-reliability item was added there).

## ADR Impact

- ADR-036 — telemetry-contract example bumped to v2 and a bullet added describing `expected_model` / `model_matches_expected`.
- ADR-054 — dated sync amendment appended (doc-coverage-gate-sync; the `lib.js` change is not a doc-coverage surface).
- No new ADR required.

## Changes

- `mcp/ground-control/lib.js` — `buildTelemetryRecord` records `expected_model` + `model_matches_expected`; `TELEMETRY_SCHEMA_VERSION` → `gc.implement.telemetry/v2`.
- `mcp/ground-control/lib.test.js` — 3 new tests (expected_model per tier; match true; the medium→opus divergence flagged false).
- ADR-036, ADR-054, `docs/DOC_STYLE.md` — doc sync.
- `changelog.d/1181.added.md`.

## Test Plan

- [x] Unit tests pass (`node --test` mcp suite: 876 pass / 0 fail, +3 new)
- [ ] Integration tests pass if applicable (`make integration`) — N/A, no backend change
- [ ] `make check` passes — N/A locally; CI runs it (no Java/source change)
- [x] No coverage regression (additive record fields + new tests)

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: none new — strengthens the existing telemetry surface under `GC-O007` / ADR-036.
- TESTS: `mcp/ground-control/lib.test.js::buildTelemetryRecord` — 3 new cases covering `expected_model` and `model_matches_expected`.

## Documentation

Diff touches `adr` and `config_parser` surfaces. Documentation is synced in-PR: the ADR-036 telemetry contract now shows the v2 record with the two new fields and explains the consistency assertion; ADR-054 and `docs/DOC_STYLE.md` carry dated amendment notes recording that the `lib.js` change is a telemetry-record field addition, not a documentation-coverage gate surface. No new doc page or DOC_STYLE style rule is required.

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer (N/A — MCP-local writer)
- [x] Domain layer has no framework imports (N/A — no domain change)
- [x] Envers `@Audited` on new entities if applicable (N/A — no entities)
- [x] Changelog fragment added under `changelog.d/1181.added.md`
- [x] Architectural docs updated (ADR-036 telemetry contract + ADR-054/DOC_STYLE sync)