### PR TITLE
fix(telemetry): record the pull request number on live-emitted workflow runs

### DIFF
--- a/architecture/adrs/090-production-line-measurement-model.md
+++ b/architecture/adrs/090-production-line-measurement-model.md
@@ -270,6 +270,10 @@ model without a second run, station, or outcome schema:
 - work item: exact `(project, repo, issue_number)`;
 - run: the `workflow_run.id` resolved by the existing
   `(project, repo, issue_number, branch)` upsert key;
+- pull request: a related, late-bound `pr_number` supplied only after the tool
+  layer authoritatively resolves the PR; it refines the existing run, is omitted
+  while unknown rather than synthesized or sent as `null`, and is never part of
+  work-item identity, run identity, or workflow authority;
 - station: the stable ADR-061 `phase` id, never the SKILL step number,
   user-facing phase label, MCP tool name, or `next_action`;
 - station attempt: the authoritative `cycle_index` when one exists, otherwise

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -271,7 +271,10 @@ in-flight run is queryable rather than reconstructable only after it ends:
   duration and the stable error code;
 - the run reaches `READY_FOR_REVIEW` (still open, no end time) after readiness, `MERGED` after the
   post-merge phase, `CLOSED`/`CLOSED_WITHOUT_MERGE` when the linked PR is observed closed unmerged,
-  and `SUPERSEDED` when a later attempt opens on a different branch for the same issue.
+  and `SUPERSEDED` when a later attempt opens on a different branch for the same issue;
+- `pr_number` is attached from the `monitor` boundary onward, once the tool layer authoritatively
+  holds it. It refines the run rather than identifying it, and is omitted while unknown so an
+  earlier boundary can never clear a PR a later one recorded.
 
 Three properties are load-bearing. Recording is **fail-open and off the control path**: each
 transition is timestamped the moment it happens and its write is queued, so the workflow never waits

