### PR TITLE
docs: remove retired GC-GRC-009 reference from ADR-084 section 4

### DIFF
--- a/architecture/adrs/084-context-graph-concept-authority.md
+++ b/architecture/adrs/084-context-graph-concept-authority.md
@@ -165,10 +165,7 @@ validated against the controlled vocabulary.
   evidence versus derived measures, and time - is extracted into a
   companion specification both products consume as domain packs. Because
   both sides use the same artifact shape from the start, extraction is a
-  merge of catalogs, not a rewrite. Ground Control's reconciliation
-  vocabulary (GC-GRC-009 impact/gap/stale, drift machinery) shall be
-  expressible in those delta terms so the convergence claim stays
-  checkable.
+  merge of catalogs, not a rewrite.
 - **Full adoption of ACES SDL as Ground Control's ontology substrate is
   rejected for now** (assessment §3, option B): the semantic core is
   DRAFT, the needed domain families do not exist there, and coupling a


### PR DESCRIPTION
## Summary

ADR-089 retired the composed GRC product surface and deprecated GC-GRC-009, but did not sweep ADR-084. Section 4 still required Ground Control's reconciliation vocabulary (GC-GRC-009 impact/gap/stale, drift machinery) to be expressible in ACES delta terms, citing a requirement and machinery that no longer exist in the backend. Issue #1310 copied the clause into its scope and became unimplementable as a result. This deletes the dead sentence.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1404

## ADR Impact

- ADR-084
- ADR-089

## Changes

- Remove the GC-GRC-009 reconciliation-vocabulary sentence from ADR-084 section 4 (The ACES relationship)

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

Doc-only change. `make policy` and pre-commit on the changed file pass, including the Vale prose lint (ADR-054). Verified GC-GRC-009 no longer appears anywhere in ADR-084.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
