### PR TITLE
fix(mcp): auto-resolve the sole in-scope requirement UID for repository gates

### DIFF
--- a/architecture/adrs/054-documentation-coverage-gate.md
+++ b/architecture/adrs/054-documentation-coverage-gate.md
@@ -616,3 +616,18 @@ the ADR-025 backup-policy assertion. The documentation-coverage classifier
 (`classifyChangedSurface`), its `outcome_required` mapping, the Vale rules,
 `tools/install-vale.sh`, and `.vale.ini` are unchanged; no new documentation
 classification or style rule is established.
+
+**2026-07-30 (#1434 follow-up: auto-resolve the requirement UID for repository
+gates).** `authorizeRequestedRequirementUid` in `mcp/ground-control/lib.js` now
+resolves an issue's sole in-scope requirement UID from its `## Requirements`
+section when the caller omits `requested_requirement_uid`, so the shared
+repository gates (`verify`, `publish`, and base-sync completion) receive
+requirement-governance context even on a branch named for the issue number
+rather than the UID. Zero (requirement-free) or multiple (ambiguous) in-scope
+requirements resolve to no UID, and an explicit UID is still validated against
+the issue and still blocks on an unreadable issue. This changes only the
+requirement-context environment carried into the gate subprocess. The
+documentation-coverage classifier (`classifyChangedSurface`), its
+`outcome_required` mapping, the Vale rules, `tools/install-vale.sh`, and
+`.vale.ini` are unchanged; no new documentation classification or style rule is
+established.

--- a/docs/DOC_STYLE.md
+++ b/docs/DOC_STYLE.md
@@ -502,3 +502,10 @@ documented in the MCP README and the tool descriptions, while the workflow
 contract is synchronized in ADR-021, ADR-029, ADR-031, ADR-036, ADR-054, and the
 workflow documents. It changes no documentation classification, Vale rule, or
 style rule.
+
+The #1434 follow-up that auto-resolves an issue's sole in-scope requirement UID
+for the mechanical repository gates (`authorizeRequestedRequirementUid` in
+`mcp/ground-control/lib.js`) follows the same convention: it changes the
+requirement-governance environment carried into the gate subprocess, not any
+reference-doc prose or contract surface. It changes no documentation
+classification, Vale rule, or style rule.

--- a/mcp/ground-control/gc-implement-base-sync.test.js
+++ b/mcp/ground-control/gc-implement-base-sync.test.js
@@ -481,14 +481,34 @@ describe("pre-PR implement synchronization", () => {
     );
   });
 
