### PR TITLE
docs: add ADR-063 release & deployment model

### DIFF
--- a/architecture/adrs/030-on-prem-hetzner-deployment.md
+++ b/architecture/adrs/030-on-prem-hetzner-deployment.md
@@ -216,3 +216,6 @@ Pending after this PR merges:
 - ADR-005 - Apache AGE on Postgres (preserved, same image).
 - ADR-025 - Backup Policy (mechanism amendment).
 - ADR-026 - REST API Access Control (preserved, unchanged).
+- ADR-063 - Release & Deployment Model. Extends this ADR with the release model
+  (versioning, release artifact, promotion, cut-a-release, rollback) that this
+  ADR deliberately did not cover.

--- a/architecture/adrs/063-release-deployment-model.md
+++ b/architecture/adrs/063-release-deployment-model.md
@@ -1,0 +1,238 @@
+# ADR-063: Release & Deployment Model
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-25
+
+## Context
+
+[ADR-030](./030-on-prem-hetzner-deployment.md) defined how Ground Control is
+*deployed*: `red-dragon` (Hetzner, tailnet-only), a GHCR image, and the
+forced-command `deploy.sh` path with drift checks, env validation, health
+gating, and rollback. It deliberately did **not** define a *release* model.
+
+The gap is that "deploy" and "release" are currently the same uncontrolled
+event. Every push to `main` runs the CI `docker` job, which publishes the
+floating tag `ghcr.io/autarchy-ai/ground-control:main`, and production pulls
+that floating tag. There is no named version, no release notes tied to a
+version, and no immutable artifact that "production" maps to. The result:
+
+- **No single version source of truth.** Three places disagree today:
+  `backend/build.gradle` says `0.20.1`, the top of `CHANGELOG.md` says
+  `0.116.3`, and the git tags are `v1.0.0` / `v1.0.1`. None of them is what
+  production runs (production runs `:main`).
+- **No immutable release artifact.** `:main` is a rolling pointer; whatever
+  main last built *is* production. There is no version-pinned image a release
+  maps to, and therefore no precise "redeploy the previous known-good version."
+- **Undefined promotion semantics.** It is unstated what `dev` and `main`
+  mean for releasing, and how a specific build becomes "the release in prod."
+
+The infrastructure for a real release model already exists and is unused at the
+policy level: the CI `docker` job is gated on `refs/tags/v*` and already emits
+`type=semver` image tags (`.github/workflows/ci.yml`), and `towncrier build
+--version <X.Y.Z>` is already passed an explicit version at release time
+(`towncrier.toml`). What is missing is the *decision and the procedure*, not new
+machinery.
+
+This ADR records that decision. It is the umbrella design for the Deployment &
+Release Engineering milestone. The mechanism change that switches production off
+the floating `:main` tag onto a versioned/digest-pinned artifact is a companion
+implementation issue ("deploy immutable versioned images"), not part of this
+decision record. The architecture preflight for this work is captured in
+[`architecture/notes/release-deployment-model-preflight.md`](../notes/release-deployment-model-preflight.md)
+and its guardrails are binding on the companion mechanism work.
+
+## Decision
+
+Release and deployment are **separate lifecycle events**. Deployment is the
+ADR-030 mechanism (push an image to the host and bring it up). A release is a
+named, immutable artifact that an operator deliberately *promotes* to
+production. The model has five parts.
+
+### 1. Versioning
+
+Ground Control follows [Semantic Versioning 2.0.0](https://semver.org/) (the
+`CHANGELOG.md` header already declares this). The **annotated git tag `vX.Y.Z`
+is the single source of truth** for "what version is this." Bump rules:
+
+- **MAJOR**: an incompatible contract change. REST API, MCP tool contract, or a
+  non-backward-compatible persisted-schema / Flyway migration.
+- **MINOR**: a backward-compatible capability addition (new endpoint, new MCP
+  tool, new feature). Most `added` / `changed` changelog fragments.
+- **PATCH**: a backward-compatible bug fix (`fixed`, and `security` fixes that
+  do not change a contract).
+
+The version derives from the `changelog.d/` fragments accumulated since the
+previous tag: the highest-impact fragment type present sets the bump. There is
+exactly one set of bump rules (this section), read alongside the existing
+towncrier/changelog convention rather than duplicated into CI or scripts.
+
+The legacy `0.116.3` (CHANGELOG) and `0.20.1` (`build.gradle`) numbers are
+abandoned as a non-release lineage. The cut-a-release procedure (§4) realigns
+`backend/build.gradle`'s `version` and the `CHANGELOG.md` header to the git tag.
+That realignment happens at the next release cut under this model; this ADR is
+the decision, not the realignment commit.
+
+### 2. Release artifact
+
+The release artifact is the GHCR image built from the tagged commit. It has two
+coordinates:
+
+- The **digest** `@sha256:…` is the immutable audit and rollback identity. It is
+  already captured in `/opt/gc/deploy-state.json` and the GitHub Deployment.
+- The **semver image tag** is the human-readable coordinate.
+
+Be precise about the tag string: `docker/metadata-action`'s
+`type=semver,pattern={{version}}` strips the leading `v`. A git tag `v1.4.0`
+therefore publishes the **image** tags `1.4.0`, `1.4`, and `sha-<short>`, not a
+literal `v1.4.0` image tag. So a release binds four identifiers:
+
+```
+git tag  vX.Y.Z   <->   image tag  X.Y.Z   <->   digest @sha256:…   <->   source commit SHA
+```
+
+The floating `:main` tag is explicitly **not** a release. It is a rolling
+integration/build coordinate and must not be the production pin in the target
+model. GHCR tags are mutable by default, so immutability is anchored on the
+**digest**, and the semver tag is treated as write-once **by convention**: a
+`vX.Y.Z` is cut once and never re-pointed. Enforcing retag-prevention via a
+GHCR immutable-tag / retention policy is a noted follow-up, not claimed here.
+
+### 3. Promotion path
+
+- **`dev`** is the integration branch. CI runs on it and publishes `:dev` and
+  `:sha-<short>` images. `dev` is **not** a deployed staging environment,
+  because there is a single production host and no separate stage (consistent
+  with ADR-030's single-host non-goals). It becomes a stage only if a real
+  deployed target is ever added, at which point the deploy-target seam
+  (§ Extensibility) covers it.
+- **`main`** is the protected release baseline. Merges to `main` publish
+  `:main`, `:latest`, and `:sha-<short>` images. A `main` commit is *releasable*
+  but is not itself a release.
+- **Cutting a release** is the act of tagging a `main` commit `vX.Y.Z`. That tag
+  triggers the CI `docker` job's `refs/tags/v*` path, producing the versioned
+  image.
+- **Promotion to production** is deploying a chosen released version (by digest)
+  to `red-dragon` through the canonical deploy path. Production runs a promoted
+  version, not "whatever `main` last built."
+
+The decoupling of production from the floating `:main` tag (switching `GC_IMAGE`
+from `...:main` to a versioned/digest reference) is the companion mechanism
+issue. Until that lands, production continues to follow `:main` (the interim
+risk in Consequences).
+
+### 4. Cut-a-release procedure
+
+The exact operator/CI steps to produce a release:
+
+1. Confirm `main` is green (CI passed) at the commit being released.
+2. Choose `X.Y.Z` by applying the §1 bump rules to the `changelog.d/` fragments
+   accumulated since the previous release tag.
+3. Collate the changelog: `towncrier build --version X.Y.Z` (consumes the
+   fragments into `CHANGELOG.md`). Commit on `main`.
+4. Set `backend/build.gradle`'s `version` to `X.Y.Z` (and the frontend version
+   if applicable). Commit on `main`.
+5. Create an annotated git tag `vX.Y.Z` on that commit (sign if the operator's
+   key is configured) and push it.
+6. CI's `docker` job (already gated on `refs/tags/v*`) builds and pushes the
+   `X.Y.Z` / `X.Y` images to GHCR. Record the published digest.
+7. Create a GitHub Release for `vX.Y.Z` using the collated changelog section as
+   the release notes. Release notes carry no secrets.
+8. Promote to production via the canonical deploy path (`make deploy` /
+   `scripts/deploy.sh`), which records the rolled-out digest and source commit
+   in `/opt/gc/deploy-state.json` and a GitHub Deployment (queryable via
+   `make deploy-status`).
+
+The version to promote is selected through the host-local `/opt/gc/.env`
+`GC_IMAGE` value (operator/CI-controlled). It is **not** smuggled through the
+forced-command SSH argv, which the forced command ignores by design (ADR-030).
+
+### 5. Rollback
+
+Rollback is the deliberate promotion of an older known-good release, performed
+**through the same canonical deploy path**, never an ad-hoc `docker compose`
+invocation that bypasses env validation, health checks, or deploy-state
+publication. Set `GC_IMAGE` to the previous version's digest; the deploy path's
+env validation (`deploy/docker/validate-env.sh`, invoked by `deploy.sh`) already
+permits a controlled, deliberate digest pin via `GC_ALLOW_IMAGE_PIN=1` (it
+otherwise rejects long-lived digest pins because they freeze the deploy, per
+#953 / GC-P022), and `deploy.sh` already auto-restores the previously running
+image if a candidate fails its health window. A rollback is recorded like any
+other promotion (digest + source commit in deploy-state and a GitHub
+Deployment).
+
+### Scope boundary
+
+This model lives in ADRs, the changelog convention, CI, deploy scripts, and
+operator tooling. It introduces **no** backend domain entity, service,
+repository, controller, API schema, or database table for release state, and it
+keeps release/deploy concerns outside the `api/ -> domain/ <- infrastructure/`
+boundary. "What is running?" is answered by `deploy-state.json` + GitHub
+Deployments, not by Ground Control domain state.
+
+## Consequences
+
+### Positive
+
+- Release and deploy are distinct: production maps to a named, immutable
+  version, not to a mutable branch tag.
+- One version source of truth (the git tag), with explicit bump rules tied to
+  the existing changelog fragments, ending the three-way disagreement.
+- Reproducible rollback: redeploy a prior release by its digest through the
+  validated deploy path.
+- GitHub Releases give every version human-readable, versioned release notes
+  collated from the changelog fragments already required per PR.
+- Reuses existing machinery (CI semver tags, towncrier, the hardened deploy
+  contract); adds process and a decision, not new infrastructure.
+
+### Negative
+
+- Cutting a release is now a deliberate, multi-step act (tag + changelog build +
+  version bump + GitHub Release + promote) rather than an implicit consequence
+  of merging to `main`.
+- The three disagreeing version sources must be reconciled at the first cut
+  under this model.
+- Full value is not realized until the companion mechanism issue switches
+  production off the floating `:main` tag.
+
+### Risks
+
+- **Interim conflation.** Until the companion "deploy immutable versioned
+  images" issue lands, production still follows `:main`, so deploy and release
+  remain conflated in practice. Mitigation: land that companion issue promptly;
+  this ADR is the contract it implements against.
+- **GHCR tag mutability.** A semver image tag could be re-pointed. Mitigation:
+  the digest is the immutable identity and the semver tag is write-once by
+  convention; a GHCR immutable-tag/retention policy is a follow-up.
+- **Procedure drift.** The cut procedure is operator-run prose. Mitigation:
+  keep the bump rules and procedure in this one ADR section; future automation
+  (a release script / CI workflow) should enforce structure against it rather
+  than restating the rules.
+
+## Non-Goals
+
+- No multi-host or multi-region deployment, and no separate staging environment
+  beyond the single production host (ADR-030 non-goal preserved).
+- No Kubernetes / Watchtower / Argo / Flux / managed-platform migration.
+- No release dashboard, database-backed release entity, or Ground Control
+  requirement-baseline automation.
+- No replacement for the existing backup/restore, Flyway migration, or repo
+  policy gates.
+- No change in this PR to `GC_IMAGE`, `env.schema`, `validate-env.sh`, the
+  deploy scripts, CI, or the policy gates. Those are the companion mechanism
+  issues' surface.
+
+## Related ADRs
+
+- [ADR-030](./030-on-prem-hetzner-deployment.md): On-prem Hetzner Deployment.
+  This ADR extends it with the release model it deliberately omitted.
+- [ADR-021](./021-gated-agentic-development-loop.md): the changelog-fragment /
+  `towncrier` discipline (Phase B, amended by issue #848) that this model's
+  versioning and release notes build on.
+- [ADR-026](./026-rest-api-access-control.md): credential and IP-allowlist
+  model preserved unchanged; deploy-time env validation is part of the cut /
+  promote / rollback path.

--- a/architecture/adrs/README.md
+++ b/architecture/adrs/README.md
@@ -46,7 +46,7 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [027](027-agent-neutral-implement-workflow-packaging.md) | Agent-Neutral Implement Workflow Packaging | Accepted (amended 2026-05-26, GC-O011/#989) |
 | [028](028-temporal-workflow-orchestration-boundary.md) | Temporal Workflow Orchestration Boundary | Accepted |
 | [029](029-issue-thread-gate-model.md) | Issue-Thread Gate Model | Accepted (amended 2026-05-26, GC-O011/#989) |
-| [030](030-on-prem-hetzner-deployment.md) | On-prem Hetzner Deployment | Accepted |
+| [030](030-on-prem-hetzner-deployment.md) | On-prem Hetzner Deployment | Accepted (extended by ADR-063) |
 | [031](031-codex-review-stopping-model.md) | Severity Rubric and Stopping Model for Pre-Push Codex Review | Proposed |
 | [032](032-age-query-construction-boundary.md) | AGE Query Construction Boundary | Accepted |
 | [033](033-authenticated-audit-actor-provenance.md) | Authenticated Audit Actor Provenance | Accepted |
@@ -80,5 +80,6 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [060](060-requirement-uid-identity.md) | Requirement UID identity | Accepted |
 | [061](061-workflow-run-telemetry-reporting.md) | Workflow-Run Telemetry & Economics Reporting Surface | Accepted |
 | [062](062-age-graph-projection-snapshot-publication.md) | AGE Graph Projection Snapshot Publication | Accepted |
+| [063](063-release-deployment-model.md) | Release & Deployment Model | Accepted |
 
 Prior ADRs from the old project frame are archived in `archive/architecture/adrs/`.

--- a/architecture/notes/release-deployment-model-preflight.md
+++ b/architecture/notes/release-deployment-model-preflight.md
@@ -1,0 +1,103 @@
+# Release and Deployment Model Preflight
+
+Issue #1221 asks for the release model ADR that ADR-030 deliberately does not
+cover: versioning, release artifacts, promotion, cut-a-release, and rollback.
+This note records the architecture guardrails for that ADR and its companion
+mechanism issues. It does not implement the release model itself.
+
+## Architecture Boundaries
+
+- Treat release and deploy as different lifecycle events. A merge to `main`
+  may publish branch images, but production promotion must be tied to an
+  explicit release version and deploy record, not the mutable `:main` tag.
+- Keep the release model in ADRs, workflow docs, CI, deploy scripts, and
+  operator tooling. Do not introduce backend controllers, DTOs, services,
+  repositories, database tables, or exception classes just to represent
+  releases.
+- Extend ADR-030 with a new release decision record or a small amendment that
+  points to one. The change reverses ADR-030's current floating-tag deploy
+  assumption, so make the contract transition explicit instead of editing
+  scattered docs as if this were wording cleanup.
+- `dev` is the integration branch, not a deployed staging environment unless a
+  real target exists. `main` is the protected release baseline. Production runs
+  a promoted versioned image, not whichever branch image was last pushed.
+- A release artifact must be a versioned GHCR image plus its resolved digest
+  and source commit. The tag is the human release coordinate; the digest is the
+  audit/rollback identity captured in deploy state.
+
+## Cross-Cutting Concerns to Reuse
+
+- **Changelog/versioning:** reuse `changelog.d/`, `towncrier.toml`,
+  `CHANGELOG.md`, and the existing changelog policy checks. Bump rules belong
+  beside that convention; do not create a second release-notes schema.
+- **CI image publishing:** build on the existing `.github/workflows/ci.yml`
+  `docker` job, pinned Docker actions, OCI revision labels, and GHCR namespace
+  guard. Verify the actual tag emitted by `docker/metadata-action`; the current
+  `type=semver,pattern={{version}}` path may not emit a literal `v` prefix.
+- **Deploy artifact contract:** reuse `deploy/docker/deploy.sh`,
+  `deploy/docker/docker-compose.prod.yml`, `deploy/docker/env.schema`,
+  `deploy/docker/validate-env.sh`, `deploy/docker/MANIFEST.sha256`,
+  `scripts/deploy.sh`, `make deploy`, `make deploy-status`, and the
+  `run_deploy_artifact_consistency` policy gate. Any change from branch tags to
+  release tags must update the schema, validator, docs, tests, and manifest
+  together.
+- **Deployment ledger:** reuse `/opt/gc/deploy-state.json` and GitHub
+  Deployments for "what is running?" Do not add a Ground Control domain entity
+  for release status unless a later product requirement asks for a UI/API.
+- **Security controls:** preserve ADR-030's tailnet-only host, forced-command
+  `gc-deploy` SSH model, `/opt/gc/.env` mode-600 secret boundary, ADR-026
+  credential inherit-only compose form, and env validation that reports names
+  only.
+
+## Security and Runtime Guardrails
+
+- Do not pass release versions, tokens, registry credentials, database
+  passwords, or session material through SSH argv, shell history, workflow
+  summaries, GitHub Release text, deploy status descriptions, or logs.
+- The forced-command deploy path ignores SSH argv by design. If promotion needs
+  to choose a version, the ADR must define a safe parameter surface such as a
+  host-local env update, checked-in deploy target config, or CI-controlled
+  environment input; do not smuggle parameters through the forced command.
+- Keep GitHub write permissions narrow. Release creation or deployment-status
+  posting should use the existing GitHub Actions `GITHUB_TOKEN` or established
+  operator/MCP surfaces, with job-scoped permissions instead of broad workflow
+  permissions.
+- Preserve deploy-time validation before restart. The new model must still pass
+  `env.schema`, `validate-env.sh`, compose variable checks, Spring security
+  binding validation, and health/rollback behavior before declaring success.
+- Release rollback is redeploying a previous known-good version through the
+  same deploy path. Do not add an ad-hoc `docker compose` rollback script that
+  bypasses validation, health checks, or deploy-state publication.
+
+## Extensibility
+
+The extension seam is deploy-target and release-candidate configuration:
+environment name, host, SSH identity, remote directory, compose project, image
+package, release version/tag, and status publisher. A future staging host or
+additional package should be one configuration row, not a fork of the deploy
+script or backend code.
+
+## Gotchas and Anti-Patterns
+
+- Do not say "immutable `vX.Y.Z` image" unless CI actually publishes that exact
+  tag and the release process prevents retagging. Record both tag and digest.
+- Do not leave `GC_IMAGE=...:main` in production documentation after the ADR
+  says `:main` is not a release. That would keep deploy and release conflated.
+- Do not treat a digest pin as the normal release model unless the policy,
+  validator, and operator docs are changed intentionally. Today's guard rejects
+  long-lived digest pins because they previously caused stale deploys.
+- Do not duplicate version bump rules in CI, docs, and scripts. One ADR section
+  plus the towncrier/changelog convention should be the source; checks should
+  enforce structure, not carry competing prose.
+- Do not broaden backend error handling, audit, persistence, or API schemas for
+  a workflow-only release model.
+
+## Non-Goals
+
+- No multi-host or multi-region deployment design.
+- No public ingress, TLS termination, auth redesign, or browser-session change.
+- No Kubernetes, Watchtower, Argo/Flux, or managed platform migration.
+- No new release dashboard, database-backed release entity, or Ground Control
+  requirement baseline automation in this issue.
+- No replacement for the existing backup/restore, Flyway migration, or policy
+  gates.


### PR DESCRIPTION
## Summary

Adds ADR-063, the release model ADR-030 deliberately left out. It separates release from deploy: SemVer carried by annotated git tags as the single version source of truth, immutable digest-pinned GHCR release artifacts (the floating :main tag is explicitly not a release), a dev -> main -> tag -> promote promotion path, an explicit cut-a-release procedure, and rollback through the canonical deploy path. This is the umbrella decision; switching production's GC_IMAGE off :main to versioned/digest artifacts is a companion mechanism issue. Documentation-only change.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1221

## ADR Impact

- ADR-063
- ADR-030 (extended)
- ADR-021

## Changes

- Add architecture/adrs/063-release-deployment-model.md defining versioning, release artifact, promotion path, cut-a-release procedure, and rollback
- Extend ADR-030: cross-link ADR-063 in its Related ADRs and annotate the README index row
- Add the ADR-063 row to architecture/adrs/README.md
- Commit the Step 2.5 architecture preflight note (architecture/notes/release-deployment-model-preflight.md)

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
