### PR TITLE
docs: context-graph concept authority assessment and adr-084

### DIFF
--- a/architecture/adrs/083-context-graph-concept-authority.md
+++ b/architecture/adrs/083-context-graph-concept-authority.md
@@ -1,0 +1,215 @@
+# ADR-083: Context-Graph Concept Authority and Time Semantics
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-03
+
+## Context
+
+The living context graph is Ground Control's thesis, and it has no
+ontology of its own. The census in
+`docs/research/context-graph-ontology/assessment.md` (issue #1301) found:
+26 node kinds with three never emitted; nine per-aggregate link enums plus
+~25 literal edge strings hard-coded in projection contributors; the same
+concept minted independently up to six times (`ASSOCIATED`,
+`EVIDENCED_BY`, `OBSERVED_IN`, ...) with nothing declaring whether the
+meanings coincide; traceability links - the founding value proposition -
+not projected into the graph at all; five time mechanisms with no declared
+as-of spine; and no machine-readable ontology artifact anywhere.
+
+Milestones 17 and 18 are about to add workflow entities, contracts,
+invariants, and the architecture registry to this vocabulary. Without a
+governing decision, they will add them the way every prior wave did:
+per-aggregate, unregistered, drift-prone.
+
+Separately, the ACES SDL project (`../aces-sdl`) has implemented a
+concept-authority stack solving exactly this problem class for its own
+domain: concept families published as data with provenance and mandatory
+extension rules, artifact bindings that tie local strings to canonical
+concepts, controlled vocabularies with governed extension, a closed effect
+vocabulary for external ontologies (`annotates | aligns | refines |
+constrains`), a content-hashed schema publication manifest, and a typed
+declared-vs-observed reconciliation model with realization provenance. It
+is cyber-range domain-specialized, carries no requirements/GRC/
+traceability families, and its semantic-integrity umbrella (SEM-200) is
+still DRAFT. The assessment weighs adoption, independence, and alignment;
+this ADR records the decision.
+
+## Decision
+
+Adopt the concept-authority **pattern** with Ground-Control-native
+content, publish the ontology as data under the ADR-082 contracts
+surface, align with ACES through a versioned crosswalk under a closed
+effect vocabulary, and declare Envers revisions the canonical time spine.
+No runtime dependency on ACES is introduced in either direction.
+
+### 1. Three-layer semantic governance
+
+- **Concept authority layer**: what a concept means, declared once.
+  Ground Control's native concept families cover the engineering-process
+  domain: requirements-and-traceability, architecture-and-boundaries,
+  threats-risks-and-controls, evidence-and-observation,
+  workflow-and-process, contracts-and-invariants (milestone 18), and
+  research. Families borrowed from established sources carry provenance
+  `adopted` or `adapted` (as ACES does with UCO/STIX); Ground Control
+  originals are `native` and must declare extension scope, relation
+  rules, and non-ambiguity constraints.
+- **Artifact binding layer**: every vocabulary-bearing artifact - the
+  `GraphEntityType` enum, each link enum, each contributor's edge
+  strings, MCP tool enums, console filters - binds its local strings to
+  canonical concepts. A local string with no binding is a policy failure.
+- **External authority layer**: what an external ontology may do to
+  native meaning is limited to the closed effect vocabulary
+  `annotates | aligns | refines | constrains`. This governs the ACES
+  crosswalk and any future alignment (UCO, OSCAL, SPDX, and kin) alike.
+
+### 2. The ontology is data under the contracts surface
+
+`contracts/ontology/` (a sibling of the ADR-082 artifact set) holds:
+
+- `gc-concept-families-v1.json` - the family catalog with provenance and
+  per-family extension rules;
+- `gc-controlled-vocabularies-v1.json` - edge and classification
+  vocabularies with owners; shared concepts (`EVIDENCED_BY`,
+  `ASSOCIATED`, `OBSERVED_IN`, ...) are declared once here and bound per
+  aggregate, replacing independent minting;
+- `gc-artifact-bindings-v1.json` - the binding of each code-level
+  vocabulary surface (enum or contributor literal set) to families and
+  vocabulary terms;
+- `crosswalks/aces-concept-families-v1.json` - the ACES alignment (see
+  §4).
+
+Enforcement is inventory-driven in the ADR-034 style: a policy check
+fails any `GraphEntityType` value, link-enum value, or contributor edge
+string that is not bound in the artifacts, and fails any binding whose
+code-level surface no longer exists. Adding vocabulary is a one-row
+registration, not a new checker. Schema evolution follows ADR-082's
+declared-breaking-change gate; the artifacts are versioned in-name.
+
+### 3. Repairs mandated by the census
+
+1. **Traceability enters the graph.** `TraceabilityLink` edges
+   (`IMPLEMENTS`, `TESTS`, `DOCUMENTS`, `CONSTRAINS`, `VERIFIES`) are
+   projected into the AGE graph with their artifact endpoints (external
+   artifacts as identifier-addressed nodes per the existing external-target
+   policy). The traceability spine is context-graph content, full stop.
+2. **Dead vocabulary is resolved.** `CONTROL_LINK` and `AUDIT_LINK` are
+   removed from `GraphEntityType` (links are edges); `RISK_APPETITE_PROFILE`
+   either gains its contributor or leaves the enum. A governed ontology
+   carries no unreachable terms.
+3. **Thesis-relevant projections are decided deliberately**: workflow
+   runs and work items (milestone 17), derivation/boundary snapshots
+   (GC-GRC-005 family), and contracts/invariants (milestone 18) join the
+   graph through registered families, not ad hoc contributors.
+
+### 4. The ACES relationship: align now, converge later, couple never (yet)
+
+- **Pattern adoption is immediate** (this ADR): the layering, the
+  families-as-data shape, the binding discipline, and the effect
+  vocabulary are taken from the proven ACES implementation - the same
+  discipline, portfolio-native.
+- **Crosswalk, not dependency.** Where a Ground Control family genuinely
+  shares a concept with an ACES family - assets, observables/evidence,
+  provenance, time, tasks-runs-studies against workflow runs - the
+  crosswalk artifact records it with `aligns`/`refines` semantics and the
+  ACES family id as an external authority. The crosswalk is versioned,
+  policy-checked for referential validity, and carries no runtime
+  coupling: Ground Control does not parse SDL, ACES does not read the GC
+  graph.
+- **Companion-spec extraction is the stated trajectory, with explicit
+  gates.** When ACES's SEM-200 umbrella reaches ACTIVE and both sides
+  operate their family sets, the shared metamodel - surface/boundary,
+  concept family, artifact binding, provenance classes
+  (declared/derived/observed), typed reconciliation deltas
+  (`CREATE/UPDATE/DELETE/UNCHANGED` against provenance-bound snapshots),
+  evidence versus derived measures, and time - is extracted into a
+  companion specification both products consume as domain packs. Because
+  both sides use the same artifact shape from the start, extraction is a
+  merge of catalogs, not a rewrite. Ground Control's reconciliation
+  vocabulary (GC-GRC-009 impact/gap/stale, drift machinery) shall be
+  expressible in those delta terms so the convergence claim stays
+  checkable.
+- **Full adoption of ACES SDL as Ground Control's ontology substrate is
+  rejected for now** (assessment §3, option B): the semantic core is
+  DRAFT, the needed domain families do not exist there, and coupling a
+  shipping product's ontology to a pre-1.0 roadmap fails the
+  no-regression rule. This rejection is revisitable at the companion-spec
+  gate, not before.
+
+### 5. Time semantics: the Envers spine
+
+- The **canonical as-of coordinate is the Envers revision number**
+  (already a total order over ~80 audited entities with actor
+  attribution). Baselines already pin to it; that pattern generalizes.
+- ADR-062 graph snapshots record the revision they were materialized
+  from in snapshot metadata, tying graph-time to domain-time.
+- Every `asOf` parameter on read surfaces resolves to one defined
+  semantics: the state reconstructable at the greatest revision whose
+  timestamp is at or before the instant. Per-service divergence from
+  this definition is a defect.
+- ADR-045's evidence supersession chains and the research provenance
+  ledger are unchanged; they are event-history semantics layered on the
+  same spine, not competing spines.
+
+## Consequences
+
+### Positive
+
+- One machine-checked answer to "what does this node/edge mean," with
+  drift converted from a code-review hope into a policy failure.
+- The traceability spine becomes graph content, aligning the product's
+  query surface with its founding claim.
+- Milestones 17/18 add vocabulary through registration instead of
+  accretion, and the CLD architecture registry (#1295) lands as a family
+  rather than a fork.
+- Portfolio-level semantic convergence with ACES becomes a mechanical
+  merge gated on evidence, not a bet placed today.
+
+### Negative
+
+- Registration is friction: new vocabulary requires artifact rows and
+  bindings before code merges.
+- Three JSON artifacts plus a crosswalk are new maintenance surface;
+  the inventory-driven checks bound but do not remove it.
+- The crosswalk tracks a moving target while ACES's semantic core
+  matures; it needs re-validation on ACES releases (policy-checkable,
+  but real work).
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| The ontology artifacts rot into documentation | The binding check fails unbound code vocabulary in CI, both directions - same teeth as ADR-034. |
+| Crosswalk asserts equivalences that quietly stop being true | Crosswalk rows carry the ACES artifact version and content hash; a hash change fails validation until re-reviewed. |
+| Companion-spec trajectory becomes coupling by stealth | The gates are explicit (SEM-200 ACTIVE, both family sets operating); until then the only shared thing is the artifact shape. |
+| Edge consolidation breaks existing graph consumers | Consolidation maps old strings to vocabulary terms in the bindings artifact first; emission changes follow with the drift gate green. |
+
+## Non-Goals
+
+- Adopting OWL/SHACL/RDF or any W3C-stack representation; this is
+  governance-as-data over the existing relational-plus-projection
+  architecture (ADR-005/032/062 unchanged).
+- Changing the source-of-truth model: relational aggregates remain
+  authoritative; the graph remains a published projection.
+- Modeling ACES scenarios in Ground Control or vice versa.
+- Deciding graph-substrate fitness (milestone 20 owns that).
+
+## Related Requirements
+
+- GC-GRC-005 (architecture model aggregate), GC-GRC-031 (code-keyed
+  reverse lookup), GC-O014 (contract surface hosts the artifacts)
+
+## Related ADRs
+
+- ADR-005, ADR-011, ADR-019/020, ADR-032, ADR-045, ADR-062, ADR-070
+  (the existing graph decisions this consolidates over)
+- ADR-034 (inventory-driven enforcement pattern)
+- ADR-082 (contracts surface; artifact hosting and evolution gates)
+- ADR-058 (derivation/drift machinery whose vocabulary converges on the
+  reconciliation deltas)
+- ACES ADR-012 (shared concept authority; the adopted pattern's source,
+  in `../aces-sdl`)

--- a/architecture/adrs/084-context-graph-concept-authority.md
+++ b/architecture/adrs/084-context-graph-concept-authority.md
@@ -1,4 +1,4 @@
-# ADR-083: Context-Graph Concept Authority and Time Semantics
+# ADR-084: Context-Graph Concept Authority and Time Semantics
 
 ## Status
 

--- a/architecture/adrs/README.md
+++ b/architecture/adrs/README.md
@@ -100,6 +100,7 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [080](080-research-methodology-requirements-contract-artifact.md) | Research Methodology Requirements Contract Artifact | Accepted |
 | [081](081-temporal-dev-workflow-and-console-program.md) | Temporal Dev Workflow and Console Program | Accepted |
 | [082](082-contract-surface-architecture.md) | Contract Surface Architecture and Enforcement Gates | Accepted |
-| [083](083-context-graph-concept-authority.md) | Context-Graph Concept Authority and Time Semantics | Accepted |
+| [083](083-research-protocol-plan-artifact-and-method-outputs.md) | Research Protocol Plan Artifact and Method-Specific Outputs | Accepted |
+| [084](084-context-graph-concept-authority.md) | Context-Graph Concept Authority and Time Semantics | Accepted |
 
 Prior ADRs from the old project frame are archived in `archive/architecture/adrs/`.

--- a/architecture/adrs/README.md
+++ b/architecture/adrs/README.md
@@ -100,5 +100,6 @@ We use [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records). Each
 | [080](080-research-methodology-requirements-contract-artifact.md) | Research Methodology Requirements Contract Artifact | Accepted |
 | [081](081-temporal-dev-workflow-and-console-program.md) | Temporal Dev Workflow and Console Program | Accepted |
 | [082](082-contract-surface-architecture.md) | Contract Surface Architecture and Enforcement Gates | Accepted |
+| [083](083-context-graph-concept-authority.md) | Context-Graph Concept Authority and Time Semantics | Accepted |
 
 Prior ADRs from the old project frame are archived in `archive/architecture/adrs/`.

--- a/docs/research/context-graph-ontology/assessment.md
+++ b/docs/research/context-graph-ontology/assessment.md
@@ -1,6 +1,6 @@
 # Context-Graph Ontology, Identity, and Time: Assessment
 
-Status: assessment for issue #1301 (milestone 19). Decision record: ADR-083.
+Status: assessment for issue #1301 (milestone 19). Decision record: ADR-084.
 Evidence: full code census of this repository plus a read-only review of
 `../aces-sdl` at `origin/dev`.
 
@@ -204,6 +204,6 @@ convergence mechanical instead of aspirational.
 
 ## 5. Decision and work layout
 
-The binding decision is ADR-083 (option C plus the repairs). Follow-on
+The binding decision is ADR-084 (option C plus the repairs). Follow-on
 implementation issues are filed in milestone 19; see the milestone for the
 current set.

--- a/docs/research/context-graph-ontology/assessment.md
+++ b/docs/research/context-graph-ontology/assessment.md
@@ -1,0 +1,209 @@
+# Context-Graph Ontology, Identity, and Time: Assessment
+
+Status: assessment for issue #1301 (milestone 19). Decision record: ADR-083.
+Evidence: full code census of this repository plus a read-only review of
+`../aces-sdl` at `origin/dev`.
+
+## 1. Census: what the vocabulary is today
+
+### Nodes
+
+`GraphEntityType` declares 26 node kinds. 23 are emitted by 16
+`GraphProjectionContributor` implementations; three are dead or reserved
+vocabulary never emitted anywhere: `CONTROL_LINK`, `AUDIT_LINK`,
+`RISK_APPETITE_PROFILE` (the first two are reified-link concepts that are
+actually projected as edges; the third has no contributor at all).
+
+Roughly 20 domain packages have no graph presence. Some are correctly
+absent (read-side composition layers such as `grcanalysis`, `evidencestate`,
+`trace`; infrastructure such as `exception`). Others are thesis-relevant
+absences: `derivation` (boundary model snapshots), `workflowtelemetry`
+(workflow runs), `testcases`, `qualitygates`, `baselines`, `adrs`.
+
+### Edges
+
+Two edge families exist with no common governance:
+
+- **Nine link/relation enums**, one per aggregate, whose `.name()` becomes
+  the edge string: requirements `RelationType` (6 values), assets
+  `AssetRelationType` (7) and `AssetLinkType` (7), controls
+  `ControlLinkType` (7), findings `FindingLinkType` (7), risk scenarios
+  `RiskScenarioLinkType` (9), threat models `ThreatModelLinkType` (7),
+  audits `AuditLinkType` (5), research `ResearchArtifactType` (8). Each has
+  a companion `*LinkTargetType` enum bounding endpoints.
+- **~25 literal edge strings hard-coded inside contributors** (`ASSESSES`,
+  `TRACKS`, `TREATS`, `MAPS_CONTROL`, `OF_CONTROL`, `HAS_SOURCE`,
+  `SUPERSEDED_BY`, `OBSERVED_ON`, `DATA_FLOW`, ...), invisible to any enum
+  or check.
+
+The drift is not hypothetical. The same concept is minted independently
+per aggregate with no declaration that the meanings coincide:
+`ASSOCIATED` appears in six vocabularies, `EVIDENCED_BY` in five,
+`OBSERVED_IN` in four, `DEPENDS_ON` and `IMPLEMENTS` and `AFFECTS` and
+`MITIGATED_BY` in multiple each. Nothing states whether
+`ControlLinkType.EVIDENCED_BY` and `FindingLinkType.EVIDENCED_BY` are one
+concept or two. This is exactly the failure mode the ACES concept-authority
+work names: artifact-local strings becoming de facto semantics.
+
+### The sharpest finding: traceability is not in the graph
+
+`TraceabilityLink` - the `IMPLEMENTS` / `TESTS` / `DOCUMENTS` /
+`CONSTRAINS` / `VERIFIES` edges from requirements to artifacts, the
+platform's founding value proposition - is **not projected into the AGE
+graph**. Only requirement-to-requirement `RelationType` edges are. The
+"living context graph" currently omits the traceability spine; coverage
+questions are answered relationally, invisible to graph traversal, and the
+GRC screening's code-keyed link walks run on a different plane than the
+graph the console renders.
+
+### Identity
+
+Uniform and healthy: node id = `GraphEntityType.name() + ":" + UUID`
+(`GraphIds.nodeId`), with the human UID (`GC-XXX-NNN`) carried as a
+property where one exists, and project scoping validated at query time.
+No changes needed beyond registering the scheme in the ontology artifact.
+
+### Time
+
+Richer than expected, but fragmented across five mechanisms with no
+declared spine:
+
+| Mechanism | Scope | As-of capable? |
+|-----------|-------|----------------|
+| Envers audit (~80 entities, custom revision entity with actor) | Nearly every aggregate | Yes - true point-in-time reconstruction exists (`BaselineService.getRequirementsAtRevision`, `AuditService` diffs) but only requirements/baselines use it |
+| ADR-045 evidence state history | Observations vs evidence artifacts; append-only supersession chains | Partially - `asOf` params on evidence-state and GRC analysis reads |
+| ADR-062 graph snapshots | Whole-projection versions with publication metadata | Snapshot-granular only; no tie to Envers revisions |
+| Baselines | Requirements only, pinned to an Envers revision | Yes, requirements only |
+| Ad hoc `asOf` params | Many GRC read services | Per-service semantics, undeclared |
+
+The asset that matters: Envers revision numbers are already a total order
+over nearly all domain writes, with actor attribution. A canonical as-of
+spine can be declared rather than built.
+
+### Ontology documentation
+
+Prose only (`docs/architecture/ARCHITECTURE.md`, Mixed-Entity Graph
+section) plus ADRs 005/011/019/020/032/045/062/070. There is no
+machine-readable ontology artifact; the authoritative vocabulary lives in
+one enum, nine link enums, and contributor literals.
+
+## 2. The ACES SDL question
+
+### What actually exists at `../aces-sdl` origin/dev
+
+A YAML-based, backend-agnostic scenario description language with a Python
+reference implementation - and, more importantly for this assessment, a
+**production-grade concept-authority stack** (its ADR-012; GOV-917 through
+GOV-922, all implemented):
+
+- Three layers: concept authority (what concepts mean; UCO as the cyber
+  semantic spine) / ACES-native concepts / **artifact bindings** (each
+  artifact binds its local strings to canonical concepts, preventing
+  artifact-local semantics).
+- **Concept families as data** (`contracts/concept-authority/concept-families-v1.json`),
+  each carrying `provenance` (adopted / adapted / native) and, for native
+  families, mandatory `extension_scope`, `relation_rules`, and
+  `non_ambiguity_constraints`.
+- **A closed effect vocabulary for external ontologies**: an external
+  authority may only `annotate | align | refine | constrain` native
+  meaning - never become syntax or implicit schema inheritance.
+- Controlled vocabularies with governed extension (`x-<owner>:<term>`),
+  shared semantic profiles, reference models, and a content-hashed schema
+  publication manifest with an explicit evolution policy.
+- Its governing rule, verbatim in spirit: work extends the existing
+  semantic authority stack rather than introducing a parallel registry.
+- A typed declared-vs-observed reconciliation model: `CREATE / UPDATE /
+  DELETE / UNCHANGED` deltas computed against provenance-bound snapshots,
+  and a realization-provenance ledger classifying every realized concern as
+  author-declared, processor-derived, or backend-realized.
+
+### What does not exist there
+
+- It is **cyber-range domain-specialized**: the concept families are
+  assets, identities, observables, actions, scenarios, episodes, runtime
+  inventory. There are no families for requirements, GRC controls,
+  traceability, evidence campaigns, or engineering process. Its "evidence"
+  is experiment evidence; its "controls" are runtime security posture.
+- It is JSON-Schema/Pydantic, not the W3C stack - a governance discipline,
+  not an OWL ontology.
+- Its semantic-integrity umbrella requirement (SEM-200) is still DRAFT
+  with an honestly tracked active/partial/planned coverage table, and no
+  production backend exists.
+
+### The overlap that matters
+
+The overlap is at the **metamodel level**, and it is large:
+
+| Shared problem | ACES artifact | Ground Control counterpart |
+|----------------|---------------|----------------------------|
+| Bounded, owned semantic scopes | The "surface" primitive (named, bounded, contract-bearing, singly owned) | Boundary / architecture-model element / CLD lock levels |
+| Vocabulary drift across artifacts | Concept families + artifact bindings | Nine link enums + literal edge strings (the drift is live here) |
+| Declared vs observed state | Snapshot reconciliation deltas + realization provenance | Derivation/drift machinery, GC-GRC-009 impact/gap/stale sets |
+| Evidence vs interpretation | Captured evidence vs derived measures (EXP-708/709) | ADR-045 observations vs evidence artifacts |
+| Proportionate assurance | Classification-based assurance policy (ASR-505) | ADR-012 ladder, CLD risk scoring |
+| Human/agent mixed control | Supervision/intervention/handoff lifecycles (ACT-617, RUN-310) | HITL gate model (ADR-029, GC-O009) |
+| Provenance | Provenance-and-evidence family, alignment provenance | Research provenance ledger (ADR-069), derivation provenance |
+
+The user's framing holds: a cyber range is an IT organization at the
+limit, and a software organization's development process is an
+environment with participants, objectives, workflows, evidence, and
+drift. The two products are modeling the same metamodel from two domains.
+
+## 3. Options
+
+**A. Ignore ACES; consolidate GC-natively with a bespoke shape.** Fixes
+the drift but invents a second, incompatible semantic-governance pattern
+inside one portfolio - the exact "parallel registry" anti-pattern ACES's
+discipline exists to forbid. Rejected.
+
+**B. Adopt ACES SDL as Ground Control's ontology substrate now.** Rejected
+on maturity and fit: SEM-200 is DRAFT, the domain families GC needs do not
+exist there, and coupling GC's shipping ontology to another pre-1.0
+product's roadmap violates the prefer-no-regression rule. GC would also
+distort ACES: cramming requirements/GRC/traceability into a cyber-range
+vocabulary serves neither.
+
+**C. Adopt the ACES concept-authority *pattern* now, with GC-native
+families in the same artifact shape, a versioned crosswalk to ACES
+families under the closed effect vocabulary, and companion-spec extraction
+as the stated trajectory.** GC publishes its ontology as machine-readable
+data (families with provenance and extension rules; controlled edge
+vocabularies with owners; artifact bindings) under the ADR-082 contracts
+surface, gated by inventory-driven policy in the ADR-034 style. Where a GC
+family genuinely shares a concept with an ACES family (assets,
+observables/evidence, provenance, time, tasks-runs-studies), a crosswalk
+artifact records the alignment with `aligns`/`refines` semantics - no
+runtime dependency in either direction. When ACES's SEM-200 reaches ACTIVE
+and both sides have working family sets, the shared metamodel (surface,
+family, binding, provenance classes, reconciliation deltas, evidence vs
+derived measures, time) is extracted into a companion spec both consume as
+domain packs - and because both sides used the same artifact shape from
+the start, that extraction is a merge, not a rewrite.
+
+**Recommendation: C.** It takes the proven thing that exists (the
+discipline, which is also portfolio-native), refuses the premature thing
+(runtime coupling to a DRAFT semantic core), and makes the eventual
+convergence mechanical instead of aspirational.
+
+## 4. Repairs the census demands regardless of the ACES decision
+
+1. Project `TraceabilityLink` edges into the graph. The traceability spine
+   belongs in the context graph; its absence undercuts the thesis directly.
+2. Retire or implement the three dead node kinds; dead vocabulary in a
+   governed ontology is a contradiction.
+3. Consolidate edge semantics: shared concepts (`EVIDENCED_BY`,
+   `ASSOCIATED`, `OBSERVED_IN`, ...) declared once in a controlled
+   vocabulary and bound per aggregate, replacing nine independent mints
+   and 25 unregistered literals.
+4. Declare the time spine: Envers revision as the canonical as-of
+   coordinate; snapshot metadata (ADR-062) records the revision it was
+   built from; `asOf` parameters get one defined semantics.
+5. Decide the thesis-relevant missing projections (workflow runs, work
+   items, derivation/boundary snapshots, contracts and invariants when
+   milestone 18 lands them).
+
+## 5. Decision and work layout
+
+The binding decision is ADR-083 (option C plus the repairs). Follow-on
+implementation issues are filed in milestone 19; see the milestone for the
+current set.


### PR DESCRIPTION
## Summary

Executes the milestone-19 assessment (#1301) and lands ADR-084. The assessment censuses the context-graph vocabulary - 26 node kinds (3 dead), 9 link enums plus ~25 unregistered literal edge strings, shared concepts minted up to six times, traceability links absent from the graph, five time mechanisms with no spine - and reviews ../aces-sdl's concept-authority stack (read-only, origin/dev). ADR-084 decides: adopt the concept-authority pattern with GC-native families published as data under the ADR-082 contracts surface, gated by inventory-driven bindings (ADR-034 style); repair the census findings (traceability into the graph, dead vocabulary resolved, thesis projections registered deliberately); align with ACES via a hash-pinned crosswalk under the closed annotates/aligns/refines/constrains effect vocabulary with no runtime coupling, companion-spec extraction gated on ACES SEM-200 reaching ACTIVE; declare Envers revisions the canonical as-of spine with snapshots recording their source revision. Follow-ons #1307-#1311 filed in milestone 19. Branch includes the #1289 commits for ADR-numbering coherence; merge after #1289.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1301

## ADR Impact

- ADR-084
- ADR-082
- ADR-034
- ADR-045
- ADR-062
- ADR-011

## Changes

- Add docs/research/context-graph-ontology/assessment.md: vocabulary census, time-mechanism matrix, ACES SDL analysis, options, recommendation
- Add ADR-084: three-layer concept authority, ontology-as-data under contracts/, census repairs, ACES crosswalk + companion-spec gates, Envers as-of spine
- Update the ADR index with the 083 row

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

Doc-only diff (3 files, 425 insertions on top of the #1289 base). Pre-commit hooks passed (policy guardrails, vale clean on all changed docs); make policy passes post-commit. No executable surface.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
