### PR TITLE
docs: add ADR-072 and ADR-073 for research REST/MCP surface and extensibility boundary

### DIFF
--- a/architecture/adrs/072-research-rest-and-mcp-tool-surface.md
+++ b/architecture/adrs/072-research-rest-and-mcp-tool-surface.md
@@ -1,0 +1,211 @@
+# ADR-072: Research REST and MCP Tool Surface
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-29
+
+## Context
+
+Issue #1004 asks Ground Control to expose research workflow and artifact
+operations through the same API/MCP pattern used by the rest of the product.
+The issue intersects four existing research contracts:
+
+- ADR-064 owns `ResearchRun`, stage legality, gate policy, artifact manifests,
+  checkpoint/resume, and project-scoped lifecycle state.
+- ADR-065 owns the bounded observability snapshot for `GC-RSCH-N011`.
+- ADR-069 owns the research provenance ledger.
+- ADR-071 owns interoperability and source identity boundaries.
+
+The remaining design risk is adapter drift. A REST controller, MCP handler, UI,
+or agent-facing read tool could become a second place that decides lifecycle
+legality, validates research content, records actors, parses workspace files,
+calls providers, or builds a different observability shape. That would break the
+run-scoped state model and weaken the shared security, validation, audit,
+error, and MCP curation layers.
+
+## Decision
+
+### 1. REST is the public product boundary; services remain authoritative
+
+Research routes live under `/api/v1/research-runs/**` and route through thin
+controllers to research services. Controllers resolve the project with
+`ProjectService`, bind request DTOs with Bean Validation/Jackson, and translate
+domain objects into response DTOs. Controllers do not call repositories, parse
+workspace files, perform provider calls, inspect local artifacts, or decide
+stage/gate legality.
+
+Research services own semantic validation: project type, project/run scope,
+stage transition legality, gate decisions, artifact readiness, source counts,
+bounded failure observations, usage/cost observations, provenance write
+legality, idempotency, and same-run reference checks.
+
+### 2. MCP is an adapter over REST, not a parallel domain layer
+
+MCP research writes are curated action-discriminated tools over the REST
+contract. The accepted surface is:
+
+- `gc_research_run` for the `ResearchRun` lifecycle, gates, artifacts,
+  observability snapshot, bounded errors, usage/cost, review comments,
+  rationale, and disclosure actions.
+- `gc_research_provenance` for run-scoped provenance node/edge writes and
+  discoverable provenance reads.
+- `gc_query` for pure GET reads under the existing `/api/v1/research-runs`
+  allowlist.
+
+MCP handlers may validate required tool arguments, map snake_case tool fields to
+the REST DTO wire shape, and call `mcp/ground-control/lib.js` request helpers.
+They must not duplicate lifecycle, gate, artifact, source, provenance, cost, or
+observability decisions.
+
+### 3. Reads and writes stay deliberately different
+
+`gc_query` remains GET-only, allowlisted, header/body-free, path-normalized, and
+body/timeout bounded per ADR-035. It is appropriate for ad hoc reads of research
+run state, snapshot state, artifacts, gates, decision logs, rationale,
+disclosure, and provenance records.
+
+State-changing research operations require curated MCP actions or REST calls.
+Do not add method/body/header knobs to `gc_query`, and do not use `gc_query` as a
+hidden write tunnel.
+
+### 4. One backend contract feeds API, MCP, and UI
+
+The `ResearchRunSnapshot` from ADR-065 is the N011 observability contract. The
+UI and MCP must consume the backend snapshot or the underlying run-scoped REST
+reads. They must not re-derive current stage, pending gates, artifact readiness,
+source counts, access gaps, errors, or cost from frontend conditionals,
+workspace file scans, skill transcripts, `workflow_phase_event`, local logs, or
+provider payloads.
+
+API-visible enum mirrors and MCP Zod enum arrays follow ADR-034. MCP write body
+field allowlists and per-action required fields are mirrors of the OpenAPI/DTO
+contract and belong in the existing OpenAPI/MCP drift-test inventory.
+
+### 5. Security, actor, and error surfaces stay shared
+
+All research API paths inherit the shared ADR-026 `/api/v1/**` authenticated
+rules unless a future cross-project or operator-only route is explicitly added
+to `ApiPathMatrix`. Run-scoped reads and writes must conceal cross-project and
+cross-run misses as `404` through project-scoped repository/service lookups.
+
+Mutation actors come from `ActorFilter` / `ActorHolder`; request DTOs and MCP
+schemas must not accept caller-supplied audit actors. Domain provenance fields
+may identify an adapter, source action, or reviewer role, but they do not
+authenticate the caller.
+
+Transport errors use `GroundControlException` subclasses through
+`GlobalExceptionHandler` and `ErrorResponse`. Research failure observations are
+bounded product facts on the run, not exception envelopes, stack traces, raw
+provider errors, or leaked request/response bodies.
+
+### 6. Sensitive content and side effects stay out of adapter payloads
+
+Research API, MCP, graph, telemetry, errors, and logs may carry bounded
+identifiers, enum names, counts, hashes, locators, short summaries, timestamps,
+and stable error codes. They must not carry prompts, completions, manuscript
+prose, PDFs, full text, raw charting rows, raw search results, raw provider
+payloads, bearer tokens, Zotero secrets, Git credentials, or private absolute
+paths.
+
+This surface introduces no new subprocess, shell-out, provider call, GitHub
+write, citation call, token-in-argv path, or secret-bearing configuration.
+Provider, citation, Git, filesystem, or orchestration side effects remain at the
+ADR-028/ADR-055/ADR-071 adapter boundaries and re-enter the backend through
+structured research service commands.
+
+### 7. Extensibility seam
+
+The extension seam is the adapter inventory, not a new adapter framework:
+
+- add a new action to `gc_research_run` when it mutates or reads the
+  `ResearchRun` aggregate family;
+- add a new action to `gc_research_provenance` when it mutates or reads the
+  provenance ledger;
+- add only a new named tool when a new research aggregate, privileged admin
+  boundary, compute-heavy operation, or non-run-scoped surface has a materially
+  different contract;
+- add pure GET routes to the `gc_query` allowlist only when ad hoc reads are
+  appropriate and response size/leakage bounds are understood.
+
+Each new public enum, DTO mirror, body-field allowlist, action discriminator, or
+allowlisted read path must update the existing drift checks and documentation
+surface that already cover MCP/OpenAPI and `gc_query`.
+
+## Consequences
+
+### Positive
+
+- Issue #1004 gets a single adapter boundary instead of separate REST, MCP, UI,
+  and agent-side state machines.
+- N011 observability stays tied to ADR-065's bounded snapshot and does not drift
+  into workflow telemetry or workspace parsing.
+- The design reuses existing auth, validation, error, actor, logging, MCP
+  curation, OpenAPI drift, and controller-slice testing conventions.
+
+### Negative
+
+- Adding research operations requires updating several mirrored adapter
+  inventories: REST docs/OpenAPI, MCP action descriptions, Zod enum arrays,
+  body-field allowlists, and drift tests.
+- Some read operations appear both as discoverable MCP actions and through
+  `gc_query`. This is accepted for high-frequency research reads, but the REST
+  backend remains the source of truth for both paths.
+
+### Risks
+
+- If MCP handlers or frontend code reimplement lifecycle checks, they can
+  disagree with `ResearchRunService` and show or perform illegal transitions.
+- If `gc_query` is widened to accept methods, headers, or bodies, it becomes a
+  write bypass around curated tool schemas.
+- If raw research content is copied into adapter payloads, logs, errors, graph
+  properties, or telemetry, unpublished research material and credentials can
+  leak outside the run scope.
+- If enum/action/body-field mirrors are not added to drift tests, MCP tools can
+  silently accept or omit fields that the backend contract does not.
+
+## Non-Goals
+
+- No implementation of controllers, DTOs, services, migrations, MCP tools,
+  frontend views, provider adapters, source ledgers, or graph contributors in
+  this ADR.
+- No replacement of ADR-064 lifecycle/gate/artifact rules, ADR-065
+  observability snapshot, ADR-069 provenance ledger, or ADR-071 source identity
+  boundary.
+- No generic workflow engine, approval engine, adapter framework, observability
+  platform, OpenTelemetry/Prometheus decision, or full-text/source store.
+- No new authentication model, actor override mechanism, exception hierarchy,
+  error envelope, logging stack, policy runner, GitHub side-effect path, or
+  token-in-argv path.
+
+## Related Requirements
+
+- `GC-RSCH-F003` - explicit state machine and upstream artifact gating.
+- `GC-RSCH-N009` - interoperability.
+- `GC-RSCH-N010` - extensibility.
+- `GC-RSCH-N011` - observability.
+
+## Related Issues
+
+- #1004 - Research REST and MCP tool surface.
+- #1000 - Research run lifecycle and phase gating.
+- #1003 - Research graph projection and traversal support.
+- #1028 - Research checkpointing, observability, and budgets.
+- #1031 - Research workspace UI and dashboard.
+
+## Related ADRs
+
+- ADR-026 - REST API Access Control.
+- ADR-028 - Temporal Workflow Orchestration Boundary.
+- ADR-033 - Authenticated Audit Actor Provenance.
+- ADR-034 - API Enum Contract Single Source of Truth.
+- ADR-035 - MCP Tool Catalog Curation.
+- ADR-055 - Research Workflow Skills and Citation MCP.
+- ADR-056 - Research Project Type and Intake Metadata.
+- ADR-064 - Research Run Lifecycle and Stage Gating.
+- ADR-065 - Research Run Observability Snapshot.
+- ADR-069 - Research Artifact Provenance Ledger.
+- ADR-071 - Research Interoperability and Source Identity Boundary.

