### PR TITLE
fix: canonicalize GitHub traceability identifiers

### DIFF
--- a/architecture/adrs/011-requirements-data-model.md
+++ b/architecture/adrs/011-requirements-data-model.md
@@ -171,6 +171,14 @@ Canonical conventions:
 
 Do not introduce alternate encodings for the same artifact (`#42`, `owner/repo#42`, `file:...`, `adr:021`) in new data. Self-referential dogfooding must reuse this existing link model rather than adding a GC-specific traceability abstraction.
 
+`TraceabilityService` enforces the issue and pull-request convention on every
+create path, including internal unchecked creates, and on reverse lookup.
+Migration V211 repairs only the historical producer spelling `#<positive
+decimal>`. It fails before updating when the canonical row already exists for
+the same requirement, artifact type, and link type; it does not guess at other
+malformed values or rewrite `traceability_link_audit`, which remains the record
+of what was originally stored.
+
 | Field | Type | Constraints | Notes |
 |-------|------|-------------|-------|
 | id | UUID | PK, generated | |

--- a/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityService.java
+++ b/backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityService.java
@@ -46,6 +46,7 @@ public class TraceabilityService {
 
     private TraceabilityLink createLink(
             UUID requirementId, CreateTraceabilityLinkCommand command, boolean enforceActiveCheck) {
+        validateArtifactIdentifier(command.artifactType(), command.artifactIdentifier());
         var requirement = requirementRepository
                 .findById(requirementId)
                 .orElseThrow(() -> new NotFoundException("Requirement not found: " + requirementId));
@@ -85,6 +86,7 @@ public class TraceabilityService {
 
     @Transactional(readOnly = true)
     public List<TraceabilityLink> findByArtifact(ArtifactType artifactType, String artifactIdentifier, UUID projectId) {
+        validateArtifactIdentifier(artifactType, artifactIdentifier);
         if (projectId == null) {
             // The reverse lookup must never run unscoped: a bare artifact identifier (issue
             // number, file path) collides across projects (#1052/#1197). The controller resolves
@@ -96,6 +98,33 @@ public class TraceabilityService {
         }
         return traceabilityLinkRepository.findByArtifactTypeAndArtifactIdentifierAndProjectIdWithRequirement(
                 artifactType, artifactIdentifier, projectId);
+    }
+
+    private static void validateArtifactIdentifier(ArtifactType artifactType, String artifactIdentifier) {
+        if (artifactType != ArtifactType.GITHUB_ISSUE && artifactType != ArtifactType.PULL_REQUEST) {
+            return;
+        }
+        if (artifactIdentifier == null) {
+            throw invalidArtifactIdentifier(artifactType);
+        }
+
+        int number;
+        try {
+            number = Integer.parseInt(artifactIdentifier);
+        } catch (NumberFormatException e) {
+            throw invalidArtifactIdentifier(artifactType);
+        }
+        if (number <= 0 || !Integer.toString(number).equals(artifactIdentifier)) {
+            throw invalidArtifactIdentifier(artifactType);
+        }
+    }
+
+    private static DomainValidationException invalidArtifactIdentifier(ArtifactType artifactType) {
+        return new DomainValidationException(
+                artifactType
+                        + " artifact identifier must be a positive decimal integer without prefixes or leading zeroes.",
+                "invalid_artifact_identifier",
+                Map.of("artifactType", artifactType.name(), "expectedFormat", "positive decimal integer"));
     }
 
     public void deleteLink(UUID requirementId, UUID linkId) {

--- a/backend/src/main/resources/db/migration/V211__normalize_github_traceability_identifiers.sql
+++ b/backend/src/main/resources/db/migration/V211__normalize_github_traceability_identifiers.sql
@@ -1,0 +1,45 @@
+-- Issue #250: historical MCP-created GitHub links used "#<number>", while the
+-- backend sync contract parses the canonical positive decimal identifier.
+--
+-- Refuse ambiguous repairs. Deleting or merging one side would discard distinct
+-- link identity and could orphan verification/audit references.
+DO $$
+DECLARE
+    collision RECORD;
+BEGIN
+    SELECT
+        legacy.requirement_id,
+        legacy.artifact_type,
+        SUBSTRING(legacy.artifact_identifier FROM 2) AS artifact_identifier,
+        legacy.link_type
+    INTO collision
+    FROM traceability_link legacy
+    JOIN traceability_link canonical
+      ON canonical.requirement_id = legacy.requirement_id
+     AND canonical.artifact_type = legacy.artifact_type
+     AND canonical.artifact_identifier = SUBSTRING(legacy.artifact_identifier FROM 2)
+     AND canonical.link_type = legacy.link_type
+     AND canonical.id <> legacy.id
+    WHERE legacy.artifact_type IN ('GITHUB_ISSUE', 'PULL_REQUEST')
+      AND legacy.artifact_identifier ~ '^#[1-9][0-9]*$'
+      AND SUBSTRING(legacy.artifact_identifier FROM 2)::NUMERIC <= 2147483647
+    LIMIT 1;
+
+    IF FOUND THEN
+        RAISE EXCEPTION
+            'canonical GitHub traceability identifier collision for requirement %, artifact type %, identifier %, link type %',
+            collision.requirement_id,
+            collision.artifact_type,
+            collision.artifact_identifier,
+            collision.link_type
+            USING ERRCODE = '23505';
+    END IF;
+END
+$$;
+
+UPDATE traceability_link
+SET artifact_identifier = SUBSTRING(artifact_identifier FROM 2),
+    updated_at = NOW()
+WHERE artifact_type IN ('GITHUB_ISSUE', 'PULL_REQUEST')
+  AND artifact_identifier ~ '^#[1-9][0-9]*$'
+  AND SUBSTRING(artifact_identifier FROM 2)::NUMERIC <= 2147483647;

--- a/backend/src/test/java/com/keplerops/groundcontrol/domain/requirements/service/AuditServiceDiffTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/domain/requirements/service/AuditServiceDiffTest.java
@@ -263,7 +263,7 @@ class AuditServiceDiffTest {
         void throwsNotFoundWhenRequirementDoesNotOwnLink() {
             var ownerId = UUID.randomUUID();
             var owner = makeRequirementWithId("REQ-OWNER", ownerId);
-            var link = new TraceabilityLink(owner, ArtifactType.GITHUB_ISSUE, "GH-123", LinkType.IMPLEMENTS);
+            var link = new TraceabilityLink(owner, ArtifactType.GITHUB_ISSUE, "123", LinkType.IMPLEMENTS);
             var linkId = UUID.randomUUID();
             setField(link, "id", linkId);
             when(traceabilityLinkRepository.findById(linkId)).thenReturn(Optional.of(link));

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/GitHubTraceabilityIdentifierMigrationIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/GitHubTraceabilityIdentifierMigrationIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.keplerops.groundcontrol.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+
+/** Exercises V211's legacy GitHub traceability repair against the actual migration SQL. */
+class GitHubTraceabilityIdentifierMigrationIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void normalizesKnownLegacyValuesWithoutRewritingAuditHistory() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                var requirementId = insertRequirement(connection, "MIG-V211-NORMALIZE");
+                var issueLinkId = insertLink(connection, requirementId, "GITHUB_ISSUE", "#42", "IMPLEMENTS");
+                var pullRequestLinkId = insertLink(connection, requirementId, "PULL_REQUEST", "#43", "DOCUMENTS");
+                var malformedLinkId = insertLink(connection, requirementId, "GITHUB_ISSUE", "GH-44", "DOCUMENTS");
+                var oversizedLinkId = insertLink(connection, requirementId, "GITHUB_ISSUE", "#2147483648", "DOCUMENTS");
+                insertAuditSnapshot(connection, issueLinkId, requirementId, "GITHUB_ISSUE", "#42", "IMPLEMENTS");
+
+                executeMigration(connection);
+
+                assertThat(readLiveIdentifier(connection, issueLinkId)).isEqualTo("42");
+                assertThat(readLiveIdentifier(connection, pullRequestLinkId)).isEqualTo("43");
+                assertThat(readLiveIdentifier(connection, malformedLinkId)).isEqualTo("GH-44");
+                assertThat(readLiveIdentifier(connection, oversizedLinkId)).isEqualTo("#2147483648");
+                assertThat(readAuditIdentifier(connection, issueLinkId)).isEqualTo("#42");
+            } finally {
+                connection.rollback();
+            }
+        }
+    }
+
+    @Test
+    void refusesToNormalizeWhenCanonicalLinkAlreadyExists() throws Exception {
+        try (Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                var requirementId = insertRequirement(connection, "MIG-V211-COLLISION");
+                insertLink(connection, requirementId, "GITHUB_ISSUE", "#42", "IMPLEMENTS");
+                insertLink(connection, requirementId, "GITHUB_ISSUE", "42", "IMPLEMENTS");
+
+                assertThatThrownBy(() -> executeMigration(connection))
+                        .rootCause()
+                        .hasMessageContaining("canonical GitHub traceability identifier collision");
+            } finally {
+                connection.rollback();
+            }
+        }
+    }
+
+    private static UUID insertRequirement(Connection connection, String uid) throws Exception {
+        var requirementId = UUID.randomUUID();
+        try (var statement = connection.prepareStatement("INSERT INTO requirement "
+                + "(id, project_id, uid, title, statement, created_at, updated_at) "
+                + "VALUES (?, 'a0000000-0000-0000-0000-000000000001', ?, ?, 'statement', now(), now())")) {
+            statement.setObject(1, requirementId);
+            statement.setString(2, uid);
+            statement.setString(3, uid);
+            statement.executeUpdate();
+        }
+        return requirementId;
+    }
+
+    private static UUID insertLink(
+            Connection connection, UUID requirementId, String artifactType, String identifier, String linkType)
+            throws Exception {
+        var linkId = UUID.randomUUID();
+        try (var statement = connection.prepareStatement("INSERT INTO traceability_link "
+                + "(id, requirement_id, artifact_type, artifact_identifier, link_type, created_at, updated_at) "
+                + "VALUES (?, ?, ?, ?, ?, now(), now())")) {
+            statement.setObject(1, linkId);
+            statement.setObject(2, requirementId);
+            statement.setString(3, artifactType);
+            statement.setString(4, identifier);
+            statement.setString(5, linkType);
+            statement.executeUpdate();
+        }
+        return linkId;
+    }
+
+    private static void insertAuditSnapshot(
+            Connection connection,
+            UUID linkId,
+            UUID requirementId,
+            String artifactType,
+            String identifier,
+            String linkType)
+            throws Exception {
+        int revision;
+        try (var statement = connection.prepareStatement("INSERT INTO revinfo (revtstmp) VALUES (0) RETURNING rev");
+                var result = statement.executeQuery()) {
+            result.next();
+            revision = result.getInt(1);
+        }
+        try (var statement = connection.prepareStatement("INSERT INTO traceability_link_audit "
+                + "(id, rev, revtype, requirement_id, artifact_type, artifact_identifier, link_type) "
+                + "VALUES (?, ?, 0, ?, ?, ?, ?)")) {
+            statement.setObject(1, linkId);
+            statement.setInt(2, revision);
+            statement.setObject(3, requirementId);
+            statement.setString(4, artifactType);
+            statement.setString(5, identifier);
+            statement.setString(6, linkType);
+            statement.executeUpdate();
+        }
+    }
+
+    private static String readLiveIdentifier(Connection connection, UUID linkId) throws Exception {
+        try (var statement =
+                connection.prepareStatement("SELECT artifact_identifier FROM traceability_link WHERE id = ?")) {
+            statement.setObject(1, linkId);
+            try (var result = statement.executeQuery()) {
+                result.next();
+                return result.getString(1);
+            }
+        }
+    }
+
+    private static String readAuditIdentifier(Connection connection, UUID linkId) throws Exception {
+        try (var statement =
+                connection.prepareStatement("SELECT artifact_identifier FROM traceability_link_audit WHERE id = ?")) {
+            statement.setObject(1, linkId);
+            try (var result = statement.executeQuery()) {
+                result.next();
+                return result.getString(1);
+            }
+        }
+    }
+
+    private static void executeMigration(Connection connection) {
+        ScriptUtils.executeSqlScript(
+                connection,
+                new EncodedResource(
+                        new ClassPathResource("db/migration/V211__normalize_github_traceability_identifiers.sql")),
+                false,
+                false,
+                ScriptUtils.DEFAULT_COMMENT_PREFIX,
+                ScriptUtils.EOF_STATEMENT_SEPARATOR,
+                ScriptUtils.DEFAULT_BLOCK_COMMENT_START_DELIMITER,
+                ScriptUtils.DEFAULT_BLOCK_COMMENT_END_DELIMITER);
+    }
+}

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/MigrationSmokeTest.java
@@ -404,7 +404,10 @@ class MigrationSmokeTest extends BaseIntegrationTest {
                         "209",
                         // V210 (#1439, ADR-090 amendment): canonical station binding backfill for
                         // resolvable ADR-061 phases in live and Envers rows.
-                        "210");
+                        "210",
+                        // V211 (#250): fail-closed normalization of legacy #<number> GitHub
+                        // traceability identifiers without rewriting Envers history.
+                        "211");
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/RequirementsE2EIntegrationTest.java
@@ -46,8 +46,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * End-to-end requirements flow against the full Flyway migration set applied by
- * {@link BaseIntegrationTest} — through V210, which adds canonical station binding for resolvable
- * ADR-061 phases in live and audit rows (issue #1439). It exercises the API and the audited
+ * {@link BaseIntegrationTest} — through V211, which normalizes legacy GitHub traceability
+ * identifiers without rewriting audit history (issue #250). It exercises the API and the audited
  * persistence spine those migrations build, so a migration that breaks the end-to-end path fails
  * here rather than only in the migration smoke test.
  */

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/SchemaMigrationVerificationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/SchemaMigrationVerificationTest.java
@@ -245,6 +245,7 @@ class SchemaMigrationVerificationTest extends BaseIntegrationTest {
                         "207", // V207: station-result axis + gate-finding projection (#1355)
                         "208", // V208: workflow_gate_finding Envers shadow (#1355)
                         "209", // V209: durable ADR-036 step observation on the phase-event row (#1354)
-                        "210"); // V210: canonical ADR-061 workflow station binding (#1439)
+                        "210", // V210: canonical ADR-061 workflow station binding (#1439)
+                        "211"); // V211: canonical GitHub traceability identifiers (#250)
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/SyncIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/SyncIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
 import com.keplerops.groundcontrol.domain.projects.repository.ProjectRepository;
 import com.keplerops.groundcontrol.domain.requirements.model.Requirement;
@@ -19,7 +20,9 @@ import com.keplerops.groundcontrol.domain.requirements.service.GitHubIssueData;
 import com.keplerops.groundcontrol.domain.requirements.service.GitHubPullRequestData;
 import com.keplerops.groundcontrol.domain.requirements.state.ArtifactType;
 import com.keplerops.groundcontrol.domain.requirements.state.LinkType;
+import com.keplerops.groundcontrol.domain.requirements.state.Status;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +30,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -93,6 +97,9 @@ class SyncIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private ProjectRepository projectRepository;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     private Project testProject;
 
     @BeforeEach
@@ -150,5 +157,37 @@ class SyncIntegrationTest extends BaseIntegrationTest {
         assertThat(updatedLinks).hasSize(1);
         assertThat(updatedLinks.get(0).getArtifactUrl()).isEqualTo("https://github.com/test/repo/issues/1");
         assertThat(updatedLinks.get(0).getArtifactTitle()).isEqualTo("#1 - Setup CI [CLOSED]");
+    }
+
+    @Test
+    void mcpTraceabilityRequest_thenSync_updatesThePersistedLink() throws Exception {
+        var requirement = new Requirement(testProject, "SYNC-MCP-001", "MCP-created issue", "Statement");
+        requirement.transitionStatus(Status.ACTIVE);
+        requirement = requirementRepository.save(requirement);
+
+        // This is the exact REST shape emitted by createGitHubIssueFromRequirement; its Node
+        // contract test independently asserts that issue 431 is serialized as "431", not "#431".
+        var mcpRequest = Map.of(
+                "artifactType", "GITHUB_ISSUE",
+                "artifactIdentifier", "1",
+                "artifactUrl", "https://github.com/test/repo/issues/1",
+                "artifactTitle", "MCP-created issue",
+                "linkType", "IMPLEMENTS");
+        mockMvc.perform(post("/api/v1/requirements/" + requirement.getId() + "/traceability")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(mcpRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.artifactIdentifier", is("1")));
+
+        mockMvc.perform(post("/api/v1/admin/sync/github").param("owner", "test").param("repo", "repo"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.linksUpdated", is(1)));
+
+        var links = traceabilityLinkRepository.findByRequirementId(requirement.getId());
+        assertThat(links).singleElement().satisfies(link -> {
+            assertThat(link.getArtifactIdentifier()).isEqualTo("1");
+            assertThat(link.getArtifactUrl()).isEqualTo("https://github.com/test/repo/issues/1");
+            assertThat(link.getArtifactTitle()).isEqualTo("#1 - Setup CI [CLOSED]");
+        });
     }
 }

--- a/backend/src/test/java/com/keplerops/groundcontrol/integration/TraceabilityLinkControllerIntegrationTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/integration/TraceabilityLinkControllerIntegrationTest.java
@@ -65,7 +65,7 @@ class TraceabilityLinkControllerIntegrationTest extends BaseIntegrationTest {
     private String createLinkAndReturnId(String requirementId) throws Exception {
         var body = Map.of(
                 "artifactType", "GITHUB_ISSUE",
-                "artifactIdentifier", "GH-42",
+                "artifactIdentifier", "42",
                 "artifactUrl", "https://github.com/org/repo/issues/42",
                 "artifactTitle", "Fix the bug",
                 "linkType", "IMPLEMENTS");
@@ -87,7 +87,7 @@ class TraceabilityLinkControllerIntegrationTest extends BaseIntegrationTest {
 
         var body = Map.of(
                 "artifactType", "GITHUB_ISSUE",
-                "artifactIdentifier", "GH-42",
+                "artifactIdentifier", "42",
                 "artifactUrl", "https://github.com/org/repo/issues/42",
                 "artifactTitle", "Fix the bug",
                 "linkType", "IMPLEMENTS");
@@ -98,7 +98,7 @@ class TraceabilityLinkControllerIntegrationTest extends BaseIntegrationTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id", notNullValue()))
                 .andExpect(jsonPath("$.artifactType", is("GITHUB_ISSUE")))
-                .andExpect(jsonPath("$.artifactIdentifier", is("GH-42")))
+                .andExpect(jsonPath("$.artifactIdentifier", is("42")))
                 .andExpect(jsonPath("$.linkType", is("IMPLEMENTS")))
                 .andExpect(jsonPath("$.syncStatus", is("SYNCED")));
     }
@@ -109,15 +109,17 @@ class TraceabilityLinkControllerIntegrationTest extends BaseIntegrationTest {
         var reqId = createRequirementAndReturnId("REQ-AT-" + type.name());
         activateRequirement(reqId);
 
-        var body = Map.of(
-                "artifactType", type.name(), "artifactIdentifier", "id:" + type.name(), "linkType", "IMPLEMENTS");
+        var artifactIdentifier =
+                type == ArtifactType.GITHUB_ISSUE || type == ArtifactType.PULL_REQUEST ? "42" : "id:" + type.name();
+        var body =
+                Map.of("artifactType", type.name(), "artifactIdentifier", artifactIdentifier, "linkType", "IMPLEMENTS");
 
         mockMvc.perform(post("/api/v1/requirements/" + reqId + "/traceability")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.artifactType", is(type.name())))
-                .andExpect(jsonPath("$.artifactIdentifier", is("id:" + type.name())));
+                .andExpect(jsonPath("$.artifactIdentifier", is(artifactIdentifier)));
     }
 
     @Test
@@ -128,7 +130,7 @@ class TraceabilityLinkControllerIntegrationTest extends BaseIntegrationTest {
 
         mockMvc.perform(get("/api/v1/requirements/" + reqId + "/traceability"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].artifactIdentifier", is("GH-42")));
+                .andExpect(jsonPath("$[0].artifactIdentifier", is("42")));
     }
 
     @Test
@@ -145,7 +147,7 @@ class TraceabilityLinkControllerIntegrationTest extends BaseIntegrationTest {
     void createLink_requirementNotFound_returns404() throws Exception {
         var body = Map.of(
                 "artifactType", "GITHUB_ISSUE",
-                "artifactIdentifier", "GH-42",
+                "artifactIdentifier", "42",
                 "linkType", "IMPLEMENTS");
 
         mockMvc.perform(post("/api/v1/requirements/" + UUID.randomUUID() + "/traceability")

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTraceabilityTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RequirementControllerTraceabilityTest.java
@@ -19,6 +19,7 @@ import com.keplerops.groundcontrol.api.requirements.RequirementController;
 import com.keplerops.groundcontrol.domain.exception.AuthenticationException;
 import com.keplerops.groundcontrol.domain.exception.AuthorizationException;
 import com.keplerops.groundcontrol.domain.exception.ConflictException;
+import com.keplerops.groundcontrol.domain.exception.DomainValidationException;
 import com.keplerops.groundcontrol.domain.exception.GroundControlException;
 import com.keplerops.groundcontrol.domain.exception.NotFoundException;
 import com.keplerops.groundcontrol.domain.projects.model.Project;
@@ -114,7 +115,7 @@ class RequirementControllerTraceabilityTest {
     class Traceability {
 
         private static TraceabilityLink createLink(Requirement req) {
-            var link = new TraceabilityLink(req, ArtifactType.GITHUB_ISSUE, "GH-123", LinkType.IMPLEMENTS);
+            var link = new TraceabilityLink(req, ArtifactType.GITHUB_ISSUE, "123", LinkType.IMPLEMENTS);
             setField(link, "id", UUID.randomUUID());
             setField(link, "createdAt", Instant.now());
             setField(link, "updatedAt", Instant.now());
@@ -130,7 +131,7 @@ class RequirementControllerTraceabilityTest {
             mockMvc.perform(get("/api/v1/requirements/" + req.getId() + "/traceability"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$[0].artifactType", is("GITHUB_ISSUE")))
-                    .andExpect(jsonPath("$[0].artifactIdentifier", is("GH-123")))
+                    .andExpect(jsonPath("$[0].artifactIdentifier", is("123")))
                     .andExpect(jsonPath("$[0].linkType", is("IMPLEMENTS")));
         }
 
@@ -145,12 +146,34 @@ class RequirementControllerTraceabilityTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(Map.of(
                                     "artifactType", "GITHUB_ISSUE",
-                                    "artifactIdentifier", "GH-123",
+                                    "artifactIdentifier", "123",
                                     "linkType", "IMPLEMENTS"))))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.artifactType", is("GITHUB_ISSUE")))
-                    .andExpect(jsonPath("$.artifactIdentifier", is("GH-123")))
+                    .andExpect(jsonPath("$.artifactIdentifier", is("123")))
                     .andExpect(jsonPath("$.linkType", is("IMPLEMENTS")));
+        }
+
+        @Test
+        void createLink_invalidGitHubIdentifier_returnsStandard422Envelope() throws Exception {
+            var reqId = UUID.randomUUID();
+            doThrow(new DomainValidationException(
+                            "GITHUB_ISSUE artifact identifier must be a positive decimal integer.",
+                            "invalid_artifact_identifier",
+                            Map.of("artifactType", "GITHUB_ISSUE", "expectedFormat", "positive decimal integer")))
+                    .when(traceabilityService)
+                    .createLink(eq(reqId), any(CreateTraceabilityLinkCommand.class));
+
+            mockMvc.perform(post("/api/v1/requirements/" + reqId + "/traceability")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of(
+                                    "artifactType", "GITHUB_ISSUE",
+                                    "artifactIdentifier", "#42",
+                                    "linkType", "DOCUMENTS"))))
+                    .andExpect(status().isUnprocessableEntity())
+                    .andExpect(jsonPath("$.error.code", is("invalid_artifact_identifier")))
+                    .andExpect(jsonPath("$.error.detail.artifactType", is("GITHUB_ISSUE")))
+                    .andExpect(jsonPath("$.error.detail.expectedFormat", is("positive decimal integer")));
         }
 
         @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskScenarioControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/RiskScenarioControllerTest.java
@@ -385,7 +385,7 @@ class RiskScenarioControllerTest {
         setField(req, "createdAt", NOW);
         setField(req, "updatedAt", NOW);
 
-        var artifact = new TraceabilityLink(req, ArtifactType.PULL_REQUEST, "PR-42", LinkType.IMPLEMENTS);
+        var artifact = new TraceabilityLink(req, ArtifactType.PULL_REQUEST, "42", LinkType.IMPLEMENTS);
         setField(artifact, "id", UUID.fromString("00000000-0000-0000-0000-000000000400"));
         setField(artifact, "createdAt", NOW);
         setField(artifact, "updatedAt", NOW);
@@ -414,7 +414,7 @@ class RiskScenarioControllerTest {
                 .andExpect(jsonPath("$.requirements", hasSize(1)))
                 .andExpect(jsonPath("$.requirements[0].requirement.uid", is("GC-H003")))
                 .andExpect(jsonPath("$.requirements[0].artifacts", hasSize(1)))
-                .andExpect(jsonPath("$.requirements[0].artifacts[0].artifactIdentifier", is("PR-42")));
+                .andExpect(jsonPath("$.requirements[0].artifacts[0].artifactIdentifier", is("42")));
     }
 
     @org.junit.jupiter.api.Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ThreatModelControllerTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/api/ThreatModelControllerTest.java
@@ -359,7 +359,7 @@ class ThreatModelControllerTest {
         setField(req, "createdAt", NOW);
         setField(req, "updatedAt", NOW);
 
-        var artifact = new TraceabilityLink(req, ArtifactType.PULL_REQUEST, "PR-42", LinkType.IMPLEMENTS);
+        var artifact = new TraceabilityLink(req, ArtifactType.PULL_REQUEST, "42", LinkType.IMPLEMENTS);
         setField(artifact, "id", UUID.fromString("00000000-0000-0000-0000-000000000400"));
         setField(artifact, "createdAt", NOW);
         setField(artifact, "updatedAt", NOW);
@@ -388,7 +388,7 @@ class ThreatModelControllerTest {
                 .andExpect(jsonPath("$.requirements", hasSize(1)))
                 .andExpect(jsonPath("$.requirements[0].requirement.uid", is("GC-H003")))
                 .andExpect(jsonPath("$.requirements[0].artifacts", hasSize(1)))
-                .andExpect(jsonPath("$.requirements[0].artifacts[0].artifactIdentifier", is("PR-42")));
+                .andExpect(jsonPath("$.requirements[0].artifacts[0].artifactIdentifier", is("42")));
     }
 
     @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AnalysisServiceExtractSubgraphTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/AnalysisServiceExtractSubgraphTest.java
@@ -184,9 +184,9 @@ class AnalysisServiceExtractSubgraphTest {
             UUID bId = UUID.randomUUID();
             var reqA = makeRequirement("REQ-A", aId);
             var reqB = makeRequirement("REQ-B", bId);
-            var linkA = new TraceabilityLink(reqA, ArtifactType.GITHUB_ISSUE, "issue-1", LinkType.IMPLEMENTS);
-            var linkB1 = new TraceabilityLink(reqB, ArtifactType.GITHUB_ISSUE, "issue-2", LinkType.TESTS);
-            var linkB2 = new TraceabilityLink(reqB, ArtifactType.GITHUB_ISSUE, "issue-3", LinkType.DOCUMENTS);
+            var linkA = new TraceabilityLink(reqA, ArtifactType.GITHUB_ISSUE, "1", LinkType.IMPLEMENTS);
+            var linkB1 = new TraceabilityLink(reqB, ArtifactType.GITHUB_ISSUE, "2", LinkType.TESTS);
+            var linkB2 = new TraceabilityLink(reqB, ArtifactType.GITHUB_ISSUE, "3", LinkType.DOCUMENTS);
 
             when(requirementRepository.findByProjectIdAndArchivedAtIsNull(PROJECT_ID))
                     .thenReturn(List.of(reqA, reqB));

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceFindTraceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/RiskScenarioServiceFindTraceTest.java
@@ -136,7 +136,7 @@ class RiskScenarioServiceFindTraceTest {
                     rs, RiskScenarioLinkTargetType.REQUIREMENT, reqId, null, RiskScenarioLinkType.AFFECTS);
             setField(reqLink, "id", UUID.randomUUID());
 
-            var artifact = new TraceabilityLink(req, ArtifactType.PULL_REQUEST, "PR-42", LinkType.IMPLEMENTS);
+            var artifact = new TraceabilityLink(req, ArtifactType.PULL_REQUEST, "42", LinkType.IMPLEMENTS);
             setField(artifact, "id", UUID.randomUUID());
 
             when(riskScenarioRepository.findByIdAndProjectId(rs.getId(), projectId))
@@ -171,7 +171,7 @@ class RiskScenarioServiceFindTraceTest {
             assertThat(trace.requirements().get(0).requirement().getUid()).isEqualTo("GC-H003");
             assertThat(trace.requirements().get(0).artifacts()).hasSize(1);
             assertThat(trace.requirements().get(0).artifacts().get(0).getArtifactIdentifier())
-                    .isEqualTo("PR-42");
+                    .isEqualTo("42");
         }
 
         @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ThreatModelServiceFindTraceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/ThreatModelServiceFindTraceTest.java
@@ -141,7 +141,7 @@ class ThreatModelServiceFindTraceTest {
                     tm, ThreatModelLinkTargetType.REQUIREMENT, reqId, null, ThreatModelLinkType.AFFECTS);
             setField(reqLink, "id", UUID.randomUUID());
 
-            var artifact = new TraceabilityLink(req, ArtifactType.PULL_REQUEST, "PR-42", LinkType.IMPLEMENTS);
+            var artifact = new TraceabilityLink(req, ArtifactType.PULL_REQUEST, "42", LinkType.IMPLEMENTS);
             setField(artifact, "id", UUID.randomUUID());
 
             when(threatModelRepository.findByIdAndProjectId(tm.getId(), projectId))
@@ -176,7 +176,7 @@ class ThreatModelServiceFindTraceTest {
             assertThat(trace.requirements().get(0).requirement().getUid()).isEqualTo("GC-H003");
             assertThat(trace.requirements().get(0).artifacts()).hasSize(1);
             assertThat(trace.requirements().get(0).artifacts().get(0).getArtifactIdentifier())
-                    .isEqualTo("PR-42");
+                    .isEqualTo("42");
         }
 
         @Test

--- a/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TraceabilityServiceTest.java
+++ b/backend/src/test/java/com/keplerops/groundcontrol/unit/domain/TraceabilityServiceTest.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -66,7 +69,7 @@ class TraceabilityServiceTest {
     }
 
     private static TraceabilityLink makeLink(Requirement req) {
-        var link = new TraceabilityLink(req, ArtifactType.GITHUB_ISSUE, "GH-123", LinkType.IMPLEMENTS);
+        var link = new TraceabilityLink(req, ArtifactType.GITHUB_ISSUE, "123", LinkType.IMPLEMENTS);
         setField(link, "id", UUID.randomUUID());
         return link;
     }
@@ -86,19 +89,48 @@ class TraceabilityServiceTest {
             when(traceabilityLinkRepository.save(any(TraceabilityLink.class))).thenAnswer(inv -> inv.getArgument(0));
 
             var cmd = new CreateTraceabilityLinkCommand(
-                    ArtifactType.GITHUB_ISSUE,
-                    "GH-123",
-                    "https://github.com/issue/123",
-                    "Fix bug",
-                    LinkType.IMPLEMENTS);
+                    ArtifactType.GITHUB_ISSUE, "123", "https://github.com/issue/123", "Fix bug", LinkType.IMPLEMENTS);
 
             var result = service.createLink(reqId, cmd);
             assertThat(result).isNotNull();
             assertThat(result.getArtifactType()).isEqualTo(ArtifactType.GITHUB_ISSUE);
-            assertThat(result.getArtifactIdentifier()).isEqualTo("GH-123");
+            assertThat(result.getArtifactIdentifier()).isEqualTo("123");
             assertThat(result.getLinkType()).isEqualTo(LinkType.IMPLEMENTS);
             assertThat(result.getArtifactUrl()).isEqualTo("https://github.com/issue/123");
             assertThat(result.getArtifactTitle()).isEqualTo("Fix bug");
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "#42", "042", "+42", "0", "-1", "owner/repo#42", "2147483648"})
+        void rejectsNonCanonicalGitHubIssueIdentifiers(String identifier) {
+            var cmd = new CreateTraceabilityLinkCommand(
+                    ArtifactType.GITHUB_ISSUE, identifier, null, null, LinkType.DOCUMENTS);
+
+            assertInvalidArtifactIdentifier(() -> service.createLink(UUID.randomUUID(), cmd));
+        }
+
+        @Test
+        void rejectsNonCanonicalPullRequestIdentifierOnUncheckedCreate() {
+            var cmd = new CreateTraceabilityLinkCommand(
+                    ArtifactType.PULL_REQUEST, "PR-42", null, null, LinkType.IMPLEMENTS);
+
+            assertInvalidArtifactIdentifier(() -> service.createLinkUnchecked(UUID.randomUUID(), cmd));
+        }
+
+        @Test
+        void uncheckedCreateAcceptsCanonicalPullRequestIdentifier() {
+            var reqId = UUID.randomUUID();
+            var req = makeRequirement("REQ-DRAFT");
+            when(requirementRepository.findById(reqId)).thenReturn(Optional.of(req));
+            when(traceabilityLinkRepository.save(any(TraceabilityLink.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            var result = service.createLinkUnchecked(
+                    reqId,
+                    new CreateTraceabilityLinkCommand(
+                            ArtifactType.PULL_REQUEST, "42", null, null, LinkType.IMPLEMENTS));
+
+            assertThat(result.getArtifactIdentifier()).isEqualTo("42");
         }
 
         @Test
@@ -107,7 +139,7 @@ class TraceabilityServiceTest {
             when(requirementRepository.findById(reqId)).thenReturn(Optional.empty());
 
             var cmd = new CreateTraceabilityLinkCommand(
-                    ArtifactType.GITHUB_ISSUE, "GH-123", null, null, LinkType.IMPLEMENTS);
+                    ArtifactType.GITHUB_ISSUE, "123", null, null, LinkType.IMPLEMENTS);
 
             assertThatThrownBy(() -> service.createLink(reqId, cmd)).isInstanceOf(NotFoundException.class);
         }
@@ -169,7 +201,7 @@ class TraceabilityServiceTest {
 
             var result = service.getLinksForRequirement(reqId);
             assertThat(result).hasSize(1);
-            assertThat(result.get(0).getArtifactIdentifier()).isEqualTo("GH-123");
+            assertThat(result.get(0).getArtifactIdentifier()).isEqualTo("123");
         }
 
         @Test
@@ -217,6 +249,12 @@ class TraceabilityServiceTest {
             assertThatThrownBy(() -> service.findByArtifact(ArtifactType.CODE_FILE, "backend/src/Main.java", null))
                     .isInstanceOf(DomainValidationException.class);
         }
+
+        @Test
+        void rejectsNonCanonicalGitHubIdentifierBeforeReverseLookup() {
+            assertInvalidArtifactIdentifier(
+                    () -> service.findByArtifact(ArtifactType.GITHUB_ISSUE, "#42", UUID.randomUUID()));
+        }
     }
 
     @Nested
@@ -252,5 +290,11 @@ class TraceabilityServiceTest {
 
             assertThatThrownBy(() -> service.deleteLink(wrongReqId, linkId)).isInstanceOf(NotFoundException.class);
         }
+    }
+
+    private static void assertInvalidArtifactIdentifier(org.assertj.core.api.ThrowableAssert.ThrowingCallable call) {
+        assertThatThrownBy(call).isInstanceOf(DomainValidationException.class).satisfies(error -> assertThat(
+                        ((DomainValidationException) error).getErrorCode())
+                .isEqualTo("invalid_artifact_identifier"));
     }
 }

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -170,7 +170,7 @@ GitHubIssueSync, RequirementImport, plus the ADR-085 identity family
 `RolePermissionAssignment`, `RoleGrant`, `ProjectAccessGrant`) - all JPA with
 Envers auditing.
 
-**Services:** RequirementService (9 methods), TraceabilityService (forward and reverse artifact lookup), ImportService (StrictDoc parser + idempotent import), GitHubIssueSyncService (CLI-based GitHub sync), AnalysisService (cycle/orphan/coverage/impact/cross-wave; status drift belongs here as read-only analysis), AgeGraphService (Apache AGE graph materialization + Cypher queries).
+**Services:** RequirementService (9 methods), TraceabilityService (forward and reverse artifact lookup, with canonical positive-decimal identity enforcement for GitHub issues and pull requests), ImportService (StrictDoc parser + idempotent import), GitHubIssueSyncService (CLI-based GitHub sync), AnalysisService (cycle/orphan/coverage/impact/cross-wave; status drift belongs here as read-only analysis), AgeGraphService (Apache AGE graph materialization + Cypher queries).
 
 **Requirement UID allocation (ADR-060, issues #532, #1052):** `RequirementUidAllocator` assigns the next free `{PREFIX}-{N}` UID atomically per project via `pg_advisory_xact_lock`, reading the current high-water mark from `findMaxUidSuffix` (archived rows included, so no suffix is ever recycled). `TraceabilityService.findByArtifact` accepts an optional `projectId` to scope the reverse lookup to a single project; this prevents cross-project issue-number collisions from returning or flagging another project's `GITHUB_ISSUE` links.
 

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -46,6 +46,22 @@ make dev                           # Spring Boot dev server on :8000
 
 Flyway migrations run automatically on application startup - there is no separate migration step.
 
+### V211 GitHub traceability repair
+
+V211 normalizes legacy `#<positive decimal>` identifiers for `GITHUB_ISSUE`
+and `PULL_REQUEST` traceability links. Startup fails closed when both the legacy
+and canonical spellings already exist for the same requirement, artifact type,
+and link type; inspect and resolve those distinct links deliberately before
+retrying the deployment. The migration preserves Envers audit rows and leaves
+other malformed values unchanged.
+
+After V211 starts successfully, invoke the existing authenticated
+`POST /api/v1/admin/graph/materialize` operation once. The relational tables
+are authoritative, but `artifactIdentifier` contributes to derivative AGE node
+identity, so a previously published graph must be rebuilt after normalization.
+Use an authenticated admin client that sends credentials in HTTP headers
+without placing tokens in command arguments.
+
 ### Docker Compose Services
 
 The `docker-compose.yml` in the project root runs infrastructure only. Spring Boot runs on the host.

--- a/frontend/src/components/__tests__/traceability-form.test.tsx
+++ b/frontend/src/components/__tests__/traceability-form.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TraceabilityForm } from "../traceability-form";
+
+describe("TraceabilityForm", () => {
+  it("shows an identifier example that matches the selected artifact type", async () => {
+    const user = userEvent.setup();
+    render(<TraceabilityForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText("e.g. 42")).toBeTruthy();
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Artifact Type" }),
+      "ADR",
+    );
+
+    expect(screen.getByPlaceholderText("e.g. ADR-011")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/traceability-form.tsx
+++ b/frontend/src/components/traceability-form.tsx
@@ -19,6 +19,21 @@ interface TraceabilityFormProps {
   loading?: boolean;
 }
 
+const IDENTIFIER_PLACEHOLDERS: Record<ArtifactType, string> = {
+  GITHUB_ISSUE: "e.g. 42",
+  PULL_REQUEST: "e.g. 42",
+  CODE_FILE: "e.g. backend/src/main/java/Example.java",
+  ADR: "e.g. ADR-011",
+  CONFIG: "e.g. config/application.yml",
+  POLICY: "e.g. policies/access-control.rego",
+  TEST: "e.g. backend/src/test/java/ExampleTest.java",
+  SPEC: "e.g. docs/specs/traceability.md",
+  PROOF: "e.g. proofs/traceability.tla",
+  DOCUMENTATION: "e.g. docs/architecture/ARCHITECTURE.md",
+  RISK_SCENARIO: "e.g. RS-001",
+  CONTROL: "e.g. CTRL-001",
+};
+
 export function TraceabilityForm({
   onSubmit,
   onCancel,
@@ -77,7 +92,7 @@ export function TraceabilityForm({
           className={inputClass}
           value={artifactIdentifier}
           onChange={(e) => setArtifactIdentifier(e.target.value)}
-          placeholder="e.g. autarchy-ai/Ground-Control#42"
+          placeholder={IDENTIFIER_PLACEHOLDERS[artifactType]}
           required
         />
       </FormField>

--- a/frontend/src/pages/__tests__/traceability-matrix.test.tsx
+++ b/frontend/src/pages/__tests__/traceability-matrix.test.tsx
@@ -88,7 +88,7 @@ const composed: PagedResponse<RequirementWithLinksResponse> = {
           requirementId: "req-1",
           linkType: "IMPLEMENTS",
           artifactType: "PULL_REQUEST",
-          artifactIdentifier: "PR-42",
+          artifactIdentifier: "42",
           artifactTitle: "Implement login",
         }),
         link({
@@ -177,7 +177,7 @@ describe("TraceabilityMatrix", () => {
                   requirementId: "req-3",
                   linkType: "IMPLEMENTS",
                   artifactType: "PULL_REQUEST",
-                  artifactIdentifier: "PR-7",
+                  artifactIdentifier: "7",
                 }),
               ],
             },


### PR DESCRIPTION
## Summary

Canonicalizes GitHub issue and pull-request traceability identifiers as positive decimal numbers across MCP production, backend validation, persistence repair, synchronization, and UI guidance.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #250

## ADR Impact

- ADR-011 (amended)
- ADR-021

## Changes

- Validate canonical GitHub issue and pull-request identifiers at the shared traceability service boundary.
- Normalize known legacy hash-prefixed identifiers with Flyway V211 while preserving audit history and failing closed on collisions.
- Align MCP, backend, frontend, migration, and synchronization tests with the canonical format.
- Document the identifier contract and post-migration graph rematerialization procedure.
- **Migration reminder:** update version lists in `MigrationSmokeTest.java` and `RequirementsE2EIntegrationTest.java` (per `.gc/plan-rules.md`).

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

Focused backend unit, controller, migration, and synchronization tests; focused MCP and frontend tests; `make check`; `make policy`; and all five Ground Control quality gates passed.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #250 ← backend/src/main/java/com/keplerops/groundcontrol/domain/requirements/service/TraceabilityService.java, Issue #250 ← backend/src/main/resources/db/migration/V211__normalize_github_traceability_identifiers.sql
- TESTS: Issue #250 ← backend/src/test/java/com/keplerops/groundcontrol/integration/GitHubTraceabilityIdentifierMigrationIntegrationTest.java, Issue #250 ← backend/src/test/java/com/keplerops/groundcontrol/integration/SyncIntegrationTest.java, Issue #250 ← frontend/src/components/__tests__/traceability-form.test.tsx

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.