### PR TITLE
ci: open the dev to main promotion pr with a conventional title

### DIFF
--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -1,0 +1,86 @@
+name: Promote dev -> main
+
+# Open the `dev` -> `main` promotion PR with a Conventional Commit title (GC-P027,
+# ADR-021 issue #901 amendment; issue #1444).
+#
+# Why this exists: a promotion PR opened by hand inherits GitHub's default title from the
+# head branch name — literally `Dev` — which fails `.github/workflows/pr-title.yml` on both
+# rules (no conventional type, uppercase subject). That check is not in `main`'s required
+# set, so those PRs merged with a red X; a permanently-red check on a recurring PR class
+# trains reviewers to merge past red. Fixing the title at the point of creation removes the
+# failure without exempting the gate or making it non-blocking.
+#
+# Why `chore(main):` is the right type: the promotion is merge-committed, so this title
+# becomes a merge-commit subject on `main`. `chore` neither bumps the version nor adds a
+# changelog entry, which is correct — the release content comes from the individual
+# `feat:` / `fix:` subjects preserved from `dev`, which Release Please parses directly.
+#
+# Why `workflow_dispatch` only: promotion timing is a human release decision. This workflow
+# changes how the PR is named, never when it is opened. Contrast
+# `sync-main-to-dev.yml`, which fires on `push: main` because a back-merge is always wanted
+# after a release lands.
+#
+# Why `--head dev` and not a dedicated automation branch: the promotion PR must merge `dev`
+# itself so the merge commit carries `dev`'s history as a parent and the Conventional Commit
+# subjects stay discoverable on `main`. `sync-main-to-dev.yml` can use a disposable branch
+# because it force-updates that branch from `main`; here the history IS the payload.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: promote-dev-to-main
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Open dev -> main promotion PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - name: Open or reuse the promotion PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TITLE: "chore(main): promote dev"
+          PR_BODY: |
+            Automated promotion PR (GC-P027, ADR-063; issue #1444): promotes the accumulated
+            `dev` work to `main`, where Release Please parses Conventional Commit history to
+            cut the next release.
+
+            **Merge with a merge commit — not squash, not rebase.** The individual
+            Conventional Commit subjects from `dev` are the release input. Squashing collapses
+            them into this PR's single `chore(main): promote dev` subject, which Release
+            Please cannot classify, and that release's CHANGELOG entries are lost. See
+            `docs/DEVELOPMENT_WORKFLOW.md` § Release model.
+
+            This PR is exempt from the per-PR body contract: each feature PR already
+            satisfied it on the way into `dev` (`_is_release_pr` in
+            `tools/policy/checks.py`).
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main dev
+
+          # Compare committed content, not commit counts: after a release the histories
+          # diverge (main carries the release commit) while there may be nothing on `dev`
+          # left to promote.
+          if git diff --quiet origin/main origin/dev; then
+            echo "main and dev content already match; nothing to promote."
+            exit 0
+          fi
+
+          # Reuse by head+base, never by title, so a retitled PR is not duplicated.
+          existing="$(gh pr list --head dev --base main --state open \
+            --json number --jq '.[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            echo "Promotion PR #${existing} is already open for dev -> main."
+            exit 0
+          fi
+
+          gh pr create --base main --head dev \
+            --title "${PR_TITLE}" \
+            --body "${PR_BODY}"

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -445,6 +445,15 @@ the mechanics below.
   the individual Conventional Commit subjects from `dev` remain discoverable
   on `main`, where Release Please parses history. A promotion that squashed or
   rewrote those subjects would give Release Please nothing to classify.
+- **The promotion PR is opened by a workflow, so its title is not a matter of memory.**
+  Run `.github/workflows/promote-dev-to-main.yml` (`workflow_dispatch`) to open the
+  `dev` to `main` PR as `chore(main): promote dev`. A promotion PR opened by hand
+  inherits GitHub's default title from the head branch name - literally `Dev` - which
+  fails the title gate on both rules and, because the check is not in `main`'s required
+  set, merges with a red X. The workflow controls only the naming: promotion timing stays
+  a human decision, and the gate is neither exempted nor made non-blocking. `chore` is the
+  correct type because it neither bumps the version nor adds a changelog entry; the release
+  content comes from the `feat:` / `fix:` subjects preserved from `dev`.
 - **The release PR does the mechanical work.** On every push to `main`,
   `.github/workflows/release-please.yml` (googleapis/release-please-action)
   maintains a `chore(main): release X.Y.Z` PR that regenerates `CHANGELOG.md`


### PR DESCRIPTION
## Summary

Every `dev` -> `main` promotion PR was titled `Dev` — GitHub's default from the head branch name — which fails `.github/workflows/pr-title.yml` on both rules at once: no conventional-commit type, and an uppercase-leading subject. Because that check is not in `main`'s required status checks, those PRs merged with a red X (#1442, #1432, #1428, #1418, #1403, #1401, #1392, #1363, #1350). A permanently-red check on a recurring PR class trains reviewers to merge past red, and it is the only signal that would object if someone squash-merged a promotion — which would collapse `dev`'s Conventional Commit subjects into one unclassifiable commit and lose that release's CHANGELOG.

This adds `.github/workflows/promote-dev-to-main.yml`, mirroring the existing `sync-main-to-dev.yml` pattern in the opposite direction, so the promotion PR is opened as `chore(main): promote dev`. The gate is not exempted, not made non-blocking, and not removed from any required set — the title is simply correct at the point of creation.

## Requirement UIDs

- (none — maintenance run; see Traceability section below)

## Related Issues

Closes #1444

## ADR Impact

- ADR-021
- ADR-063

## Changes

- Add `.github/workflows/promote-dev-to-main.yml`: `workflow_dispatch`-only job that opens the `dev` -> `main` PR with the title `chore(main): promote dev`
- Guard on content equality (`git diff --quiet origin/main origin/dev`) so a no-op promotion opens nothing
- Reuse an existing open promotion PR by head+base rather than by title, so a retitled PR is never duplicated
- PR body instructs a merge commit and states why squash or rebase would destroy the release input
- Document the promotion step in `docs/DEVELOPMENT_WORKFLOW.md` § Release model

## Design notes

- **`workflow_dispatch` only.** Promotion timing is a human release decision; this changes how the PR is named, never when it is opened. `sync-main-to-dev.yml` fires on `push: main` because a back-merge is always wanted after a release lands — the promotion direction is not analogous.
- **`--head dev`, not a disposable automation branch.** The merge commit must carry `dev`'s history as a parent so the Conventional Commit subjects stay discoverable on `main`. `sync-main-to-dev.yml` can force-update a throwaway branch because it copies `main`; here the history is the payload.
- **`chore` is the correct type.** The promotion is merge-committed, so this title becomes a merge-commit subject on `main`. `chore` neither bumps the version nor adds a changelog entry, which is right — release content comes from the preserved `feat:` / `fix:` subjects.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Title verified against the repository's own validator rather than by inspection: `validateImplementPrTitle("chore(main): promote dev")` returns ok, and `validateImplementPrTitle("Dev")` fails with `title must match <type>(<optional-scope>): <subject>` — reproducing the observed production failure. `actionlint` exits 0 on the new workflow; the YAML parses and the `run` block passes `bash -n`. 184 policy tests pass, `make policy` passes, Vale clean.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-021 ← .github/workflows/promote-dev-to-main.yml
- TESTS: ADR-021 ← verified via validateImplementPrTitle and actionlint (no new test file; the title contract is already covered by mcp/ground-control/lib.test.js and the pr-title workflow itself)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: `docs/DEVELOPMENT_WORKFLOW.md` § Release model documents how the promotion PR is opened and why the title matters.
