### PR TITLE
Resolve SonarCloud new-code findings blocking dev release gate

### DIFF
--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/derivation/service/DerivationService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/derivation/service/DerivationService.java
@@ -37,6 +37,7 @@ public class DerivationService {
     private static final Pattern SCOPE_TOKEN = Pattern.compile("^[a-z0-9][a-z0-9_.+-]{0,79}$");
     private static final int MAX_SCOPE_VALUES = 50;
     private static final int MAX_PATHS = 200;
+    private static final String PATHS_FIELD = "paths";
     private static final Set<String> BLOCKED_PAYLOAD_KEYS = Set.of(
             "secret",
             "secret_value",
@@ -247,13 +248,13 @@ public class DerivationService {
     private List<String> normalizePaths(List<String> input, DerivationScopeMode mode) {
         var paths = input == null ? List.<String>of() : input;
         if (paths.size() > MAX_PATHS) {
-            throw validation("paths must contain at most " + MAX_PATHS + " entries", "paths");
+            throw validation("paths must contain at most " + MAX_PATHS + " entries", PATHS_FIELD);
         }
         if (mode == DerivationScopeMode.PATH_SET && paths.isEmpty()) {
-            throw validation("paths is required for PATH_SET scope", "paths");
+            throw validation("paths is required for PATH_SET scope", PATHS_FIELD);
         }
         if (mode == DerivationScopeMode.FULL_REPO && !paths.isEmpty()) {
-            throw validation("paths must be empty for FULL_REPO scope", "paths");
+            throw validation("paths must be empty for FULL_REPO scope", PATHS_FIELD);
         }
         var normalized = new ArrayList<String>(paths.size());
         for (String path : paths) {
@@ -264,21 +265,22 @@ public class DerivationService {
 
     private String normalizePath(String value) {
         if (value == null || value.isBlank()) {
-            throw validation("paths must not contain blank entries", "paths");
+            throw validation("paths must not contain blank entries", PATHS_FIELD);
         }
         var path = value.trim().replace('\\', '/');
         if (path.startsWith("/") || path.matches("^[A-Za-z]:.*")) {
-            throw validation("paths must be relative repository paths", "paths");
+            throw validation("paths must be relative repository paths", PATHS_FIELD);
         }
         while (path.startsWith("./")) {
             path = path.substring(2);
         }
-        for (int segmentStart = 0; segmentStart <= path.length(); ) {
+        int segmentStart = 0;
+        while (segmentStart <= path.length()) {
             var slashIndex = path.indexOf('/', segmentStart);
             var segmentEnd = slashIndex == -1 ? path.length() : slashIndex;
             var segment = path.substring(segmentStart, segmentEnd);
             if (segment.isBlank() || segment.equals("..")) {
-                throw validation("paths must not contain empty or parent-directory segments", "paths");
+                throw validation("paths must not contain empty or parent-directory segments", PATHS_FIELD);
             }
             if (slashIndex == -1) {
                 break;

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/AuditService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/AuditService.java
@@ -320,9 +320,10 @@ public class AuditService {
     /**
      * Returns a unified, chronologically-sorted audit timeline across all requirements in a project.
      *
-     * <p>TODO: This loads all revisions into memory then filters/paginates. Move to DB-level
-     * pagination (e.g. a native query joining revinfo with audit tables) before beta to avoid
-     * O(requirements * revisions) memory usage on large projects.
+     * <p>Known limitation (tracked by issue #1212): this loads all revisions into memory then
+     * filters/paginates. DB-level pagination (e.g. a native query joining revinfo with audit
+     * tables) is planned before beta to avoid O(requirements * revisions) memory usage on large
+     * projects.
      */
     public List<TimelineEntry> getProjectTimeline(
             UUID projectId,

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/MethodologyProfileService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/riskscenarios/service/MethodologyProfileService.java
@@ -558,13 +558,17 @@ public class MethodologyProfileService {
 
     @Transactional(readOnly = true)
     public MethodologyProfile getById(UUID projectId, UUID id) {
+        return findByIdOrThrow(projectId, id);
+    }
+
+    private MethodologyProfile findByIdOrThrow(UUID projectId, UUID id) {
         return repository
                 .findByIdAndProjectId(id, projectId)
                 .orElseThrow(() -> new NotFoundException("Methodology profile not found: " + id));
     }
 
     public MethodologyProfile update(UUID projectId, UUID id, UpdateMethodologyProfileCommand command) {
-        var profile = getById(projectId, id);
+        var profile = findByIdOrThrow(projectId, id);
         if (command.name() != null) {
             profile.setName(command.name());
         }
@@ -586,7 +590,7 @@ public class MethodologyProfileService {
     }
 
     public void delete(UUID projectId, UUID id) {
-        repository.delete(getById(projectId, id));
+        repository.delete(findByIdOrThrow(projectId, id));
     }
 
     // GC-T012 crosswalk semantic constants (shared scale/units literals across seeds)
@@ -779,51 +783,54 @@ public class MethodologyProfileService {
         var project = projectService.getById(projectId);
         seedIfMissing(
                 project,
-                "LEGACY_QUALITATIVE_V1",
-                "Legacy Qualitative",
-                "1",
-                MethodologyFamily.CUSTOM,
-                "Compatibility profile for migrated pre-methodology qualitative assessments.",
-                parseSchema(LEGACY_INPUT_SCHEMA),
-                parseSchema(LEGACY_OUTPUT_SCHEMA),
-                null);
+                new MethodologyProfileSeed(
+                        "LEGACY_QUALITATIVE_V1",
+                        "Legacy Qualitative",
+                        "1",
+                        MethodologyFamily.CUSTOM,
+                        "Compatibility profile for migrated pre-methodology qualitative assessments.",
+                        parseSchema(LEGACY_INPUT_SCHEMA),
+                        parseSchema(LEGACY_OUTPUT_SCHEMA),
+                        null));
         seedIfMissing(
                 project,
-                "FAIR_V3_0",
-                "Open FAIR",
-                "O-RT 3.0.1 / O-RA 2.0.1",
-                MethodologyFamily.FAIR,
-                "Open FAIR quantitative profile aligned to O-RT 3.0.1 and O-RA 2.0.1. "
-                        + "Profile key FAIR_V3_0 is retained for compatibility.",
-                parseSchema(FAIR_INPUT_SCHEMA),
-                parseSchema(FAIR_OUTPUT_SCHEMA),
-                FAIR_CROSSWALK_ENTRIES);
+                new MethodologyProfileSeed(
+                        "FAIR_V3_0",
+                        "Open FAIR",
+                        "O-RT 3.0.1 / O-RA 2.0.1",
+                        MethodologyFamily.FAIR,
+                        "Open FAIR quantitative profile aligned to O-RT 3.0.1 and O-RA 2.0.1. "
+                                + "Profile key FAIR_V3_0 is retained for compatibility.",
+                        parseSchema(FAIR_INPUT_SCHEMA),
+                        parseSchema(FAIR_OUTPUT_SCHEMA),
+                        FAIR_CROSSWALK_ENTRIES));
         seedIfMissing(
                 project,
-                "NIST_SP800_30_R1",
-                "NIST SP 800-30 Rev. 1",
-                "1",
-                MethodologyFamily.NIST_SP800_30_R1,
-                "NIST SP 800-30 Rev. 1 qualitative risk assessment using five-level "
-                        + "likelihood and impact scales with a 5x5 risk matrix.",
-                parseSchema(NIST_INPUT_SCHEMA),
-                parseSchema(NIST_OUTPUT_SCHEMA),
-                NIST_CROSSWALK_ENTRIES);
+                new MethodologyProfileSeed(
+                        "NIST_SP800_30_R1",
+                        "NIST SP 800-30 Rev. 1",
+                        "1",
+                        MethodologyFamily.NIST_SP800_30_R1,
+                        "NIST SP 800-30 Rev. 1 qualitative risk assessment using five-level "
+                                + "likelihood and impact scales with a 5x5 risk matrix.",
+                        parseSchema(NIST_INPUT_SCHEMA),
+                        parseSchema(NIST_OUTPUT_SCHEMA),
+                        NIST_CROSSWALK_ENTRIES));
         seedIfMissing(
                 project,
-                "ISO_27005_V2022",
-                "ISO 27005",
-                "2022",
-                MethodologyFamily.ISO_27005,
-                "ISO/IEC 27005:2022-aligned risk assessment supporting ISO 27001 "
-                        + "information security management system risk criteria.",
-                parseSchema(ISO_INPUT_SCHEMA),
-                parseSchema(ISO_OUTPUT_SCHEMA),
-                ISO_CROSSWALK_ENTRIES);
+                new MethodologyProfileSeed(
+                        "ISO_27005_V2022",
+                        "ISO 27005",
+                        "2022",
+                        MethodologyFamily.ISO_27005,
+                        "ISO/IEC 27005:2022-aligned risk assessment supporting ISO 27001 "
+                                + "information security management system risk criteria.",
+                        parseSchema(ISO_INPUT_SCHEMA),
+                        parseSchema(ISO_OUTPUT_SCHEMA),
+                        ISO_CROSSWALK_ENTRIES));
     }
 
-    private void seedIfMissing(
-            Project project,
+    private record MethodologyProfileSeed(
             String key,
             String name,
             String version,
@@ -831,17 +838,19 @@ public class MethodologyProfileService {
             String description,
             Map<String, Object> inputSchema,
             Map<String, Object> outputSchema,
-            List<CrosswalkEntry> crosswalkEntries) {
-        if (repository.existsByProjectIdAndProfileKeyAndVersion(project.getId(), key, version)) {
+            List<CrosswalkEntry> crosswalkEntries) {}
+
+    private void seedIfMissing(Project project, MethodologyProfileSeed seed) {
+        if (repository.existsByProjectIdAndProfileKeyAndVersion(project.getId(), seed.key(), seed.version())) {
             return;
         }
-        var profile = new MethodologyProfile(project, key, name, version, family);
-        profile.setDescription(description);
-        profile.setInputSchema(inputSchema);
-        profile.setOutputSchema(outputSchema);
+        var profile = new MethodologyProfile(project, seed.key(), seed.name(), seed.version(), seed.family());
+        profile.setDescription(seed.description());
+        profile.setInputSchema(seed.inputSchema());
+        profile.setOutputSchema(seed.outputSchema());
         profile.setStatus(MethodologyProfileStatus.ACTIVE);
-        if (crosswalkEntries != null && !crosswalkEntries.isEmpty()) {
-            profile.setCrosswalkEntries(crosswalkEntries);
+        if (seed.crosswalkEntries() != null && !seed.crosswalkEntries().isEmpty()) {
+            profile.setCrosswalkEntries(seed.crosswalkEntries());
         }
         repository.save(profile);
     }

--- a/backend/src/test/java/com/keplerops/groundcontrol/domain/requirements/service/AuditServiceDiffTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/domain/requirements/service/AuditServiceDiffTest.java
@@ -353,9 +353,7 @@ class AuditServiceDiffTest {
                     results, row -> Map.entry((UUID) row[3], (Map<String, Object>) row[4]), row ->
                             (RevisionType) row[2]);
 
-            assertThat(alive).hasSize(1);
-            assertThat(alive).containsKey(id2);
-            assertThat(alive).doesNotContainKey(id1);
+            assertThat(alive).hasSize(1).containsKey(id2).doesNotContainKey(id1);
         }
 
         @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/derivation/DerivationServiceIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/derivation/DerivationServiceIntegrationTest.java
@@ -76,14 +76,15 @@ class DerivationServiceIntegrationTest extends BaseIntegrationTest {
         var project = projectRepository.save(new Project(
                 "derivation-path-" + UUID.randomUUID().toString().substring(0, 8), "Derivation Path Validation"));
 
-        assertThatThrownBy(() -> derivationService.run(new CreateDerivationRunCommand(
-                        project.getId(),
-                        DerivationScopeMode.PATH_SET,
-                        COMMIT,
-                        null,
-                        List.of("backend/src/main/java/"),
-                        List.of("java"),
-                        List.of("application"))))
+        var command = new CreateDerivationRunCommand(
+                project.getId(),
+                DerivationScopeMode.PATH_SET,
+                COMMIT,
+                null,
+                List.of("backend/src/main/java/"),
+                List.of("java"),
+                List.of("application"));
+        assertThatThrownBy(() -> derivationService.run(command))
                 .isInstanceOf(DomainValidationException.class)
                 .hasMessageContaining("empty or parent-directory segments");
     }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTest.java
@@ -200,7 +200,7 @@ class RequirementControllerTest {
         @Test
         void returns200() throws Exception {
             var req = createRequirement("REQ-001");
-            when(requirementService.getByUid(eq(PROJECT_ID), eq("REQ-001"))).thenReturn(req);
+            when(requirementService.getByUid(PROJECT_ID, "REQ-001")).thenReturn(req);
 
             mockMvc.perform(get("/api/v1/requirements/uid/REQ-001"))
                     .andExpect(status().isOk())

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/derivation/DerivationServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/derivation/DerivationServiceTest.java
@@ -191,7 +191,8 @@ class DerivationServiceTest {
                                 Map.of("metadata", Map.of("raw_output", "do-not-store"))))))),
                         List.of()));
 
-        assertThatThrownBy(() -> service.run(validCommand()))
+        var command = validCommand();
+        assertThatThrownBy(() -> service.run(command))
                 .isInstanceOf(DomainValidationException.class)
                 .hasMessageContaining("blocked raw-content field");
         verify(transactionTemplate, never()).execute(any(TransactionCallback.class));
@@ -206,7 +207,8 @@ class DerivationServiceTest {
                                 List.of(fact("component:wrong-commit", BASE_COMMIT, Map.of()))))),
                         List.of()));
 
-        assertThatThrownBy(() -> service.run(validCommand()))
+        var command = validCommand();
+        assertThatThrownBy(() -> service.run(command))
                 .isInstanceOf(DomainValidationException.class)
                 .hasMessageContaining("provenance commitSha");
         verify(transactionTemplate, never()).execute(any(TransactionCallback.class));
@@ -227,7 +229,8 @@ class DerivationServiceTest {
                                 BASE_COMMIT,
                                 DERIVED_AT))));
 
-        assertThatThrownBy(() -> service.run(validCommand()))
+        var command = validCommand();
+        assertThatThrownBy(() -> service.run(command))
                 .isInstanceOf(DomainValidationException.class)
                 .hasMessageContaining("Capture limit commitSha");
         verify(transactionTemplate, never()).execute(any(TransactionCallback.class));
@@ -239,7 +242,8 @@ class DerivationServiceTest {
         when(adapterRegistry.route(any(), any())).thenReturn(new DerivationRoutePlan(List.of(), List.of()));
         when(transactionTemplate.execute(any(TransactionCallback.class))).thenReturn(null);
 
-        assertThatThrownBy(() -> service.run(validCommand()))
+        var command = validCommand();
+        assertThatThrownBy(() -> service.run(command))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("transaction returned no result");
     }

--- a/changelog.d/+sonar-new-issue-cleanup-dev.fixed.md
+++ b/changelog.d/+sonar-new-issue-cleanup-dev.fixed.md
@@ -1,0 +1,9 @@
+Resolve 13 SonarCloud new-code findings blocking the dev → main release gate:
+extract a `paths` field constant and replace a `for`-counter mutation with a
+`while` loop in `DerivationService`; route internal lookups through a private
+helper instead of self-invoking the transactional `getById` in
+`MethodologyProfileService`, and collapse the 9-parameter `seedIfMissing` into a
+`MethodologyProfileSeed` parameter object; hoist throwing setup calls out of
+`assertThatThrownBy` lambdas, chain duplicate assertions, drop redundant `eq(...)`
+matchers in the affected tests; and convert a bare `TODO` in `AuditService` into a
+tracked known-limitation note (issue #1212).


### PR DESCRIPTION
## Summary

Resolves the 13 new-code findings reported by the repo-native `Fail on new SonarCloud issues` gate (`tools/sonar/assert_no_new_issues.py`) on `dev`, which was blocking the `sonar` check on the dev → main release PR #1210. SonarCloud's own quality gate (coverage, ratings, duplications) was already green; this gate fails on *any* new issue regardless of severity.

## Requirement UIDs

- (none — repo-hygiene / static-analysis cleanup across already-merged feature code; SonarCloud gate governed by ADR-021)

## Related Issues

- Opens #1212 (AuditService DB-level pagination — extracted from a `TODO`)

## ADR Impact

- ADR-021 (Gated Agentic Development Loop — quality gates); no new ADR required

## Changes

- `DerivationService`: extract `PATHS_FIELD` constant (S1192); replace `for`-loop counter mutation with a `while` loop (S127)
- `MethodologyProfileService`: route internal lookups through a private `findByIdOrThrow` helper instead of self-invoking the `@Transactional` `getById` (S6809); collapse the 9-parameter `seedIfMissing` into a `MethodologyProfileSeed` parameter object (S107)
- `DerivationServiceTest` / `DerivationServiceIntegrationTest`: hoist throwing setup calls out of `assertThatThrownBy` lambdas (S5778)
- `AuditServiceDiffTest`: chain duplicate assertions on one subject (S5853)
- `RequirementControllerTest`: drop redundant `eq(...)` matchers (S6068)
- `AuditService`: convert a bare `TODO` into a tracked known-limitation note referencing #1212 (S1135)

## Documentation

- Documentation outcome: no documented surface changed. Changes are internal refactors of existing service/test code with no API, schema, workflow, or ADR impact; the only externally visible artifact is the new tracking issue #1212. No doc update required (ADR-054).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`) — covered by pre-commit gradle check
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — static-analysis cleanup)
- TESTS: existing DerivationService / AuditService / RequirementController suites cover the refactored paths

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added under `changelog.d/<issue>.<type>.md` (or `+<slug>.<type>.md`)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
