### PR TITLE
docs: remove unrelated policy sync notes

### DIFF
--- a/architecture/adrs/054-documentation-coverage-gate.md
+++ b/architecture/adrs/054-documentation-coverage-gate.md
@@ -616,18 +616,3 @@ the ADR-025 backup-policy assertion. The documentation-coverage classifier
 (`classifyChangedSurface`), its `outcome_required` mapping, the Vale rules,
 `tools/install-vale.sh`, and `.vale.ini` are unchanged; no new documentation
 classification or style rule is established.
-
-**2026-07-30 (#1434 follow-up: auto-resolve the requirement UID for repository
-gates).** `authorizeRequestedRequirementUid` in `mcp/ground-control/lib.js` now
-resolves an issue's sole in-scope requirement UID from its `## Requirements`
-section when the caller omits `requested_requirement_uid`, so the shared
-repository gates (`verify`, `publish`, and base-sync completion) receive
-requirement-governance context even on a branch named for the issue number
-rather than the UID. Zero (requirement-free) or multiple (ambiguous) in-scope
-requirements resolve to no UID, and an explicit UID is still validated against
-the issue and still blocks on an unreadable issue. This changes only the
-requirement-context environment carried into the gate subprocess. The
-documentation-coverage classifier (`classifyChangedSurface`), its
-`outcome_required` mapping, the Vale rules, `tools/install-vale.sh`, and
-`.vale.ini` are unchanged; no new documentation classification or style rule is
-established.

--- a/docs/DOC_STYLE.md
+++ b/docs/DOC_STYLE.md
@@ -502,10 +502,3 @@ documented in the MCP README and the tool descriptions, while the workflow
 contract is synchronized in ADR-021, ADR-029, ADR-031, ADR-036, ADR-054, and the
 workflow documents. It changes no documentation classification, Vale rule, or
 style rule.
-
-The #1434 follow-up that auto-resolves an issue's sole in-scope requirement UID
-for the mechanical repository gates (`authorizeRequestedRequirementUid` in
-`mcp/ground-control/lib.js`) follows the same convention: it changes the
-requirement-governance environment carried into the gate subprocess, not any
-reference-doc prose or contract surface. It changes no documentation
-classification, Vale rule, or style rule.


### PR DESCRIPTION
## Summary

Remove issue-specific documentation notes that do not describe a documentation-coverage or style-policy change.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1434

## ADR Impact

- ADR-054

## Changes

- Remove the #1434 follow-up note from ADR-054 because requirement-UID auto-resolution did not change documentation coverage behavior.
- Remove the matching note from DOC_STYLE.md because the follow-up introduced no documentation style rule.

## Test Plan

- [x] Configured completion command passes
- [x] Configured repository policy command passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

Validated with `make policy BASE_REF=origin/main`, `make vale-lint BASE_REF=origin/main`, and pre-commit hooks.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.