### PR TITLE
fix: publish AGE graph projection as atomic versioned snapshots

### DIFF
--- a/architecture/adrs/062-age-graph-projection-snapshot-publication.md
+++ b/architecture/adrs/062-age-graph-projection-snapshot-publication.md
@@ -1,0 +1,145 @@
+# ADR-062: AGE Graph Projection Snapshot Publication
+
+## Status
+
+accepted
+
+## Date
+
+2026-06-25
+
+## Context
+
+Issue #252 identifies a reliability gap in the Apache AGE graph read model:
+`POST /api/v1/admin/graph/materialize` rebuilds the live graph by deleting every
+node and recreating nodes and edges row by row. Graph readers can observe an empty
+or partially rebuilt projection, and a failed refresh can leave the live graph in a
+corrupt intermediate state.
+
+ADR-005 already chooses Apache AGE as the graph store. ADR-032 already makes the
+AGE adapter the SQL/Cypher construction boundary. Neither ADR defines ownership of
+the projection lifecycle or how a rebuilt graph becomes visible to readers.
+
+The repository already has the important schema boundary: relational aggregates are
+the source of truth, `GraphProjectionContributor` implementations emit the canonical
+domain projection, and `AgeGraphService` is only an infrastructure adapter for AGE.
+The fix must preserve that boundary instead of making requirement writes, control
+writes, or other aggregate services directly maintain AGE state.
+
+## Decision
+
+Ground Control uses a versioned snapshot publication model for the AGE graph
+projection.
+
+Materialization builds a new, inactive graph snapshot from
+`GraphProjectionRegistryService`. The active snapshot that readers query is never
+destructively rebuilt in place. After a refresh has successfully written and
+validated the new snapshot, publication is a single database transaction that
+advances an active-snapshot pointer. A failed refresh leaves the previous active
+snapshot untouched. Old snapshots are cleaned up only after they are no longer
+active; cleanup is best effort and not part of the reader path.
+
+Two lifecycle edges are explicit. First, an upgrade/bootstrap path: the snapshot
+pointer table starts empty, but an existing deployment can already have the
+configured base graph populated by the pre-this-ADR in-place materializer, so reads
+fall back to the configured base graph only while no snapshot row exists. Once the
+first snapshot is published the pointer always wins and the base graph is never read
+again. Second, cleanup is bounded by both a retained-count and a
+minimum-age grace period: a superseded snapshot is dropped only once it is beyond the
+retained count AND was retired more than the grace ago. The count bound alone is
+insufficient because a reader can resolve a snapshot and then rapid publications can
+push it beyond the count and drop it mid-read; repeatable-read protects the metadata
+lookup but not the AGE graph object's lifetime. The grace is measured from retirement
+(the publication instant of the successor snapshot), not from the snapshot's own
+publication, because a snapshot can be active for a long time and then be superseded
+while a reader is using it. The grace must exceed the maximum read duration, which is
+itself bounded by the graph traversal and projection-size caps.
+
+The relational model remains the source of truth. Graph nodes and edges continue to
+come from the existing `GraphProjection`, `GraphNode`, `GraphEdge`,
+`GraphEntityType`, `GraphIds`, and `GraphProjectionContributor` contracts. The
+snapshot metadata may record publication state, counts, timestamps, actor, and
+scope, but it must not become a duplicate graph schema.
+
+Projection capture must use a consistent relational snapshot. The current
+class-level transaction in `AgeGraphService` is useful because AGE setup
+(`LOAD 'age'`, `SET search_path`) is connection-local, but default read-committed
+semantics are not enough for a multi-query rebuild. The publisher must either use a
+repeatable-read transaction, or another explicit consistency mechanism, so one
+materialization does not mix unrelated committed states from different moments.
+
+Projection refresh is a graph concern, not a requirements concern. The admin
+endpoint, a future scheduler, and any future durable eventing worker should call the
+same graph projection publisher. Do not add AGE write side effects to
+`RequirementService`, `ControlService`, `AssetService`, or other aggregate services.
+The existing in-process Spring events are acceptable for synchronous domain
+reactions, but they are not a durable graph projection pipeline. If asynchronous
+projection becomes necessary, introduce a durable outbox/worker that still publishes
+versioned snapshots through the same boundary.
+
+AGE SQL/Cypher construction stays inside the AGE infrastructure adapter per ADR-032.
+Dynamic graph or snapshot identifiers must come from configuration, generated
+snapshot names, enums, or allowlists and must be validated before execution. Request
+DTO validation, domain validation, traversal caps, and the approved AGE property-key
+registry remain defense in depth, not replacements for adapter-side validation and
+JDBC parameter binding.
+
+The operational trigger remains privileged. HTTP refresh entry points stay under
+`/api/v1/admin/**` so both bearer and browser security chains apply the shared
+`ROLE_ADMIN` policy from `ApiPathMatrix`; browser-session mutations also keep the
+existing CSRF protections. Refresh outcomes and publication decisions use the
+standard `ErrorResponse` / `GlobalExceptionHandler` envelope and structured SLF4J
+logging. Do not expose raw SQL, Cypher, stack traces, or user-controlled graph
+properties in API error bodies.
+
+Configuration for new graph publication knobs, such as retention count, scheduled
+refresh enablement, or snapshot naming limits, must be bound through validated
+`@ConfigurationProperties` instead of adding more ad hoc `@Value` fields.
+
+The extensibility seam is refresh scope. The initial production fix may publish one
+global all-project snapshot, matching the current materialization behavior, but the
+metadata and publisher contract should make that scope explicit so a later
+project-scoped refresh or scheduled refresh can reuse the same publication model.
+
+## Consequences
+
+### Positive
+
+- Readers observe either the previous complete snapshot or the newly published
+  complete snapshot, never a destructive rebuild in progress.
+- Aggregate services stay focused on relational source-of-truth writes and do not
+  import AGE or duplicate graph schema rules.
+- Future scheduled or durable-event refresh triggers can reuse the same publisher
+  without changing the reader contract.
+- ADR-032's query-construction boundary remains intact for snapshot names and graph
+  metadata, not just node and edge properties.
+
+### Negative
+
+- The implementation needs projection metadata and snapshot cleanup logic rather
+  than a single `DETACH DELETE` followed by `CREATE` calls.
+- A full all-project snapshot can still be expensive; project-scoped refresh is a
+  later optimization, not required for the initial atomicity fix.
+- Concurrent refresh requests need an explicit serialization mechanism so two
+  publishers cannot race the active-snapshot pointer.
+
+### Risks
+
+- Treating an in-process event listener as "async projection" would keep the system
+  non-durable and can still lose graph updates on process failure.
+- Building the snapshot under read-committed isolation can publish a graph assembled
+  from multiple database moments.
+- Deleting old snapshots before the active pointer swap is visible can recreate the
+  empty-graph failure mode this ADR is meant to remove.
+- Adding project-scoped snapshot state without a project-scoped reader contract can
+  make cross-project graph reads ambiguous. Scope must be explicit in both metadata
+  and reader resolution.
+
+### Out of scope
+
+- Replacing Apache AGE with Neo4j or another graph database.
+- Introducing user-supplied Cypher or graph query language support.
+- Replacing the existing graph projection contributor model.
+- Building a general event bus or outbox solely for this issue.
+- Making graph projection a GRC derivation engine or changing ADR-057/ADR-058
+  screening behavior.

--- a/architecture/adrs/README.md
+++ b/architecture/adrs/README.md
@@ -77,5 +77,8 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [057](057-per-run-grc-screening-gate.md) | Per-run GRC Screening Gate in /implement | Accepted (amended/superseded in part by ADR-058) |
 | [058](058-derivation-first-continuous-grc.md) | Derivation-First Continuous GRC | Accepted |
 | [059](059-mcp-usage-telemetry.md) | MCP Tool Usage Telemetry | Accepted |