-  it("injects no requirement UID override when none is requested (#1434)", async () => {
-    // The branch already carries its UID in this case, so the repository gate
-    // must keep deriving requirement context exactly as it did before.
+  it("auto-resolves the issue's sole in-scope requirement UID when none is requested (#1434 follow-up)", async () => {
+    // A branch named for the issue number carries no UID to pass, so the gate
+    // would otherwise fail requirement-context-missing. The issue's single
+    // in-scope requirement is unambiguous context and reaches both gates.
     const { calls, runner } = completeRunner();
     const result = await runSynchronizeImplementBranch(completeInput(), {
       workspaceAuthorizationResolver: workspaceAuthorization,
       commandRunner: runner,
       contextResolver: async () => context(),
+      issueThreadReader: requirementsThreadReader(),
+      syncRecordReader: async () => ({ ok: false, error: "implement_pr_sync_record_missing" }),
+    });
+    assert.equal(result.ok, true, JSON.stringify(result));
+    const gateEnvs = calls
+      .filter(([command]) => command === "bash")
+      .map(([, , options]) => options?.env?.[REQUIREMENT_UID_GATE_ENV_VAR]);
+    assert.deepEqual(gateEnvs, ["DSL-437", "DSL-437"]);
+  });
+
+  it("injects no requirement UID override when the issue lists multiple in-scope requirements (#1434 follow-up)", async () => {
+    // Ambiguous scope must not be guessed: with more than one in-scope
+    // requirement and no requested UID, the gate keeps deriving context as before.
+    const { calls, runner } = completeRunner();
+    const result = await runSynchronizeImplementBranch(completeInput(), {
+      workspaceAuthorizationResolver: workspaceAuthorization,
+      commandRunner: runner,
+      contextResolver: async () => context(),
+      issueThreadReader: requirementsThreadReader("## Requirements\n- DSL-437\n- DSL-438\n"),
       syncRecordReader: async () => ({ ok: false, error: "implement_pr_sync_record_missing" }),
     });
     assert.equal(result.ok, true, JSON.stringify(result));
@@ -496,7 +516,7 @@ describe("pre-PR implement synchronization", () => {
       assert.equal(
         REQUIREMENT_UID_GATE_ENV_VAR in (options?.env ?? {}),
         false,
-        `${command} gate must not receive an unrequested requirement override`,
+        `${command} gate must not receive an ambiguous requirement override`,
       );
     }
   });

--- a/mcp/ground-control/gc-implement-mechanical.test.js
+++ b/mcp/ground-control/gc-implement-mechanical.test.js
@@ -350,8 +350,9 @@ describe("runImplementMechanical verify", () => {
   });
 
   it("injects no requirement UID override when none is requested (#1434)", async () => {
-    // The issue branch already carries its UID here, so the repository gate
-    // keeps deriving requirement context the way it always has.
+    // With no requested UID and no single in-scope requirement resolvable from
+    // the issue, the gate keeps deriving requirement context the way it always
+    // has — no override injected.
     const commands = [];
     await runImplementMechanical({
       action: "verify",

--- a/mcp/ground-control/lib.js
+++ b/mcp/ground-control/lib.js
@@ -4103,11 +4103,17 @@ export async function authorizeRequestedRequirementUid(
   { repoPath, issueNumber, requestedRequirementUid },
   { issueThreadReader = runGetIssueThread } = {},
 ) {
-  if (requestedRequirementUid == null || requestedRequirementUid === "") {
+  const explicit = requestedRequirementUid != null && requestedRequirementUid !== "";
+  if (!explicit && issueNumber == null) {
     return { ok: true, requirementUid: null };
   }
   const thread = await issueThreadReader({ repoPath, issueNumber });
   if (!thread?.ok) {
+    if (!explicit) {
+      // Auto-resolution is best-effort gate context, not a caller assertion, so
+      // an unreadable issue keeps the prior no-UID behaviour instead of blocking.
+      return { ok: true, requirementUid: null };
+    }
     return {
       ok: false,
       error: thread?.error ?? "implement_requested_requirement_uid_unverifiable",
@@ -4116,7 +4122,19 @@ export async function authorizeRequestedRequirementUid(
       next_action: "repair_issue_access_and_retry",
     };
   }
-  return requestedRequirementUidAuthorization(thread.body, requestedRequirementUid);
+  if (explicit) {
+    return requestedRequirementUidAuthorization(thread.body, requestedRequirementUid);
+  }
+  // No explicit UID: carry the issue's sole in-scope requirement into the
+  // repository gates so a branch that names the issue number instead of the
+  // requirement UID still gives the governance gate its context. This completes
+  // the #1434 expectation that the UID reach "any mechanical phase that runs
+  // repository gates" (verify, publish, and base-sync completion) — those paths
+  // already export it, but only when a value reaches them, and the caller does
+  // not always have one to pass. Zero (requirement-free) or multiple (ambiguous)
+  // in-scope requirements resolve to no UID, unchanged.
+  const inScope = extractInScopeRequirementUids(thread.body);
+  return { ok: true, requirementUid: inScope.length === 1 ? inScope[0] : null };
 }
 
 async function runImplementGit(repoRoot, args, commandRunner = execFile) {

--- a/mcp/ground-control/lib.test.js
+++ b/mcp/ground-control/lib.test.js
@@ -47,6 +47,7 @@ import {
   REQUIREMENT_UID_GATE_ENV_VAR,
   implementGateEnvironment,
   requestedRequirementUidAuthorization,
+  authorizeRequestedRequirementUid,
   PR_BODY_POLICY_CHECK_LINE,
   resolveWorkflowRouteFromConfig,
   runResolveWorkflowRoute,
@@ -1215,6 +1216,97 @@ describe("requestedRequirementUidAuthorization (#1434)", () => {
 
   it("refuses every UID when the issue has no Requirements section", () => {
     const result = requestedRequirementUidAuthorization("## Problem\nNo requirements.\n", "DSL-437");
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "implement_requested_requirement_uid_out_of_scope");
+  });
+});
+
+describe("authorizeRequestedRequirementUid (#1434 follow-up: auto-resolve gate UID)", () => {
+  const reader = (body) => async () => ({ ok: true, body });
+  const singleReqBody = "## Requirements\n- DSL-437\n";
+  const multiReqBody = "## Requirements\n- DSL-437\n- DSL-438\n";
+  const noReqBody = "## Problem\nA bug fix.\n";
+
+  it("carries the sole in-scope requirement UID when the caller omits it", async () => {
+    // A branch named for the issue number (e.g. 785-batch-trial-scheduling) has
+    // no UID to pass, so the gate would otherwise fail requirement-context-missing.
+    for (const omitted of [undefined, null, ""]) {
+      const result = await authorizeRequestedRequirementUid(
+        { repoPath: "/r", issueNumber: 785, requestedRequirementUid: omitted },
+        { issueThreadReader: reader(singleReqBody) },
+      );
+      assert.equal(result.ok, true);
+      assert.equal(result.requirementUid, "DSL-437");
+    }
+  });
+
+  it("binds no UID when the caller omits it and the issue lists multiple requirements", async () => {
+    const result = await authorizeRequestedRequirementUid(
+      { repoPath: "/r", issueNumber: 785, requestedRequirementUid: null },
+      { issueThreadReader: reader(multiReqBody) },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.requirementUid, null);
+  });
+
+  it("binds no UID for a requirement-free issue", async () => {
+    const result = await authorizeRequestedRequirementUid(
+      { repoPath: "/r", issueNumber: 785, requestedRequirementUid: null },
+      { issueThreadReader: reader(noReqBody) },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.requirementUid, null);
+  });
+
+  it("does not block the gate when auto-resolution cannot read the issue", async () => {
+    const result = await authorizeRequestedRequirementUid(
+      { repoPath: "/r", issueNumber: 785, requestedRequirementUid: null },
+      { issueThreadReader: async () => ({ ok: false, error: "issue_unreadable" }) },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.requirementUid, null);
+  });
+
+  it("does not read the issue to auto-resolve when there is no issue number", async () => {
+    let read = false;
+    const result = await authorizeRequestedRequirementUid(
+      { repoPath: "/r", issueNumber: null, requestedRequirementUid: null },
+      {
+        issueThreadReader: async () => {
+          read = true;
+          return { ok: true, body: singleReqBody };
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.requirementUid, null);
+    assert.equal(read, false);
+  });
+
+  it("still authorizes an explicit in-scope UID against the issue", async () => {
+    const result = await authorizeRequestedRequirementUid(
+      { repoPath: "/r", issueNumber: 785, requestedRequirementUid: "DSL-437" },
+      { issueThreadReader: reader(multiReqBody) },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.requirementUid, "DSL-437");
+  });
+
+  it("still blocks an explicit UID when the issue cannot be read", async () => {
+    const result = await authorizeRequestedRequirementUid(
+      { repoPath: "/r", issueNumber: 785, requestedRequirementUid: "DSL-437" },
+      { issueThreadReader: async () => ({ ok: false, error: "issue_unreadable" }) },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "issue_unreadable");
+    assert.equal(result.next_action, "repair_issue_access_and_retry");
+  });
+
+  it("still refuses an explicit out-of-scope UID", async () => {
+    const result = await authorizeRequestedRequirementUid(
+      { repoPath: "/r", issueNumber: 785, requestedRequirementUid: "OTHER-999" },
+      { issueThreadReader: reader(singleReqBody) },
+    );
     assert.equal(result.ok, false);
     assert.equal(result.error, "implement_requested_requirement_uid_out_of_scope");
   });


### PR DESCRIPTION
## Summary

Extends the #1434 fix. That change carried a requested requirement UID into every mechanical repository gate — `verify`, `publish`, and base-sync completion — but only when the caller passed `requested_requirement_uid`. `authorizeRequestedRequirementUid` short-circuits to no UID otherwise, so a branch named for the issue number (e.g. `785-batch-trial-scheduling`) still fails the requirement-governance gate with `requirement-context-missing`. This resolves the issue's sole in-scope requirement UID when the caller omits one, so every driver's mechanical gates receive requirement context without the caller having to supply a UID it does not always have.

## Requirement UIDs

- (none — bug fix; no Ground Control requirement. Extends #1434.)

## Related Issues

Extends #1434.

## ADR Impact

- ADR-054 amended: recorded this `mcp/ground-control/lib.js` change under the documentation-coverage-gate surface rule, affirming the doc-coverage classifier, Vale rules, and style rules are unchanged.

## Changes

- `authorizeRequestedRequirementUid` resolves an issue's sole in-scope requirement UID from its `## Requirements` section when the caller omits `requested_requirement_uid`. Zero (requirement-free) or multiple (ambiguous) in-scope requirements resolve to no UID, unchanged.
- An explicit UID is still validated against the issue and still blocks on an unreadable issue; the best-effort auto-resolution path fails open (no UID) rather than blocking, and does not read the issue when there is no issue number.
- `architecture/adrs/054-documentation-coverage-gate.md` and `docs/DOC_STYLE.md` amended per the doc-coverage-gate surface rule.

## Documentation

- Outcome: verified_unchanged. This resolves the requirement-governance environment carried into the mechanical gate subprocess; it does not alter the `.ground-control.yaml` config-parser contract (ADR-027) or `docs/DEVELOPMENT_WORKFLOW.md`. ADR-054 and `docs/DOC_STYLE.md` were amended solely to satisfy the `doc-coverage-gate-sync` surface rule (any `lib.js` change syncs them); the doc-coverage classifier, Vale rules, and style rules are unchanged.

## Test Plan

- New `authorizeRequestedRequirementUid` unit suite in `mcp/ground-control/lib.test.js`: single in-scope → resolves; multiple/zero → none; unreadable → none (fails open); explicit in-scope/out-of-scope/unreadable paths unchanged.
- `mcp/ground-control/gc-implement-base-sync.test.js`: the `#1434` no-override test split into single-requirement auto-resolve (both gates receive the UID via env, never argv) and multiple-requirement no-override.
- Full suite: 1706 pass / 0 fail; eslint 0 errors.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: `mcp/ground-control/lib.js` (`authorizeRequestedRequirementUid`) — bug fix, no Ground Control requirement
- TESTS: `mcp/ground-control/lib.test.js`, `mcp/ground-control/gc-implement-base-sync.test.js` cover `authorizeRequestedRequirementUid`

## Alternative considered

Threading `requested_requirement_uid` through the `/implement` skill's synchronize/publish calls would also work, but server-side auto-resolution fixes it once for every driver (Claude Code, Codex, Cursor) rather than relying on each caller to pass a UID it does not always have.
