### PR TITLE
fix: scope policy diff to merge-base so trailing branches aren't over-flagged

### DIFF
--- a/architecture/adrs/054-documentation-coverage-gate.md
+++ b/architecture/adrs/054-documentation-coverage-gate.md
@@ -8,6 +8,23 @@ accepted
 
 2026-05-23
 
+> **Sync note (2026-07-14, policy diff-base merge-base fix):** Fixed the `base`
+> arm of `read_changed_files` in `tools/policy/checks.py` to scope the diff to
+> `merge-base(base, HEAD)` (new `merge_base_or` helper) instead of the two-dot
+> `git diff <base> --`. Two-dot compares the tip of `base` against the working
+> tree, so any commit `base` gains after a branch forks is attributed to the
+> branch. On a busy repo where `dev` advances mid-PR, the diff-scoped gates
+> (this documentation-coverage gate, the changelog-fragment gate, and
+> enum/controller parity) fire on files the branch never touched (observed on
+> PR #1393). The merge-base scope matches GitHub's own PR diff. The working-tree
+> comparison is preserved so the local and pre-push path still catches
+> uncommitted changes, and the helper falls back to `base` when no common
+> ancestor exists. This is a
+> policy-tooling correctness fix, not a documentation-classifier change: the
+> documentation-coverage classifier, `outcome_required` mapping, Vale rule set,
+> `tools/install-vale.sh`, and `.vale.ini` are unchanged, and no new
+> `docs/DOC_STYLE.md` style rule is established.
+
 > **Sync note for issue #1307 (2026-07-14, ontology binding gate):** Added
 > `tools/policy/checks.py::run_ontology_binding_check` to validate the three
 > ADR-084 ontology contracts and compare their surface-qualified bindings with

--- a/docs/DOC_STYLE.md
+++ b/docs/DOC_STYLE.md
@@ -1,5 +1,15 @@
 # Documentation style
 
+> **Sync note (2026-07-14, policy diff-base merge-base fix):** Fixed the `base`
+> arm of `read_changed_files` in `tools/policy/checks.py` to scope the diff to
+> `merge-base(base, HEAD)` instead of the two-dot `git diff <base> --`, so a PR
+> branch that trails `dev` is no longer charged with `dev`'s later commits by
+> the diff-scoped gates (observed on PR #1393, where an unrelated 2-file change
+> tripped `doc-coverage-outcome-missing` on `dev`'s own docs). This is a
+> policy-tooling correctness fix, not a documentation-classifier change: the
+> documentation-coverage classifier, Vale rule set, `tools/install-vale.sh`,
+> and `.vale.ini` are unchanged, and no DOC_STYLE.md style rule changed.
+
 > **Sync note for issue #1307 (2026-07-14, ontology binding gate):** Added
 > `tools/policy/checks.py::run_ontology_binding_check` for the ADR-084 ontology
 > contracts and their independently discovered Java vocabulary inventory.

--- a/tools/policy/checks.py
+++ b/tools/policy/checks.py
@@ -370,6 +370,40 @@ def run_git(args: list[str], root: Path = REPO_ROOT) -> str:
     return result.stdout
 
 
+def merge_base_or(base: str, ref: str = "HEAD", root: Path = REPO_ROOT) -> str:
+    """Resolve the point from which ``ref`` diverged from ``base``.
+
+    ``git diff <base> --`` is a two-dot comparison: it reports every path that
+    differs between the tip of ``base`` and the working tree, so any commit
+    ``base`` gained AFTER the branch forked is wrongly attributed to the branch.
+    On a busy repo where ``dev`` advances while a PR is open, that mis-attributes
+    ``dev``'s own later changes to the PR — spuriously tripping the diff-scoped
+    gates (documentation coverage, changelog fragments) on files the branch
+    never touched.
+
+    Diffing from ``merge-base(base, ref)`` instead yields only what the branch
+    itself changed, matching what GitHub shows as the PR diff. Comparing that
+    merge base against the working tree (rather than ``base...ref``) preserves
+    the caller's intent of catching still-uncommitted changes in the local /
+    pre-push path.
+
+    Falls back to ``base`` when no common ancestor exists (unrelated histories)
+    or ``git merge-base`` fails, so the check degrades to the prior behavior
+    instead of raising.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", base, ref],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return base
+    return result.stdout.strip() or base
+
+
 def read_changed_files(
     *,
     files: Iterable[str] | None = None,
@@ -384,7 +418,10 @@ def read_changed_files(
         raw = os.getenv(env_var, "")
         return sorted({normalize_path(path) for path in raw.splitlines() if path.strip()})
     if base:
-        output = run_git(["diff", "--name-only", "--diff-filter=ACDMRTUXB", base, "--"], root=root)
+        diff_base = merge_base_or(base, root=root)
+        output = run_git(
+            ["diff", "--name-only", "--diff-filter=ACDMRTUXB", diff_base, "--"], root=root
+        )
         return sorted({normalize_path(path) for path in output.splitlines() if path.strip()})
     if staged:
         output = run_git(["diff", "--cached", "--name-only", "--diff-filter=ACDMRTUXB", "--"], root=root)

--- a/tools/tests/test_policy.py
+++ b/tools/tests/test_policy.py
@@ -2923,6 +2923,54 @@ class ChangelogFragmentChecksTest(unittest.TestCase):
                 "changelog fragment.",
             )
 
+    def test_read_changed_files_base_uses_merge_base_not_two_dot(self):
+        # Regression: `git diff <base>` is a two-dot comparison, so commits
+        # `base` gains AFTER the branch forks get mis-attributed to the
+        # branch. On a busy repo where dev advances while a PR is open, that
+        # spuriously trips the diff-scoped gates (documentation coverage,
+        # changelog fragments) on files the branch never touched.
+        # read_changed_files(base=...) must diff from the merge base so it
+        # reports only what the branch itself changed.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir).resolve()
+            import subprocess
+
+            def git(*args: str) -> str:
+                return subprocess.run(
+                    ["git", "-c", "user.email=t@e", "-c", "user.name=t", *args],
+                    cwd=root,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout
+
+            git("init", "-q", "-b", "dev")
+            (root / "seed.txt").write_text("seed\n")
+            git("add", "-A")
+            git("commit", "-q", "-m", "seed")
+            # Fork a feature branch from this point.
+            git("switch", "-q", "-c", "feature")
+            (root / "feature_only.txt").write_text("f\n")
+            git("add", "-A")
+            git("commit", "-q", "-m", "feature change")
+            # dev advances AFTER the fork with an unrelated file.
+            git("switch", "-q", "dev")
+            (root / "dev_only.txt").write_text("d\n")
+            git("add", "-A")
+            git("commit", "-q", "-m", "dev advances")
+            # Back on the feature branch, diff against the advanced dev tip.
+            git("switch", "-q", "feature")
+
+            paths = read_changed_files(base="dev", root=root)
+            self.assertIn("feature_only.txt", paths)
+            self.assertNotIn(
+                "dev_only.txt",
+                paths,
+                "read_changed_files(base=...) must diff from the merge base; a "
+                "commit dev gained after the branch forked must not be "
+                "attributed to the branch.",
+            )
+
     def test_changelog_signal_flags_pure_deletion_of_source(self):
         # The fragment gate must apply even when the entire diff is a
         # deletion of application source — the user-visible behavior


### PR DESCRIPTION
## Summary

`read_changed_files(base=...)` in `tools/policy/checks.py` computed the PR's changed-file set with a two-dot `git diff --name-only <base> --`, which compares the *tip* of `base` against the working tree. Any commit `base` gains after a branch forks is therefore attributed to the branch. On a busy repo where `dev` advances while a PR is open, the diff-scoped gates (documentation coverage, changelog fragments, enum/controller parity) fire on files the branch never touched.

This surfaced on PR #1393: a 2-file `.gitignore`/`.claude` hygiene change failed `doc-coverage-outcome-missing` because `dev` had advanced 11 commits after the branch forked, so CI counted `dev`'s own `ADR-054`/`docs/*`/`checks.py` changes as part of the PR.

The fix diffs from `merge-base(base, HEAD)` via a new `merge_base_or` helper, matching what GitHub shows as the PR diff. The working-tree comparison is preserved so the local and pre-push path still catches uncommitted changes, and the helper falls back to `base` when no common ancestor exists.

## Requirement UIDs

- (none — policy-tooling correctness fix; see ADR Impact and Traceability below)

## Related Issues

None as a tracked issue — bug found while landing PR #1393.

## ADR Impact

- ADR-054 (Documentation coverage gate): sync note added recording the diff-base change. No new ADR required; behavior of the doc-coverage classifier, outcome mapping, and Vale rules is unchanged.

## Changes

- `tools/policy/checks.py`: add `merge_base_or`; the `base` arm of `read_changed_files` now diffs from `merge-base(base, HEAD)` instead of two-dot `git diff <base> --`.
- `tools/tests/test_policy.py`: regression test proving a commit `dev` gains after the branch forks is not attributed to the branch.
- `architecture/adrs/054-documentation-coverage-gate.md`, `docs/DOC_STYLE.md`: sync notes required by the `doc-coverage-gate-sync` rule.

## Test Plan

- [x] `make policy` passes (261 policy-tool tests, backup policy, Vale, repo guardrails).
- [x] New regression test `test_read_changed_files_base_uses_merge_base_not_two_dot` passes; verified it fails against the old two-dot behavior.
- Integration tests: N/A — no backend runtime surface touched.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: N/A — policy-tooling fix, no requirement UID; governance recorded in the ADR-054 sync note.
- TESTS: `tools/tests/test_policy.py::ChangelogFragmentChecksTest::test_read_changed_files_base_uses_merge_base_not_two_dot`.

## Documentation

- Outcome: updated. `architecture/adrs/054-documentation-coverage-gate.md` and `docs/DOC_STYLE.md` carry the required policy-surface sync notes for the diff-base change.
- `docs/DEVELOPMENT_WORKFLOW.md` and `architecture/adrs/README.md`: verified unchanged. This is an internal correctness fix to an existing check's diff scope, not a new workflow step or ADR, so neither the workflow reference nor the ADR index needs an entry.

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- Changelog fragment: N/A — `tools/policy/`, `tools/tests/`, and docs are outside the application-source paths that require a fragment.
- [x] Architectural docs updated (ADR-054 + DOC_STYLE.md sync notes).