+| [060](060-requirement-uid-identity.md) | Requirement UID identity | Accepted |
+| [061](061-workflow-run-telemetry-reporting.md) | Workflow-Run Telemetry & Economics Reporting Surface | Accepted |
+| [062](062-age-graph-projection-snapshot-publication.md) | AGE Graph Projection Snapshot Publication | Accepted |
 
 Prior ADRs from the old project frame are archived in `archive/architecture/adrs/`.

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/MixedGraphService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/graph/service/MixedGraphService.java
@@ -20,10 +20,14 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+// Repeatable-read so a getVisualization call that resolves the active AGE snapshot and then issues
+// its node and edge queries observes one consistent snapshot even if a materialization commits a
+// new snapshot mid-read (ADR-062). Harmless for the AGE-disabled in-memory fallback path.
+@Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)
 public class MixedGraphService {
 
     private final MixedGraphClient mixedGraphClient;

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
@@ -297,9 +297,13 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
         String snapshotGraph = validateGraphName(baseGraph + "_v" + version);
 
         // Build the new snapshot into a fresh, inactive graph — the active snapshot readers query is
-        // never touched. snapshotGraph is allowlist-validated, so embedding it as a SQL literal is
-        // safe (ADR-032); user data still flows only through the bound agtype params of each CREATE.
-        jdbcTemplate.execute("SELECT create_graph('" + snapshotGraph + "')");
+        // never touched. The snapshot name is allowlist-validated (ADR-032) AND bound as a parameter
+        // here (cast to AGE's name type) rather than concatenated into the SQL; user data still flows
+        // only through the bound agtype params of each CREATE.
+        jdbcTemplate.query(
+                "SELECT create_graph(?::name)",
+                (PreparedStatementSetter) ps -> ps.setString(1, snapshotGraph),
+                (RowCallbackHandler) rs -> {});
 
         var projection = graphProjectionRegistryService.buildProjection();
         for (GraphNode node : projection.nodes()) {

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.keplerops.groundcontrol.domain.audit.ActorHolder;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.graph.GraphTraversalLimits;
@@ -31,7 +32,10 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * AGE adapter. Owns Cypher/SQL construction for the {@code ag_catalog.cypher(...)} surface.
@@ -47,21 +51,29 @@ import org.springframework.transaction.annotation.Transactional;
  * </ul>
  *
  * <p>String concatenation of user-supplied data into the SQL or Cypher text is not allowed. The
- * {@link #SAFE_IDENTIFIER} allowlist and {@link #SAFE_PARAM_NAME} allowlist are defense in depth;
- * the primary mitigation is parameter binding.
+ * {@link AgeIdentifiers} graph-identifier allowlist and {@link #SAFE_PARAM_NAME} allowlist are
+ * defense in depth; the primary mitigation is parameter binding.
  *
  * <p>Class-level {@link Transactional} pins every public AGE call to a single connection. AGE's
  * {@code LOAD 'age'} and {@code SET search_path} commands are connection-local, so without a
  * transaction those settings could land on one pooled connection and the subsequent
  * {@code ag_catalog.cypher(...)} call could land on another — failing with "function
  * ag_catalog.cypher does not exist" or returning empty results.
+ *
+ * <p>The transaction also runs at {@link Isolation#REPEATABLE_READ} (ADR-062). A read resolves the
+ * active snapshot name and then issues its graph query/queries; under the default read-committed
+ * isolation a snapshot publication committing between those statements could let a reader observe
+ * one statement against the old snapshot and the next against the new. A repeatable-read snapshot
+ * pins every statement of a read — and the multi-query projection capture during publication — to a
+ * single consistent moment. Because publication is INSERT-only (it never updates a prior snapshot
+ * row), repeatable-read raises no write-serialization conflict for concurrent publishers, which are
+ * additionally serialized by an advisory lock.
  */
 @Component
-@Transactional
+@Transactional(isolation = Isolation.REPEATABLE_READ)
 public class AgeGraphService implements GraphClient, MixedGraphClient {
 
     private static final Logger log = LoggerFactory.getLogger(AgeGraphService.class);
-    private static final java.util.regex.Pattern SAFE_IDENTIFIER = java.util.regex.Pattern.compile("^[a-zA-Z0-9_-]+$");
     private static final java.util.regex.Pattern SAFE_PARAM_NAME = java.util.regex.Pattern.compile("^[a-zA-Z_]\\w*$");
 
     // Implicit AGE property keys this adapter writes / reads. Centralized so
@@ -233,20 +245,37 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
     // (graph name, entity-type labels, edge-type labels, property keys — all validated by
     // validateGraphName) and Cypher template syntax. No user value ever reaches the SQL string.
 
+    /** Scope recorded on every snapshot today: one global all-project graph (ADR-062 seam). */
+    private static final String SNAPSHOT_SCOPE_GLOBAL = "GLOBAL";
+
+    /**
+     * Advisory-lock key serializing concurrent graph publications so two refreshes cannot
+     * interleave their snapshot writes or race the active-snapshot version. Arbitrary stable
+     * constant; held for the duration of the publishing transaction via {@code
+     * pg_advisory_xact_lock}.
+     */
+    private static final long GRAPH_PUBLICATION_ADVISORY_LOCK_KEY = 0x6763_6772_6170_68L; // "gcgraph"
+
     private final JdbcTemplate jdbcTemplate;
     private final AgeProperties ageProperties;
     private final GraphProjectionRegistryService graphProjectionRegistryService;
     private final ProjectRepository projectRepository;
+    private final AgeGraphSnapshotRepository snapshotRepository;
+    private final AgeSnapshotCleaner snapshotCleaner;
 
     public AgeGraphService(
             JdbcTemplate jdbcTemplate,
             AgeProperties ageProperties,
             GraphProjectionRegistryService graphProjectionRegistryService,
-            ProjectRepository projectRepository) {
+            ProjectRepository projectRepository,
+            AgeGraphSnapshotRepository snapshotRepository,
+            AgeSnapshotCleaner snapshotCleaner) {
         this.jdbcTemplate = jdbcTemplate;
         this.ageProperties = ageProperties;
         this.graphProjectionRegistryService = graphProjectionRegistryService;
         this.projectRepository = projectRepository;
+        this.snapshotRepository = snapshotRepository;
+        this.snapshotCleaner = snapshotCleaner;
     }
 
     @Override
@@ -256,23 +285,77 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
             return;
         }
 
-        String graph = validateGraphName(ageProperties.graphName());
+        // Fail fast on a misconfigured base graph name before acquiring any lock or sequence value.
+        String baseGraph = validateGraphName(ageProperties.graphName());
         setupSearchPath();
-        executeCypher(graph, "MATCH (n) DETACH DELETE n", "{}");
+
+        // Serialize concurrent publishers: only one materialization at a time builds a snapshot and
+        // advances the active version. Held until this transaction ends (ADR-062).
+        jdbcTemplate.execute("SELECT pg_advisory_xact_lock(" + GRAPH_PUBLICATION_ADVISORY_LOCK_KEY + ")");
+
+        long version = snapshotRepository.nextVersion();
+        String snapshotGraph = validateGraphName(baseGraph + "_v" + version);
+
+        // Build the new snapshot into a fresh, inactive graph — the active snapshot readers query is
+        // never touched. snapshotGraph is allowlist-validated, so embedding it as a SQL literal is
+        // safe (ADR-032); user data still flows only through the bound agtype params of each CREATE.
+        jdbcTemplate.execute("SELECT create_graph('" + snapshotGraph + "')");
 
         var projection = graphProjectionRegistryService.buildProjection();
         for (GraphNode node : projection.nodes()) {
-            executeCreateNode(graph, node);
+            executeCreateNode(snapshotGraph, node);
         }
         for (GraphEdge edge : projection.edges()) {
-            executeCreateEdge(graph, edge);
+            executeCreateEdge(snapshotGraph, edge);
         }
 
-        log.info(
-                "graph_materialized: nodes={} edges={} graph={}",
+        // Publish: record the new snapshot. Because the active snapshot is the greatest-version row,
+        // this INSERT — visible only at commit — is the atomic pointer swap. A failed refresh rolls
+        // back the new graph and this row together, leaving the previous snapshot active.
+        snapshotRepository.insertSnapshot(
+                version,
+                snapshotGraph,
+                SNAPSHOT_SCOPE_GLOBAL,
                 projection.nodes().size(),
                 projection.edges().size(),
-                graph);
+                ActorHolder.get());
+
+        log.info(
+                "graph_snapshot_published: graph={} nodes={} edges={} version={}",
+                snapshotGraph,
+                projection.nodes().size(),
+                projection.edges().size(),
+                version);
+
+        // Drop snapshots beyond retention only AFTER this swap commits — never before, so a reader
+        // mid-resolution cannot lose its snapshot. Skipped when no transaction synchronization is
+        // active (e.g. a unit test invoking the method without a surrounding transaction).
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    snapshotCleaner.cleanup();
+                }
+            });
+        }
+    }
+
+    /**
+     * Resolve the graph name a read should query: the active snapshot when one has been published,
+     * otherwise the configured base graph.
+     *
+     * <p>The base-graph fallback is the upgrade/bootstrap compatibility path. {@code
+     * age_graph_snapshot} starts empty, but an existing deployment can already have the configured
+     * base graph populated by the pre-ADR-062 in-place materializer; without this fallback every
+     * graph read would return empty after deploy until an operator re-materialized, violating the
+     * "readers keep seeing the previous complete graph" guarantee. It is bounded: the fallback
+     * applies ONLY while no snapshot row exists. Once the first snapshot is published the pointer
+     * always wins, and the base graph is never read again. On a truly fresh database the base graph
+     * is the empty graph created by V010, so the fallback reads empty — exactly the pre-snapshot
+     * behavior. The name is allowlist-validated before any caller embeds it as a SQL literal.
+     */
+    private String resolveActiveGraph() {
+        return validateGraphName(snapshotRepository.findActiveGraphName().orElseGet(ageProperties::graphName));
     }
 
     @Override
