### PR TITLE
fix: activate and verify commit-time pre-commit hooks under a global hooks dispatcher

### DIFF
--- a/.claude/skills/repo-setup/SKILL.md
+++ b/.claude/skills/repo-setup/SKILL.md
@@ -118,17 +118,20 @@ Add based on what's relevant:
 - Use `pass_filenames: false` for test runners
 - Scope with appropriate `files:` patterns
 
-4. Install the hooks:
+4. Activate **and verify** the hooks with the repo-native installer rather than a bare `pre-commit install`:
 ```bash
-pre-commit install
+scripts/install-hooks.sh   # or: make hooks
 ```
 
-5. Run against all files to verify:
-```bash
-pre-commit run --all-files
-```
+   **Do not run `pre-commit install` directly.** It cowardly refuses whenever git's `core.hooksPath` is set (any value), so under an environment-level global hooks dispatcher (for example `~/.git-hooks` with a `_chain` script) it silently produces **no** commit-time hook: the repo gets a valid `.pre-commit-config.yaml` and a green CI pre-commit job while commits run zero hooks. Commit-time activation is a **separate contract** from config presence and CI execution (ADR-079).
 
-Fix any issues that arise. It's normal for formatters to make changes on first run - stage those changes.
+   `scripts/install-hooks.sh` is the durable, repo-native installer/verifier. For the current clone it:
+   - writes GC-managed `pre-commit`/`pre-push` hooks into the clone-local hook path the dispatcher delegates to (`$(git rev-parse --git-dir)/hooks`), which is what `pre-commit install` cannot do while `core.hooksPath` is set;
+   - **never touches global git config** and never overwrites an unmanaged or symlinked hook without `--force` (host ownership boundary);
+   - **proves** git's effective dispatch actually reaches the managed hook (via `git hook run`) instead of trusting config presence, and **fails closed** with an actionable diagnostic when a non-empty `core.hooksPath` points at a dispatcher that does not delegate to the clone-local hook path;
+   - finally runs `pre-commit run --all-files`.
+
+   Because `.git/hooks/` is not versioned, every fresh clone must re-run `make hooks`; document that in the onboarded repo's CONTRIBUTING/README. It's normal for formatters to make changes on the first `pre-commit run`, so stage those changes.
 
 ### 3. SonarCloud Setup
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         name: bash -n (deploy + ops scripts)
         entry: bash -c 'for f in "$@"; do bash -n "$f" || exit 1; done' --
         language: system
-        files: ^(deploy/scripts/.*\.sh|scripts/(assert-backup-policy|deploy)\.sh)$
+        files: ^(deploy/scripts/.*\.sh|scripts/(assert-backup-policy|deploy|install-hooks)\.sh)$
 
       - id: assert-backup-policy
         name: assert GC-P021 backup policy defaults

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,15 +16,18 @@ git clone https://github.com/KeplerOps/Ground-Control.git
 cd Ground-Control
 git checkout -b feature/your-feature dev
 
-# 2. Start PostgreSQL and Redis
+# 2. Activate commit-time hooks for THIS clone (required once per clone, ADR-079)
+make hooks                         # writes + verifies the pre-commit/pre-push hooks
+
+# 3. Start PostgreSQL and Redis
 cp .env.example .env
 make up
 
-# 3. Build and test
+# 4. Build and test
 make rapid                         # Format + compile (~1s with warm daemon)
 make test                          # Unit tests
 
