### PR TITLE
fix: replace deprecated Spring matchers

### DIFF
--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/RequirementSpecifications.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/repository/RequirementSpecifications.java
@@ -48,8 +48,7 @@ public final class RequirementSpecifications {
     public static Specification<Requirement> fromFilter(RequirementFilter filter) {
         // Exclude archived by default unless explicitly filtering for ARCHIVED status
         boolean wantsArchived = filter != null && filter.status() == Status.ARCHIVED;
-        Specification<Requirement> spec =
-                wantsArchived ? Specification.where(null) : Specification.where(notArchived());
+        Specification<Requirement> spec = wantsArchived ? Specification.unrestricted() : notArchived();
 
         if (filter == null) {
             return spec;

--- a/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiRequestPaths.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/shared/security/ApiRequestPaths.java
@@ -1,7 +1,7 @@
 package com.keplerops.groundcontrol.shared.security;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
@@ -30,12 +30,15 @@ public final class ApiRequestPaths {
         "/api/", "/v3/api-docs", "/swagger-ui",
     };
 
+    private static final PathPatternRequestMatcher.Builder PATH_MATCHER_BUILDER =
+            PathPatternRequestMatcher.withDefaults();
+
     private static final RequestMatcher MATCHER = new OrRequestMatcher(
-            new AntPathRequestMatcher("/api/**"),
-            new AntPathRequestMatcher("/v3/api-docs/**"),
-            new AntPathRequestMatcher("/v3/api-docs"),
-            new AntPathRequestMatcher("/swagger-ui/**"),
-            new AntPathRequestMatcher("/swagger-ui.html"));
+            PATH_MATCHER_BUILDER.matcher("/api/**"),
+            PATH_MATCHER_BUILDER.matcher("/v3/api-docs/**"),
+            PATH_MATCHER_BUILDER.matcher("/v3/api-docs"),
+            PATH_MATCHER_BUILDER.matcher("/swagger-ui/**"),
+            PATH_MATCHER_BUILDER.matcher("/swagger-ui.html"));
 
     private ApiRequestPaths() {
         // utility

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiRequestPathsTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/security/ApiRequestPathsTest.java
@@ -1,0 +1,32 @@
+package com.keplerops.groundcontrol.unit.api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.keplerops.groundcontrol.shared.security.ApiRequestPaths;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class ApiRequestPathsTest {
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "/api/v1/requirements",
+                "/v3/api-docs",
+                "/v3/api-docs/swagger-config",
+                "/swagger-ui/index.html",
+                "/swagger-ui.html"
+            })
+    void matcherRecognizesApiAndDocumentationPaths(String path) {
+        assertThat(ApiRequestPaths.matcher().matches(new MockHttpServletRequest("GET", path)))
+                .isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/", "/requirements", "/apiary", "/v3/api-docs-extra", "/swagger-uiish"})
+    void matcherRejectsNonApiPaths(String path) {
+        assertThat(ApiRequestPaths.matcher().matches(new MockHttpServletRequest("GET", path)))
+                .isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Replace the seven Spring deprecation findings that blocked Sonar on `main`.

## Requirement UIDs

- (none — requirement-free maintenance)

Behavior-preserving maintenance of existing Spring integrations; no requirement status change.

## Related Issues

- Main CI failure: https://github.com/autarchy-ai/Ground-Control/actions/runs/30224158073

## ADR Impact

- No ADR required

## Changes

- Replace deprecated `Specification.where(...)` calls with `Specification.unrestricted()` and the existing concrete specification.
- Replace `AntPathRequestMatcher` with `PathPatternRequestMatcher` while preserving the configured API and documentation paths.
- Add focused positive and negative matcher coverage.

## Test Plan

- [x] Unit tests pass (`./gradlew test`)
- [x] Integration tests pass for the affected requirement specifications
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

## Ground Control Checks

- [x] Configured repository policy command passes (`make policy`)
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: existing requirement behavior preserved; no new production requirement coverage claimed
- TESTS: `GC-P011` via `ApiRequestPathsTest`; existing requirement-specification coverage remains valid

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no new framework imports
- [x] Envers `@Audited` on new entities if applicable (no new entities)
- [x] PR title is a Conventional Commit (`type(optional-scope): subject`, lowercase-leading subject)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed (not applicable)
