### PR TITLE
ci: drop broad verification from commit-time pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,25 +58,26 @@ repos:
       - id: gitleaks
 
   # =============================================================================
-  # STAGE 3: Full verification (CI-equivalent)
+  # STAGE 3: Push-time checks
   # =============================================================================
+  #
+  # Broad verification (`./gradlew check`, `bin/policy`, Vale, OpenJML ESC) is
+  # deliberately absent here. Each of those already runs twice per change: once
+  # at the /implement completion + policy gates (Step 6, then again on the
+  # post-base-sync tree at Step 8.5) and once in the CI `policy` / `test` /
+  # `openjml` jobs. Re-running them at commit time made every commit pay for
+  # verification the workflow had just performed on the same tree, and the
+  # commit-time copy is the weakest of the three: it is skippable with
+  # `--no-verify`, it is path-filtered so it silently degrades on diffs outside
+  # `^backend/`, and it leaves no record any gate can attest to. Commit time
+  # keeps only what nothing else does: file hygiene, secret scanning, and
+  # auto-formatting.
+  #
+  # `make check` / `make policy` remain the local way to run the broad gates on
+  # demand; nothing about their coverage changed.
 
   - repo: local
     hooks:
-      - id: repo-policy
-        name: repo policy guardrails
-        entry: bash -c 'BASE_REF="${BASE_REF:-origin/dev}"; python3 bin/policy --base "$BASE_REF" --skip-pr-body'
-        language: system
-        files: ^(AGENTS\.md|\.claude/|\.github/|architecture/|backend/|docs/|mcp/|specs/|tools/)
-        pass_filenames: false
-
-      - id: vale-prose-lint
-        name: Vale prose lint (ADR-054)
-        entry: tools/vale-lint-hook.sh
-        language: system
-        types_or: [markdown]
-        exclude: ^(CHANGELOG\.md|node_modules/|\.tools/|\.vale/)
-
       - id: pr-body-policy
         name: pr body template (only on push, when a PR exists)
         entry: scripts/check-pr-body.sh
@@ -84,17 +85,3 @@ repos:
         stages: [pre-push]
         pass_filenames: false
         always_run: true
-
-      - id: gradle-check
-        name: gradle check (build + test + static analysis + coverage)
-        entry: bash -c 'cd backend && ./gradlew check -q'
-        language: system
-        files: ^backend/
-        pass_filenames: false
-
-      - id: openjml-esc
-        name: openjml ESC (formal verification of JML contracts)
-        entry: bash -c 'cd backend && ./gradlew openjmlEsc -q'
-        language: system
-        files: ^backend/src/main/java/com/keplerops/groundcontrol/domain/(requirements|adrs)/state/
-        pass_filenames: false

--- a/architecture/adrs/054-documentation-coverage-gate.md
+++ b/architecture/adrs/054-documentation-coverage-gate.md
@@ -144,13 +144,14 @@ third value permits a rationale string (1-2000 characters); the other two
 reject it (strict). When `outcome_required` is true and the field is absent,
 the renderer rejects the input rather than posting an incomplete record.
 
-**Layer 3: Vale prose linter wired into `make policy`, CI, and pre-commit.**
+**Layer 3: Vale prose linter wired into `make policy` and CI.**
 Vale with the `errata-ai/Google` package enforces the Google Developer
 Documentation Style Guide on docs modified in the current diff. The binary is
 pinned to a specific version, verified by SHA-256 checksum, and installed by
-`tools/install-vale.sh` to `.tools/vale/` (gitignored). The pre-commit hook
-installs Vale automatically on first need rather than skipping; agents and
-contributors do not bypass the gate by virtue of a fresh clone.
+`tools/install-vale.sh` to `.tools/vale/` (gitignored). Both `make policy` and
+the CI policy job install Vale automatically on first need rather than
+skipping; agents and contributors do not bypass the gate by virtue of a fresh
+clone.
 
 **House-style overrides (`GoogleProject/` namespace).** The `.vale/styles/GoogleProject/`
 directory is the registry for project-specific rules that augment the upstream
@@ -225,8 +226,8 @@ current with the actual classifier surface.
   deliberate cost.
 - **Graceful skip when Vale is not installed locally**: rejected. Lets agents
   and contributors commit unlinted prose on fresh clones, which is the
