### PR TITLE
Repoint container image to ghcr.io/autarchy-ai namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,7 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
         with:
           images: |
-            ghcr.io/brad-edwards/ground-control
+            ghcr.io/autarchy-ai/ground-control
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}

--- a/changelog.d/+ghcr-namespace-autarchy.fixed.md
+++ b/changelog.d/+ghcr-namespace-autarchy.fixed.md
@@ -1,0 +1,7 @@
+Repoint the production container image from `ghcr.io/brad-edwards/ground-control`
+to `ghcr.io/autarchy-ai/ground-control` across CI, deploy scripts, and docs. After
+the repository moved into the `autarchy-ai` org the CI `GITHUB_TOKEN` could no
+longer push to the old user namespace (`permission_denied: The requested
+installation does not exist`), breaking every `main`/`dev` image build. The image
+now lives under the owning org so the workflow token's `packages: write` scope
+applies.

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -21,7 +21,7 @@ every merge, so `:main` continues to track current `main`.
 ## Image resolution
 
 `GC_IMAGE` in `/opt/gc/.env` MUST be a floating tag like
-`ghcr.io/brad-edwards/ground-control:main`. `deploy.sh` runs `docker compose
+`ghcr.io/autarchy-ai/ground-control:main`. `deploy.sh` runs `docker compose
 pull` which resolves the tag to the current digest on GHCR, so each deploy
 picks up whatever the CI `docker` job most recently pushed. Pinning
 `GC_IMAGE` to a digest here freezes the deploy on that image forever - CI

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -29,13 +29,13 @@ cd "${GC_DIR}"
 
 # Optional: rewrite GC_IMAGE to the supplied ref. The ref is taken
 # verbatim, so callers that want a digest pin pass the full
-# `ghcr.io/brad-edwards/ground-control@sha256:...` string; tag-style
-# `ghcr.io/brad-edwards/ground-control:dev` also works.
+# `ghcr.io/autarchy-ai/ground-control@sha256:...` string; tag-style
+# `ghcr.io/autarchy-ai/ground-control:dev` also works.
 if [ "${1:-}" != "" ]; then
   REF="$1"
   case "${REF}" in
     ghcr.io/*) ;;
-    *) REF="ghcr.io/brad-edwards/ground-control:${REF}" ;;
+    *) REF="ghcr.io/autarchy-ai/ground-control:${REF}" ;;
   esac
   sed -i "s|^GC_IMAGE=.*|GC_IMAGE=${REF}|" .env
   echo "Pinned GC_IMAGE=${REF}"

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -27,7 +27,7 @@ See [ADR-014](../../architecture/adrs/014-pluggable-verification-architecture.md
 | Logging | SLF4J + Logback (JSON in prod, console in dev) |
 | API docs | Springdoc-OpenAPI |
 | Container | Docker (multi-stage, non-root, JDK 21) |
-| Registry | GHCR (`ghcr.io/brad-edwards/ground-control`) |
+| Registry | GHCR (`ghcr.io/autarchy-ai/ground-control`) |
 
 See [ADR-013](../../architecture/adrs/013-java-spring-boot-rewrite.md) for the Java migration rationale.
 

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -375,10 +375,10 @@ within seconds. Order matters; do not skip ahead.
      (immutable) to refer to the actual candidate. Resolve a stable digest
      from either with:
      ```bash
-     docker pull ghcr.io/brad-edwards/ground-control:dev
-     docker inspect ghcr.io/brad-edwards/ground-control:dev \
+     docker pull ghcr.io/autarchy-ai/ground-control:dev
+     docker inspect ghcr.io/autarchy-ai/ground-control:dev \
        --format '{{index .RepoDigests 0}}'