@@ -282,8 +365,8 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
         }
         validateUid(uid);
         validateDepth(depth);
+        String graph = resolveActiveGraph();
         String projectIdentifier = getProjectIdentifier(projectId);
-        String graph = validateGraphName(ageProperties.graphName());
         setupSearchPath();
 
         // PARENT edges are materialized source→target and the domain convention is
@@ -306,8 +389,8 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
         }
         validateUid(uid);
         validateDepth(depth);
+        String graph = resolveActiveGraph();
         String projectIdentifier = getProjectIdentifier(projectId);
-        String graph = validateGraphName(ageProperties.graphName());
         setupSearchPath();
 
         // Inverse of getAncestors: descendants of n are reachable by following INCOMING PARENT
@@ -327,8 +410,8 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
         }
         validateUid(sourceUid);
         validateUid(targetUid);
+        String graph = resolveActiveGraph();
         String projectIdentifier = getProjectIdentifier(projectId);
-        String graph = validateGraphName(ageProperties.graphName());
         setupSearchPath();
 
         // findPaths has no depth in its API contract, so we hard-cap variable-length traversal
@@ -369,7 +452,7 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
             GraphProjection filtered = filter.isEmpty() ? full : filterByEntityType(full, filter);
             return enforceProjectionSizeCap(filtered);
         }
-        String graph = validateGraphName(ageProperties.graphName());
+        String graph = resolveActiveGraph();
         String projectIdentifier = getProjectIdentifier(projectId);
         setupSearchPath();
 
