### PR TITLE
Use static imports for Mockito mock/times/atLeast in research and security tests

### DIFF
--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiSecurityConfigTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiSecurityConfigTest.java
@@ -1,5 +1,6 @@
 package com.keplerops.groundcontrol.unit.api.security;
 
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -436,17 +436,17 @@ class ApiSecurityConfigTest {
 
         @Bean
         DataSource dataSourceStub() {
-            return Mockito.mock(DataSource.class);
+            return mock(DataSource.class);
         }
 
         @Bean
         JdbcUserDetailsManager userDetailsManagerStub() {
-            return Mockito.mock(JdbcUserDetailsManager.class);
+            return mock(JdbcUserDetailsManager.class);
         }
 
         @Bean
         JdbcTemplate jdbcTemplateStub() {
-            return Mockito.mock(JdbcTemplate.class);
+            return mock(JdbcTemplate.class);
         }
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/research/ResearchRunDecisionSurfacesServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/research/ResearchRunDecisionSurfacesServiceTest.java
@@ -3,6 +3,7 @@ package com.keplerops.groundcontrol.unit.domain.research;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -148,24 +149,21 @@ class ResearchRunDecisionSurfacesServiceTest {
                 selectionRepository,
                 sourceRepository,
                 methodologyCatalog,
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository.MethodologyRequirementsContractRepository
                                 .class),
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository
                                 .MethodologyRequirementsContractEntryRepository.class),
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository
                                 .MethodologyRequirementsContractEntrySourceLinkRepository.class),
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository
                                 .MethodologyRequirementsContractRejectedAlternativeRepository.class),
-                org.mockito.Mockito.mock(
-                        com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanRepository.class),
-                org.mockito.Mockito.mock(
-                        com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanCoverageRepository.class),
-                org.mockito.Mockito.mock(
-                        com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanSectionRepository.class));
+                mock(com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanRepository.class),
+                mock(com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanCoverageRepository.class),
+                mock(com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanSectionRepository.class));
         project = new Project("research-p", "Research Project", ProjectType.RESEARCH);
         TestUtil.setField(project, "id", PROJECT_ID);
         when(projectService.getById(PROJECT_ID)).thenReturn(project);

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/research/ResearchRunMethodologyServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/research/ResearchRunMethodologyServiceTest.java
@@ -3,7 +3,10 @@ package com.keplerops.groundcontrol.unit.domain.research;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -125,24 +128,21 @@ class ResearchRunMethodologyServiceTest {
                 selectionRepository,
                 sourceRepository,
                 methodologyCatalog,
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository.MethodologyRequirementsContractRepository
                                 .class),
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository
                                 .MethodologyRequirementsContractEntryRepository.class),
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository
                                 .MethodologyRequirementsContractEntrySourceLinkRepository.class),
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository
                                 .MethodologyRequirementsContractRejectedAlternativeRepository.class),