-     # → ghcr.io/brad-edwards/ground-control@sha256:<digest>
+     # → ghcr.io/autarchy-ai/ground-control@sha256:<digest>
      ```
      Pin the dry-run AND the production `/opt/gc/.env` to that digest so
      the image you tested is the image you deploy.
@@ -401,7 +401,7 @@ within seconds. Order matters; do not skip ahead.
      # token values that will land in /opt/gc/.env. Set GC_IMAGE to the
      # candidate digest you resolved above. Run with a separate compose
      # project name (gc-dryrun) and rebind the prod port + DB volume:
-     GC_IMAGE=ghcr.io/brad-edwards/ground-control@sha256:<digest> \
+     GC_IMAGE=ghcr.io/autarchy-ai/ground-control@sha256:<digest> \
        docker compose -p gc-dryrun --env-file "${dryrun_env}" \
        -f deploy/docker/docker-compose.prod.yml up -d
      # When done:
@@ -470,7 +470,7 @@ within seconds. Order matters; do not skip ahead.
    digest.** Use the indexed `GROUNDCONTROL_SECURITY_CREDENTIALS_*` shape
    (matches the env-var table above and `deploy/docker/.env.template`).
    The same digest you dry-ran against in step 4 belongs in `GC_IMAGE`
-   here - pinning by digest (`ghcr.io/brad-edwards/ground-control@sha256:...`)
+   here - pinning by digest (`ghcr.io/autarchy-ai/ground-control@sha256:...`)
    guarantees the cutover rolls the image you tested, not whatever has
    moved under `:dev` since. After editing, `chmod 600`.
 
@@ -552,7 +552,7 @@ The backend ships as a multi-stage Docker image (`backend/Dockerfile`):
 ```bash
 make docker-build
 # or directly:
-docker build -f backend/Dockerfile -t ghcr.io/brad-edwards/ground-control:latest .
+docker build -f backend/Dockerfile -t ghcr.io/autarchy-ai/ground-control:latest .
 ```
 
 #### Run locally
@@ -562,7 +562,7 @@ docker run --rm -p 8000:8000 \
   -e GC_DATABASE_URL=jdbc:postgresql://host:5432/ground_control \
   -e GC_DATABASE_USER=gc \
   -e GC_DATABASE_PASSWORD=gc \
-  ghcr.io/brad-edwards/ground-control:latest
+  ghcr.io/autarchy-ai/ground-control:latest
 ```
 
 Flyway migrations run automatically on startup - no separate migration step needed.