@@ -752,15 +835,13 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
 
     /**
      * Validate a token that will be embedded in the SQL/Cypher text as an identifier (graph
-     * name, node label, edge type). Allows alphanumerics plus `_` and `-` because some entity
-     * type names use hyphens. Identifiers reach AGE as part of a SQL literal — they cannot be
-     * parameter-bound — so the allowlist is a hard requirement, not defense in depth.
+     * name, node label, edge type, snapshot graph name). Delegates to the canonical
+     * {@link AgeIdentifiers} allowlist so this adapter and {@link AgeSnapshotCleaner} share one
+     * policy. Identifiers reach AGE as part of a SQL literal — they cannot be parameter-bound —
+     * so the allowlist is a hard requirement, not defense in depth.
      */
     private static String validateGraphName(String name) {
-        if (name == null || !SAFE_IDENTIFIER.matcher(name).matches()) {
-            throw new DomainValidationException("Invalid graph identifier: " + name);
-        }
-        return name;
+        return AgeIdentifiers.validateGraphName(name);
     }
 
     /**
@@ -786,8 +867,8 @@ public class AgeGraphService implements GraphClient, MixedGraphClient {
      * enforces the operational bounds the rest of the domain enforces (length matches the
      * {@code requirement.uid} column width; no control characters that would corrupt logs or
      * confuse downstream tooling). It deliberately does NOT enforce the
-     * {@link #SAFE_IDENTIFIER} grammar because importers (StrictDoc, ReqIF) accept richer UID
-     * shapes and persisted requirements with such UIDs must remain queryable.
+     * {@link AgeIdentifiers} graph-identifier grammar because importers (StrictDoc, ReqIF) accept
+     * richer UID shapes and persisted requirements with such UIDs must remain queryable.
      */
     private static void validateUid(String uid) {
         if (uid == null || uid.isBlank()) {

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphSnapshotRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphSnapshotRepository.java
@@ -1,0 +1,101 @@
+package com.keplerops.groundcontrol.infrastructure.age;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Persistence for the AGE graph snapshot pointer + metadata table (ADR-062). Publication is
+ * INSERT-only: each materialization writes one new row, and the active snapshot a reader queries
+ * is the row with the greatest {@code version}. The "pointer swap" is therefore the new row
+ * becoming visible at the publisher's transaction commit — the previously-active snapshot row is
+ * never mutated, so there is no read-then-update conflict under repeatable-read isolation.
+ *
+ * <p>This is plain relational bookkeeping (no AGE/Cypher), kept in the AGE infrastructure package
+ * alongside the adapter that owns it. The {@code scope}/{@code state}-free, INSERT-only shape is
+ * deliberate; see ADR-062.
+ */
+@Repository
+public class AgeGraphSnapshotRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public AgeGraphSnapshotRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * Next monotonic snapshot version, used to build a unique snapshot graph name and to order
+     * snapshots. {@code nextval} is non-transactional, so a rolled-back publication still
+     * consumes the version — that is fine, names only need to be unique, not contiguous.
+     */
+    public long nextVersion() {
+        Long version = jdbcTemplate.queryForObject("SELECT nextval('age_graph_snapshot_version_seq')", Long.class);
+        if (version == null) {
+            throw new IllegalStateException("age_graph_snapshot_version_seq returned null");
+        }
+        return version;
+    }
+
+    /** Graph name of the currently-active (greatest-version) snapshot, or empty when none exists. */
+    public Optional<String> findActiveGraphName() {
+        try {
+            return Optional.ofNullable(jdbcTemplate.queryForObject(
+                    "SELECT graph_name FROM age_graph_snapshot ORDER BY version DESC LIMIT 1", String.class));
+        } catch (EmptyResultDataAccessException noRows) {
+            return Optional.empty();
+        }
+    }
+
+    /** Record a newly-published snapshot. The greatest-version row is the active one. */
+    public void insertSnapshot(
+            long version, String graphName, String scope, int nodeCount, int edgeCount, String publishedBy) {
+        jdbcTemplate.update(
+                "INSERT INTO age_graph_snapshot "
+                        + "(version, graph_name, scope, node_count, edge_count, published_at, published_by) "
+                        + "VALUES (?, ?, ?, ?, ?, now(), ?)",
+                version,
+                graphName,
+                scope,
+                nodeCount,
+                edgeCount,
+                publishedBy);
+    }
+
+    /**
+     * Snapshot graph names safe to drop: those that are BOTH outside the newest-{@code
+     * retainedSnapshots} window AND retired (superseded) more than {@code minAgeSeconds} ago. The
+     * count bound keeps the active snapshot plus a buffer of recent ones; the age bound is the
+     * grace period that keeps a snapshot a live reader may have just resolved from being dropped
+     * mid-read (the metadata lookup is repeatable-read consistent, but that does not extend the AGE
+     * graph object's lifetime).
+     *
+     * <p>The grace is measured from when a snapshot stopped being active, NOT from when it was
+     * published: a snapshot can be active for hours and then be superseded and read concurrently,
+     * so a publish-time grace would not protect it. A snapshot's retirement instant is the
+     * publication instant of its successor (the next-higher version), computed here with {@code
+     * lead(published_at) OVER (ORDER BY version)}. The active snapshot (greatest version) has no
+     * successor, so its {@code retired_at} is NULL and it is never eligible.
+     */
+    public List<String> graphsToDrop(int retainedSnapshots, long minAgeSeconds) {
+        int keep = Math.max(retainedSnapshots, 0);
+        return jdbcTemplate.queryForList(
+                "SELECT graph_name FROM "
+                        + "(SELECT graph_name, version, lead(published_at) OVER (ORDER BY version) AS retired_at "
+                        + "FROM age_graph_snapshot) s "
+                        + "WHERE graph_name NOT IN "
+                        + "(SELECT graph_name FROM age_graph_snapshot ORDER BY version DESC LIMIT ?) "
+                        + "AND retired_at IS NOT NULL "
+                        + "AND retired_at < now() - make_interval(secs => ?) "
+                        + "ORDER BY version",
+                String.class,
+                keep,
+                (double) minAgeSeconds);
+    }
+
+    public void deleteByGraphName(String graphName) {
+        jdbcTemplate.update("DELETE FROM age_graph_snapshot WHERE graph_name = ?", graphName);
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeIdentifiers.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeIdentifiers.java
@@ -1,0 +1,32 @@
+package com.keplerops.groundcontrol.infrastructure.age;
+
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
+import java.util.regex.Pattern;
+
+/**
+ * Allowlist validation for AGE identifiers that are embedded into SQL/Cypher text as literals
+ * (graph names, node labels, relationship types). Per ADR-032 these tokens cannot be
+ * parameter-bound, so they must come from configuration, generated names, enums, or allowlists
+ * and be validated before execution. Centralized here so the AGE adapter
+ * ({@link AgeGraphService}) and the snapshot cleaner ({@link AgeSnapshotCleaner}) share one
+ * canonical policy and cannot drift apart.
+ */
+final class AgeIdentifiers {
+
+    private static final Pattern SAFE_IDENTIFIER = Pattern.compile("^[a-zA-Z0-9_-]+$");
+
+    private AgeIdentifiers() {}
+
+    /**
+     * Validate a token embedded in SQL/Cypher text as an identifier. Allows alphanumerics plus
+     * {@code _} and {@code -} (some entity-type names use hyphens). The allowlist is a hard
+     * requirement, not defense in depth, because these identifiers reach AGE as part of a SQL
+     * literal and cannot be parameter-bound.
+     */
+    static String validateGraphName(String name) {
+        if (name == null || !SAFE_IDENTIFIER.matcher(name).matches()) {
+            throw new DomainValidationException("Invalid graph identifier: " + name);
+        }
+        return name;
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeSnapshotCleaner.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeSnapshotCleaner.java
@@ -1,0 +1,59 @@
+package com.keplerops.groundcontrol.infrastructure.age;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Best-effort cleanup of superseded AGE graph snapshots (ADR-062). Runs after a publication
+ * commits — the publisher registers it as an after-commit synchronization — so old snapshots are
+ * dropped only once the active-pointer swap is visible, never before; dropping a still-resolvable
+ * snapshot is exactly the empty-graph failure mode this ADR removes.
+ *
+ * <p>Cleanup is never on the reader path and never fails a publication: it runs in its own
+ * transaction (so AGE's connection-local {@code LOAD 'age'} / {@code search_path} apply to the
+ * same connection as {@code drop_graph}), and each drop is isolated so a single failure is logged
+ * and skipped, leaving that snapshot's metadata row for a later attempt.
+ */
+@Component
+public class AgeSnapshotCleaner {
+
+    private static final Logger log = LoggerFactory.getLogger(AgeSnapshotCleaner.class);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final AgeGraphSnapshotRepository snapshotRepository;
+    private final GraphPublicationProperties publicationProperties;
+
+    public AgeSnapshotCleaner(
+            JdbcTemplate jdbcTemplate,
+            AgeGraphSnapshotRepository snapshotRepository,
+            GraphPublicationProperties publicationProperties) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.snapshotRepository = snapshotRepository;
+        this.publicationProperties = publicationProperties;
+    }
+
+    /** Drop snapshot graphs outside the retention window and forget their metadata. */
+    @Transactional
+    public void cleanup() {
+        var staleGraphs = snapshotRepository.graphsToDrop(
+                publicationProperties.retainedSnapshots(), publicationProperties.minRetainedAgeSeconds());
+        if (staleGraphs.isEmpty()) {
+            return;
+        }
+        jdbcTemplate.execute("LOAD 'age'");
+        jdbcTemplate.execute("SET search_path = ag_catalog, \"$user\", public");
+        for (String graphName : staleGraphs) {
+            try {
+                // graphName is allowlist-validated before it reaches the drop_graph SQL literal
+                // (ADR-032); the second argument true cascades the schema drop.
+                jdbcTemplate.execute("SELECT drop_graph('" + AgeIdentifiers.validateGraphName(graphName) + "', true)");
+                snapshotRepository.deleteByGraphName(graphName);
+            } catch (RuntimeException dropFailed) {
+                log.warn("graph_snapshot_cleanup_skipped: graph={} reason={}", graphName, dropFailed.getMessage());
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/GraphPublicationProperties.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/GraphPublicationProperties.java
@@ -1,0 +1,31 @@
+package com.keplerops.groundcontrol.infrastructure.age;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration for AGE graph snapshot publication (ADR-062). New publication knobs are bound
+ * here through validated {@link ConfigurationProperties} rather than ad hoc {@code @Value}
+ * fields, and the record is registered via the application's {@code @ConfigurationPropertiesScan}.
+ *
+ * @param retainedSnapshots total number of snapshots kept after a publication — the active
+ *     snapshot plus the most-recent superseded ones. Must be at least 2 so the snapshot that was
+ *     active immediately before a swap survives cleanup long enough for any in-flight reader that
+ *     already resolved it; only snapshots older than the retention window are dropped.
+ * @param minRetainedAgeSeconds grace period: a superseded snapshot is dropped only once it is BOTH
+ *     beyond {@code retainedSnapshots} AND was retired (stopped being the active snapshot) more
+ *     than this many seconds ago. The count bound alone is not enough — a reader can resolve a
+ *     snapshot and then two rapid publications can push it beyond the count and drop it mid-read
+ *     (repeatable-read protects the metadata lookup, not the AGE graph object's lifetime). The
+ *     grace is measured from retirement, not publication, because a snapshot can be active for a
+ *     long time and then be superseded while a reader is using it. The grace must exceed the
+ *     maximum read duration, which is itself bounded by the graph traversal and projection-size
+ *     caps. Default 300s is far larger than any bounded read, so a snapshot a live reader resolved
+ *     is never dropped before that reader finishes.
+ */
+@Validated
+@ConfigurationProperties(prefix = "groundcontrol.age.publication")
+public record GraphPublicationProperties(
+        @DefaultValue("2") @Min(2) int retainedSnapshots, @DefaultValue("300") @Min(0) long minRetainedAgeSeconds) {}

--- a/backend/src/main/resources/db/migration/V143__create_age_graph_snapshot.sql
+++ b/backend/src/main/resources/db/migration/V143__create_age_graph_snapshot.sql
@@ -1,0 +1,23 @@
+-- ADR-062 / issue #252: AGE graph projection snapshot publication.
+--
+-- Versioned-snapshot publication replaces the destructive in-place rebuild of the live
+-- AGE graph. Each materialization builds a new, inactive AGE graph and records it here;
+-- the active snapshot a reader queries is simply the row with the greatest version, so
+-- publication is INSERT-only and the "pointer swap" is the new row becoming visible at
+-- commit. The previously-active snapshot is never destructively mutated, and a failed
+-- refresh leaves the prior snapshot untouched.
+--
+-- This table is plain relational bookkeeping with no AGE dependency, so it applies on
+-- plain PostgreSQL too; the AGE graphs themselves are created and dropped at runtime by
+-- the snapshot publisher (AgeGraphService) and cleaner (AgeSnapshotCleaner).
+CREATE SEQUENCE IF NOT EXISTS age_graph_snapshot_version_seq;
+
+CREATE TABLE age_graph_snapshot (
+    version      BIGINT      PRIMARY KEY,
+    graph_name   TEXT        NOT NULL UNIQUE,
+    scope        TEXT        NOT NULL,
+    node_count   INTEGER     NOT NULL CHECK (node_count >= 0),
+    edge_count   INTEGER     NOT NULL CHECK (edge_count >= 0),
+    published_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_by TEXT
+);

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/AgeGraphSnapshotConcurrentRefreshIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/AgeGraphSnapshotConcurrentRefreshIntegrationTest.java
@@ -1,0 +1,194 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keplerops.groundcontrol.domain.graph.service.MixedGraphService;
+import com.keplerops.groundcontrol.domain.projects.model.Project;
+import com.keplerops.groundcontrol.domain.projects.repository.ProjectRepository;
+import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
+import com.keplerops.groundcontrol.domain.requirements.repository.RequirementRepository;
+import com.keplerops.groundcontrol.domain.requirements.service.GraphClient;
+import com.keplerops.groundcontrol.infrastructure.age.AgeGraphSnapshotRepository;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * ADR-062 / issue #252: proves the versioned-snapshot publication is atomic from the reader's
+ * perspective and non-destructive.
+ *
+ * <p>Deliberately NOT {@code @Transactional}: the behaviour under test is cross-transaction
+ * visibility — a reader in one transaction must never see a publisher's half-built graph — so each
+ * materialization and read has to really commit. A test-wide rollback would hide exactly the
+ * property being verified.
+ */
+class AgeGraphSnapshotConcurrentRefreshIntegrationTest extends BaseAgeIntegrationTest {
+
+    @Autowired
+    private GraphClient graphClient;
+
+    @Autowired
+    private MixedGraphService mixedGraphService;
+
+    @Autowired
+    private RequirementRepository requirementRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private AgeGraphSnapshotRepository snapshotRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void publishingNewSnapshotLeavesThePreviousSnapshotIntact() {
+        Project project = newProject();
+        saveRequirements(project, 2);
+        graphClient.materializeGraph();
+        String v1Graph = snapshotRepository.findActiveGraphName().orElseThrow();
+        long v1NodeCount = countNodes(v1Graph);
+        assertThat(v1NodeCount)
+                .as("v1 snapshot should contain the materialized nodes")
+                .isPositive();
+
+        saveRequirements(project, 1);
+        graphClient.materializeGraph();
+        String v2Graph = snapshotRepository.findActiveGraphName().orElseThrow();
+
+        assertThat(v2Graph).as("publication builds a NEW snapshot graph").isNotEqualTo(v1Graph);
+        // Non-destructive: the previous snapshot graph still exists and is byte-for-byte unchanged —
+        // it was never DETACH DELETEd or rebuilt in place.
+        assertThat(countNodes(v1Graph))
+                .as("the previous snapshot must be untouched by a new publication")
+                .isEqualTo(v1NodeCount);
+        // The new snapshot reflects the added requirement.
+        assertThat(countNodes(v2Graph))
+                .as("the new snapshot reflects the added requirement")
+                .isGreaterThan(v1NodeCount);
+    }
+
+    @Test
+    void concurrentReadsNeverObservePartialGraphDuringRefresh() throws Exception {
+        Project project = newProject();
+        saveRequirements(project, 2);
+        graphClient.materializeGraph();
+        int v1Count = projectNodeCount(project);
+        assertThat(v1Count).as("v1 is this project's two requirements").isEqualTo(2);
+
+        // Stage the data the next snapshot will capture, but do not publish it yet.
+        saveRequirements(project, 3);
+        int expectedV2Count = 5;
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            Callable<List<Integer>> reader = () -> {
+                start.await();
+                List<Integer> observed = new ArrayList<>();
+                for (int i = 0; i < 300; i++) {
+                    observed.add(projectNodeCount(project));
+                }
+                return observed;
+            };
+            Callable<Void> publisher = () -> {
+                start.await();
+                graphClient.materializeGraph();
+                return null;
+            };
+
+            Future<List<Integer>> readerFuture = pool.submit(reader);
+            Future<Void> publisherFuture = pool.submit(publisher);
+            start.countDown();
+
+            publisherFuture.get(60, TimeUnit.SECONDS);
+            List<Integer> observed = readerFuture.get(60, TimeUnit.SECONDS);
+
+            // Every observation is a COMPLETE snapshot: either the old graph (2) or the newly
+            // published one (5), never a partial or empty count in between. This is the atomicity
+            // guarantee — it holds regardless of how the two threads interleave.
+            assertThat(observed)
+                    .isNotEmpty()
+                    .allMatch(
+                            count -> count == v1Count || count == expectedV2Count,
+                            "every read sees a complete snapshot (" + v1Count + " or " + expectedV2Count + ")");
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void cleanupEligibilityIsBeyondRetentionAndRetiredPastGrace() {
+        Project project = newProject();
+        saveRequirements(project, 1);
+        graphClient.materializeGraph();
+        String firstSnapshot = snapshotRepository.findActiveGraphName().orElseThrow();
+        saveRequirements(project, 1);
+        graphClient.materializeGraph();
+        saveRequirements(project, 1);
+        graphClient.materializeGraph();
+
+        // With retention 2 and a zero grace, a snapshot that is beyond the newest two AND already
+        // retired (it has a successor) is eligible to drop. This exercises the lead()-over-version
+        // retirement query against real PostgreSQL. The current globally-active snapshot has no
+        // successor, so its retired_at is NULL and it is never eligible — regardless of how many
+        // snapshots other test methods left in the table.
+        String globalActive = snapshotRepository.findActiveGraphName().orElseThrow();
+        assertThat(snapshotRepository.graphsToDrop(2, 0L))
+                .contains(firstSnapshot)
+                .doesNotContain(globalActive);
+        // And the default grace protects the just-retired snapshot from being dropped.
+        assertThat(snapshotRepository.graphsToDrop(2, 300L)).doesNotContain(globalActive);
+    }
+
+    private Project newProject() {
+        return projectRepository.save(new Project("snap-" + shortId(), "Snapshot Test " + shortId()));
+    }
+
+    private void saveRequirements(Project project, int count) {
+        for (int i = 0; i < count; i++) {
+            String uid = "SNAP-" + shortId();
+            requirementRepository.save(new Requirement(project, uid, "Req " + uid, "Statement " + uid));
+        }
+    }
+
+    private int projectNodeCount(Project project) {
+        return mixedGraphService
+                .getVisualization(project.getId(), List.of())
+                .nodes()
+                .size();
+    }
+
+    /** Count all vertices in a specific snapshot graph, on a single pinned connection. */
+    private long countNodes(String graph) {
+        Long count = jdbcTemplate.execute((ConnectionCallback<Long>) connection -> {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("LOAD 'age'");
+                statement.execute("SET search_path = ag_catalog, \"$user\", public");
+                try (ResultSet rs = statement.executeQuery(
+                        "SELECT count(*) FROM cypher('" + graph + "', $$ MATCH (n) RETURN n $$) AS (n agtype)")) {
+                    rs.next();
+                    return rs.getLong(1);
+                }
+            }
+        });
+        return count == null ? 0L : count;
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
@@ -60,7 +60,7 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         "092", "093", "094", "095", "096", "097", "098", "099", "100", "101", "102", "103", "104",
                         "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122",
                         "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135",
-                        "136", "137", "138", "139", "140", "141", "142");
+                        "136", "137", "138", "139", "140", "141", "142", "143");
     }
 
     @Test
@@ -1211,6 +1211,35 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                 .contains("model_invocation_count")
                 .contains("wall_clock_minutes")
                 .contains("cost_proxy");
+    }
+
+    /**
+     * V143: AGE graph projection snapshot pointer/metadata (#252 / ADR-062). Plain relational
+     * bookkeeping (no AGE dependency); the active snapshot is the greatest-version row. ddl-auto
+     * does not own this table (it is managed via JdbcTemplate), so probe the table, the version
+     * sequence, and the non-negative count CHECK constraints explicitly here.
+     */
+    @Test
+    @Transactional
+    void ageGraphSnapshotTableExists() {
+        org.assertj.core.api.Assertions.assertThatCode(() -> entityManager
+                        .createNativeQuery("SELECT version, graph_name, scope, node_count, edge_count,"
+                                + " published_at, published_by FROM age_graph_snapshot LIMIT 1")
+                        .getResultList())
+                .doesNotThrowAnyException();
+        org.assertj.core.api.Assertions.assertThatCode(() -> entityManager
+                        .createNativeQuery("SELECT nextval('age_graph_snapshot_version_seq')")
+                        .getSingleResult())
+                .doesNotThrowAnyException();
+        var snapshotChecks = entityManager
+                .createNativeQuery("SELECT string_agg(pg_get_constraintdef(c.oid), ' ')"
+                        + " FROM pg_constraint c JOIN pg_class t ON t.oid = c.conrelid"
+                        + " WHERE t.relname = 'age_graph_snapshot' AND c.contype = 'c'")
+                .getSingleResult();
+        assertThat(snapshotChecks.toString())
+                .as("age_graph_snapshot must CHECK non-negative node/edge counts")
+                .contains("node_count")
+                .contains("edge_count");
     }
 
     private void assertSeededMethodologyProfilesAligned() {

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EAgeIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EAgeIntegrationTest.java
@@ -6,6 +6,7 @@ import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.repository.ProjectRepository;
 import com.keplerops.groundcontrol.domain.requirements.service.GraphClient;
 import com.keplerops.groundcontrol.domain.requirements.service.ImportService;
+import com.keplerops.groundcontrol.infrastructure.age.AgeGraphSnapshotRepository;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -14,9 +15,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
+// Intentionally NOT @Transactional: this is an ordered accumulate-then-verify sequence — import
+// (Order 1) → materialize (Order 2) → ancestor/descendant queries (Order 3/4). Each @Test method
+// runs in its own transaction, so a class-level @Transactional would roll the import back before
+// materialization could read it, and (under ADR-062) roll the published snapshot back before the
+// read methods could resolve its active pointer. Committing between methods is what makes the
+// cross-method verification meaningful; the Testcontainers database is torn down with the JVM.
 @TestMethodOrder(OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RequirementsE2EAgeIntegrationTest extends BaseAgeIntegrationTest {
@@ -29,6 +34,9 @@ class RequirementsE2EAgeIntegrationTest extends BaseAgeIntegrationTest {
 
     @Autowired
     private ProjectRepository projectRepository;
+
+    @Autowired
+    private AgeGraphSnapshotRepository snapshotRepository;
 
     private Project testProject;
 
@@ -55,6 +63,12 @@ class RequirementsE2EAgeIntegrationTest extends BaseAgeIntegrationTest {
     @Order(2)
     void materializeGraph() {
         graphClient.materializeGraph();
+        // Gate the setup step itself: a no-op or all-swallowing materialize would otherwise pass
+        // silently here and surface only as empty ancestor/descendant results in Order(3)/(4),
+        // misdirecting triage to the read path rather than to publication.
+        assertThat(snapshotRepository.findActiveGraphName())
+                .as("a snapshot must be published after materialization")
+                .isPresent();
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -561,6 +561,7 @@ class RequirementsE2EIntegrationTest extends BaseIntegrationTest {
                         "139", // V139: O-RT forms-of-loss materiality + stakeholder secondary effects (GC-T016)
                         "140", // V140: create risk_appetite_profile (GC-T005, #260)
                         "141", // V141: create risk_appetite_profile_audit (GC-T005 audit parity)
-                        "142"); // V142: create workflow_run telemetry reporting tables (#859, ADR-061)
+                        "142", // V142: create workflow_run telemetry reporting tables (#859, ADR-061)
+                        "143"); // V143: create age_graph_snapshot pointer/metadata (#252, ADR-062)
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphServiceTest.java
@@ -218,13 +218,18 @@ class AgeGraphServiceTest {
             verify(jdbcTemplate).execute("LOAD 'age'");
             verify(jdbcTemplate).execute("SET search_path = ag_catalog, \"$user\", public");
             // The publish is serialized by an advisory lock and builds into a NEW versioned graph
-            // (create_graph). Crucially, the live graph is NEVER DETACH DELETEd — that was the
-            // destructive rebuild ADR-062 removes.
+            // (create_graph, with the snapshot name bound as a parameter). Crucially, the live graph
+            // is NEVER DETACH DELETEd — that was the destructive rebuild ADR-062 removes.
             ArgumentCaptor<String> execCaptor = ArgumentCaptor.forClass(String.class);
             verify(jdbcTemplate, atLeast(1)).execute(execCaptor.capture());
             assertThat(execCaptor.getAllValues())
                     .anyMatch(sql -> sql.contains("pg_advisory_xact_lock"))
-                    .anyMatch(sql -> sql.contains("create_graph('test_graph_v1')"))
+                    .noneMatch(sql -> sql.contains("DETACH DELETE"));
+            ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+            verify(jdbcTemplate, atLeast(1))
+                    .query(queryCaptor.capture(), any(PreparedStatementSetter.class), any(RowCallbackHandler.class));
+            assertThat(queryCaptor.getAllValues())
+                    .anyMatch(sql -> sql.contains("create_graph(?"))
                     .noneMatch(sql -> sql.contains("DETACH DELETE"));
             // Publication records the new snapshot — the atomic active-version swap on commit.
             verify(snapshotRepository).insertSnapshot(eq(1L), eq("test_graph_v1"), eq("GLOBAL"), eq(0), eq(0), any());
@@ -249,19 +254,18 @@ class AgeGraphServiceTest {
 
             enabledService.materializeGraph();
 
-            // create_graph for the new snapshot goes through execute(); the node CREATE goes through
-            // query(sql, pss, callback) — AGE's cypher() always returns SETOF agtype. Capture both to
-            // confirm a CREATE was emitted into the NEW snapshot graph (not the base name) and that
-            // no DETACH DELETE was issued anywhere.
-            ArgumentCaptor<String> execCaptor = ArgumentCaptor.forClass(String.class);
-            verify(jdbcTemplate, atLeast(1)).execute(execCaptor.capture());
-            assertThat(execCaptor.getAllValues()).anyMatch(sql -> sql.contains("create_graph('test_graph_v1')"));
+            // create_graph (snapshot name bound as a parameter) and the node CREATE both go through
+            // query(sql, pss, callback). Confirm a CREATE was emitted into the NEW snapshot graph
+            // (the snapshot name reaches the cypher() graph argument via the existing ADR-032 path,
+            // while user values stay bound) and that no DETACH DELETE was issued anywhere.
             ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
-            verify(jdbcTemplate, atLeast(1))
+            verify(jdbcTemplate, atLeast(2))
                     .query(queryCaptor.capture(), any(PreparedStatementSetter.class), any(RowCallbackHandler.class));
             assertThat(queryCaptor.getAllValues())
-                    .anyMatch(sql ->
-                            sql.contains("CREATE (:") && sql.contains("REQUIREMENT") && sql.contains("'test_graph_v1'"))
+                    .anyMatch(sql -> sql.contains("create_graph(?"))
+                    .anyMatch(sql -> sql.contains("CREATE (:")
+                            && sql.contains("REQUIREMENT")
+                            && sql.contains("cypher('test_graph_v1'"))
                     .noneMatch(sql -> sql.contains("DETACH DELETE"));
             verify(snapshotRepository).insertSnapshot(eq(1L), eq("test_graph_v1"), eq("GLOBAL"), eq(1), eq(0), any());
         }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -25,7 +26,9 @@ import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.repository.ProjectRepository;
 import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
 import com.keplerops.groundcontrol.infrastructure.age.AgeGraphService;
+import com.keplerops.groundcontrol.infrastructure.age.AgeGraphSnapshotRepository;
 import com.keplerops.groundcontrol.infrastructure.age.AgeProperties;
+import com.keplerops.groundcontrol.infrastructure.age.AgeSnapshotCleaner;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
@@ -57,6 +60,12 @@ class AgeGraphServiceTest {
     @Mock
     private ProjectRepository projectRepository;
 
+    @Mock
+    private AgeGraphSnapshotRepository snapshotRepository;
+
+    @Mock
+    private AgeSnapshotCleaner snapshotCleaner;
+
     private AgeGraphService service;
 
     private static final UUID PROJECT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
@@ -72,7 +81,12 @@ class AgeGraphServiceTest {
     void setUp() {
         var disabledProperties = new AgeProperties(false, "requirements");
         service = new AgeGraphService(
-                jdbcTemplate, disabledProperties, graphProjectionRegistryService, projectRepository);
+                jdbcTemplate,
+                disabledProperties,
+                graphProjectionRegistryService,
+                projectRepository,
+                snapshotRepository,
+                snapshotCleaner);
     }
 
     @Nested
@@ -82,7 +96,12 @@ class AgeGraphServiceTest {
         void materializeGraph_isNoOp() {
             service.materializeGraph();
 
-            verifyNoInteractions(jdbcTemplate, graphProjectionRegistryService, projectRepository);
+            verifyNoInteractions(
+                    jdbcTemplate,
+                    graphProjectionRegistryService,
+                    projectRepository,
+                    snapshotRepository,
+                    snapshotCleaner);
         }
 
         @Test
@@ -176,32 +195,43 @@ class AgeGraphServiceTest {
         void setUp() {
             var enabledProperties = new AgeProperties(true, "test_graph");
             enabledService = new AgeGraphService(
-                    jdbcTemplate, enabledProperties, graphProjectionRegistryService, projectRepository);
+                    jdbcTemplate,
+                    enabledProperties,
+                    graphProjectionRegistryService,
+                    projectRepository,
+                    snapshotRepository,
+                    snapshotCleaner);
+            // An active snapshot exists (reads resolve it) and publication gets version 1; lenient
+            // so the subset of tests that exercise only one of read/materialize don't trip strict stubs.
+            lenient().when(snapshotRepository.findActiveGraphName()).thenReturn(Optional.of("test_graph"));
+            lenient().when(snapshotRepository.nextVersion()).thenReturn(1L);
         }
 
         @Test
-        void materializeGraph_createsNodesAndEdges() {
+        void materializeGraph_buildsNewSnapshotGraphWithoutDestroyingActive() {
             when(graphProjectionRegistryService.buildProjection())
                     .thenReturn(new GraphProjection(List.of(), List.of()));
 
             enabledService.materializeGraph();
 
-            // setupSearchPath: LOAD + SET via execute(String)
+            // setupSearchPath: LOAD + SET via execute(String).
             verify(jdbcTemplate).execute("LOAD 'age'");
             verify(jdbcTemplate).execute("SET search_path = ag_catalog, \"$user\", public");
-            // DETACH DELETE is a parameterized cypher() call — the cypher text is concatenated
-            // into the SQL literal (AGE parses it at SQL parse time), and only the agtype params
-            // payload is bound through a PreparedStatementSetter. AGE's cypher() always returns
-            // SETOF agtype even for write statements, so we route through query(), not update().
-            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-            verify(jdbcTemplate, atLeast(1))
-                    .query(sqlCaptor.capture(), any(PreparedStatementSetter.class), any(RowCallbackHandler.class));
-            assertThat(sqlCaptor.getAllValues().stream().anyMatch(sql -> sql.contains("DETACH DELETE")))
-                    .isTrue();
+            // The publish is serialized by an advisory lock and builds into a NEW versioned graph
+            // (create_graph). Crucially, the live graph is NEVER DETACH DELETEd — that was the
+            // destructive rebuild ADR-062 removes.
+            ArgumentCaptor<String> execCaptor = ArgumentCaptor.forClass(String.class);
+            verify(jdbcTemplate, atLeast(1)).execute(execCaptor.capture());
+            assertThat(execCaptor.getAllValues())
+                    .anyMatch(sql -> sql.contains("pg_advisory_xact_lock"))
+                    .anyMatch(sql -> sql.contains("create_graph('test_graph_v1')"))
+                    .noneMatch(sql -> sql.contains("DETACH DELETE"));
+            // Publication records the new snapshot — the atomic active-version swap on commit.
+            verify(snapshotRepository).insertSnapshot(eq(1L), eq("test_graph_v1"), eq("GLOBAL"), eq(0), eq(0), any());
         }
 
         @Test
-        void materializeGraph_withRequirements_createsNodes() {
+        void materializeGraph_withRequirements_createsNodesInSnapshotGraph() {
             var req = new Requirement(TEST_PROJECT, "GC-A001", "Test Req", "Statement");
             when(graphProjectionRegistryService.buildProjection())
                     .thenReturn(new GraphProjection(
@@ -219,17 +249,51 @@ class AgeGraphServiceTest {
 
             enabledService.materializeGraph();
 
-            // setupSearchPath issues LOAD + SET via execute(String); DETACH DELETE + CREATE go
-            // through query(sql, pss, callback) — AGE's cypher() always returns SETOF agtype.
-            // Capture the SQL to confirm a CREATE was actually emitted for the REQUIREMENT
-            // node, not just that two queries ran (mock-interaction-only assertions would
-            // pass even if the CREATE loop were silently dropped).
-            verify(jdbcTemplate, times(2)).execute(anyString());
+            // create_graph for the new snapshot goes through execute(); the node CREATE goes through
+            // query(sql, pss, callback) — AGE's cypher() always returns SETOF agtype. Capture both to
+            // confirm a CREATE was emitted into the NEW snapshot graph (not the base name) and that
+            // no DETACH DELETE was issued anywhere.
+            ArgumentCaptor<String> execCaptor = ArgumentCaptor.forClass(String.class);
+            verify(jdbcTemplate, atLeast(1)).execute(execCaptor.capture());
+            assertThat(execCaptor.getAllValues()).anyMatch(sql -> sql.contains("create_graph('test_graph_v1')"));
+            ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+            verify(jdbcTemplate, atLeast(1))
+                    .query(queryCaptor.capture(), any(PreparedStatementSetter.class), any(RowCallbackHandler.class));
+            assertThat(queryCaptor.getAllValues())
+                    .anyMatch(sql ->
+                            sql.contains("CREATE (:") && sql.contains("REQUIREMENT") && sql.contains("'test_graph_v1'"))
+                    .noneMatch(sql -> sql.contains("DETACH DELETE"));
+            verify(snapshotRepository).insertSnapshot(eq(1L), eq("test_graph_v1"), eq("GLOBAL"), eq(1), eq(0), any());
+        }
+
+        @Test
+        void getVisualization_fallsBackToConfiguredBaseGraphWhenNoSnapshotPublished() {
+            // Upgrade/bootstrap path (codex F1): with no snapshot row yet, reads target the
+            // configured base graph so an already-populated AGE graph keeps serving reads after a
+            // deploy instead of going empty.
+            when(snapshotRepository.findActiveGraphName()).thenReturn(Optional.empty());
+            when(projectRepository.findById(PROJECT_ID)).thenReturn(Optional.of(TEST_PROJECT));
+
+            enabledService.getVisualization(PROJECT_ID, java.util.Set.of());
+
             ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-            verify(jdbcTemplate, atLeast(2))
+            verify(jdbcTemplate, times(2))
                     .query(sqlCaptor.capture(), any(PreparedStatementSetter.class), any(RowCallbackHandler.class));
-            assertThat(sqlCaptor.getAllValues())
-                    .anyMatch(sql -> sql.contains("CREATE (:") && sql.contains("REQUIREMENT"));
+            assertThat(sqlCaptor.getAllValues()).allMatch(sql -> sql.contains("cypher('test_graph'"));
+        }
+
+        @Test
+        void getAncestors_fallsBackToConfiguredBaseGraphWhenNoSnapshotPublished() {
+            when(snapshotRepository.findActiveGraphName()).thenReturn(Optional.empty());
+            when(projectRepository.findById(PROJECT_ID)).thenReturn(Optional.of(TEST_PROJECT));
+
+            enabledService.getAncestors(PROJECT_ID, "REQ-001", 5);
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(jdbcTemplate)
+                    .query(sqlCaptor.capture(), any(PreparedStatementSetter.class), any(RowCallbackHandler.class));
+            // The fallback issues a real query against the base graph rather than returning empty.
+            assertThat(sqlCaptor.getValue()).contains("cypher('test_graph'");
         }
 
         @Test
@@ -343,7 +407,16 @@ class AgeGraphServiceTest {
         void setUp() {
             var enabledProperties = new AgeProperties(true, "test_graph");
             enabledService = new AgeGraphService(
-                    jdbcTemplate, enabledProperties, graphProjectionRegistryService, projectRepository);
+                    jdbcTemplate,
+                    enabledProperties,
+                    graphProjectionRegistryService,
+                    projectRepository,
+                    snapshotRepository,
+                    snapshotCleaner);
+            // An active snapshot exists (reads resolve it) and publication gets version 1; lenient
+            // so the subset of tests that exercise only one of read/materialize don't trip strict stubs.
+            lenient().when(snapshotRepository.findActiveGraphName()).thenReturn(Optional.of("test_graph"));
+            lenient().when(snapshotRepository.nextVersion()).thenReturn(1L);
         }
 
         @SuppressWarnings("unchecked")
@@ -663,7 +736,12 @@ class AgeGraphServiceTest {
         void validateGraphName_rejectsPayloadsContainingDollarSigns() {
             var dangerousProps = new AgeProperties(true, "graph$gc$");
             var dangerousService = new AgeGraphService(
-                    jdbcTemplate, dangerousProps, graphProjectionRegistryService, projectRepository);
+                    jdbcTemplate,
+                    dangerousProps,
+                    graphProjectionRegistryService,
+                    projectRepository,
+                    snapshotRepository,
+                    snapshotCleaner);
             // No buildProjection stub: validateGraphName fails before the projection is read.
 
             assertThatThrownBy(dangerousService::materializeGraph).isInstanceOf(DomainValidationException.class);
@@ -747,7 +825,16 @@ class AgeGraphServiceTest {
         void setUp() {
             var enabledProperties = new AgeProperties(true, "test_graph");
             enabledService = new AgeGraphService(
-                    jdbcTemplate, enabledProperties, graphProjectionRegistryService, projectRepository);
+                    jdbcTemplate,
+                    enabledProperties,
+                    graphProjectionRegistryService,
+                    projectRepository,
+                    snapshotRepository,
+                    snapshotCleaner);
+            // An active snapshot exists (reads resolve it) and publication gets version 1; lenient
+            // so the subset of tests that exercise only one of read/materialize don't trip strict stubs.
+            lenient().when(snapshotRepository.findActiveGraphName()).thenReturn(Optional.of("test_graph"));
+            lenient().when(snapshotRepository.nextVersion()).thenReturn(1L);
         }
 
         @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphSnapshotRepositoryTest.java
@@ -2,7 +2,6 @@ package com.keplerops.groundcontrol.unit.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -69,15 +68,15 @@ class AgeGraphSnapshotRepositoryTest {
 
         verify(jdbcTemplate)
                 .update(
-                        eq("INSERT INTO age_graph_snapshot "
+                        "INSERT INTO age_graph_snapshot "
                                 + "(version, graph_name, scope, node_count, edge_count, published_at, published_by) "
-                                + "VALUES (?, ?, ?, ?, ?, now(), ?)"),
-                        eq(3L),
-                        eq("requirements_v3"),
-                        eq("GLOBAL"),
-                        eq(12),
-                        eq(5),
-                        eq("alice"));
+                                + "VALUES (?, ?, ?, ?, ?, now(), ?)",
+                        3L,
+                        "requirements_v3",
+                        "GLOBAL",
+                        12,
+                        5,
+                        "alice");
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphSnapshotRepositoryTest.java
@@ -1,0 +1,110 @@
+package com.keplerops.groundcontrol.unit.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.keplerops.groundcontrol.infrastructure.age.AgeGraphSnapshotRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class AgeGraphSnapshotRepositoryTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    private AgeGraphSnapshotRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new AgeGraphSnapshotRepository(jdbcTemplate);
+    }
+
+    @Test
+    void nextVersion_returnsSequenceValue() {
+        when(jdbcTemplate.queryForObject("SELECT nextval('age_graph_snapshot_version_seq')", Long.class))
+                .thenReturn(7L);
+
+        assertThat(repository.nextVersion()).isEqualTo(7L);
+    }
+
+    @Test
+    void nextVersion_throwsWhenSequenceReturnsNull() {
+        when(jdbcTemplate.queryForObject("SELECT nextval('age_graph_snapshot_version_seq')", Long.class))
+                .thenReturn(null);
+
+        assertThatThrownBy(() -> repository.nextVersion()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void findActiveGraphName_returnsGreatestVersionRow() {
+        when(jdbcTemplate.queryForObject(
+                        "SELECT graph_name FROM age_graph_snapshot ORDER BY version DESC LIMIT 1", String.class))
+                .thenReturn("requirements_v9");
+
+        assertThat(repository.findActiveGraphName()).contains("requirements_v9");
+    }
+
+    @Test
+    void findActiveGraphName_emptyWhenNoSnapshots() {
+        when(jdbcTemplate.queryForObject(
+                        "SELECT graph_name FROM age_graph_snapshot ORDER BY version DESC LIMIT 1", String.class))
+                .thenThrow(new EmptyResultDataAccessException(1));
+
+        assertThat(repository.findActiveGraphName()).isEmpty();
+    }
+
+    @Test
+    void insertSnapshot_bindsAllColumns() {
+        repository.insertSnapshot(3L, "requirements_v3", "GLOBAL", 12, 5, "alice");
+
+        verify(jdbcTemplate)
+                .update(
+                        eq("INSERT INTO age_graph_snapshot "
+                                + "(version, graph_name, scope, node_count, edge_count, published_at, published_by) "
+                                + "VALUES (?, ?, ?, ?, ?, now(), ?)"),
+                        eq(3L),
+                        eq("requirements_v3"),
+                        eq("GLOBAL"),
+                        eq(12),
+                        eq(5),
+                        eq("alice"));
+    }
+
+    @Test
+    void graphsToDrop_keepsNewestRetainedAndAppliesRetirementAgeGrace() {
+        // The grace is measured from retirement (the successor's published_at via lead()), not from
+        // the snapshot's own publication — so a long-active snapshot superseded just now is safe.
+        when(jdbcTemplate.queryForList(
+                        "SELECT graph_name FROM "
+                                + "(SELECT graph_name, version, lead(published_at) OVER (ORDER BY version) AS retired_at "
+                                + "FROM age_graph_snapshot) s "
+                                + "WHERE graph_name NOT IN "
+                                + "(SELECT graph_name FROM age_graph_snapshot ORDER BY version DESC LIMIT ?) "
+                                + "AND retired_at IS NOT NULL "
+                                + "AND retired_at < now() - make_interval(secs => ?) "
+                                + "ORDER BY version",
+                        String.class,
+                        2,
+                        300.0))
+                .thenReturn(List.of("requirements_v1"));
+
+        assertThat(repository.graphsToDrop(2, 300L)).containsExactly("requirements_v1");
+    }
+
+    @Test
+    void deleteByGraphName_deletesMetadataRow() {
+        repository.deleteByGraphName("requirements_v1");
+
+        verify(jdbcTemplate).update("DELETE FROM age_graph_snapshot WHERE graph_name = ?", "requirements_v1");
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeSnapshotCleanerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeSnapshotCleanerTest.java
@@ -1,0 +1,77 @@
+package com.keplerops.groundcontrol.unit.infrastructure;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.keplerops.groundcontrol.infrastructure.age.AgeGraphSnapshotRepository;
+import com.keplerops.groundcontrol.infrastructure.age.AgeSnapshotCleaner;
+import com.keplerops.groundcontrol.infrastructure.age.GraphPublicationProperties;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class AgeSnapshotCleanerTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private AgeGraphSnapshotRepository snapshotRepository;
+
+    private AgeSnapshotCleaner cleaner;
+
+    @BeforeEach
+    void setUp() {
+        cleaner = new AgeSnapshotCleaner(jdbcTemplate, snapshotRepository, new GraphPublicationProperties(2, 300L));
+    }
+
+    @Test
+    void cleanup_dropsStaleSnapshotGraphsAndForgetsTheirMetadata() {
+        when(snapshotRepository.graphsToDrop(2, 300L)).thenReturn(List.of("requirements_v1", "requirements_v2"));
+
+        cleaner.cleanup();
+
+        verify(jdbcTemplate).execute("LOAD 'age'");
+        verify(jdbcTemplate).execute("SET search_path = ag_catalog, \"$user\", public");
+        verify(jdbcTemplate).execute("SELECT drop_graph('requirements_v1', true)");
+        verify(jdbcTemplate).execute("SELECT drop_graph('requirements_v2', true)");
+        verify(snapshotRepository).deleteByGraphName("requirements_v1");
+        verify(snapshotRepository).deleteByGraphName("requirements_v2");
+    }
+
+    @Test
+    void cleanup_isNoOpWhenNothingToRetire() {
+        when(snapshotRepository.graphsToDrop(2, 300L)).thenReturn(List.of());
+
+        cleaner.cleanup();
+
+        // No AGE session setup or drops when there is nothing beyond the retention window.
+        verifyNoMoreInteractions(jdbcTemplate);
+    }
+
+    @Test
+    void cleanup_isBestEffortWhenADropFails() {
+        when(snapshotRepository.graphsToDrop(2, 300L)).thenReturn(List.of("requirements_v1", "requirements_v2"));
+        lenient()
+                .doThrow(new RuntimeException("lock timeout"))
+                .when(jdbcTemplate)
+                .execute(contains("drop_graph('requirements_v1'"));
+
+        cleaner.cleanup();
+
+        // The failed drop does not abort the loop and its metadata row is left for a later attempt;
+        // the next snapshot is still dropped and forgotten.
+        verify(snapshotRepository, never()).deleteByGraphName("requirements_v1");
+        verify(jdbcTemplate).execute("SELECT drop_graph('requirements_v2', true)");
+        verify(snapshotRepository).deleteByGraphName("requirements_v2");
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeSnapshotCleanerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeSnapshotCleanerTest.java
@@ -68,8 +68,8 @@ class AgeSnapshotCleanerTest {
 
         cleaner.cleanup();
 
-        // The failed drop does not abort the loop and its metadata row is left for a later attempt;
-        // the next snapshot is still dropped and forgotten.
+        // Best-effort behaviour: the failed drop is logged and skipped, leaving its metadata row for
+        // a later attempt, and the next snapshot is still dropped and forgotten.
         verify(snapshotRepository, never()).deleteByGraphName("requirements_v1");
         verify(jdbcTemplate).execute("SELECT drop_graph('requirements_v2', true)");
         verify(snapshotRepository).deleteByGraphName("requirements_v2");

--- a/changelog.d/252.fixed.md
+++ b/changelog.d/252.fixed.md
@@ -4,4 +4,6 @@
 deleting and recreating every node. Materialization now builds a new, inactive AGE graph
 snapshot and publishes it with an atomic active-version swap (ADR-062). Graph readers always
 observe either the previous complete snapshot or the newly published one, never an empty or
-partially rebuilt graph, and a failed refresh leaves the previous snapshot untouched.
+partially rebuilt graph, and a failed refresh leaves the previous snapshot untouched. On
+upgrade, reads fall back to the existing configured graph until the first snapshot is published,
+so an already-populated graph keeps serving readers without a manual re-materialize.

--- a/changelog.d/252.fixed.md
+++ b/changelog.d/252.fixed.md
@@ -1,0 +1,7 @@
+### Fixed - Atomic AGE graph materialization via versioned snapshots
+
+`POST /api/v1/admin/graph/materialize` no longer rebuilds the live graph in place by
+deleting and recreating every node. Materialization now builds a new, inactive AGE graph
+snapshot and publishes it with an atomic active-version swap (ADR-062). Graph readers always
+observe either the previous complete snapshot or the newly published one, never an empty or
+partially rebuilt graph, and a failed refresh leaves the previous snapshot untouched.


### PR DESCRIPTION
## Summary

Replaces the destructive in-place AGE graph materialization (DETACH DELETE then row-by-row recreate of the live graph) with a versioned-snapshot publication model (ADR-062). Each materialize builds a new, inactive AGE graph and records it in a new `age_graph_snapshot` pointer table; the active snapshot readers query is the greatest-version row, so publication is INSERT-only and the pointer swap is the new row becoming visible at commit. A failed refresh leaves the previous snapshot untouched, so readers always observe a complete graph instead of an empty or half-rebuilt one. Reads run under REPEATABLE READ so resolving the snapshot plus its node and edge queries see one consistent moment; concurrent publishers serialize on a pg_advisory_xact_lock. Two lifecycle edges are handled explicitly: an upgrade fallback to the configured base graph while no snapshot exists, and grace-period cleanup that drops a superseded snapshot only once it is beyond the retained count AND was retired (per its successor's publication) longer than the grace ago, so a snapshot a live reader resolved is never dropped mid-read.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #252

## ADR Impact

- ADR-062
- ADR-032
- ADR-021

## Changes

- AgeGraphService.materializeGraph: build a new versioned snapshot graph (create_graph), populate it, and INSERT-only publish via the snapshot pointer; advisory-lock serialized; REPEATABLE READ capture; afterCommit best-effort cleanup. No DETACH DELETE.
- AgeGraphService read methods + MixedGraphService: resolve the active snapshot (or fall back to the configured base graph when none exists) and run under REPEATABLE READ so multi-statement reads observe one snapshot.
- New V143 migration: age_graph_snapshot pointer/metadata table + version sequence (plain PG, AGE-independent).
- New AgeGraphSnapshotRepository (INSERT-only pointer + lead()-based retirement-aware cleanup query), AgeSnapshotCleaner (@Transactional best-effort drop_graph), GraphPublicationProperties (validated @ConfigurationProperties: retainedSnapshots, minRetainedAgeSeconds), AgeIdentifiers (shared allowlist).
- Tests: rewritten AgeGraphServiceTest for the snapshot flow; new AgeGraphSnapshotRepositoryTest + AgeSnapshotCleanerTest; new AgeGraphSnapshotConcurrentRefreshIntegrationTest (non-destructive, concurrent-reads-during-refresh, retirement-grace cleanup eligibility).
- Fixed a pre-existing silently-failing test: RequirementsE2EAgeIntegrationTest was @Transactional, rolling back its ordered import->materialize->read sequence; removed @Transactional and added a published-snapshot gate assertion.
- **Migration reminder:** update version lists in `MigrationSmokeTest.java` and `RequirementsE2EIntegrationTest.java` (per `.gc/plan-rules.md`).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/252.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
