### PR TITLE
fix(review): keep ANTHROPIC_API_KEY when it is the review engine's only auth

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,9 +4,7 @@
       "type": "stdio",
       "command": "node",
       "args": ["/home/atomik/src/Ground-Control/mcp/ground-control/index.js"],
-      "env": {
-        "GC_BASE_URL": "http://red-dragon:8000"
-      }
+      "env": {}
     },
     "citation": {
       "type": "stdio",

--- a/mcp/ground-control/lib.reviewengineenv.test.js
+++ b/mcp/ground-control/lib.reviewengineenv.test.js
@@ -1,0 +1,45 @@
+// The review engine (`claude`) inherits the launcher's environment minus
+// ANTHROPIC_API_KEY — but only when another auth path survives (Vertex/Bedrock
+// or a dedicated CLAUDE_CONFIG_DIR profile). If the key is the only auth, it is
+// kept, so the review runs across any repo/folder/tmux session and whichever
+// auth mode (Vertex or a personal profile) launched the MCP, instead of falling
+// through to an expired default OAuth profile (issue #1500).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { reviewEngineEnv } from "./lib/runtime-primitives.js";
+
+describe("reviewEngineEnv — review-engine auth follows the launch mode", () => {
+  it("strips ANTHROPIC_API_KEY when Vertex is the auth mode", () => {
+    const env = reviewEngineEnv({ CLAUDE_CODE_USE_VERTEX: "1", GOOGLE_CLOUD_PROJECT: "p", ANTHROPIC_API_KEY: "sk-x" });
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+    assert.equal(env.CLAUDE_CODE_USE_VERTEX, "1");
+  });
+
+  it("strips ANTHROPIC_API_KEY when Bedrock is the auth mode", () => {
+    const env = reviewEngineEnv({ CLAUDE_CODE_USE_BEDROCK: "1", ANTHROPIC_API_KEY: "sk-x" });
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+  });
+
+  it("strips ANTHROPIC_API_KEY when a dedicated CLAUDE_CONFIG_DIR profile is present", () => {
+    const env = reviewEngineEnv({ CLAUDE_CONFIG_DIR: "/home/u/.claude-personal", ANTHROPIC_API_KEY: "sk-x" });
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+    assert.equal(env.CLAUDE_CONFIG_DIR, "/home/u/.claude-personal");
+  });
+
+  it("KEEPS ANTHROPIC_API_KEY when it is the only auth present", () => {
+    const env = reviewEngineEnv({ ANTHROPIC_API_KEY: "sk-x", PATH: "/usr/bin" });
+    assert.equal(env.ANTHROPIC_API_KEY, "sk-x");
+  });
+
+  it("is a no-op on the key when there is no key at all", () => {
+    const env = reviewEngineEnv({ CLAUDE_CODE_USE_VERTEX: "1" });
+    assert.equal("ANTHROPIC_API_KEY" in env, false);
+  });
+
+  it("does not mutate the input environment", () => {
+    const base = { CLAUDE_CODE_USE_VERTEX: "1", ANTHROPIC_API_KEY: "sk-x" };
+    reviewEngineEnv(base);
+    assert.equal(base.ANTHROPIC_API_KEY, "sk-x");
+  });
+});

--- a/mcp/ground-control/lib/codex-verify-cap.js
+++ b/mcp/ground-control/lib/codex-verify-cap.js
@@ -10,7 +10,7 @@ import { classifyChangedSurface } from "./doc-coverage.js";
 import { getPullRequestClosingIssues, readIssueCommentBodies } from "./grc-legacy-compat-3.js";
 import { enrichCommentsWithThreadIds } from "./grc-legacy-compat-4.js";
 import { REVIEW_AUTO_DISPOSITION_JUDGE_SCHEMA, buildDispositionJudgePrompt, parseDispositionJudgeOutput, parseNumstatManifest, summarizeFindingsForDisposition } from "./review-cap-disposition.js";
-import { execFile, execFileWithInput } from "./runtime-primitives.js";
+import { execFile, execFileWithInput, reviewEngineEnv } from "./runtime-primitives.js";
 import { TEST_QUALITY_REVIEW_HARD_CAP } from "./test-quality-runner.js";
 
 export const CODEX_VERIFY_HARD_CAP = 2;
@@ -311,8 +311,7 @@ export async function runDispositionJudge({ repoRoot, signalsSnapshot, config, r
     "--allowedTools",
     "Read Glob Grep",
   ];
-  const childEnv = { ...process.env };
-  delete childEnv.ANTHROPIC_API_KEY;
+  const childEnv = reviewEngineEnv();
   const { stdout } = await execFileWithInput("claude", args, {
     input: prompt,
     cwd: repoRoot,

--- a/mcp/ground-control/lib/codex-workflow-5.js
+++ b/mcp/ground-control/lib/codex-workflow-5.js
@@ -13,7 +13,7 @@ import { assertSafeImplementCheckoutConfiguration, authorizeImplementRepoRoot, e
 import { readTrustedImplementSyncRecord } from "./knowledge-capture.js";
 import { getRepoGroundControlContext } from "./repo-vocabulary-2.js";
 import { rejectReservedMarkerSequence } from "./repo-vocabulary.js";
-import { checkPrBodyShape, execFile, execFileWithInput } from "./runtime-primitives.js";
+import { checkPrBodyShape, execFile, execFileWithInput, reviewEngineEnv } from "./runtime-primitives.js";
 import { TEST_QUALITY_REVIEW_FINDINGS_SCHEMA } from "./test-quality-prompt.js";
 import { ReviewerCapConfigError } from "./test-quality-runner.js";
 
@@ -283,8 +283,7 @@ export async function runSingleClaudeTestQualityReview({
     "--allowedTools",
     "Read Glob Grep",
   ];
-  const childEnv = { ...process.env };
-  delete childEnv.ANTHROPIC_API_KEY;
+  const childEnv = reviewEngineEnv();
   const { stdout } = await execFileWithInput("claude", args, {
     input: prompt,
     cwd: repoRoot,

--- a/mcp/ground-control/lib/runtime-primitives.js
+++ b/mcp/ground-control/lib/runtime-primitives.js
@@ -231,6 +231,27 @@ export async function execFileWithInput(
     }
   });
 }
+
+// The review engine (`claude`) is spawned as a separate process from the agent,
+// so by default ANTHROPIC_API_KEY is stripped from its environment. Strip it,
+// though, ONLY when the child still has another way to authenticate — Vertex or
+// Bedrock, or a dedicated CLAUDE_CONFIG_DIR profile. If the key is the only auth
+// present, keep it: otherwise the review falls through to a default OAuth
+// profile that is frequently expired, which surfaces as
+// `test_quality_review_engine_failed`. This makes the review inherit whatever
+// auth mode launched the MCP — Vertex vars, a personal config dir, or a bare
+// key — across any repo, folder, or tmux session, whether codex or claude loaded
+// the server.
+export function reviewEngineEnv(baseEnv = process.env) {
+  const env = { ...baseEnv };
+  const hasAlternativeAuth = Boolean(
+    env.CLAUDE_CODE_USE_VERTEX || env.CLAUDE_CODE_USE_BEDROCK || env.CLAUDE_CONFIG_DIR,
+  );
+  if (hasAlternativeAuth) {
+    delete env.ANTHROPIC_API_KEY;
+  }
+  return env;
+}
 export function resolveWorkflowRouteFromConfig({ routing, stage, tier = null }) {
   if (typeof stage !== "string" || stage.trim() === "") {
     return { ok: false, error: "routing_stage_invalid", message: "stage must be a non-empty string" };


### PR DESCRIPTION
## Summary

The test-quality / codex-verify review engine (`claude`) was spawned with `ANTHROPIC_API_KEY` always stripped. When the launcher's only auth was a bare key (no Vertex/Bedrock vars, no `CLAUDE_CONFIG_DIR`), stripping it left no auth, so the review fell through to an often-expired default OAuth profile and surfaced as `test_quality_review_engine_failed`. Now the key is stripped only when another auth path survives, so the review follows whatever mode launched the MCP — Vertex, a personal config dir, or a bare key — across any repo, folder, or tmux session, whether codex or claude loaded the server. One shared code path, so it covers every consuming repo.

## Requirement UIDs

- (none) fix-shaped work

## Related Issues

(none)

## ADR Impact

- No ADR required.

## Changes

- New `reviewEngineEnv()` in `runtime-primitives.js`; `codex-workflow-5.js` and `codex-verify-cap.js` use it instead of unconditionally deleting the key.
- Drop the dead `GC_BASE_URL` from `.mcp.json` (backend removed in #1500).

## Documentation

- No documented surface changed.

## Test Plan

- [x] New `lib.reviewengineenv.test.js` (6 cases); full MCP suite 1946 pass

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: n/a
- TESTS: `mcp/ground-control/lib.reviewengineenv.test.js`

## Checklist

- [x] PR title is a Conventional Commit
