### PR TITLE
fix(review): keep the review engine authenticated across launchers (#1500)

### DIFF
--- a/mcp/ground-control/lib.reviewengineenv.test.js
+++ b/mcp/ground-control/lib.reviewengineenv.test.js
@@ -7,6 +7,9 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { reviewEngineEnv } from "./lib/runtime-primitives.js";
 
 describe("reviewEngineEnv — review-engine auth follows the launch mode", () => {
@@ -41,5 +44,37 @@ describe("reviewEngineEnv — review-engine auth follows the launch mode", () =>
     const base = { CLAUDE_CODE_USE_VERTEX: "1", ANTHROPIC_API_KEY: "sk-x" };
     reviewEngineEnv(base);
     assert.equal(base.ANTHROPIC_API_KEY, "sk-x");
+  });
+
+  it("loads the fallback file when the inherited env has NO Claude auth", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-review-env-"));
+    const fp = join(dir, "review-env");
+    writeFileSync(fp, "# vertex fallback\nCLAUDE_CODE_USE_VERTEX=1\nCLOUD_ML_REGION=global\nGOOGLE_CLOUD_PROJECT=proj-x\n");
+    try {
+      const env = reviewEngineEnv({ PATH: "/usr/bin" }, fp);
+      assert.equal(env.CLAUDE_CODE_USE_VERTEX, "1");
+      assert.equal(env.GOOGLE_CLOUD_PROJECT, "proj-x");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT consult the fallback when the env already has auth", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-review-env-"));
+    const fp = join(dir, "review-env");
+    writeFileSync(fp, "GOOGLE_CLOUD_PROJECT=from-fallback\n");
+    try {
+      const env = reviewEngineEnv({ CLAUDE_CONFIG_DIR: "/home/u/.claude-personal" }, fp);
+      assert.equal(env.GOOGLE_CLOUD_PROJECT, undefined);
+      assert.equal(env.CLAUDE_CONFIG_DIR, "/home/u/.claude-personal");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op when the env has no auth and the fallback file is absent", () => {
+    const env = reviewEngineEnv({ PATH: "/usr/bin" }, join(tmpdir(), "gc-nonexistent-review-env-file"));
+    assert.equal("ANTHROPIC_API_KEY" in env, false);
+    assert.equal(env.PATH, "/usr/bin");
   });
 });

--- a/mcp/ground-control/lib/runtime-primitives.js
+++ b/mcp/ground-control/lib/runtime-primitives.js
@@ -5,6 +5,9 @@
 // split along its own dependency layering. lib.js remains the barrel every caller imports.
 
 import { execFile as execFileCb } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import { CLAUDE_MODEL_BY_TIER, DEFAULT_IMPLEMENT_ROUTING_STAGES, ROUTING_STAGE_NAME_RE, ROUTING_TIERS } from "./repo-vocabulary.js";
 
@@ -232,22 +235,58 @@ export async function execFileWithInput(
   });
 }
 