--- a/architecture/adrs/073-research-extensibility-and-adapter-boundary.md
+++ b/architecture/adrs/073-research-extensibility-and-adapter-boundary.md
@@ -1,0 +1,244 @@
+# ADR-073: Research Extensibility and Adapter Boundary
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-29
+
+## Context
+
+`GC-RSCH-N010` requires research methods, search providers, reviewers,
+extraction schemas, writing templates, and output formats to be plugin-like.
+The adjacent research decisions already define the durable lifecycle and data
+surfaces:
+
+- ADR-055 owns the skill-side workflow, methodology catalog, and citation MCP.
+- ADR-056 owns research project type and intake.
+- ADR-064 through ADR-070 own run lifecycle, observability, review/rationale
+  records, disclosure, provenance, and graph projection.
+- ADR-071 owns provider-neutral source identity and format/provider
+  interoperability.
+- ADR-072 owns the REST/MCP research tool surface and rejects a second adapter
+  framework for tool routing.
+
+The repository also has incumbents that should shape this work rather than be
+replaced: ADR-023's `PluginRegistry`, typed adapter registries such as
+`DerivationAdapterRegistry` and `EvidenceCollectionAdapterRegistry`, existing
+document export services, and the REST/MCP validation and error-handling
+contracts.
+
+Without a specific extensibility boundary, likely failure modes are:
+
+- treating "plugin-like" as arbitrary runtime code loading;
+- putting provider/search/reviewer side effects in controllers, MCP handlers,
+  or domain services;
+- using `RegisteredPlugin.metadata` as an untyped semantic schema for lifecycle
+  gating or source validation;
+- creating one schema, aggregate, or controller per provider, bibliography
+  format, method, or output format;
+- making prompt text or skill prose the enforcement layer for extension
+  behavior;
+- bypassing Bean Validation, service validation, `ErrorResponse`,
+  `ActorHolder`, Envers, MCP Zod schemas, or OpenAPI/MCP drift gates;
+- leaking provider credentials, Git remotes, local paths, raw source content,
+  prompts, manuscripts, or provider payloads through logs, errors, graph
+  properties, MCP responses, or process arguments.
+
+## Decision
+
+### 1. "Plugin-like" means registered, typed, selectable, and bounded
+
+Research extensibility uses stable extension identifiers, versions,
+capabilities, and typed contracts. It does not mean untrusted code is loaded or
+executed at runtime.
+
+The existing `PluginRegistry` remains the inventory and lifecycle metadata
+surface for classpath plugins and dynamic registrations. Dynamic registration is
+metadata-only unless the backend already has a compiled, trusted implementation
+for the corresponding typed adapter. The registry is not a package installer,
+dependency solver, script runner, provider client, or policy engine.
+
+For API-visible plugin categories, extend the existing `PluginType` vocabulary
+at category granularity only. Do not add one enum value per provider, method, or
+format. Specific capabilities such as `provider:crossref`, `format:bibtex`, or
+`method:scoping` belong in capability/metadata fields or category-specific
+records, not as new plugin types.
+
+### 2. Each research extension family has a narrow semantic owner
+
+The six N010 extension families stay separate because they answer different
+product questions:
+
+| Family | Boundary |
+|---|---|
+| Methods | Versioned method profiles/catalog entries that feed intake defaults, gate policy, source-state rules, and artifact/schema requirements. They are data and policy inputs, not provider clients. |
+| Search providers | Infrastructure adapters behind a domain port. They call Crossref, OpenAlex, Unpaywall, arXiv, PubMed, Zotero, local indexes, or offline stores only at the adapter boundary and return normalized source/import commands. |
+| Reviewers | Recommendation adapters that produce bounded review, gate, or rationale suggestions. They cannot approve gates, resolve comments, set audit actors, or persist lifecycle state directly. |
+| Extraction schemas | Versioned charting/extraction schema definitions plus validators. They shape accepted charting/provenance data; they are not arbitrary JSON bags that bypass service validation. |
+| Writing templates | Versioned rendering templates selected by id/version. They consume accepted artifacts/provenance/rationale data and do not become prompt-only policy enforcement. |
+| Output formats | Export/render adapters over canonical research/document records. Where the format overlaps existing document export (`DocumentExportService` and format-specific services), reuse that export boundary rather than creating a parallel research document stack. |
+
+Do not introduce a universal `ResearchExtension.execute(Map)` abstraction. Use a
+typed port or data registry only when the family needs behavior, validation, or
+selection independently of the others.
+
+### 3. Selection is explicit and historical
+
+When a research run, stage action, artifact, source import, extraction, review,
+or export depends on an extension, the accepted command records the selected
+extension id and version as bounded metadata. That snapshot is part of the
+run's history; later plugin/catalog/template upgrades do not rewrite existing
+runs or silently change replay/resume behavior.
+
+The extensibility seam is therefore the stable `extensionId` / `version` /
+`capability` tuple plus parameters specific to each extension family, not Java class names,
+provider-specific payloads, free-text filenames, or workspace-local prompt
+instructions.
+
+### 4. Adapters normalize; services validate and persist
+
+Adapters may acquire external data or render output, but they do not own
+research business state. A provider, reviewer, extractor, or renderer returns a
+typed result that the research service accepts or rejects through the same
+command DTO and aggregate rules as REST and MCP writes.
+
+Controllers stay thin: resolve project/run identity, bind and validate request
+DTOs, and call services. Domain services own project scoping, run status, stage
+legality, gate policy, source disposition, provenance/rationale consistency,
+idempotency, and content bounds. Repositories own project-scoped queries.
+
+Infrastructure implementations own external calls, local filesystem access,
+Git/local index access, parsers, and renderers. They must not be imported by
+`api/` and must not pull Spring Web concerns into `domain/`.
+
+### 5. Cross-cutting layers remain the enforcement boundary
+
+Research extensibility must reuse the repo's existing cross-cutting layers:
+
+- **Auth:** REST surfaces stay under ADR-026 bearer/browser security and
+  `ApiPathMatrix`; cross-project misses are concealed as not found.
+- **Validation:** REST DTOs use Bean Validation and Jackson enum binding; MCP
+  tool inputs use Zod; services own semantic validation and content bounds.
+- **Errors:** failures use existing `GroundControlException` subclasses through
+  `GlobalExceptionHandler` and `ErrorResponse`. No research-specific error
+  envelope.
+- **Audit and actors:** mutation actors come from `ActorFilter` / `ActorHolder`
+  and Envers revision metadata. Reviewer/provider metadata cannot override the
+  authenticated actor.
+- **Logging:** use SLF4J with low-cardinality fields: project, run id, stage,
+  extension id/version, provider, schema id/version, template id/version,
+  format, action id, counts, and stable error code. Do not log raw content,
+  prompts, provider payloads, secrets, private paths, or credential-bearing
+  remotes.
+- **Configuration and OS exposure:** provider keys, Zotero settings, network
+  timeouts, offline roots, parser toggles, and renderer options use validated
+  `@ConfigurationProperties` or the existing MCP-server environment boundary.
+  Do not put secrets in API payloads, plugin metadata, process argv, Envers rows,
+  graph properties, logs, or error bodies.
+- **MCP:** curated research write tools mirror REST through flat Zod schemas,
+  existing request helpers, and body-field allowlists. Read-only ad hoc access
+  uses `gc_query` allowlisted `/api/v1/**` paths. MCP handlers do not parse
+  workspace files, shell out, call providers, or implement parallel validators.
+- **API/MCP drift:** API-visible enums, body allowlists, and write shapes follow
+  ADR-034/OpenAPI contract checks. Adding a new extension category or command is
+  a contract change, not an unreviewed metadata key.
+
+### 6. Security posture for extension execution
+
+No v1 research extension executes operator-supplied code. Classpath plugins are
+trusted application code. Dynamic plugin rows can advertise availability,
+capabilities, configuration references, or installed-pack metadata, but they
+cannot point to a shell command, arbitrary file, arbitrary URL, Git remote, or
+dependency artifact that the backend executes.
+
+If a future requirement needs dynamic code loading, it needs a separate ADR for
+artifact resolution, trust policy, sandboxing, signature verification,
+dependency isolation, privilege boundaries, audit records, and rollback.
+
+Provider and local/offline adapters must fail closed on unsafe inputs:
+configured roots only, realpath checks for filesystem access, bounded read
+sizes, structured parsers for BibTeX/RIS/CSL/markdown where available, relative
+locators in product records, and no direct token or path echo in logs/errors.
+
+## Consequences
+
+### Positive
+
+- N010 can evolve one extension family at a time while keeping research
+  lifecycle, source identity, provenance, rationale, and disclosure boundaries
+  intact.
+- The existing plugin registry remains useful for discovery without becoming a
+  dynamic execution mechanism.
+- Search, review, extraction, writing, and export adapters feed normalized
+  service commands, so REST, MCP, audit, validation, and error behavior stay
+  consistent.
+- Extension selection is replayable because runs record ids and versions rather
+  than depending on whatever plugin/template/provider happens to be latest.
+
+### Negative
+
+- Implementations must define small typed contracts instead of quickly pushing
+  provider/template-specific maps through `metadata`.
+- Dynamic plugin rows remain metadata-only until trusted backend code exists for
+  the adapter family, which limits "install a plugin and execute it" behavior.
+- Adding API-visible extension categories requires enum and OpenAPI/MCP mirror
+  updates under ADR-034.
+
+### Risks
+
+- If `RegisteredPlugin.metadata` becomes the place where lifecycle or source
+  semantics live, validation and audit will drift from the research services.
+- If adapters persist directly, provider-specific behavior can bypass stage
+  gates, provenance, actor capture, and idempotency.
+- If prompt text or skill prose is treated as the extension contract, the repo
+  will have no enforceable backend boundary for N010.
+- If output renderers grow a parallel document model, research final outputs
+  will drift from existing document export and disclosure/accountability
+  surfaces.
+
+## Non-Goals
+
+- No implementation of new entities, migrations, controllers, DTOs, MCP tools,
+  frontend views, providers, parsers, renderers, templates, or graph
+  contributors in this ADR.
+- No dynamic code loading, plugin marketplace, dependency resolver, provider
+  credential store, or sandboxing model.
+- No new authentication model, actor override mechanism, error envelope,
+  logging stack, enum-mirror system, policy runner, or workflow engine.
+- No storage decision for full text, PDFs, manuscripts, raw provider payloads,
+  prompts, completions, or large charting datasets.
+- No change to ADR-055's citation MCP server name or skill-side phase workflow.
+
+## Related Requirements
+
+- `GC-RSCH-N010` - extensibility.
+- `GC-RSCH-N009` - interoperability.
+- `GC-RSCH-N011` - observability.
+- `GC-RSCH-R004` - provenance chain.
+- `GC-RSCH-F003` - stage gating.
+
+## Related Issues
+
+- #1004 - Research REST and MCP tool surface.
+- #1021 - Research full-text evidence Q&A adapter.
+- #1029 - Research adapter/plugin boundary.
+- #1030 - Research local/offline execution mode.
+
+## Related ADRs
+
+- ADR-023 - Plugin Architecture.
+- ADR-026 - REST API Access Control.
+- ADR-033 - Authenticated Audit Actor Provenance.
+- ADR-034 - API Enum Contract Single Source of Truth.
+- ADR-035 - MCP Tool Catalog Curation.
+- ADR-045 - Evidence Derivation and Temporal State History.
+- ADR-055 - Research Workflow Skills and Citation MCP.
+- ADR-056 - Research Project Type and Intake Metadata.
+- ADR-064 - Research Run Lifecycle and Stage Gating.
+- ADR-065 - Research Run Observability Snapshot.
+- ADR-069 - Research Artifact Provenance Ledger.
+- ADR-071 - Research Interoperability and Source Identity Boundary.
+- ADR-072 - Research REST and MCP Tool Surface.