--- a/mcp/ground-control/gc-implement-mechanical.js
+++ b/mcp/ground-control/gc-implement-mechanical.js
@@ -908,6 +908,9 @@ async function resolveEmitter(args, deps) {
       workflowType: "IMPLEMENT",
       runtimeDriver: args.driver,
       requirementUids: args.requirements?.map((item) => item.uid),
+      // Known from the monitor boundary onward; absent on the earlier actions, which leave the
+      // field alone rather than clearing it.
+      prNumber: args.prNumber,
     });
   } catch {
     return INERT_EMITTER;

--- a/mcp/ground-control/gc-implement-mechanical.test.js
+++ b/mcp/ground-control/gc-implement-mechanical.test.js
@@ -863,6 +863,22 @@ describe("runImplementMechanical live lifecycle emission", () => {
     assert.equal(identity.runtimeDriver, "codex");
   });
 
+  it("passes the PR number to the emitter on the actions that know one", async () => {
+    // monitor, readiness, and finalize are the boundaries where the tool layer holds the PR. If the
+    // identity drops it, the run row keeps pr_number null for its whole life and only a deliberate
+    // issue-thread backfill can ever supply it.
+    const spy = lifecycleSpy();
+    await runImplementMechanical({
+      action: "monitor",
+      repoPath: "/repo",
+      issueNumber: 1426,
+      branchName: "1426-script-phases",
+      prNumber: 99,
+    }, baseDeps({ createLifecycle: spy.factory }));
+
+    assert.equal(spy.calls[0][1].prNumber, 99);
+  });
+
   it("resolves the run without re-asserting RUNNING on a mid-run boundary", async () => {
     const spy = lifecycleSpy();
     await runImplementMechanical({

--- a/mcp/ground-control/workflow-run-lifecycle.js
+++ b/mcp/ground-control/workflow-run-lifecycle.js
@@ -72,6 +72,7 @@ const defaultDeps = {
  * @param {string} p.workflowType      closed WorkflowType vocabulary value
  * @param {string} [p.runtimeDriver]   agent/runtime that is executing the run
  * @param {string[]} [p.requirementUids] in-scope requirement UIDs
+ * @param {number} [p.prNumber]        pull request carrying this attempt, once one exists
  * @param {object} [p.deps]            injected collaborators (tests and alternate transports)
  */
 export function createWorkflowRunLifecycleEmitter({
@@ -82,6 +83,7 @@ export function createWorkflowRunLifecycleEmitter({
   workflowType,
   runtimeDriver,
   requirementUids,
+  prNumber,
   deps = {},
 } = {}) {
   const d = { ...defaultDeps, ...deps };
@@ -151,6 +153,11 @@ export function createWorkflowRunLifecycleEmitter({
       runtime_driver: runtimeDriver,
       provenance: LIFECYCLE_PROVENANCE,
       ...(requirementUids?.length ? { requirement_uids: requirementUids } : {}),
+      // Omitted rather than sent as null until a PR exists: the early boundaries upsert the same row
+      // the later ones do, so an explicit null would let a re-run erase a PR a later boundary
+      // recorded. Without this the run holds no link to the pull request that carried it, and only a
+      // deliberate gc_workflow_run_ingest backfill — which does record one — could ever supply it.
+      ...(Number.isInteger(prNumber) && prNumber > 0 ? { pr_number: prNumber } : {}),
     };
   }
 

--- a/mcp/ground-control/workflow-run-lifecycle.test.js
+++ b/mcp/ground-control/workflow-run-lifecycle.test.js
@@ -86,6 +86,33 @@ describe("workflow-run lifecycle emitter", () => {
     assert.equal(runs[0].started_at, undefined);
   });
 
+  it("carries the PR number on every write once the tool layer knows it", async () => {
+    // A run's PR only becomes knowable at the monitor boundary. Dropping it leaves the read-model
+    // with no join from a live-emitted run to the pull request that carried it, while the
+    // issue-thread backfill records one — the two writers would disagree about the same row.
+    const { runs, deps } = recorder();
+    const emitter = createWorkflowRunLifecycleEmitter({ ...IDENTITY, prNumber: 1452, deps });
+
+    emitter.ensureRun();
+    emitter.markState("READY_FOR_REVIEW");
+    emitter.closeRun({ finalState: "MERGED", outcome: "MERGED" });
+    await emitter.flush();
+
+    assert.deepEqual(runs.map((run) => run.pr_number), [1452, 1452, 1452]);
+  });
+
+  it("omits the PR number before one is known, so an earlier link is never cleared", async () => {
+    // The early boundaries upsert the same row the later ones do. Sending an absent PR as an
+    // explicit null would let a bootstrap retry erase a PR number a later boundary had recorded.
+    const { runs, deps } = recorder();
+    const emitter = createWorkflowRunLifecycleEmitter({ ...IDENTITY, deps });
+
+    emitter.openRun();
+    await emitter.flush();
+
+    assert.equal("pr_number" in runs[0], false);
+  });
+
   it("brackets a station with STARTED then COMPLETED carrying the measured duration", async () => {
     const { events, deps } = recorder();
     let clock = 1000;
@@ -350,6 +377,7 @@ describe("workflow-run lifecycle emitter — wire contract", () => {
       const emitter = createWorkflowRunLifecycleEmitter({
         ...IDENTITY,
         requirementUids: ["GC-O007"],
+        prNumber: 1452,
         deps: {
           createRun: createWorkflowRun,
           recordEvent: recordWorkflowRunEvent,
@@ -369,6 +397,7 @@ describe("workflow-run lifecycle emitter — wire contract", () => {
     const keys = new Set(sent.flatMap((body) => Object.keys(body)));
     for (const expected of [
       "issueNumber",
+      "prNumber",
       "workflowType",
       "runtimeDriver",
       "requirementUids",


### PR DESCRIPTION
## Summary

Live-emitted workflow runs never recorded `pr_number`, so every row in the ADR-061 read-model — including merged ones whose PR is known — carried a null PR link. `gc_workflow_run_ingest` does record it, so the live emitter and the backfill path disagreed about the same row. The tool layer already receives the PR number at the `monitor`, `readiness`, and `finalize` boundaries and dropped it. It is now attached to the run there. The field refines an existing run and is never part of run identity; it is omitted while unknown rather than sent as null, so an earlier boundary can never clear a PR a later one recorded.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1435

## ADR Impact

- ADR-090 (amended)
- ADR-061
- ADR-021

## Changes

- `workflow-run-lifecycle.js`: the emitter accepts `prNumber` and includes `pr_number` in the upsert body only when it is a positive integer
- `gc-implement-mechanical.js`: `resolveEmitter` forwards `args.prNumber`, which the `monitor`/`readiness`/`finalize` actions already carry
- ADR-090: the live-emitter amendment gains the late-bound-correlation rule (written by the architecture preflight)
- `docs/DEVELOPMENT_WORKFLOW.md`: documents when the PR number is attached and why it is omitted while unknown

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

No migration, endpoint, or DTO change: `pr_number` already exists on `workflow_run`, the backend applies it through null-safe `setIfPresent`, and `lib.js` already carries the `pr_number → prNumber` rename. The wire-contract test pins `prNumber` as a real camelCase key, because that rename is an allowlist and a missing entry would be dropped silently by the fail-open emission path.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-061 ← mcp/ground-control/workflow-run-lifecycle.js, ADR-090 ← architecture/adrs/090-production-line-measurement-model.md
- TESTS: ADR-061 ← mcp/ground-control/workflow-run-lifecycle.test.js, ADR-061 ← mcp/ground-control/gc-implement-mechanical.test.js

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.