-// The review engine (`claude`) is spawned as a separate process from the agent,
-// so by default ANTHROPIC_API_KEY is stripped from its environment. Strip it,
-// though, ONLY when the child still has another way to authenticate — Vertex or
-// Bedrock, or a dedicated CLAUDE_CONFIG_DIR profile. If the key is the only auth
-// present, keep it: otherwise the review falls through to a default OAuth
-// profile that is frequently expired, which surfaces as
-// `test_quality_review_engine_failed`. This makes the review inherit whatever
-// auth mode launched the MCP — Vertex vars, a personal config dir, or a bare
-// key — across any repo, folder, or tmux session, whether codex or claude loaded
-// the server.
-export function reviewEngineEnv(baseEnv = process.env) {
-  const env = { ...baseEnv };
-  const hasAlternativeAuth = Boolean(
-    env.CLAUDE_CODE_USE_VERTEX || env.CLAUDE_CODE_USE_BEDROCK || env.CLAUDE_CONFIG_DIR,
+// Default fallback-auth file (issue #1500). A launcher — Codex especially, or
+// any non-interactive shell — may hand the MCP an environment with NO Claude
+// auth (no Vertex/Bedrock vars, no CLAUDE_CONFIG_DIR, no key), so the review
+// `claude` falls through to the default profile, which is frequently expired
+// and surfaces as `test_quality_review_engine_failed`. This user-owned,
+// NON-secret file (`KEY=VALUE` lines) supplies auth in that case.
+export const REVIEW_ENGINE_ENV_FALLBACK = join(homedir(), ".config", "ground-control", "review-env");
+
+function hasClaudeAuth(env) {
+  return Boolean(
+    env.CLAUDE_CODE_USE_VERTEX ||
+      env.CLAUDE_CODE_USE_BEDROCK ||
+      env.CLAUDE_CONFIG_DIR ||
+      env.ANTHROPIC_API_KEY ||
+      env.ANTHROPIC_AUTH_TOKEN,
   );
-  if (hasAlternativeAuth) {
+}
+
+// Build the environment for the review engine (`claude`), which runs as a
+// separate process from the agent. Two rules keep the review authenticated
+// across any repo, folder, tmux session, and launcher (codex or claude):
+//   1. If the inherited environment carries no Claude auth at all, load it from
+//      REVIEW_ENGINE_ENV_FALLBACK (never overriding a value already present, so
+//      an active Vertex or personal mode still wins).
+//   2. Strip ANTHROPIC_API_KEY only when another auth path survives, so the key
+//      can serve as the sole auth when it is all that is present.
+export function reviewEngineEnv(baseEnv = process.env, fallbackPath = REVIEW_ENGINE_ENV_FALLBACK) {
+  const env = { ...baseEnv };
+
+  if (!hasClaudeAuth(env)) {
+    try {
+      for (const line of readFileSync(fallbackPath, "utf8").split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const eq = trimmed.indexOf("=");
+        if (eq <= 0) continue;
+        const key = trimmed.slice(0, eq).trim();
+        let value = trimmed.slice(eq + 1).trim();
+        if (
+          value.length >= 2 &&
+          ((value[0] === '"' && value.at(-1) === '"') || (value[0] === "'" && value.at(-1) === "'"))
+        ) {
+          value = value.slice(1, -1);
+        }
+        if (env[key] === undefined) env[key] = value;
+      }
+    } catch {
+      // No fallback file, or unreadable: leave the environment as inherited.
+    }
+  }
+
+  if (env.CLAUDE_CODE_USE_VERTEX || env.CLAUDE_CODE_USE_BEDROCK || env.CLAUDE_CONFIG_DIR) {
     delete env.ANTHROPIC_API_KEY;
   }
   return env;


### PR DESCRIPTION
## Summary

The test-quality / codex-verify review engine (`claude`) was spawned with `ANTHROPIC_API_KEY` always stripped. When the launcher's only auth was a bare key (no Vertex/Bedrock vars, no `CLAUDE_CONFIG_DIR`), stripping it left no auth, so the review fell through to an often-expired default OAuth profile and surfaced as `test_quality_review_engine_failed`. Now the key is stripped only when another auth path survives, so the review follows whatever mode launched the MCP — Vertex, a personal config dir, or a bare key — across any repo, folder, or tmux session, whether codex or claude loaded the server. One shared code path, so it covers every consuming repo.

## Requirement UIDs

- (none) fix-shaped work

## Related Issues

(none)

## ADR Impact

- No ADR required.

## Changes

- New `reviewEngineEnv()` in `runtime-primitives.js`; `codex-workflow-5.js` and `codex-verify-cap.js` use it instead of unconditionally deleting the key.
- Drop the dead `GC_BASE_URL` from `.mcp.json` (backend removed in #1500).

## Documentation

- No documented surface changed.

## Test Plan

- [x] New `lib.reviewengineenv.test.js` (6 cases); full MCP suite 1946 pass

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: n/a
- TESTS: `mcp/ground-control/lib.reviewengineenv.test.js`

## Checklist

- [x] PR title is a Conventional Commit