-  failure mode the gate exists to prevent. The pre-commit hook installs Vale
-  via `tools/install-vale.sh` on first need.
+  failure mode the gate exists to prevent. `make policy` and the CI policy job
+  install Vale via `tools/install-vale.sh` on first need.
 
 ## References
 
@@ -592,6 +593,24 @@ is documented in `docs/DEVELOPMENT_WORKFLOW.md` and an ADR-027 amendment, and
 `docs/DOC_STYLE.md` records why a new environment variable that repository
 commands depend on needs a durable record even though the field itself is only
 a contract surface. The documentation-coverage classifier
+(`classifyChangedSurface`), its `outcome_required` mapping, the Vale rules,
+`tools/install-vale.sh`, and `.vale.ini` are unchanged; no new documentation
+classification or style rule is established.
+
+**2026-07-27 (commit-time broad-gate de-duplication).** Removed the
+`vale-prose-lint`, `repo-policy`, `gradle-check`, and `openjml-esc` hooks from
+`.pre-commit-config.yaml`. Each re-ran work the `/implement` completion and
+policy gates already perform at Step 6 and again on the post-base-sync tree at
+Step 8.5, and that the CI `policy`, `test`, and `openjml` jobs perform on every
+pull request. The commit-time copy was the weakest of the three: skippable with
+`--no-verify`, path-filtered so it degraded silently on diffs outside its
+`files:` patterns, and producing no result any gate or workflow record could
+attest to. Vale enforcement is unchanged in substance - `make policy` and the
+CI policy job remain the authoritative surfaces, and both still install Vale on
+first need. Layer 3 prose and the rejected "graceful skip" alternative are
+updated to name those two surfaces instead of the hook. The eight hygiene and
+secret-scan hooks pinned by `run_ci_strictness_contract` are untouched, as is
+the ADR-025 backup-policy assertion. The documentation-coverage classifier
 (`classifyChangedSurface`), its `outcome_required` mapping, the Vale rules,
 `tools/install-vale.sh`, and `.vale.ini` are unchanged; no new documentation
 classification or style rule is established.

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -344,7 +344,7 @@ The guard is a pre-execution *lexical* policy control, not an OS sandbox. It pro
   `allowed_edges`. The backend surface is enforced against the same registry by
   `RegistryBoundaryArchitectureTest` (ArchUnit, in the `test` job). See
   `architecture/registry/README.md` for the schema (GC-CLD-2 / ADR-087 §3).
-- `make policy` is the common path for Claude, Codex, pre-commit, and CI
+- `make policy` is the common path for Claude, Codex, and CI
 - `make sync-ground-control-policy` and `make policy-live` keep Ground Control quality gates and ADR metadata aligned when a live GC instance is available
 
 Commit-time pre-commit activation is a separate per-clone contract from the
@@ -357,6 +357,19 @@ once per fresh clone: it writes managed `pre-commit`/`pre-push` hooks into the
 clone-local hook path the dispatcher delegates to, proves Git actually dispatches
 to them, then runs `pre-commit run --all-files`. `.git/hooks/` is not versioned, so
 this step does not survive a fresh clone by design; re-run it after cloning.
+
+Commit time carries only the checks nothing else performs: file hygiene, secret
+scanning with gitleaks, `bash -n` on operator scripts, Spotless auto-formatting,
+and the GC-P021 backup-policy assertion required by ADR-025. Broad verification
+runs at three points that each see a tree the commit hook cannot: the
+`/implement` completion and policy gates at Step 6, the same two gates on the
+post-base-sync tree at Step 8.5, and the CI `policy`, `test`, and `openjml`
+jobs. A fourth copy at commit time re-verified a tree the Step 6 gates had just
+certified, and it was the weakest copy of the four - skippable with
+`--no-verify`, path-filtered so it degraded silently on diffs outside its
+`files:` patterns, and leaving no result any gate or workflow record could
+attest to. Run `make check` or `make policy` directly to exercise the broad
+gates locally on demand.
 
 ### Contract Surface and MCP Write-Contract Gates (ADR-034, ADR-082)
 

--- a/docs/DOC_STYLE.md
+++ b/docs/DOC_STYLE.md
@@ -186,9 +186,11 @@ prose-lint gate. See `.vale/styles/GoogleProject/EmDashDensity.yml`.
 ## Enforcement
 
 Vale with the `errata-ai/Google` package runs on docs touched in the current
