### PR TITLE
chore: enable review-cap disposition gate in shadow mode (judge on)

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -6,6 +6,12 @@ workflow:
   completion_command: make check
   lint_command: cd backend && ./gradlew spotlessCheck
   format_command: cd backend && ./gradlew spotlessApply
+  review_disposition:
+    enabled: true
+    mode: shadow
+    max_auto_overrides: 1
+    judge:
+      enabled: true
 sonarcloud:
   project_key: autarchy-ai_Ground-Control
   organization: autarchy-ai


### PR DESCRIPTION
## What

Enables the review-cap **disposition gate** in **SHADOW** mode by adding `workflow.review_disposition` to `.ground-control.yaml`:

```yaml
workflow:
  review_disposition:
    enabled: true
    mode: shadow
    max_auto_overrides: 1
    judge:
      enabled: true
```

## Why

In `shadow` mode the gate **records** its would-be cap-boundary disposition — including the LLM-judge calls for gray-zone cases — but still **escalates to the human** and takes **no auto-action**. This collects readiness/calibration data ahead of an authoritative (enforcing) rollout. `max_auto_overrides: 1` bounds the auto-override budget for when the mode is later promoted; in shadow it has no effect beyond being recorded.

This is a config-only change: no source, no changelog fragment.

## ⚠️ Merge gate

**DO NOT MERGE until autarchy-ai/Ground-Control#1246 is merged and the MCP server is restarted on that code — until then the older `.ground-control.yaml` parser rejects the `review_disposition` key and breaks `gc_get_repo_ground_control_context`.**