@@ -601,7 +601,7 @@ Ground Control runs on `red-dragon` (Hetzner dedicated, AMD Ryzen 7 3700X / 128 
 - **Host**: `red-dragon` (single tailnet-resident host, Ubuntu, Docker Engine 29.x, Compose v5.x).
 - **Access**: Tailscale only. sshd binds to `100.98.28.66:22` (the tailnet IP) - no public ingress. Application reachable on tailnet at `http://red-dragon:8000`.
 - **Storage**: `/data/postgres` (bind-mounted into the db container) and `/data/backups` (pg_dump artifacts). Both on red-dragon's main NVMe.
-- **Image registry**: GHCR (`ghcr.io/brad-edwards/ground-control`). Pulled by `docker compose pull` on each deploy.
+- **Image registry**: GHCR (`ghcr.io/autarchy-ai/ground-control`). Pulled by `docker compose pull` on each deploy.
 - **Backups**: 3×/day `pg_dump` cron to `/data/backups/`, 30-day local retention. Off-box copy via rsync over the tailnet to `aurora`. Policy is GC-P021 / [ADR-025](../../architecture/adrs/025-backup-policy.md).
 - **Cost**: $0 marginal (red-dragon is paid for unrelated reasons).
 
@@ -738,7 +738,7 @@ JAVA_TOOL_OPTIONS=-Xmx512m -Xms256m
 POSTGRES_DB=ground_control
 POSTGRES_USER=gc
 POSTGRES_PASSWORD=...
-GC_IMAGE=ghcr.io/brad-edwards/ground-control:main
+GC_IMAGE=ghcr.io/autarchy-ai/ground-control:main
 GC_BIND_IP=<host's tailnet IP>
 GC_EMBEDDING_PROVIDER=openai
 GC_EMBEDDING_API_KEY=...

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -61,7 +61,7 @@ ssh red-dragon 'curl -sf http://100.98.28.66:8000/actuator/health'
 There is no argv-driven rollback over the SSH forced-command path (it ignores client argv by design). To roll back:
 
 1. SSH into red-dragon as a sudoer (for example, `ssh red-dragon`).
-2. `sudo -u gc-deploy vi /opt/gc/.env` and pin `GC_IMAGE` to the target ref - either a tag (`ghcr.io/brad-edwards/ground-control:sha-abc123`) or a digest (`ghcr.io/brad-edwards/ground-control@sha256:...`). Available tags are listed at `https://github.com/Brad-Edwards/Ground-Control/pkgs/container/ground-control`; CI publishes `sha-<short>` tags for every `main` build.
+2. `sudo -u gc-deploy vi /opt/gc/.env` and pin `GC_IMAGE` to the target ref - either a tag (`ghcr.io/autarchy-ai/ground-control:sha-abc123`) or a digest (`ghcr.io/autarchy-ai/ground-control@sha256:...`). Available tags are listed at `https://github.com/autarchy-ai/Ground-Control/pkgs/container/ground-control`; CI publishes `sha-<short>` tags for every `main` build.
 3. Re-run `make deploy` (or `sudo -u gc-deploy /opt/gc/deploy.sh`). The pull resolves the pinned ref and the restart picks it up.
 4. **Restore the floating `:main` pin** in `/opt/gc/.env` once the rollback is no longer needed - otherwise the next CI deploy will succeed but never actually roll out.
 


### PR DESCRIPTION
## Summary

Repoints the production container image from `ghcr.io/brad-edwards/ground-control` to `ghcr.io/autarchy-ai/ground-control`.

After the repository moved into the `autarchy-ai` org, the CI `docker` job authenticates with the repo `GITHUB_TOKEN` (scoped `packages: write` for **autarchy-ai**) but still pushed to the **brad-edwards** user namespace. That token has no write access there, so every `main`/`dev` image build failed at the push step with `denied: permission_denied: The requested installation does not exist`, blocking deploys (the running production image is stale as of 2026-06-17). Moving the image under the owning org lets the workflow token's scope apply. The new package is created private on first push; the red-dragon `gc-deploy` host is being configured with a `read:packages` pull login out-of-band.

## Requirement UIDs

- (none — CI/deploy infrastructure fix following the org move; deployment governed by ADR-030)

## Related Issues

<!-- none -->

## ADR Impact

- ADR-030 (on-prem Hetzner/red-dragon deployment — registry reference); no new ADR required

## Changes

- `.github/workflows/ci.yml`: push image namespace -> `ghcr.io/autarchy-ai/ground-control`
- `deploy/scripts/deploy.sh`: rollback/pin ref construction -> autarchy-ai namespace
- `deploy/docker/README.md`, `docs/deployment/DEPLOYMENT.md`, `docs/architecture/ARCHITECTURE.md`, `skills/deploy/SKILL.md`: update image/registry references (incl. the GHCR package URL)

## Documentation

- Documentation outcome: deployment and architecture docs updated in this PR to reference the new `ghcr.io/autarchy-ai/ground-control` registry namespace (ADR-054). No API/schema/workflow-surface docs affected.

## Test Plan

- [x] Unit tests pass (`make test`) — no source change
- [x] Integration tests pass if applicable (`make integration`) — n/a
- [x] `make check` passes — n/a, CI-config + docs only
- [x] No coverage regression
- [x] Push validated on `dev` build before promoting to `main` (docker job creates the package on first push)

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — infrastructure fix)
- TESTS: (none — CI-config + docs change; validated by the docker job push succeeding)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added under `changelog.d/<issue>.<type>.md` (or `+<slug>.<type>.md`)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