--- a/architecture/adrs/README.md
+++ b/architecture/adrs/README.md
@@ -89,5 +89,7 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [069](069-research-artifact-provenance-ledger.md) | Research Artifact Provenance Ledger | Accepted |
 | [070](070-research-artifact-graph-projection.md) | Research Artifact Graph Projection | Accepted |
 | [071](071-research-interoperability-source-identity.md) | Research Interoperability and Source Identity Boundary | Accepted |
+| [072](072-research-rest-and-mcp-tool-surface.md) | Research REST and MCP Tool Surface | Accepted |
+| [073](073-research-extensibility-and-adapter-boundary.md) | Research Extensibility and Adapter Boundary | Accepted |
 
 Prior ADRs from the old project frame are archived in `archive/architecture/adrs/`.


### PR DESCRIPTION
## Summary

Adds ADR-072 (Research REST and MCP Tool Surface) and ADR-073 (Research Extensibility and Adapter Boundary) plus the ADR README index entries. The research REST controllers, MCP tools (gc_research_run, gc_research_provenance), and gc_query allowlist this issue describes already shipped under #1003 and the ADR-064..071 series; these two ADRs govern and lock that boundary. In-scope requirements: GC-RSCH-F003 (ACTIVE) and GC-RSCH-N011 (ACTIVE) are implemented by existing code; GC-RSCH-N009 and GC-RSCH-N010 stay DRAFT because the interoperability integrations and plugin families they describe are out of scope for this change and are owned by separate issues (#1010, #1011, #1021, #1025, #1029, #1030). Documentation-only change.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1004

## ADR Impact

- ADR-072
- ADR-073

## Changes

- Add ADR-072: Research REST and MCP Tool Surface — REST as the public product boundary, research services authoritative, MCP tools as thin REST adapters, gc_query GET-only/allowlisted, shared auth/actor/error surfaces, no sensitive content in adapter payloads (governs GC-RSCH-F003, N009, N010, N011)
- Add ADR-073: Research Extensibility and Adapter Boundary — plugin-like = registered/typed/selectable/bounded (no runtime code loading), per-family semantic owners, explicit+historical selection via extensionId/version/capability, adapters normalize while services validate+persist (governs GC-RSCH-N009, N010)
- Index ADR-072 and ADR-073 in architecture/adrs/README.md

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