-                org.mockito.Mockito.mock(
-                        com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanRepository.class),
-                org.mockito.Mockito.mock(
-                        com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanCoverageRepository.class),
-                org.mockito.Mockito.mock(
-                        com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanSectionRepository.class));
+                mock(com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanRepository.class),
+                mock(com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanCoverageRepository.class),
+                mock(com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanSectionRepository.class));
         project = new Project("research-p", "Research Project", ProjectType.RESEARCH);
         TestUtil.setField(project, "id", PROJECT_ID);
         when(selectionRepository.save(any())).thenAnswer(inv -> {
@@ -233,7 +233,7 @@ class ResearchRunMethodologyServiceTest {
         // The catalog "systematic" profile declares two required sources; both are
         // snapshotted as required=true rows in ATTEMPTED state.
         var captor = ArgumentCaptor.forClass(ResearchRunMethodologySource.class);
-        verify(sourceRepository, org.mockito.Mockito.times(2)).save(captor.capture());
+        verify(sourceRepository, times(2)).save(captor.capture());
         assertThat(captor.getAllValues())
                 .allSatisfy(s -> {
                     assertThat(s.isRequired()).isTrue();
@@ -295,13 +295,13 @@ class ResearchRunMethodologyServiceTest {
         verify(selectionRepository).save(existing);
         ArgumentCaptor<ResearchRunMethodologySelection> captor =
                 ArgumentCaptor.forClass(ResearchRunMethodologySelection.class);
-        verify(selectionRepository, org.mockito.Mockito.atLeast(2)).save(captor.capture());
+        verify(selectionRepository, atLeast(2)).save(captor.capture());
         var newSel = captor.getAllValues().stream()
                 .filter(s -> s.getMethodKey().equals("scoping"))
                 .findFirst();
         assertThat(newSel).isPresent();
         // The new selection re-snapshots the catalog "scoping" profile's 3 required sources.
-        verify(sourceRepository, org.mockito.Mockito.times(3)).save(any());
+        verify(sourceRepository, times(3)).save(any());
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/research/ResearchRunServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/research/ResearchRunServiceTest.java
@@ -3,7 +3,9 @@ package com.keplerops.groundcontrol.unit.domain.research;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -126,24 +128,21 @@ class ResearchRunServiceTest {
                 selectionRepository,
                 sourceRepository,
                 methodologyCatalog,
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository.MethodologyRequirementsContractRepository
                                 .class),
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository
                                 .MethodologyRequirementsContractEntryRepository.class),
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository
                                 .MethodologyRequirementsContractEntrySourceLinkRepository.class),
-                org.mockito.Mockito.mock(
+                mock(
                         com.keplerops.groundcontrol.domain.research.repository
                                 .MethodologyRequirementsContractRejectedAlternativeRepository.class),
-                org.mockito.Mockito.mock(
-                        com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanRepository.class),
-                org.mockito.Mockito.mock(
-                        com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanCoverageRepository.class),
-                org.mockito.Mockito.mock(
-                        com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanSectionRepository.class));
+                mock(com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanRepository.class),
+                mock(com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanCoverageRepository.class),
+                mock(com.keplerops.groundcontrol.domain.research.repository.ProtocolPlanSectionRepository.class));
         project = new Project("research-p", "Research Project", ProjectType.RESEARCH);
         TestUtil.setField(project, "id", PROJECT_ID);
         when(projectService.getById(PROJECT_ID)).thenReturn(project);
@@ -234,7 +233,7 @@ class ResearchRunServiceTest {
         assertThat(run.getBudgetTokens()).isEqualTo(1000L);
 
         var captor = ArgumentCaptor.forClass(ResearchRunGate.class);
-        verify(gateRepository, org.mockito.Mockito.times(5)).save(captor.capture());
+        verify(gateRepository, times(5)).save(captor.capture());
         assertThat(captor.getAllValues()).hasSize(5).allSatisfy(g -> assertThat(g.getBehavior())
                 .isEqualTo(ResearchGateBehavior.REQUIRE_HUMAN));
     }
@@ -275,7 +274,7 @@ class ResearchRunServiceTest {
         service.start(new StartCmd("RUN-1", AutonomyLevel.AUTONOMOUS, null).toCommand());
 
         var captor = ArgumentCaptor.forClass(ResearchRunGate.class);
-        verify(gateRepository, org.mockito.Mockito.times(5)).save(captor.capture());
+        verify(gateRepository, times(5)).save(captor.capture());
         assertThat(captor.getAllValues())
                 .allSatisfy(g -> assertThat(g.getBehavior()).isEqualTo(ResearchGateBehavior.AUTONOMOUS_DEFAULT));
     }

--- a/changelog.d/+mockito-static-imports.changed.md
+++ b/changelog.d/+mockito-static-imports.changed.md
@@ -1,0 +1,1 @@
+Use static imports for Mockito `mock`/`times`/`atLeast` in the research and API-security unit tests, clearing 28 SonarCloud `java:S8924` findings that were failing the new-issue gate. Mechanical; no behaviour or test semantics change.


### PR DESCRIPTION
## Summary

The SonarCloud new-issue gate is failing on `dev` with 28 `java:S8924` findings, which blocks the `dev → main` release PR (#1350). None of them come from #1346/#1347 — they are pre-existing on `dev`. GC-O007 clause (D) requires the SonarCloud quality gate to be validated and all reviewer findings fixed; this restores it to green.

The call sites spelled Mockito out in full (`org.mockito.Mockito.mock(...)`) while `verify`/`when`/`never` were already static-imported in the same files. Mechanical: no behaviour change, no test semantics touched. No new requirement is implemented and no traceability links are added — this is gate hygiene on existing tests.

## Requirement UIDs

- `GC-O007`

## Related Issues

Unblocks #1350 (`dev → main`), which gates the backend deploy that #1346 Phase E depends on.

## ADR Impact

- No ADR required

## Changes

- `ResearchRunServiceTest` — static imports for `mock`, `times`.
- `ResearchRunMethodologyServiceTest` — static imports for `mock`, `times`, `atLeast` (`atLeast` was the same smell in the same file and would have tripped the gate on the next analysis).
- `ResearchRunDecisionSurfacesServiceTest` — static import for `mock`.
- `ApiSecurityConfigTest` — static import for `mock`; drops the now-unused plain `import org.mockito.Mockito;`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

`make check` green (build + tests + SpotBugs + Spotless + JaCoCo). Affected suites pass: `*ResearchRun*`, `*ApiSecurityConfigTest*`. `make policy` green. No behaviour or test-semantics change — assertions, stubs and verification counts are byte-identical; only the import form changed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/+mockito-static-imports.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.