-# 4. Start development server
+# 5. Start development server
 make dev                           # Spring Boot on :8000
 ```
 
@@ -32,6 +35,7 @@ make dev                           # Spring Boot on :8000
 
 | Target | Description |
 |--------|-------------|
+| `make hooks` | Activate + verify commit-time pre-commit hooks for this clone (run once per clone) |
 | `make rapid` | Format + compile, no tests or static analysis (~1 second warm) |
 | `make test` | Run unit tests (no static analysis) |
 | `make check` | Full build + tests + static analysis + coverage (CI-equivalent) |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
        assert-backup-policy test-backup-restore-local vale-install vale-lint \
        ground-control-mcp-install sync-ground-control-policy scaffold-controller scaffold-audited-entity \
        scaffold-l2-state-machine sync-packs trigger-pack-sync dev clean up down docker-build smoke frontend-install frontend-dev \
-       frontend-build frontend-lint frontend-format frontend-test deploy deploy-status deploy-manifest deploy-infra mcp-openapi-contract rollback
+       frontend-build frontend-lint frontend-format frontend-test deploy deploy-status deploy-manifest deploy-infra mcp-openapi-contract rollback hooks
 
 # --- Rapid dev loop (< 5s) ---
 
@@ -28,6 +28,9 @@ format: ## Format code with Spotless
 
 lint: ## Check formatting
 	cd backend && ./gradlew spotlessCheck
+
+hooks: ## Activate + verify commit-time pre-commit hooks for this clone (ADR-079)
+	bash scripts/install-hooks.sh
 
 # --- Full verification (CI-equivalent) ---
 

--- a/architecture/adrs/079-commit-time-pre-commit-hook-activation.md
+++ b/architecture/adrs/079-commit-time-pre-commit-hook-activation.md
@@ -1,0 +1,136 @@
+# ADR-079: Commit-Time Pre-commit Hook Activation
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-01
+
+## Context
+
+Ground Control onboarding treats pre-commit as an active local gate: an
+onboarded repository has a `.pre-commit-config.yaml`, contributors run
+`pre-commit run --all-files`, and commits are expected to execute the same
+policy automatically.
+
+That assumption fails on hosts that use a global Git `core.hooksPath`
+dispatcher. In the observed environment, `core.hooksPath` points at a global
+hooks directory where each hook delegates through a `_chain` script to the
+repo-local hook under Git's hook path. The dispatcher can run a repo-local
+`pre-commit` hook when one exists, but `pre-commit install` refuses to create
+that hook whenever `core.hooksPath` is set at all. A freshly onboarded repo can
+therefore contain a valid `.pre-commit-config.yaml` and pass CI while commits
+run no local hooks.
+
+This is a workflow reliability problem, not a pre-commit configuration problem.
+The repository already verifies selected pre-commit hooks in CI through
+`tools/policy/checks.py::run_ci_strictness_contract`, but CI execution and
+commit-time activation are distinct contracts.
+
+## Decision
+
+Ground Control onboarding must treat commit-time hook activation as a separate
+invariant from pre-commit configuration and CI coverage.
+
+An onboarding run is incomplete until it can verify all of the following for
+the current clone:
+
+- `.pre-commit-config.yaml` exists and contains the repo's selected hooks.
+- the Git hook dispatch path for the current clone reaches a `pre-commit`
+  hook at commit time.
+- `pre-commit run --all-files` has been executed successfully after hook
+  activation is wired.
+
+### Ownership Boundary
+
+The repository owns the committed pre-commit configuration, the repo-native
+installer/verifier, and any managed clone-local hook payload it writes under
+Git's hook path. The host environment owns global `core.hooksPath` and any
+global dispatcher installed there.
+
+Ground Control onboarding must not unset or rewrite global `core.hooksPath`.
+When no `core.hooksPath` is configured, onboarding may use the normal
+`pre-commit install` path. When a supported global dispatcher delegates to the
+repo-local Git hook path, onboarding may create or repair the clone-local
+`pre-commit` hook directly because `pre-commit install` cannot do so. When a
+non-empty `core.hooksPath` cannot be recognized as a supported dispatcher,
+onboarding must fail closed with an actionable diagnostic rather than reporting
+success with inactive hooks.
+
+### Verification Boundary
+
+Hook activation verification must inspect Git's effective hook configuration
+and Git-resolved hook path for the current clone. It must not infer activation
+from the presence of `.pre-commit-config.yaml`, installed Python packages, or a
+green CI pre-commit job.
+
+For managed clone-local hook files, the verifier must distinguish
+Ground-Control-managed content from user-managed content. Existing unmanaged
+hooks are not overwritten silently; setup fails with a merge/repair diagnostic
+unless the operator explicitly chooses the clobber path supported by the future
+installer.
+
+Fresh clones remain a per-clone setup problem because `.git/hooks/` is not
+versioned. The durable repo contract is the checked-in installer/verifier and
+the `/repo-setup` workflow invoking it, not a committed hook file.
+
+### Security and Runtime Constraints
+
+The hook activation path is local repository hygiene. It must not introduce a
+GitHub, Ground Control API, or network side effect. Hook bodies and diagnostics
+must not embed tokens, secrets, or environment dumps. Any path supplied by Git
+configuration is data: quote it, avoid shell evaluation, and resolve hook paths
+through Git rather than by assuming `.git/hooks` is a directory.
+
+Expected setup failures should surface as stable diagnostics and non-zero exit
+codes, not as silent success followed by commits that run no hooks.
+
+## Consequences
+
+### Positive
+
+- Onboarding can detect the "config present but hook not wired" state before a
+  contributor relies on local enforcement.
+- The repository and host responsibilities are explicit: repo setup adapts to
+  a compatible dispatcher but does not take ownership of global Git policy.
+- CI pre-commit coverage remains useful without being confused for per-clone
+  commit-time activation.
+
+### Negative
+
+- Fresh clones need an explicit local setup/verification step because Git hooks
+  remain unversioned by design.
+- Unsupported global hook dispatchers become visible setup failures that need
+  host-level remediation or an added supported strategy.
+
+### Risks
+
+- A too-narrow dispatcher check would reject a valid host setup; keep the
+  strategy detection small, explicit, and testable.
+- A too-permissive check would recreate the current silent no-op under another
+  name; activation must be proven against Git's effective hook path.
+- Silently overwriting an existing user hook could drop local controls. Managed
+  hook markers and fail-closed repair behavior are required.
+
+## Non-Goals
+
+- Replacing or standardizing the host's global hooks dispatcher.
+- Moving pre-commit enforcement out of CI or weakening
+  `run_ci_strictness_contract`.
+- Adding a backend controller, database table, MCP tool, or Ground Control
+  server state for local Git hook activation.
+- Making `--no-verify` an accepted workflow path.
+
+## Related Issues
+
+- #1153 - Onboarded repos silently get no commit-time pre-commit hooks when
+  `pre-commit install` refuses under a global `core.hooksPath` dispatcher.
+
+## Related ADRs
+
+- ADR-027 - Agent-neutral workflow packaging and `.ground-control.yaml` as the
+  repo context boundary.
+- ADR-029 - Issue-thread gate model and durable workflow record.
+- ADR-036 - Per-step routing, deterministic tool surfaces, and telemetry.

--- a/architecture/adrs/README.md
+++ b/architecture/adrs/README.md
@@ -96,5 +96,6 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [076](076-research-scientific-humility-surface.md) | Research Scientific Humility Surface | Accepted |
 | [077](077-research-behavior-versioning-and-regression-tests.md) | Research Behavior Versioning and Regression Tests | Accepted (amended by ADR-078) |
 | [078](078-research-methodology-catalog-reference-data.md) | Research Methodology Catalog as Backend Reference Data | Accepted |
+| [079](079-commit-time-pre-commit-hook-activation.md) | Commit-Time Pre-commit Hook Activation | Accepted |
 
 Prior ADRs from the old project frame are archived in `archive/architecture/adrs/`.

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -364,6 +364,17 @@ PreToolUse hook on `Bash`. The user owns every actual merge. Blocked uncondition
 - `make policy` is the common path for Claude, Codex, pre-commit, and CI
 - `make sync-ground-control-policy` and `make policy-live` keep Ground Control quality gates and ADR metadata aligned when a live GC instance is available
 
+Commit-time pre-commit activation is a separate per-clone contract from the
+presence of `.pre-commit-config.yaml` and the CI pre-commit job. ADR-079 requires
+repo setup to verify Git's effective hook dispatch path for the current clone,
+adapt to a supported global `core.hooksPath` dispatcher without mutating global
+Git config, and fail closed when hooks are present in config but not wired for
+commit-time execution. Run `make hooks` (a wrapper for `scripts/install-hooks.sh`)
+once per fresh clone: it writes managed `pre-commit`/`pre-push` hooks into the
+clone-local hook path the dispatcher delegates to, proves Git actually dispatches
+to them, then runs `pre-commit run --all-files`. `.git/hooks/` is not versioned, so
+this step does not survive a fresh clone by design; re-run it after cloning.
+
 ### MCP–Backend Write-Contract Gate (ADR-034, #1106)
 
 `make mcp-openapi-contract` (CI job `mcp-contract`) fails the build when an MCP

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# install-hooks.sh — activate and verify commit-time pre-commit hooks for THIS clone.
+#
+# Ground Control onboarding treats pre-commit as an active local gate, but three
+# things are distinct contracts (ADR-079): the committed .pre-commit-config.yaml,
+# CI pre-commit execution, and commit-time hook ACTIVATION in a given clone.
+# `pre-commit install` cowardly-refuses whenever git's core.hooksPath is set, so a
+# repo onboarded under a global hooks dispatcher (e.g. ~/.git-hooks with a _chain
+# script) can hold a valid config, pass CI, and still run zero hooks on commit —
+# silently. This script is the repo-native installer + verifier that closes that gap.
+#
+# What it does, for the current clone only:
+#   * writes a Ground-Control-managed pre-commit and pre-push hook into git's
+#     resolved hook path (the location a _chain-style dispatcher delegates to, and
+#     the location git uses directly when no dispatcher is set). Each managed hook
+#     execs `pre-commit hook-impl` — the same entrypoint `pre-commit install` wires.
+#   * PROVES activation by asking git to run the hook (`git hook run`) and checking
+#     the managed hook is actually reached through git's EFFECTIVE dispatch, so a
+#     green config/CI is never mistaken for a wired commit-time hook.
+#   * runs `pre-commit run --all-files` and requires it to pass.
+#
+# It never unsets or rewrites GLOBAL git config, never overwrites an unmanaged hook
+# without --force, and fails closed (non-zero, actionable diagnostic) when git's
+# core.hooksPath points at a dispatcher that does not reach this clone's hook path.
+#
+# Usage: scripts/install-hooks.sh [--force] [--dry-run] [--help]
+#   --force     replace an existing unmanaged hook instead of failing closed
+#   --dry-run   report the actions without writing hooks or running verification
+#   --help      print this header and exit
+#
+# Fresh clones must re-run this (via `make hooks`) because .git/hooks is not
+# versioned — that is by design (ADR-079), not a bug.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+MANAGED_MARKER="ground-control-managed-hook"
+MANAGED_VERSION="v1"
+# Hook types this repo activates. Add a type here to activate a new stage; the
+# managed-hook body and verification are parameterised over it (no new framework).
+MANAGED_HOOK_TYPES=(pre-commit pre-push)
+
+force=0
+dry_run=0
+for arg in "$@"; do
+  case "$arg" in
+    --force) force=1 ;;
+    --dry-run) dry_run=1 ;;
+    -h|--help)
+      sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "install-hooks: unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+log()  { printf 'install-hooks: %s\n' "$1"; }
+fail() { printf 'install-hooks: %s\n' "$1" >&2; exit 1; }
+
+cd "$REPO_ROOT"
+
+# --- Preconditions ----------------------------------------------------------
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || fail "not inside a git work tree ($REPO_ROOT)"
+
+[ -f "$REPO_ROOT/.pre-commit-config.yaml" ] \
+  || fail "no .pre-commit-config.yaml at repo root — nothing to activate"
+
+PRE_COMMIT_BIN="$(command -v pre-commit || true)"
+[ -n "$PRE_COMMIT_BIN" ] \
+  || fail "pre-commit not found on PATH — install it (e.g. 'pipx install pre-commit' or 'pip install pre-commit') and re-run"
+
+# Resolve the interpreter pre-commit runs under, mirroring the shim pre-commit
+# itself generates, so the managed hook works even when PATH is thin at commit
+# time. Falls back to `command -v pre-commit` inside the hook body.
+INSTALL_PYTHON="$(sed -n '1s/^#!//p' "$PRE_COMMIT_BIN" 2>/dev/null || true)"
+case "$INSTALL_PYTHON" in
+  /*) : ;;              # a real interpreter path from the shebang
+  *)  INSTALL_PYTHON="" ;;
+esac
+
+HOOKS_PATH="$(git config --get core.hooksPath || true)"
+
+# Resolve the hook directory THIS clone actually dispatches to. Treat every
+# git-supplied path as data; do not assume `.git/hooks` is a plain directory.
+#
+# CRITICAL: `git rev-parse --git-path hooks` HONORS core.hooksPath — when a global
+# dispatcher is set it returns that host-owned global dir (e.g. ~/.git-hooks), NOT
+# this clone's hooks. Writing there would clobber the host's global hooks. So:
+#   * dispatcher set  -> target the clone-local `<git-dir>/hooks`, which is exactly
+#     where a _chain-style dispatcher delegates (`$(git rev-parse --git-dir)/hooks`).
+#   * no dispatcher   -> use git's resolved hooks path (repo/common `.git/hooks`).
+if [ -n "$HOOKS_PATH" ]; then
+  HOOK_DIR="$(cd "$REPO_ROOT" && git rev-parse --git-dir)/hooks"
+  log "core.hooksPath is set ('$HOOKS_PATH'); pre-commit install would refuse — writing managed hooks into the clone-local hook dir the dispatcher delegates to."
+else
+  HOOK_DIR="$(cd "$REPO_ROOT" && git rev-parse --git-path hooks)"
+  log "core.hooksPath is unset; writing managed hooks into git's hook path."
+fi
+case "$HOOK_DIR" in
+  /*) : ;;
+  *)  HOOK_DIR="$REPO_ROOT/$HOOK_DIR" ;;
+esac
+
+# --- Hook body --------------------------------------------------------------
+
+# Emit a managed hook script for the given hook type to stdout. The verify probe
+# (GC_HOOK_VERIFY) lets install-hooks confirm this exact file is reached through
+# git's effective dispatch without mutating the work tree. The body carries no
+# secrets, tokens, or network/API calls — pure local dispatch to pre-commit.
+managed_hook_body() {
+  local hook_type="$1"
+  cat <<EOF
+#!/usr/bin/env bash
+# ${MANAGED_MARKER} ${MANAGED_VERSION} (${hook_type})
+# Installed by scripts/install-hooks.sh — do not edit. Regenerate with: make hooks
+# Activates .pre-commit-config.yaml at ${hook_type} time, including under a global
+# core.hooksPath dispatcher that delegates to this clone's git hook path (ADR-079).
+set -euo pipefail
+
+# Activation probe used by scripts/install-hooks.sh — proves git's effective
+# dispatch reaches this managed hook, then exits without running pre-commit.
+if [ -n "\${GC_HOOK_VERIFY:-}" ]; then
+  printf '%s\n' '${MANAGED_MARKER}:${hook_type}'
+  exit 0
+fi
+
+ARGS=(hook-impl --config=.pre-commit-config.yaml --hook-type=${hook_type} --hook-dir="\$(cd "\$(dirname "\$0")" && pwd)")
+INSTALL_PYTHON="${INSTALL_PYTHON}"
+if [ -n "\$INSTALL_PYTHON" ] && [ -x "\$INSTALL_PYTHON" ]; then
+  exec "\$INSTALL_PYTHON" -mpre_commit "\${ARGS[@]}" -- "\$@"
+elif command -v pre-commit >/dev/null 2>&1; then
+  exec pre-commit "\${ARGS[@]}" -- "\$@"
+else
+  echo '${hook_type}: pre-commit not found; run scripts/install-hooks.sh' >&2
+  exit 1
+fi
+EOF
+}
+
+# Fail closed unless the existing hook is safe to replace: our managed marker, or a
+# stock pre-commit-generated shim. An unmanaged, hand-written hook is never clobbered
+# without --force (ADR-079: managed vs user-managed content must be distinguished).
+guard_existing_hook() {
+  local target="$1" hook_type="$2"
+  # A symlink is never GC-managed (we write regular files) and must never be
+  # followed — writing through it would clobber the link's target (e.g. a shared
+  # dispatcher). Inspect with lstat semantics only.
+  if [ -L "$target" ]; then
+    if [ "$force" -eq 1 ]; then
+      log "replacing symlinked $hook_type hook at $target (--force)"
+      return 0
+    fi
+    fail "refusing to replace symlinked $hook_type hook at $target (-> $(readlink "$target" 2>/dev/null)) — re-run with --force to replace"
+  fi
+  [ -e "$target" ] || return 0
+  if grep -q "$MANAGED_MARKER" "$target" 2>/dev/null; then
+    return 0  # ours — safe to re-manage idempotently
+  fi
+  if grep -q "File generated by pre-commit" "$target" 2>/dev/null; then
+    return 0  # stock pre-commit shim — safe to replace with the managed equivalent
+  fi
+  if [ "$force" -eq 1 ]; then
+    log "overwriting unmanaged $hook_type hook at $target (--force)"
+    return 0
+  fi
+  fail "refusing to overwrite unmanaged $hook_type hook at $target — inspect it, then merge its logic or re-run with --force"
+}
+
+write_managed_hook() {
+  local hook_type="$1"
+  local target="$HOOK_DIR/$hook_type"
+  guard_existing_hook "$target" "$hook_type"
+  if [ "$dry_run" -eq 1 ]; then
+    log "[dry-run] would write managed $hook_type hook to $target"
+    return 0
+  fi
+  # Write to a temp file in the same dir, then atomically mv into place. mv
+  # replaces the directory entry and NEVER writes through an existing symlink.
+  local tmp="$HOOK_DIR/.${hook_type}.gc.$$"
+  managed_hook_body "$hook_type" > "$tmp"
+  chmod +x "$tmp"
+  mv -f "$tmp" "$target"
+  log "wrote managed $hook_type hook to $target"
+}
+
+# --- Activation proof -------------------------------------------------------
+
+# Prove git's EFFECTIVE dispatch (including any global core.hooksPath dispatcher)
+# reaches our managed hook for this type. Never infers activation from config
+# presence, installed packages, or CI (ADR-079 Verification Boundary).
+verify_activation() {
+  local hook_type="$1"
+  local out
+  if ! out="$(GC_HOOK_VERIFY=1 git hook run "$hook_type" 2>&1)"; then
+    # `git hook run` needs git >= 2.36. A non-zero here with no marker means the
+    # probe could not be dispatched — surface it rather than passing silently.
+    if ! printf '%s' "$out" | grep -q "${MANAGED_MARKER}:${hook_type}"; then
+      fail "could not verify $hook_type activation via 'git hook run' (git >= 2.36 required); output: ${out:-<none>}"
+    fi
+  fi
+  printf '%s' "$out" | grep -q "${MANAGED_MARKER}:${hook_type}" || fail \
+    "$hook_type hook is NOT reached through git's effective dispatch (core.hooksPath='${HOOKS_PATH:-<unset>}' points at a dispatcher that does not delegate to this clone's hook path). Global git config was left untouched; wire the dispatcher to '$HOOK_DIR' or clear core.hooksPath for this clone, then re-run."
+  log "verified: git dispatches $hook_type to the managed hook"
+}
+
+# --- Run --------------------------------------------------------------------
+
+mkdir -p "$HOOK_DIR"
+for hook_type in "${MANAGED_HOOK_TYPES[@]}"; do
+  write_managed_hook "$hook_type"
+done
+
+if [ "$dry_run" -eq 1 ]; then
+  log "[dry-run] skipping activation proof and 'pre-commit run --all-files'"
+  exit 0
+fi
+
+for hook_type in "${MANAGED_HOOK_TYPES[@]}"; do
+  verify_activation "$hook_type"
+done
+
+log "running 'pre-commit run --all-files' to confirm the config executes cleanly…"
+"$PRE_COMMIT_BIN" run --all-files
+log "commit-time hooks are active and verified for this clone."

--- a/tools/tests/test_install_hooks.py
+++ b/tools/tests/test_install_hooks.py
@@ -1,0 +1,207 @@
+"""Tests for scripts/install-hooks.sh — commit-time pre-commit hook activation.
+
+These exercise the installer against real (throwaway) git repositories with a
+fully isolated HOME and git config, so the host's global hooks are never
+touched. They cover the four activation strategies plus the symlink-safety
+invariant (ADR-079): never write through a symlink, never clobber the
+host-owned global hooks dir, fail closed on an unsupported dispatcher.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_HOOKS = REPO_ROOT / "scripts" / "install-hooks.sh"
+
+MARKER = "ground-control-managed-hook"
+
+
+class InstallHooksTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="gc-install-hooks-"))
+        # Fully isolated HOME + git config: the real ~/.git-hooks is unreachable.
+        self.home = self.tmp / "home"
+        self.home.mkdir()
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+        # Stub `pre-commit` so `pre-commit run --all-files` and any hook-impl
+        # dispatch succeed without a real install or network.
+        stub = self.bin / "pre-commit"
+        stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+        stub.chmod(0o755)
+        self.global_cfg = self.home / ".gitconfig"
+        self.global_cfg.write_text("")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # -- helpers ---------------------------------------------------------
+
+    def _env(self):
+        env = dict(os.environ)
+        env.update(
+            HOME=str(self.home),
+            GIT_CONFIG_GLOBAL=str(self.global_cfg),
+            GIT_CONFIG_SYSTEM="/dev/null",
+            GIT_AUTHOR_NAME="t",
+            GIT_AUTHOR_EMAIL="t@t",
+            GIT_COMMITTER_NAME="t",
+            GIT_COMMITTER_EMAIL="t@t",
+            PATH=f"{self.bin}:{env.get('PATH', '')}",
+        )
+        return env
+
+    def _git(self, repo, *args):
+        subprocess.run(["git", "-C", str(repo), *args], env=self._env(),
+                       check=True, capture_output=True, text=True)
+
+    def _set_global_hookspath(self, path):
+        # Write directly to the isolated global config; never the real one.
+        subprocess.run(
+            ["git", "config", "--global", "core.hooksPath", str(path)],
+            env=self._env(), check=True, capture_output=True, text=True)
+
+    def _make_repo(self, name):
+        repo = self.tmp / name
+        repo.mkdir()
+        self._git(repo, "init", "-q")
+        (repo / ".pre-commit-config.yaml").write_text("fail_fast: true\nrepos: []\n")
+        scripts = repo / "scripts"
+        scripts.mkdir()
+        dest = scripts / "install-hooks.sh"
+        shutil.copy2(INSTALL_HOOKS, dest)
+        dest.chmod(0o755)
+        return repo
+
+    def _run(self, repo, *flags):
+        return subprocess.run(
+            ["./scripts/install-hooks.sh", *flags],
+            cwd=str(repo), env=self._env(), capture_output=True, text=True)
+
+    def _make_chain_dispatcher(self, name, delegating=True):
+        """A global core.hooksPath dir. delegating=True mimics the host's
+        `_chain` (delegates to the clone-local hook); False ignores it."""
+        d = self.tmp / name
+        d.mkdir()
+        if delegating:
+            chain = d / "_chain"
+            chain.write_text(textwrap.dedent("""\
+                #!/usr/bin/env bash
+                set -e
+                hook="$(basename "$0")"
+                gd="$(git rev-parse --git-dir 2>/dev/null || true)"
+                [ -n "$gd" ] && [ -x "${gd}/hooks/${hook}" ] && exec "${gd}/hooks/${hook}" "$@"
+                exit 0
+                """))
+            chain.chmod(0o755)
+            for h in ("pre-commit", "pre-push"):
+                (d / h).symlink_to("_chain")
+        else:
+            for h in ("pre-commit", "pre-push"):
+                p = d / h
+                p.write_text("#!/usr/bin/env bash\nexit 0\n")
+                p.chmod(0o755)
+        return d
+
+    def _hook(self, repo, name):
+        return repo / ".git" / "hooks" / name
+
+    # -- tests -----------------------------------------------------------
+
+    def test_normal_no_hookspath_writes_managed_hooks(self):
+        repo = self._make_repo("r_normal")
+        r = self._run(repo)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        for name in ("pre-commit", "pre-push"):
+            self.assertIn(MARKER, self._hook(repo, name).read_text())
+
+    def test_supported_dispatcher_writes_local_and_leaves_global_untouched(self):
+        chain = self._make_chain_dispatcher("chain", delegating=True)
+        chain_before = (chain / "_chain").read_text()
+        self._set_global_hookspath(chain)
+        repo = self._make_repo("r_dispatch")
+        r = self._run(repo)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        # Both managed hooks land in the clone-local hook dir, not the dispatcher dir.
+        self.assertIn(MARKER, self._hook(repo, "pre-commit").read_text())
+        self.assertIn(MARKER, self._hook(repo, "pre-push").read_text())
+        # The host-owned global dispatcher is untouched — this is the whole point.
+        # Assert it for BOTH managed slots so a pre-push write-through would fail here.
+        self.assertEqual((chain / "_chain").read_text(), chain_before)
+        for slot in ("pre-commit", "pre-push"):
+            self.assertTrue((chain / slot).is_symlink())
+            self.assertNotIn(MARKER, (chain / slot).read_text())
+
+    def test_unsupported_dispatcher_fails_closed(self):
+        bad = self._make_chain_dispatcher("bad", delegating=False)
+        bad_before = {slot: (bad / slot).read_text() for slot in ("pre-commit", "pre-push")}
+        self._set_global_hookspath(bad)
+        repo = self._make_repo("r_bad")
+        r = self._run(repo)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("NOT reached through git's effective dispatch", r.stderr)
+        # Global config left untouched; neither slot of the dispatcher dir is modified.
+        for slot in ("pre-commit", "pre-push"):
+            self.assertEqual((bad / slot).read_text(), bad_before[slot])
+
+    def test_unmanaged_existing_hook_is_preserved_without_force(self):
+        repo = self._make_repo("r_unmanaged")
+        target = self._hook(repo, "pre-commit")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("#!/usr/bin/env bash\necho custom\n")
+        target.chmod(0o755)
+        r = self._run(repo)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("echo custom", target.read_text())
+        # --force replaces it with a managed hook — both slots end up managed.
+        r2 = self._run(repo, "--force")
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        self.assertIn(MARKER, target.read_text())
+        self.assertIn(MARKER, self._hook(repo, "pre-push").read_text())
+
+    def test_symlinked_hook_is_never_written_through(self):
+        """Regression: a shell redirect to a symlinked hook must NOT overwrite the
+        symlink's target (that once clobbered a shared dispatcher)."""
+        repo = self._make_repo("r_symlink")
+        link_target = repo / "linktarget"
+        link_target.write_text("SENTINEL-ORIGINAL\n")
+        link_target.chmod(0o755)
+        target = self._hook(repo, "pre-commit")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to(link_target)
+        r = self._run(repo, "--force")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        # The link's target is untouched; the hook is now a managed regular file.
+        self.assertEqual(link_target.read_text(), "SENTINEL-ORIGINAL\n")
+        self.assertFalse(target.is_symlink())
+        self.assertIn(MARKER, target.read_text())
+        # The parallel pre-push slot is written as a managed regular file too.
+        self.assertFalse(self._hook(repo, "pre-push").is_symlink())
+        self.assertIn(MARKER, self._hook(repo, "pre-push").read_text())
+
+    def test_symlinked_hook_fails_closed_without_force(self):
+        repo = self._make_repo("r_symlink_noforce")
+        link_target = repo / "linktarget"
+        link_target.write_text("SENTINEL\n")
+        target = self._hook(repo, "pre-commit")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to(link_target)
+        r = self._run(repo)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertTrue(target.is_symlink())
+
+    def test_dry_run_writes_nothing(self):
+        repo = self._make_repo("r_dry")
+        r = self._run(repo, "--dry-run")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertFalse(self._hook(repo, "pre-commit").exists())
+        self.assertFalse(self._hook(repo, "pre-push").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Onboarding ran a bare `pre-commit install`, which cowardly-refuses whenever git's core.hooksPath is set (any value). Under an environment-level global hooks dispatcher (e.g. ~/.git-hooks with a _chain script), a freshly onboarded repo therefore got a valid .pre-commit-config.yaml and a green CI pre-commit job while commits ran zero hooks — silently, with no verification surface. Per ADR-079, commit-time hook activation is a separate contract from config presence and CI execution. This adds `scripts/install-hooks.sh` (`make hooks`), the repo-native installer/verifier: for the current clone it writes GC-managed pre-commit/pre-push hooks into the clone-local hook path the dispatcher delegates to, proves git's effective dispatch actually reaches them (`git hook run`), then runs `pre-commit run --all-files`. It never mutates global git config, never writes through a symlink, never overwrites an unmanaged hook without --force, and fails closed with an actionable diagnostic on an unsupported dispatcher. Onboarding, CONTRIBUTING, and the workflow docs now use it; `.git/hooks/` is unversioned by design, so fresh clones re-run `make hooks`.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1153

## ADR Impact

- ADR-079
- ADR-021

## Changes

- scripts/install-hooks.sh: writes managed pre-commit/pre-push hooks into the clone-local hook dir the dispatcher delegates to; proves activation via `git hook run`; runs `pre-commit run --all-files`; fails closed on an unsupported dispatcher; never touches global git config or writes through a symlink
- tools/tests/test_install_hooks.py: hermetic tests for every strategy (normal / supported dispatcher / unsupported / unmanaged / dry-run) plus symlink-safety and host-config-untouched invariants
- .claude/skills/repo-setup: replaces bare `pre-commit install` with the installer/verifier and documents the activation contract (config != CI != commit-time activation)
- CONTRIBUTING.md + docs/DEVELOPMENT_WORKFLOW.md: `make hooks` documented as a required per-clone step
- architecture/adrs/079: commit-time hook activation decision + repo/host ownership boundary
- Makefile `hooks` target; .pre-commit-config.yaml bash-syntax coverage for the new script

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

All hermetic: temp HOME + temp git config, so the host's global hooks are never touched. `make policy` (203 tests incl. 7 new install-hooks cases) green; codex review clean; test-quality review clean after adding parallel pre-push assertions.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-079 ← scripts/install-hooks.sh
- TESTS: ADR-079 ← tools/tests/test_install_hooks.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
