### PR TITLE
fix: resolve SonarCloud findings

### DIFF
--- a/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java
@@ -70,6 +70,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  * row), repeatable-read raises no write-serialization conflict for concurrent publishers, which are
  * additionally serialized by an advisory lock.
  */
+// This is an infrastructure adapter; ArchitectureTest reserves @Service for ..service.. packages.
+@SuppressWarnings("java:S5673")
 @Component
 @Transactional(isolation = Isolation.REPEATABLE_READ)
 public class AgeGraphService implements GraphClient, MixedGraphClient {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AsOfRevisionResolverTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AsOfRevisionResolverTest.java
@@ -9,10 +9,10 @@ import com.keplerops.groundcontrol.domain.audit.repository.RevisionRepository;
 import com.keplerops.groundcontrol.domain.audit.service.AsOfRevisionResolver;
 import java.time.Instant;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -22,12 +22,8 @@ class AsOfRevisionResolverTest {
     @Mock
     private RevisionRepository revisionRepository;
 
+    @InjectMocks
     private AsOfRevisionResolver resolver;
-
-    @BeforeEach
-    void setUp() {
-        resolver = new AsOfRevisionResolver(revisionRepository);
-    }
 
     @Test
     void resolveAsOf_convertsInstantToExactEpochMillisBoundary() {

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/BaselineServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/BaselineServiceTest.java
@@ -27,10 +27,10 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -48,18 +48,15 @@ class BaselineServiceTest {
     @Mock
     private ProjectRepository projectRepository;
 
+    @SuppressWarnings("UnusedVariable") // Injected into BaselineService via @InjectMocks; Error Prone misses the wire.
     @Mock
     private EntityManager entityManager;
 
     @Mock
     private AsOfRevisionResolver asOfRevisionResolver;
 
+    @InjectMocks
     private BaselineService service;
-
-    @BeforeEach
-    void setUp() {
-        service = new BaselineService(baselineRepository, projectRepository, entityManager, asOfRevisionResolver);
-    }
 
     private Project makeProject() {
         var project = new Project("test-project", "Test Project");

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/infrastructure/AgeGraphSnapshotRepositoryTest.java
@@ -7,9 +7,9 @@ import static org.mockito.Mockito.when;
 
 import com.keplerops.groundcontrol.infrastructure.age.AgeGraphSnapshotRepository;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -21,12 +21,8 @@ class AgeGraphSnapshotRepositoryTest {
     @Mock
     private JdbcTemplate jdbcTemplate;
 
+    @InjectMocks
     private AgeGraphSnapshotRepository repository;
-
-    @BeforeEach
-    void setUp() {
-        repository = new AgeGraphSnapshotRepository(jdbcTemplate);
-    }
 
     @Test
     void nextVersion_returnsSequenceValue() {


### PR DESCRIPTION
## Summary

Resolve the four SonarCloud findings blocking the `dev` to `main` promotion PR by moving three constructor-injected tests to Mockito-managed `@InjectMocks` wiring and explicitly documenting why the AGE infrastructure adapter remains a Spring `@Component`.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1419

## ADR Impact

- ADR-021

## Changes

- Replace manual `AsOfRevisionResolver`, `BaselineService`, and `AgeGraphSnapshotRepository` construction with the repository-standard `@InjectMocks` pattern.
- Preserve `AgeGraphService` as an infrastructure `@Component` and suppress `java:S5673` with the architectural reason: the ArchUnit contract reserves `@Service` for `..service..` packages.
- Add the narrow Error Prone suppression required for the `EntityManager` mock whose use occurs through Mockito injection.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Focused verification passed for the four affected unit-test classes and the architecture rule. Final `make check`, `make policy`, all five project quality gates, and `pre-commit run --all-files` passed.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #1419 ← backend/src/main/java/com/keplerops/groundcontrol/infrastructure/age/AgeGraphService.java, Issue #1419 ← three affected Mockito unit-test classes
- TESTS: Issue #1419 ← AsOfRevisionResolverTest, Issue #1419 ← BaselineServiceTest, Issue #1419 ← AgeGraphSnapshotRepositoryTest, Issue #1419 ← AgeGraphServiceTest and ArchitectureTest

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed