### PR TITLE
fix(telemetry): bind phases to canonical stations

### DIFF
--- a/architecture/adrs/090-production-line-measurement-model.md
+++ b/architecture/adrs/090-production-line-measurement-model.md
@@ -684,3 +684,43 @@ Ground Control backend with telemetry enabled. Durable queuing, offline
 backfill, retention/partitioning, new aggregates or dashboards, price
 translation, changing ADR-029 workflow authority, and making telemetry
 mandatory workflow evidence are separate decisions.
+
+## Amendment (issue #1439, 2026-07-29): canonical station binding on the ADR-061 write path
+
+Issue #1355 added the station-result column and formula surface before #1439
+reconciled the original ADR-061 migration issue. This overlap does not authorize
+a second result field, event entity, measurement aggregate, endpoint, or
+catalogue. #1439 makes the existing path obey the already-published contract.
+
+For an ADR-061 phase event, the backend station catalogue is the authority for
+binding. The service resolves the persisted `phase` as either a direct catalogue
+entry or an `adr061_phase` alias. A station entry supplies the canonical
+`station_id`; a lifecycle marker supplies no station id and can carry no verdict
+or findings. A caller-provided station id is only a consistency assertion. It
+must match the catalogue resolution and must never override it. The original
+`phase` remains stored exactly as observed, so the binding adds identity without
+rewriting history.
+
+Legacy live and Envers rows may receive a `station_id` only where their persisted
+phase resolves unambiguously through the published catalogue. Marker and
+unresolved legacy phases retain a null station id. Every legacy station result
+remains `UNOBSERVED`, including a row whose phase can be mapped safely. Station
+identity may be resolved from a governed alias; a verdict must never be inferred
+from phase, event type, free-text outcome, run state, temporal order, or the
+absence of a later failure. Forward migration keeps the live and audit shapes in
+lockstep and does not edit V203 or another applied migration.
+
+The measurement contract uses lower snake-case values while the existing
+REST/OpenAPI enum surface uses Java enum names. Contract-native emitters cross
+that representation boundary in the workflow-run REST adapter. The generic
+snake-to-camel key mapper remains a key mapper; it does not rewrite arbitrary
+values. Global case-insensitive Jackson parsing, a second permissive enum, or a
+second station-result vocabulary would hide drift instead of validating it.
+
+Yield and rework continue to group by canonical `station_id` and consume only
+explicit `PASS` and `FAIL` results. `UNOBSERVED`, `SKIPPED_STATION`,
+`CANCELLED`, and `NOT_EVALUABLE` remain coverage facts outside formula
+denominators. Aggregate ratios continue to expose numerator, denominator,
+unresolved count, and `gc.measurement/v1`. The catalogue-backed resolver is the
+extension seam: adding a catalogue station or alias must not require another
+hard-coded service mapping.

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/repository/WorkflowPhaseEventRepository.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/repository/WorkflowPhaseEventRepository.java
@@ -1,5 +1,6 @@
 package com.keplerops.groundcontrol.domain.workflowtelemetry.repository;
 
+import com.keplerops.groundcontrol.domain.workflowtelemetry.PhaseEventEmitter;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.PhaseEventType;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.StationResult;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.WorkflowPhaseEvent;
@@ -118,8 +119,9 @@ public interface WorkflowPhaseEventRepository extends JpaRepository<WorkflowPhas
     @Query(
             """
             select e.stationId, e.runId, e.cycleIndex, e.stationResult
-              from WorkflowPhaseEvent e
+             from WorkflowPhaseEvent e
              where e.project = :project
+               and e.emitter = :emitter
                and e.stationId is not null
                and e.stationResult in :evaluable
                and e.occurredAt >= :from
@@ -127,6 +129,7 @@ public interface WorkflowPhaseEventRepository extends JpaRepository<WorkflowPhas
             """)
     List<Object[]> findEvaluableAttempts(
             @Param("project") String project,
+            @Param("emitter") PhaseEventEmitter emitter,
             @Param("evaluable") java.util.Collection<StationResult> evaluable,
             @Param("from") Instant from,
             @Param("to") Instant to);

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/StationCatalog.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/StationCatalog.java
@@ -35,6 +35,9 @@ public final class StationCatalog {
     /** The catalogue alias kind that names an ADR-036 routing stage (issue #1354). */
     private static final String ADR036_STAGE_ALIAS = "adr036_stage";
 
+    /** The catalogue alias kind that names an ADR-061 persisted phase (issue #1439). */
+    private static final String ADR061_PHASE_ALIAS = "adr061_phase";
+
     private final Set<String> stationIds;
     private final Set<String> markerIds;
 
@@ -45,6 +48,12 @@ public final class StationCatalog {
      * two can never disagree.
      */
     private final Map<String, String> stationByStage;
+
+    /** ADR-061 phase or direct station id → canonical station id. */
+    private final Map<String, String> stationByPhase;
+
+    /** Direct marker ids and their ADR-061 phase aliases. */
+    private final Set<String> markerPhases;
 
     /**
      * Every ADR-036 stage the catalogue declares — as a station alias, a lifecycle-marker alias, or a
@@ -70,6 +79,8 @@ public final class StationCatalog {
         this.stationIds = ids(root, "stations", "station_id");
         this.markerIds = ids(root, "lifecycle_markers", "marker_id");
         this.stationByStage = stationByStage(root);
+        this.stationByPhase = stationByPhase(root);
+        this.markerPhases = markerPhases(root);
         this.knownStages = knownStages(root, stationByStage);
         if (stationIds.isEmpty()) {
             // An empty set would accept nothing, but an empty *parse* means the shape changed and
@@ -104,6 +115,41 @@ public final class StationCatalog {
             }
         }
         return Map.copyOf(byStage);
+    }
+
+    private static Map<String, String> stationByPhase(JsonNode root) {
+        var byPhase = new LinkedHashMap<String, String>();
+        for (var station : root.path("stations")) {
+            var stationId = station.path("station_id").asText(null);
+            if (stationId == null || stationId.isBlank()) {
+                continue;
+            }
+            byPhase.put(stationId, stationId);
+            for (var alias : station.path("aliases").path(ADR061_PHASE_ALIAS)) {
+                var phase = alias.asText(null);
+                if (phase != null && !phase.isBlank()) {
+                    byPhase.put(phase, stationId);
+                }
+            }
+        }
+        return Map.copyOf(byPhase);
+    }
+
+    private static Set<String> markerPhases(JsonNode root) {
+        var phases = new LinkedHashSet<String>();
+        for (var marker : root.path("lifecycle_markers")) {
+            var markerId = marker.path("marker_id").asText(null);
+            if (markerId != null && !markerId.isBlank()) {
+                phases.add(markerId);
+            }
+            for (var alias : marker.path("aliases").path(ADR061_PHASE_ALIAS)) {
+                var phase = alias.asText(null);
+                if (phase != null && !phase.isBlank()) {
+                    phases.add(phase);
+                }
+            }
+        }
+        return Set.copyOf(phases);
     }
 
     private static Set<String> knownStages(JsonNode root, Map<String, String> stationByStage) {
@@ -145,6 +191,22 @@ public final class StationCatalog {
             return Optional.empty();
         }
         return Optional.ofNullable(stationByStage.get(stageId));
+    }
+
+    /**
+     * Resolve an ADR-061 phase to its canonical station id. Direct station ids and declared
+     * {@code adr061_phase} aliases are equivalent inputs; markers and unknown phases resolve empty.
+     */
+    public Optional<String> resolveStationForPhase(String phase) {
+        if (phase == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(stationByPhase.get(phase));
+    }
+
+    /** Whether an ADR-061 phase names a lifecycle marker rather than an inspecting station. */
+    public boolean isLifecycleMarkerPhase(String phase) {
+        return phase != null && markerPhases.contains(phase);
     }
 
     /** Whether the catalogue declares this ADR-036 stage at all (station, marker, or non-station). */

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/StationCatalog.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/StationCatalog.java
@@ -32,6 +32,11 @@ public final class StationCatalog {
 
     static final String DEFAULT_RESOURCE = "measurement/gc-station-catalogue-v2.json";
 
+    private static final String ALIASES_FIELD = "aliases";
+    private static final String LIFECYCLE_MARKERS_FIELD = "lifecycle_markers";
+    private static final String STATION_ID_FIELD = "station_id";
+    private static final String STATIONS_FIELD = "stations";
+
     /** The catalogue alias kind that names an ADR-036 routing stage (issue #1354). */
     private static final String ADR036_STAGE_ALIAS = "adr036_stage";
 
@@ -76,8 +81,8 @@ public final class StationCatalog {
         } catch (IOException | RuntimeException e) {
             throw new IllegalStateException("Could not load the station catalogue: " + resourcePath, e);
         }
-        this.stationIds = ids(root, "stations", "station_id");
-        this.markerIds = ids(root, "lifecycle_markers", "marker_id");
+        this.stationIds = ids(root, STATIONS_FIELD, STATION_ID_FIELD);
+        this.markerIds = ids(root, LIFECYCLE_MARKERS_FIELD, "marker_id");
         this.stationByStage = stationByStage(root);
         this.stationByPhase = stationByPhase(root);
         this.markerPhases = markerPhases(root);
@@ -102,12 +107,12 @@ public final class StationCatalog {
 
     private static Map<String, String> stationByStage(JsonNode root) {
         var byStage = new LinkedHashMap<String, String>();
-        for (var station : root.path("stations")) {
-            var stationId = station.path("station_id").asText(null);
+        for (var station : root.path(STATIONS_FIELD)) {
+            var stationId = station.path(STATION_ID_FIELD).asText(null);
             if (stationId == null || stationId.isBlank()) {
                 continue;
             }
-            for (var alias : station.path("aliases").path(ADR036_STAGE_ALIAS)) {
+            for (var alias : station.path(ALIASES_FIELD).path(ADR036_STAGE_ALIAS)) {
                 var stage = alias.asText(null);
                 if (stage != null && !stage.isBlank()) {
                     byStage.put(stage, stationId);
@@ -119,13 +124,13 @@ public final class StationCatalog {
 
     private static Map<String, String> stationByPhase(JsonNode root) {
         var byPhase = new LinkedHashMap<String, String>();
-        for (var station : root.path("stations")) {
-            var stationId = station.path("station_id").asText(null);
+        for (var station : root.path(STATIONS_FIELD)) {
+            var stationId = station.path(STATION_ID_FIELD).asText(null);
             if (stationId == null || stationId.isBlank()) {
                 continue;
             }
             byPhase.put(stationId, stationId);
-            for (var alias : station.path("aliases").path(ADR061_PHASE_ALIAS)) {
+            for (var alias : station.path(ALIASES_FIELD).path(ADR061_PHASE_ALIAS)) {
                 var phase = alias.asText(null);
                 if (phase != null && !phase.isBlank()) {
                     byPhase.put(phase, stationId);
@@ -137,12 +142,12 @@ public final class StationCatalog {
 
     private static Set<String> markerPhases(JsonNode root) {
         var phases = new LinkedHashSet<String>();
-        for (var marker : root.path("lifecycle_markers")) {
+        for (var marker : root.path(LIFECYCLE_MARKERS_FIELD)) {
             var markerId = marker.path("marker_id").asText(null);
             if (markerId != null && !markerId.isBlank()) {
                 phases.add(markerId);
             }
-            for (var alias : marker.path("aliases").path(ADR061_PHASE_ALIAS)) {
+            for (var alias : marker.path(ALIASES_FIELD).path(ADR061_PHASE_ALIAS)) {
                 var phase = alias.asText(null);
                 if (phase != null && !phase.isBlank()) {
                     phases.add(phase);
@@ -154,8 +159,8 @@ public final class StationCatalog {
 
     private static Set<String> knownStages(JsonNode root, Map<String, String> stationByStage) {
         var stages = new LinkedHashSet<>(stationByStage.keySet());
-        for (var marker : root.path("lifecycle_markers")) {
-            for (var alias : marker.path("aliases").path(ADR036_STAGE_ALIAS)) {
+        for (var marker : root.path(LIFECYCLE_MARKERS_FIELD)) {
+            for (var alias : marker.path(ALIASES_FIELD).path(ADR036_STAGE_ALIAS)) {
                 var stage = alias.asText(null);
                 if (stage != null && !stage.isBlank()) {
                     stages.add(stage);

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/WorkflowMeasurementService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/WorkflowMeasurementService.java
@@ -4,6 +4,7 @@ import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.FindingDisposition;
+import com.keplerops.groundcontrol.domain.workflowtelemetry.PhaseEventEmitter;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.StationResult;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.WorkflowGateFinding;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.WorkflowPhaseEvent;
@@ -158,7 +159,10 @@ public class WorkflowMeasurementService {
             String project, Instant from, Instant to) {
         requireText(project, PROJECT_FIELD);
         var window = resolveWindow(from, to);
-        var rows = phaseEventRepository.findEvaluableAttempts(project, EVALUABLE, window.from(), window.to()).stream()
+        var rows = phaseEventRepository
+                .findEvaluableAttempts(
+                        project, PhaseEventEmitter.ADR061_WORKFLOW_TELEMETRY, EVALUABLE, window.from(), window.to())
+                .stream()
                 .map(r -> new StationYieldCalculator.AttemptRow(
                         (String) r[0], (UUID) r[1], (Integer) r[2], (StationResult) r[3]))
                 .toList();

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/WorkflowTelemetryValidation.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/WorkflowTelemetryValidation.java
@@ -198,11 +198,38 @@ final class WorkflowTelemetryValidation {
         var emitter = command.emitter() == null ? PhaseEventEmitter.ADR061_WORKFLOW_TELEMETRY : command.emitter();
         if (emitter != PhaseEventEmitter.ADR036_STEP_JSONL) {
             rejectStepObservationFields(command);
-            return new StepEmission(emitter, command.stationId(), command.stationResult());
+            return resolveLifecycleEmission(catalog, command, emitter);
         }
         requireStepObservationContract(catalog, command);
         return new StepEmission(
                 emitter, catalog.resolveStationForStage(command.phase()).orElse(null), StationResult.UNOBSERVED);
+    }
+
+    /**
+     * Bind an ADR-061 phase to the catalogue station. A supplied station id can only confirm the
+     * binding; it cannot redirect an event to a different valid station.
+     */
+    private static StepEmission resolveLifecycleEmission(
+            StationCatalog catalog, RecordPhaseEventCommand command, PhaseEventEmitter emitter) {
+        var resolved = catalog.resolveStationForPhase(command.phase());
+        if (resolved.isPresent()) {
+            var canonical = resolved.orElseThrow();
+            if (command.stationId() != null && !Objects.equals(command.stationId(), canonical)) {
+                throw new DomainValidationException("stationId '" + command.stationId() + "' does not match phase '"
+                        + command.phase() + "', which resolves to '" + canonical + "'");
+            }
+            return new StepEmission(emitter, canonical, command.stationResult());
+        }
+        if (command.stationId() != null) {
+            if (catalog.isLifecycleMarkerPhase(command.phase())) {
+                throw new DomainValidationException(command.phase()
+                        + " is a lifecycle marker: it inspects nothing and cannot carry stationId '"
+                        + command.stationId() + "'");
+            }
+            throw new DomainValidationException("stationId '" + command.stationId() + "' does not match phase '"
+                    + command.phase() + "', which resolves to no station");
+        }
+        return new StepEmission(emitter, null, command.stationResult());
     }
 
     /**

--- a/backend/src/main/resources/db/migration/V210__canonical_workflow_station_binding.sql
+++ b/backend/src/main/resources/db/migration/V210__canonical_workflow_station_binding.sql
@@ -1,0 +1,78 @@
+-- Issue #1439 (ADR-090 amendment): bind safely resolvable ADR-061 phases to the canonical station
+-- identity. V207 deliberately left every legacy verdict UNOBSERVED; this migration adds identity
+-- only and never infers a result from phase, event type, outcome, order, or absence of failure.
+--
+-- This CASE is the historical v2-catalogue snapshot applied to rows that predate catalogue-driven
+-- write-path resolution. Runtime resolution remains data-driven by the classpath catalogue.
+
+UPDATE workflow_phase_event
+SET station_id = CASE
+    WHEN phase = 'preflight' THEN 'architecture_preflight'
+    WHEN phase IN (
+        'issue_branch_resolution',
+        'architecture_preflight',
+        'completion_gate',
+        'spotbugs',
+        'policy',
+        'vale',
+        'codex_review',
+        'test_quality_review',
+        'precommit',
+        'git_publish',
+        'ci',
+        'sonarcloud'
+    ) THEN phase
+END
+WHERE station_id IS NULL
+  AND emitter = 'ADR061_WORKFLOW_TELEMETRY'
+  AND phase IN (
+      'preflight',
+      'issue_branch_resolution',
+      'architecture_preflight',
+      'completion_gate',
+      'spotbugs',
+      'policy',
+      'vale',
+      'codex_review',
+      'test_quality_review',
+      'precommit',
+      'git_publish',
+      'ci',
+      'sonarcloud'
+  );
+
+UPDATE workflow_phase_event_audit
+SET station_id = CASE
+    WHEN phase = 'preflight' THEN 'architecture_preflight'
+    WHEN phase IN (
+        'issue_branch_resolution',
+        'architecture_preflight',
+        'completion_gate',
+        'spotbugs',
+        'policy',
+        'vale',
+        'codex_review',
+        'test_quality_review',
+        'precommit',
+        'git_publish',
+        'ci',
+        'sonarcloud'
+    ) THEN phase
+END
+WHERE station_id IS NULL
+  AND emitter = 'ADR061_WORKFLOW_TELEMETRY'
+  AND phase IN (
+      'preflight',
+      'issue_branch_resolution',
+      'architecture_preflight',
+      'completion_gate',
+      'spotbugs',
+      'policy',
+      'vale',
+      'codex_review',
+      'test_quality_review',
+      'precommit',
+      'git_publish',
+      'ci',
+      'sonarcloud'
+  );

--- a/backend/src/test/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/WorkflowMeasurementServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/domain/workflowtelemetry/service/WorkflowMeasurementServiceTest.java
@@ -12,6 +12,7 @@ import com.keplerops.groundcontrol.domain.exception.ConflictException;
 import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.FindingDisposition;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.FindingSourceKind;
+import com.keplerops.groundcontrol.domain.workflowtelemetry.PhaseEventEmitter;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.PhaseEventType;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.StationResult;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.TelemetryProvenance;
@@ -209,13 +210,15 @@ class WorkflowMeasurementServiceTest {
 
     @Test
     void onlyEvaluableAttemptsReachTheYieldQuery() {
-        when(phaseEventRepository.findEvaluableAttempts(any(), any(), any(), any()))
+        when(phaseEventRepository.findEvaluableAttempts(any(), any(), any(), any(), any()))
                 .thenReturn(List.of());
 
         service.aggregateStationYield("gc", null, null);
 
         var results = ArgumentCaptor.forClass(java.util.Collection.class);
-        verify(phaseEventRepository).findEvaluableAttempts(any(), results.capture(), any(), any());
+        var emitter = ArgumentCaptor.forClass(PhaseEventEmitter.class);
+        verify(phaseEventRepository).findEvaluableAttempts(any(), emitter.capture(), results.capture(), any(), any());
+        assertThat(emitter.getValue()).isEqualTo(PhaseEventEmitter.ADR061_WORKFLOW_TELEMETRY);
         // Skipped, cancelled, not-evaluable and unobserved attempts stay measurable coverage
         // but must never enter a yield denominator, or an unmeasured gate reads as a failing one.
         assertThat(results.getValue()).containsExactlyInAnyOrder(StationResult.PASS, StationResult.FAIL);

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/CanonicalStationBindingMigrationIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/CanonicalStationBindingMigrationIntegrationTest.java
@@ -1,0 +1,134 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+/** Exercises V210's live/audit backfill against the actual migration SQL. */
+class CanonicalStationBindingMigrationIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void backfillsOnlyResolvableStationsAndNeverInventsLegacyVerdicts() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                var runId = UUID.randomUUID();
+                var stationEventId = UUID.randomUUID();
+                var markerEventId = UUID.randomUUID();
+                var stepEventId = UUID.randomUUID();
+                int revision;
+
+                try (var statement = connection.prepareStatement("INSERT INTO workflow_run "
+                        + "(id, project, workflow_type, final_state, outcome, provenance) "
+                        + "VALUES (?, 'migration-v210', 'IMPLEMENT', 'RUNNING', 'NONE', 'LIVE_EMISSION')")) {
+                    statement.setObject(1, runId);
+                    statement.executeUpdate();
+                }
+                insertLiveEvent(connection, stationEventId, runId, "preflight", "station", "ADR061_WORKFLOW_TELEMETRY");
+                insertLiveEvent(connection, markerEventId, runId, "plan", "marker", "ADR061_WORKFLOW_TELEMETRY");
+                insertLiveEvent(connection, stepEventId, runId, "ci", "step", "ADR036_STEP_JSONL");
+
+                try (var statement =
+                                connection.prepareStatement("INSERT INTO revinfo (revtstmp) VALUES (0) RETURNING rev");
+                        var result = statement.executeQuery()) {
+                    result.next();
+                    revision = result.getInt(1);
+                }
+                insertAuditEvent(
+                        connection,
+                        stationEventId,
+                        runId,
+                        revision,
+                        "preflight",
+                        "station",
+                        "ADR061_WORKFLOW_TELEMETRY");
+                insertAuditEvent(
+                        connection, markerEventId, runId, revision, "plan", "marker", "ADR061_WORKFLOW_TELEMETRY");
+                insertAuditEvent(connection, stepEventId, runId, revision, "ci", "step", "ADR036_STEP_JSONL");
+
+                ScriptUtils.executeSqlScript(
+                        connection, new ClassPathResource("db/migration/V210__canonical_workflow_station_binding.sql"));
+
+                assertThat(readValue(connection, "workflow_phase_event", stationEventId, "station_id"))
+                        .isEqualTo("architecture_preflight");
+                assertThat(readValue(connection, "workflow_phase_event_audit", stationEventId, "station_id"))
+                        .isEqualTo("architecture_preflight");
+                assertThat(readValue(connection, "workflow_phase_event", markerEventId, "station_id"))
+                        .isNull();
+                assertThat(readValue(connection, "workflow_phase_event_audit", markerEventId, "station_id"))
+                        .isNull();
+                assertThat(readValue(connection, "workflow_phase_event", stepEventId, "station_id"))
+                        .isNull();
+                assertThat(readValue(connection, "workflow_phase_event_audit", stepEventId, "station_id"))
+                        .isNull();
+                assertThat(readValue(connection, "workflow_phase_event", stationEventId, "station_result"))
+                        .isEqualTo("UNOBSERVED");
+                assertThat(readValue(connection, "workflow_phase_event_audit", stationEventId, "station_result"))
+                        .isEqualTo("UNOBSERVED");
+            } finally {
+                connection.rollback();
+            }
+        }
+    }
+
+    private static void insertLiveEvent(
+            Connection connection, UUID eventId, UUID runId, String phase, String sourceSuffix, String emitter)
+            throws Exception {
+        try (var statement = connection.prepareStatement("INSERT INTO workflow_phase_event "
+                + "(id, run_id, project, phase, event_type, occurred_at, provenance, source_id, "
+                + "station_result, findings_dropped, emitter) "
+                + "VALUES (?, ?, 'migration-v210', ?, 'COMPLETED', now(), 'LIVE_EMISSION', ?, "
+                + "'UNOBSERVED', 0, ?)")) {
+            statement.setObject(1, eventId);
+            statement.setObject(2, runId);
+            statement.setString(3, phase);
+            statement.setString(4, "migration-v210:" + sourceSuffix);
+            statement.setString(5, emitter);
+            statement.executeUpdate();
+        }
+    }
+
+    private static void insertAuditEvent(
+            Connection connection,
+            UUID eventId,
+            UUID runId,
+            int revision,
+            String phase,
+            String sourceSuffix,
+            String emitter)
+            throws Exception {
+        try (var statement = connection.prepareStatement("INSERT INTO workflow_phase_event_audit "
+                + "(id, rev, revtype, run_id, project, phase, event_type, occurred_at, provenance, "
+                + "source_id, station_result, findings_dropped, emitter) "
+                + "VALUES (?, ?, 0, ?, 'migration-v210', ?, 'COMPLETED', now(), 'LIVE_EMISSION', ?, "
+                + "'UNOBSERVED', 0, ?)")) {
+            statement.setObject(1, eventId);
+            statement.setInt(2, revision);
+            statement.setObject(3, runId);
+            statement.setString(4, phase);
+            statement.setString(5, "migration-v210:" + sourceSuffix);
+            statement.setString(6, emitter);
+            statement.executeUpdate();
+        }
+    }
+
+    private static String readValue(Connection connection, String table, UUID eventId, String column) throws Exception {
+        var sql = "SELECT " + column + " FROM " + table + " WHERE id = ?";
+        try (var statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, eventId);
+            try (var result = statement.executeQuery()) {
+                result.next();
+                return result.getString(1);
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
@@ -401,7 +401,10 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         // V209 (#1354, ADR-090 amendment): durable ADR-036 step observation — the
                         // emitter discriminator plus the ADR-036 step facts on the phase-event row
                         // and its Envers shadow.
-                        "209");
+                        "209",
+                        // V210 (#1439, ADR-090 amendment): canonical station binding backfill for
+                        // resolvable ADR-061 phases in live and Envers rows.
+                        "210");
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -46,10 +46,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * End-to-end requirements flow against the full Flyway migration set applied by
- * {@link BaseIntegrationTest} — through V209, which adds the ADR-036 durable step-observation columns
- * to {@code workflow_phase_event} and its audit shadow (issue #1354). It exercises the API and the
- * audited persistence spine those migrations build, so a migration that breaks the end-to-end path
- * fails here rather than only in the migration smoke test.
+ * {@link BaseIntegrationTest} — through V210, which adds canonical station binding for resolvable
+ * ADR-061 phases in live and audit rows (issue #1439). It exercises the API and the audited
+ * persistence spine those migrations build, so a migration that breaks the end-to-end path fails
+ * here rather than only in the migration smoke test.
  */
 @AutoConfigureMockMvc
 @TestMethodOrder(OrderAnnotation.class)

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/SchemaMigrationVerificationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/SchemaMigrationVerificationTest.java
@@ -244,6 +244,7 @@ class SchemaMigrationVerificationTest extends BaseIntegrationTest {
                         "206", // V206: identity/RBAC Envers audit shadows (#1282)
                         "207", // V207: station-result axis + gate-finding projection (#1355)
                         "208", // V208: workflow_gate_finding Envers shadow (#1355)
-                        "209"); // V209: durable ADR-036 step observation on the phase-event row (#1354)
+                        "209", // V209: durable ADR-036 step observation on the phase-event row (#1354)
+                        "210"); // V210: canonical ADR-061 workflow station binding (#1439)
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/workflowtelemetry/StationCatalogStageResolutionTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/workflowtelemetry/StationCatalogStageResolutionTest.java
@@ -45,4 +45,19 @@ class StationCatalogStageResolutionTest {
         assertThat(catalog.resolveStationForStage("not_a_real_stage")).isEmpty();
         assertThat(catalog.isKnownStage(null)).isFalse();
     }
+
+    @Test
+    void adr061PhaseAliasesResolveToCanonicalStationIds() {
+        assertThat(catalog.resolveStationForPhase("preflight")).contains("architecture_preflight");
+        assertThat(catalog.resolveStationForPhase("completion_gate")).contains("completion_gate");
+        assertThat(catalog.resolveStationForPhase("ci")).contains("ci");
+    }
+
+    @Test
+    void directAndAliasedLifecycleMarkersResolveWithoutBecomingStations() {
+        assertThat(catalog.isLifecycleMarkerPhase("plan")).isTrue();
+        assertThat(catalog.resolveStationForPhase("plan")).isEmpty();
+        assertThat(catalog.isLifecycleMarkerPhase("traceability_reconcile")).isTrue();
+        assertThat(catalog.resolveStationForPhase("traceability_reconcile")).isEmpty();
+    }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/workflowtelemetry/StationMeasurementValidationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/workflowtelemetry/StationMeasurementValidationTest.java
@@ -75,10 +75,19 @@ class StationMeasurementValidationTest {
 
     private RecordPhaseEventCommand command(
             String stationId, StationResult result, PhaseEventType type, List<GateFindingCommand> findings) {
+        return command(stationId == null ? "planning" : stationId, stationId, result, type, findings);
+    }
+
+    private RecordPhaseEventCommand command(
+            String phase,
+            String stationId,
+            StationResult result,
+            PhaseEventType type,
+            List<GateFindingCommand> findings) {
         return new RecordPhaseEventCommand(
                 runId,
                 "gc",
-                stationId == null ? "planning" : stationId,
+                phase,
                 type,
                 0,
                 FROM,
@@ -117,6 +126,27 @@ class StationMeasurementValidationTest {
     }
 
     @Test
+    void phaseAliasSuppliesTheCanonicalStationWhenTheEmitterOmitsIt() {
+        var event = service.recordPhaseEvent(
+                command("preflight", null, StationResult.PASS, PhaseEventType.COMPLETED, null));
+
+        assertThat(event.getPhase()).isEqualTo("preflight");
+        assertThat(event.getStationId()).isEqualTo("architecture_preflight");
+        assertThat(event.getStationResult()).isEqualTo(StationResult.PASS);
+    }
+
+    @Test
+    void aSuppliedStationIdMustMatchThePhaseBinding() {
+        var mismatched = command("ci", "policy", StationResult.PASS, PhaseEventType.COMPLETED, null);
+
+        assertThatThrownBy(() -> service.recordPhaseEvent(mismatched))
+                .isInstanceOf(DomainValidationException.class)
+                .hasMessageContaining("policy")
+                .hasMessageContaining("ci");
+        verify(phaseEventRepository, never()).save(any());
+    }
+
+    @Test
     void aStationIdOutsideTheCatalogueIsRefused() {
         // A typo does not fail on its own. It opens a phantom station holding one attempt and
         // silently removes that attempt from the real station's denominator, and no later query can
@@ -151,9 +181,9 @@ class StationMeasurementValidationTest {
 
     @Test
     void aMarkerWithNoMeasurementIsRecorded() {
-        var event = service.recordPhaseEvent(command("plan", null, PhaseEventType.COMPLETED, null));
+        var event = service.recordPhaseEvent(command("plan", null, null, PhaseEventType.COMPLETED, null));
 
-        assertThat(event.getStationId()).isEqualTo("plan");
+        assertThat(event.getStationId()).isNull();
         assertThat(event.getStationResult()).isEqualTo(StationResult.UNOBSERVED);
     }
 
@@ -204,7 +234,8 @@ class StationMeasurementValidationTest {
         assertThat(service.recordPhaseEvent(command("ci", StationResult.UNOBSERVED, PhaseEventType.STARTED, null))
                         .getStationResult())
                 .isEqualTo(StationResult.UNOBSERVED);
-        assertThat(service.recordPhaseEvent(command("plan", StationResult.UNOBSERVED, PhaseEventType.COMPLETED, null))
+        assertThat(service.recordPhaseEvent(
+                                command("plan", null, StationResult.UNOBSERVED, PhaseEventType.COMPLETED, null))
                         .getStationResult())
                 .isEqualTo(StationResult.UNOBSERVED);
     }

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/workflowtelemetry/WorkflowPhaseEventRecordingTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/workflowtelemetry/WorkflowPhaseEventRecordingTest.java
@@ -20,6 +20,7 @@ import com.keplerops.groundcontrol.domain.workflowtelemetry.WorkflowRun;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.repository.WorkflowPhaseEventRepository;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.repository.WorkflowRunRepository;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.service.RecordPhaseEventCommand;
+import com.keplerops.groundcontrol.domain.workflowtelemetry.service.StationCatalog;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.service.WorkflowMeasurementService;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.service.WorkflowTelemetryService;
 import java.util.List;
@@ -45,6 +46,9 @@ class WorkflowPhaseEventRecordingTest {
 
     @Mock
     private WorkflowMeasurementService measurementService;
+
+    @Mock
+    private StationCatalog stationCatalog;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/workflowtelemetry/WorkflowTelemetryServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/workflowtelemetry/WorkflowTelemetryServiceTest.java
@@ -28,6 +28,7 @@ import com.keplerops.groundcontrol.domain.workflowtelemetry.repository.WorkflowP
 import com.keplerops.groundcontrol.domain.workflowtelemetry.repository.WorkflowRunRepository;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.service.ImportRunCostCommand;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.service.RecordWorkflowRunCommand;
+import com.keplerops.groundcontrol.domain.workflowtelemetry.service.StationCatalog;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.service.WorkflowMeasurementService;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.service.WorkflowTelemetryChangeEvent;
 import com.keplerops.groundcontrol.domain.workflowtelemetry.service.WorkflowTelemetryService;
@@ -56,6 +57,9 @@ class WorkflowTelemetryServiceTest {
 
     @Mock
     private WorkflowMeasurementService measurementService;
+
+    @Mock
+    private StationCatalog stationCatalog;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;

--- a/mcp/ground-control/lib.recordworkflowrunevent.stationresult.test.js
+++ b/mcp/ground-control/lib.recordworkflowrunevent.stationresult.test.js
@@ -1,0 +1,92 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { recordWorkflowRunEvent } from "./lib.js";
+
+const ORIGINAL_BASE_URL = process.env.GC_BASE_URL;
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function withWorkflowRunEnv(fn) {
+  return async () => {
+    process.env.GC_BASE_URL = "https://gc.test";
+    delete process.env.GROUND_CONTROL_API_TOKEN;
+    try {
+      await fn();
+    } finally {
+      if (ORIGINAL_BASE_URL === undefined) delete process.env.GC_BASE_URL;
+      else process.env.GC_BASE_URL = ORIGINAL_BASE_URL;
+      globalThis.fetch = ORIGINAL_FETCH;
+    }
+  };
+}
+
+function makeFetchSpy() {
+  const calls = [];
+  globalThis.fetch = async (url, opts) => {
+    calls.push({
+      url: url.toString(),
+      method: opts?.method ?? "GET",
+      body: opts?.body ? JSON.parse(opts.body) : null,
+    });
+    return new Response(JSON.stringify({ id: "evt-1" }), {
+      status: 201,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return calls;
+}
+
+describe("recordWorkflowRunEvent station-result representation", () => {
+  it(
+    "maps the contract vocabulary to the REST enum representation",
+    withWorkflowRunEnv(async () => {
+      const expected = {
+        pass: "PASS",
+        fail: "FAIL",
+        skipped_station: "SKIPPED_STATION",
+        cancelled: "CANCELLED",
+        not_evaluable: "NOT_EVALUABLE",
+        unobserved: "UNOBSERVED",
+      };
+
+      for (const [contractResult, restResult] of Object.entries(expected)) {
+        const calls = makeFetchSpy();
+        await recordWorkflowRunEvent(
+          "run-abc",
+          {
+            phase: "ci",
+            event_type: "COMPLETED",
+            occurred_at: "2026-01-01T12:00:00Z",
+            provenance: "LIVE_EMISSION",
+            station_result: contractResult,
+          },
+          "proj-a",
+        );
+        assert.equal(calls[0].body.stationResult, restResult);
+      }
+    }),
+  );
+
+  it(
+    "rejects an unknown station result before transport",
+    withWorkflowRunEnv(async () => {
+      const calls = makeFetchSpy();
+
+      await assert.rejects(
+        () =>
+          recordWorkflowRunEvent(
+            "run-abc",
+            {
+              phase: "ci",
+              event_type: "COMPLETED",
+              occurred_at: "2026-01-01T12:00:00Z",
+              provenance: "LIVE_EMISSION",
+              station_result: "ok",
+            },
+            "proj-a",
+          ),
+        /Unknown station_result/,
+      );
+      assert.equal(calls.length, 0);
+    }),
+  );
+});

--- a/mcp/ground-control/lib.recordworkflowrunevent.test.js
+++ b/mcp/ground-control/lib.recordworkflowrunevent.test.js
@@ -77,6 +77,7 @@ describe("recordWorkflowRunEvent", () => {
       assert.equal(calls[0].body.occurredAt, "2026-01-01T12:00:00Z");
     }),
   );
+
 });
 
 describe("importWorkflowRunCost", () => {

--- a/mcp/ground-control/lib/api-workflow-run.js
+++ b/mcp/ground-control/lib/api-workflow-run.js
@@ -258,9 +258,28 @@ export async function checkPackCompatibility(data, project) {
 export async function createWorkflowRun(data, project, { signal } = {}) {
   return request("POST", "/api/v1/workflow-runs", { body: data, params: { project }, signal });
 }
+
+const REST_STATION_RESULT = Object.freeze({
+  pass: "PASS",
+  fail: "FAIL",
+  skipped_station: "SKIPPED_STATION",
+  cancelled: "CANCELLED",
+  not_evaluable: "NOT_EVALUABLE",
+  unobserved: "UNOBSERVED",
+});
+
+function workflowRunEventBody(data) {
+  if (data?.station_result === undefined) return data;
+  const stationResult = REST_STATION_RESULT[data.station_result];
+  if (stationResult === undefined) {
+    throw new TypeError(`Unknown station_result: ${String(data.station_result)}`);
+  }
+  return { ...data, station_result: stationResult };
+}
+
 export async function recordWorkflowRunEvent(runId, data, project, { signal } = {}) {
   return request("POST", `/api/v1/workflow-runs/${encodeURIComponent(runId)}/events`, {
-    body: data,
+    body: workflowRunEventBody(data),
     params: { project },
     signal,
   });


### PR DESCRIPTION
## Summary

Reconciles #1439 with the station-result model delivered by #1355 by making station identity catalogue-authoritative, preserving honest legacy verdicts, and keeping ADR-036 step observations out of ADR-061 yield and migration paths.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1439

## ADR Impact

- ADR-090 (amended)
- ADR-061
- ADR-036

## Changes

- Resolve ADR-061 phase aliases through the authoritative station catalogue and reject phase/station mismatches.
- Translate the contract station-result vocabulary at the MCP-to-REST boundary and restrict yield queries to ADR-061 events.
- Backfill canonical station IDs for resolvable legacy ADR-061 live and audit rows without changing their UNOBSERVED verdicts.
- Cover catalogue binding, emitter isolation, legacy migration behavior, formula filtering, and producer serialization with focused tests.
- **Migration reminder:** update version lists in `MigrationSmokeTest.java` and `RequirementsE2EIntegrationTest.java` (per `.gc/plan-rules.md`).

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

`make check` and `make policy` pass; focused Java migration/domain tests and MCP Node tests pass; test-quality review is clean.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #1439 ← backend workflow telemetry services, V210 migration, and MCP workflow-run adapter
- TESTS: Issue #1439 ← CanonicalStationBindingMigrationIntegrationTest, StationMeasurementValidationTest, WorkflowMeasurementServiceTest, and MCP station-result tests

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.