-diff via `make policy`, the CI `policy` job, and the pre-commit `vale-prose-lint`
-hook. The hook installs Vale via `tools/install-vale.sh` on first need; no
-manual `make vale-install` step is required.
+diff via `make policy` and the CI `policy` job. Both install Vale via
+`tools/install-vale.sh` on first need; no manual `make vale-install` step is
+required. Vale does not run at commit time: `make policy` already runs it at
+the `/implement` policy gate and again on the post-base-sync tree, and CI runs
+it on every pull request.
 
 Changes to any doc-coverage gate surface - `mcp/ground-control/index.js`,
 `mcp/ground-control/lib.js`, `tools/policy/checks.py`, `tools/install-vale.sh`,


### PR DESCRIPTION
## Summary

Removes the four broad verification hooks from `.pre-commit-config.yaml`. Each one
re-ran work that already happens twice per change, and the commit-time copy was the
weakest of the three surfaces that run it.

`gradle-check`, `repo-policy`, `vale-prose-lint`, and `openjml-esc` duplicated:

- the `/implement` completion and policy gates, which run `make check` and `make policy`
  at Step 6 and again on the post-base-sync tree at Step 8.5, and
- the CI `policy`, `test`, and `openjml` jobs, which run `bin/policy`, `make vale-lint`,
  `./gradlew check`, and `./gradlew openjmlEsc` on every pull request.

So every commit paid for a third pass over a tree Step 6 had just certified. The
commit-time copy is also the least trustworthy of the three: it is skippable with
`--no-verify`, it is path-filtered so it degraded silently on diffs outside its `files:`
patterns, and it produced no result any gate or workflow record could attest to.

`docs/DEVELOPMENT_WORKFLOW.md` already stated this intent - "Step 7 owns the single
mandatory pre-publish pre-commit boundary. This avoids duplicated broad work" - but the
hook config still carried the broad work. This change makes the config match the
documented design.

## Requirement UIDs

- (none - repository tooling configuration; no product requirement)

## Related Issues

<!-- none -->

## ADR Impact

- ADR-054 - amended. Layer 3 and the rejected "graceful skip" alternative now name
  `make policy` and the CI policy job as the Vale surfaces instead of the pre-commit
  hook, plus a dated amendment entry recording the de-duplication.
- ADR-025 - unchanged, and deliberately so. The `assert-backup-policy` hook stays at
  commit time: it is path-filtered to rarely-touched backup artifacts, so it costs
  nothing on a normal diff, and CI does not run it, so removing it would have reduced
  enforcement rather than duplication.
- ADR-079 - unaffected. Commit-time hook activation remains a per-clone invariant and
  `run_ci_strictness_contract` is untouched.

## Changes

- `.pre-commit-config.yaml`: removed `repo-policy`, `vale-prose-lint`, `gradle-check`,
  and `openjml-esc`. Kept the eight hygiene and secret-scan hooks pinned by
  `run_ci_strictness_contract`, `bash-syntax`, `assert-backup-policy`, `spotless`, and
  the pre-push `pr-body-policy`. Added a comment recording why the broad gates are
  absent so they are not reinstated by reflex.
- `architecture/adrs/054-documentation-coverage-gate.md`: Layer 3 + rejected-alternative
  wording, and a 2026-07-27 amendment.
- `docs/DOC_STYLE.md`: Vale enforcement surfaces.
- `docs/DEVELOPMENT_WORKFLOW.md`: `make policy` consumer list, plus a paragraph on what
  commit time now covers and why.

## Test Plan

- [x] `make policy` passes (264 policy tool tests, backup assertion, Vale on the three
      changed docs, full `bin/policy` suite)
- [x] `pre-commit run --all-files` passes and now completes in seconds
- [x] Commit-time hook run verified on this branch's own commit
- [ ] Unit tests pass (`make test`) - no code changed; CI `test` job covers it
- [ ] Integration tests pass if applicable (`make integration`) - not applicable
- [ ] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo) - no
      backend source changed; CI `test` job covers it
- [x] No coverage regression - no source changes

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: none - repository tooling configuration, no product requirement
- TESTS: none - no behavior change; `run_ci_strictness_contract` already pins the hooks
  that must remain configured, and it passes

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable - no entities changed
- [x] PR title is a Conventional Commit
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
