### PR TITLE
fix(mcp): bound the model-engine subprocess tree, not just the direct child

### DIFF
--- a/architecture/adrs/031-codex-review-stopping-model.md
+++ b/architecture/adrs/031-codex-review-stopping-model.md
@@ -247,8 +247,8 @@ manufacture findings. See issue #931 and the preflight note at
 and the `gc_codex_review_cycle` wrapper gain an opt-in `async` mode: the tool
 spawns the `codex exec` child as a background job and returns a `job_id`
 immediately; the new `gc_codex_job` tool polls for the verdict envelope or
-cancels the job (the cancel aborts an `AbortController` whose signal kills the
-child, so nothing is orphaned). Run synchronously, the call blocked past the
+cancels the job (the cancel aborts an `AbortController` whose signal terminates
+the model invocation). Run synchronously, the call blocked past the
 MCP client's per-call timeout and the client abandoned it while the child ran
 on (issue #893). The stopping model this ADR defines is **unchanged**: the
 per-issue cycle cap, the `gc:codex-review-cycle` marker family, the
@@ -266,6 +266,19 @@ executors and every stopping decision remain unchanged under terminal
 roll back durable GitHub writes. After `job_not_found`, the caller refreshes
 the issue thread before selecting a new key. Cap counters, marker families,
 override authorization, and clean/findings/capped outcomes are unchanged.
+
+**2026-08-08 (issue #1518): cancellation and timeout own the subprocess tree.**
+The issue #937 wording above described the intended terminal behavior but the
+shared subprocess helper signalled only the direct CLI child. A CLI-spawned
+search process could therefore survive timeout or cancellation as an orphan.
+Every bounded model invocation must have one process-tree ownership contract:
+timeout, abort, direct-child failure, and direct-child success must leave no
+descendants. Architecture preflight additionally defines repository-wide
+inspection as repository-scoped inspection; `-C` and `workspace-write` are not
+represented as host read-confinement controls. The binding guardrails and
+non-goals are recorded in
+`architecture/notes/codex-subprocess-containment-preflight.md`. Review caps,
+job retention, durable-write ordering, and stopping decisions are unchanged.
 
 **Amendment: renderer summary byte caps (#964).** `gc_render_pr_body` and `gc_post_final_report` now enforce reject-not-truncate byte caps on their caller-controlled summary fields. `gc_post_decision_record` (the per-cycle decision-record surface this ADR's stopping model writes to) is unchanged at the schema layer; its caller-controlled prose fields (`notes[].text`, finding rationales, titles) already had per-field caps. The canonical succinctness rule lives in `skills/implement/steps/_review-loop-rules.md § Update succinctness (canonical)`.
 

--- a/architecture/notes/codex-subprocess-containment-preflight.md
+++ b/architecture/notes/codex-subprocess-containment-preflight.md
@@ -1,0 +1,199 @@
+# Codex Subprocess Containment Preflight
+
+Issue: #1518
+Requirement: none
+
+This note records the architecture boundaries for repository-scoped Codex
+execution and descendant cleanup. It is not an implementation plan.
+
+## Decisions
+
+### Keep working-directory selection, read scope, and OS isolation distinct
+
+The canonical repository root returned by `ensureGitRepo` is the only search
+scope for architecture preflight. `buildCodexArchitecturePreflightPrompt` must
+state that repository-wide inspection means the current repository only: use
+the working directory or repo-relative paths, and never recursively search
+`/`, a parent directory, a home directory, `/proc`, or another checkout.
+Tests must pin that contract.
+
+`codex exec -C <repo> --sandbox workspace-write` does not enforce that read
+scope. `-C` selects a working directory, and `workspace-write` constrains
+writes; neither prevents a model-issued read from traversing the host. The
+prompt rule is therefore a guard against accidental unscoped inspection, not a
+host confidentiality boundary. Do not describe it as a sandbox guarantee or
+add a second path validator that cannot see model-generated command arguments.
+Strong read confinement would require a separately operated OS/container
+permission profile that exposes the repository plus the minimum Codex runtime
+and authentication material. That is a future hardening boundary, not a claim
+this maintenance fix can make through prompt text.
+
+Preflight retains `workspace-write` because it may update ADRs or design notes.
+Read-only Codex review and finding verification retain their existing
+`read-only` mode. Sandbox mode and repository search scope are separate
+concepts even though all three entry points share the same process-lifecycle
+rules.
+
+### The MCP server owns the complete model subprocess tree
+
+`execFileWithInput` is the canonical bounded model-process primitive. A timed
+or cancellable model invocation must run in a dedicated POSIX process group
+that does not include the MCP server. Timeout, `AbortSignal`, direct-child
+failure, and direct-child success must all leave no descendants owned by that
+invocation. Graceful termination signals the group once, waits the existing
+bounded grace period, and escalates the same group to `SIGKILL` if anything
+remains. An already-empty group is success; any other signalling failure must
+remain visible in bounded diagnostics rather than being silently treated as
+cleanup.
+
+Do not pass cancellation only to Node's direct-child `execFile` handling and do
+not implement separate timeout, abort, and Codex-specific kill functions.
+Those paths are one lifecycle state machine in `execFileWithInput`. Preserve
+the existing error distinction: timeouts remain `ETIMEDOUT`, aborts remain
+cancellations, and ordinary command failures remain ordinary failures. The
+async job registry uses that distinction but does not own OS processes.
+
+Process-group isolation is not async-job detachment. The child remains awaited
+and must not be `unref()`'d. The intentionally detached knowledge-ingest
+launcher in `defaultSpawnIngest` is a different ownership model and must not be
+folded into this change. Likewise, ordinary fixed-argv `execFile` calls for
+bounded Git/GitHub reads and writes do not acquire model-runner semantics.
+
+Ground Control and its CI run on Linux, and POSIX group signalling is the
+supported contract for this boundary. A platform that cannot provide
+equivalent tree termination must fail closed for group-owned model execution
+or supply a tested native equivalent; it must not silently fall back to killing
+only the leader.
+
+### Keep a finite host-owned wall cap
+
+`DEFAULT_CODEX_TIMEOUT_MS` and the per-call `timeoutMs` option are the existing
+wall-time seam. Once they terminate the process group, the cap applies to the
+work that consumed the host rather than only to the `codex` leader. The timeout
+is execution-layer safety, distinct from the MCP client request timeout, async
+job terminal-retention TTL, review-cycle cap, and non-verdict retry limit.
+
+`GC_CODEX_TIMEOUT_MS` is host configuration, not repository policy. Its parser
+must not let zero, a negative value, malformed input, or an excessive value
+disable the safety cap; invalid values fall back to the finite default, and a
+finite upper bound remains enforced. Do not add an MCP input or
+`.ground-control.yaml` field that lets an untrusted repository or caller raise
+or disable this host limit.
+
+A process group does not impose an aggregate CPU quota and cannot clean up if
+the MCP server itself is killed before it can signal the group. A cgroup,
+service manager, or external watchdog can add those guarantees later at the
+host launcher boundary. Do not approximate them with shell interpolation,
+per-command `ulimit`, a repository-supplied wrapper, or a claim that the
+JavaScript timer survives its own process.
+
+## Canonical Incumbents
+
+- **Process lifecycle:** `execFileWithInput`, `DEFAULT_CODEX_TIMEOUT_MS`, its
+  existing TERM-to-KILL grace period, and `formatCommandFailure` in
+  `mcp/ground-control/lib/runtime-primitives.js`. Extend this seam; do not add a
+  preflight-only process runner.
+- **Codex launch surfaces:** `runCodexArchitecturePreflight` and
+  `runCodexVerifyFinding` in `mcp/ground-control/lib/codex-verify.js`, plus
+  `runSingleCodexReview` in
+  `mcp/ground-control/lib/grc-legacy-compat-4.js`. Their fixed argv builders,
+  prompt-on-stdin behavior, bounded buffers, temp-output cleanup, and sandbox
+  modes remain authoritative.
+- **Repository and configuration validation:** the preflight tool's Zod input
+  shape, `ensureGitRepo`, `getRepoGroundControlContext`, the strict
+  `.ground-control.yaml` parser, repo-relative path/realpath guards, and the
+  untrusted-vocabulary delimiters. The canonicalized root, not the caller's raw
+  string, is the scope named to Codex.
+- **Cancellation:** `startAsyncJob`, `cancelAsyncJob`, and the existing
+  `AbortSignal` path in `mcp/ground-control/lib/async-job-registry.js`.
+  Cancellation is not complete until the model process tree is gone; the
+  registry must not duplicate child ownership.
+- **Errors and secret handling:** existing MCP `ok`/`err` envelopes,
+  `formatCommandFailure`, async-job error bounding/scrubbing, and
+  `detectSensitiveBodyContent`. Process diagnostics may include a stable
+  failure code, executable label, timeout, signal, and grace duration, but not
+  prompts, model output, repository contents, raw environment, or tokens.
+- **Observability and workflow record:** the async job's bounded elapsed time,
+  existing tool telemetry, and the preflight issue-thread phase marker. A
+  timeout or cancellation writes no successful preflight marker. Process
+  groups are runtime machinery, not a new workflow station, persistence
+  record, marker family, or telemetry schema.
+
+## Security and Validation Layers
+
+- Zod continues to shape `repo_path`, positive `issue_number`, optional
+  requirement/repository identity, and `async`. This issue adds no public
+  timeout, command, signal, path allowlist, or environment override.
+- `ensureGitRepo` continues to resolve the canonical Git top level before any
+  issue lookup, config read, working-tree snapshot, prompt construction, or
+  Codex launch. Existing repository-identity checks continue to bind GitHub
+  reads and phase-marker writes to that checkout.
+- `.ground-control.yaml` remains the only repository context schema. Its strict
+  parser and path containment checks remain authoritative, and architecture
+  vocabulary remains explicitly untrusted prompt data. No process-safety
+  setting belongs in that repository-controlled file.
+- Codex argv remains a fixed array containing only CLI options plus the
+  canonical repository and server-created temporary output paths. The prompt,
+  issue body, vocabulary, and repository content remain on stdin or on disk;
+  no shell command or secret is interpolated into argv.
+- The Codex child environment must be built once for all Codex launch sites and
+  must not forward unrelated host credentials such as GitHub, Sonar, deploy,
+  cloud, or Claude secrets. Preserve only the minimum runtime and Codex
+  authentication/configuration inputs required by the supported launcher.
+  This is a shared engine-environment concern, not three caller-local delete
+  lists. Environment minimization reduces direct exposure but does not turn
+  `workspace-write` into host read confinement.
+- Timeout, abort, and cleanup failures must pass through a bounded error
+  envelope. Raw stdout/stderr from a model-controlled process must not be
+  concatenated into a tool or async-job error without the existing sensitive
+  content and size protections. No new exception hierarchy is needed.
+
+## Extensibility Seam
+
+The reusable seam is model-process ownership in `execFileWithInput`: a finite
+wall timeout, graceful signal, grace duration, abort signal, and process-group
+cleanup. The next model engine can use the same seam without changing MCP tool
+schemas or the async registry. Engine-specific sandbox mode, prompt, output
+parser, and minimal environment remain at the engine launch boundary; do not
+collapse them into a generic "agent sandbox" configuration object.
+
+An independent CPU/memory quota or parent-death guarantee belongs at a future
+host launcher/cgroup seam. It must compose with, not replace, process-group
+cleanup and the wall timeout.
+
+## Required Regression Coverage
+
+- A hermetic Node fixture spawns a descendant that outlives or ignores its
+  leader. Timeout must terminate the group, exercise TERM-to-KILL escalation,
+  return `ETIMEDOUT`, and leave the recorded descendant PID dead.
+- The same fixture under `AbortController` must prove async cancellation kills
+  the group and reaches the registry's terminal `cancelled` envelope.
+- A leader that exits after starting a background descendant must not let that
+  descendant survive an otherwise successful or failed invocation.
+- Existing success, stdout/stderr capture, omitted-timeout, grace-period, and
+  temp-directory cleanup behavior remains covered. Tests must clean up their
+  fixtures defensively if the assertion fails so the regression suite cannot
+  reproduce the production orphan.
+- Timeout environment parsing covers unset, valid, malformed, zero, negative,
+  and excessive values and proves none of the invalid forms disables the cap.
+- Prompt and argv tests pin repo-only search guidance, stdin prompt transport,
+  canonical `-C`, preflight `workspace-write`, and review/verify `read-only`.
+- Environment and error-envelope tests prove unrelated credential variables,
+  raw model output, and oversized diagnostics do not reach the child command
+  environment or caller-visible failure.
+
+## Non-Goals and Anti-Patterns
+
+- No backend controller, DTO, service, repository, database record, external
+  queue, Temporal workflow, process registry, PID file, or new GitHub marker.
+- No new MCP field, `.ground-control.yaml` key, timeout schema, polling tool,
+  async job kind, review-cycle rule, or persistence contract.
+- No prompt-only claim of security confinement, no assumption that `cwd`
+  confines reads, and no assertion that `workspace-write` is repo-read-only.
+- No direct-child-only kill, silent signal failure, unbounded grace timer,
+  `unref()` for awaited model work, or use of `detached: true` without group
+  cleanup semantics.
+- No shell wrapper, interpolated command, repository-provided resource limit,
+  or per-caller clone of timeout/abort/kill logic.
+- No broad cleanup of stale MCP server processes. The operational housekeeping
+  noted in issue #1518 is separate from the model child-tree defect.

--- a/mcp/ground-control/lib.buildcodexarchitecturepreflightprompt-repo-scope.test.js
+++ b/mcp/ground-control/lib.buildcodexarchitecturepreflightprompt-repo-scope.test.js
@@ -1,0 +1,31 @@
+// Architecture preflight (`--sandbox workspace-write -C <repo>`) does not
+// confine reads to the repo — a codex-issued grep with no path argument
+// searched `/` and ran orphaned for 10+ days (issue #1518). `-C` and
+// `workspace-write` are not a host read boundary, so the prompt must say so
+// explicitly as a guard against accidental unscoped inspection.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildCodexArchitecturePreflightPrompt } from "./lib/codex-workflow-3.js";
+
+describe("buildCodexArchitecturePreflightPrompt — repository search scope", () => {
+  it("states that repository-wide inspection means the current repository only", () => {
+    const prompt = buildCodexArchitecturePreflightPrompt({ issueContext: { title: "x", body: "" } });
+    assert.match(prompt, /current repository only/i);
+  });
+
+  it("explicitly forbids searching outside the repository root", () => {
+    const prompt = buildCodexArchitecturePreflightPrompt({ issueContext: { title: "x", body: "" } });
+    assert.match(prompt, /never (?:recursively )?search .*(?:\/|parent directory|home directory)/i);
+  });
+
+  it("is present on both the requirement-backed and requirement-free prompt shapes", () => {
+    const requirementFree = buildCodexArchitecturePreflightPrompt({ issueContext: { title: "x", body: "" } });
+    const requirementBacked = buildCodexArchitecturePreflightPrompt({
+      requirement: { uid: "GC-X001", statement: "..." },
+      issueContext: { title: "x", body: "" },
+    });
+    assert.match(requirementFree, /current repository only/i);
+    assert.match(requirementBacked, /current repository only/i);
+  });
+});

--- a/mcp/ground-control/lib.codexengineenv-minimal-environment.test.js
+++ b/mcp/ground-control/lib.codexengineenv-minimal-environment.test.js
@@ -1,0 +1,56 @@
+// The codex child inherited the FULL parent environment ({...process.env}),
+// forwarding unrelated GitHub, Sonar, cloud, and Claude credentials into a
+// sandbox whose reads are not confined (issue #1518 preflight guardrail).
+// codexEngineEnv() allowlists only what `codex exec` needs.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { codexEngineEnv } from "./lib/codex-engine-env.js";
+
+describe("codexEngineEnv", () => {
+  it("strips unrelated host credentials", () => {
+    const env = codexEngineEnv({
+      HOME: "/home/u",
+      PATH: "/usr/bin",
+      GH_TOKEN: "gh-secret",
+      SONAR_TOKEN: "sonar-secret",
+      AWS_SECRET_ACCESS_KEY: "aws-secret",
+      ANTHROPIC_API_KEY: "claude-secret",
+      CLAUDE_CONFIG_DIR: "/home/u/.claude-personal",
+    });
+    assert.equal(env.GH_TOKEN, undefined);
+    assert.equal(env.SONAR_TOKEN, undefined);
+    assert.equal(env.AWS_SECRET_ACCESS_KEY, undefined);
+    assert.equal(env.ANTHROPIC_API_KEY, undefined);
+    assert.equal(env.CLAUDE_CONFIG_DIR, undefined);
+  });
+
+  it("preserves the runtime and auth inputs codex needs", () => {
+    const env = codexEngineEnv({
+      HOME: "/home/u",
+      PATH: "/usr/bin:/usr/local/bin",
+      OPENAI_API_KEY: "sk-x",
+      CODEX_HOME: "/home/u/.codex",
+    });
+    assert.equal(env.HOME, "/home/u");
+    assert.equal(env.PATH, "/usr/bin:/usr/local/bin");
+    assert.equal(env.OPENAI_API_KEY, "sk-x");
+    assert.equal(env.CODEX_HOME, "/home/u/.codex");
+  });
+
+  it("omits an allowlisted key entirely when absent from the source env, rather than forwarding undefined", () => {
+    const env = codexEngineEnv({ HOME: "/home/u", PATH: "/usr/bin" });
+    assert.equal("OPENAI_API_KEY" in env, false);
+    assert.equal("CODEX_HOME" in env, false);
+  });
+
+  it("always sets NO_COLOR, overriding any inherited value", () => {
+    const env = codexEngineEnv({ HOME: "/home/u", PATH: "/usr/bin", NO_COLOR: "0" });
+    assert.equal(env.NO_COLOR, "1");
+  });
+
+  it("defaults to process.env when no source is given", () => {
+    const env = codexEngineEnv();
+    assert.equal(env.NO_COLOR, "1");
+  });
+});

--- a/mcp/ground-control/lib.execfilewithinput-process-tree-kill.test.js
+++ b/mcp/ground-control/lib.execfilewithinput-process-tree-kill.test.js
@@ -1,0 +1,199 @@
+// execFileWithInput must bound the WHOLE process tree it starts, not just
+// the direct child. A codex-spawned `ugrep` outlived a direct-child-only
+// timeout kill and ran orphaned for 10+ days at ~11 cores (issue #1518).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileWithInput } from "./lib/runtime-primitives.js";
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(predicate, { timeoutMs = 2000, intervalMs = 20 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (predicate()) return true;
+    if (Date.now() >= deadline) return predicate();
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+function backgroundedGrandchildScript(pidFile) {
+  // Backgrounds a long-lived grandchild under the SAME process group as the
+  // direct child (bash), writes its pid, then blocks on it — mirroring how
+  // a shell tool call under codex backgrounds work without detaching.
+  // Redirected off the inherited stdout/stderr pipes: a background process
+  // that still holds those pipes open blocks Node's exec callback from ever
+  // firing (it waits for the pipes to fully close), independent of the
+  // process-tree bug this suite exercises.
+  return ["-c", "sleep 300 >/dev/null 2>&1 & echo $! > \"$1\"; wait", "_", pidFile];
+}
+
+describe("execFileWithInput — process-tree cleanup (issue #1518)", () => {
+  it("still resolves normally for a fast, well-behaved command", async () => {
+    const { stdout } = await execFileWithInput("bash", ["-c", "cat"], { input: "hello\n", timeoutMs: 5000 });
+    assert.equal(stdout, "hello\n");
+  });
+
+  it("still rejects with the underlying error for a nonzero exit", async () => {
+    await assert.rejects(
+      execFileWithInput("bash", ["-c", "exit 3"], { timeoutMs: 5000 }),
+      (err) => err.code === 3,
+    );
+  });
+
+  it("kills a backgrounded grandchild when the timeout fires, not just the direct child", { timeout: 5000 }, async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-exec-tree-"));
+    const pidFile = join(dir, "grandchild.pid");
+    try {
+      await assert.rejects(
+        execFileWithInput("bash", backgroundedGrandchildScript(pidFile), {
+          timeoutMs: 150,
+          killGraceMs: 150,
+        }),
+        (err) => err.code === "ETIMEDOUT",
+      );
+      const grandchildPid = Number(readFileSync(pidFile, "utf8").trim());
+      assert.ok(Number.isInteger(grandchildPid) && grandchildPid > 0);
+      const dead = await waitUntil(() => !isAlive(grandchildPid));
+      assert.equal(dead, true, `grandchild pid ${grandchildPid} survived the timeout kill`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("kills the same backgrounded grandchild when the caller aborts via AbortSignal", { timeout: 5000 }, async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-exec-tree-"));
+    const pidFile = join(dir, "grandchild.pid");
+    const controller = new AbortController();
+    try {
+      const promise = execFileWithInput("bash", backgroundedGrandchildScript(pidFile), {
+        signal: controller.signal,
+        killGraceMs: 150,
+      });
+      await waitUntil(() => {
+        try {
+          return readFileSync(pidFile, "utf8").trim() !== "";
+        } catch {
+          return false;
+        }
+      });
+      controller.abort();
+      await assert.rejects(promise);
+      const grandchildPid = Number(readFileSync(pidFile, "utf8").trim());
+      const dead = await waitUntil(() => !isAlive(grandchildPid));
+      assert.equal(dead, true, `grandchild pid ${grandchildPid} survived the abort kill`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reaps a background descendant even when the leader exits successfully", { timeout: 5000 }, async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-exec-tree-"));
+    const pidFile = join(dir, "grandchild.pid");
+    try {
+      // The leader backgrounds a grandchild, disowns it (so it survives the
+      // leader's own exit), and exits 0 immediately without waiting.
+      const { stdout } = await execFileWithInput(
+        "bash",
+        ["-c", "sleep 300 >/dev/null 2>&1 & echo $! > \"$1\"; disown; echo done", "_", pidFile],
+        { timeoutMs: 5000 },
+      );
+      assert.equal(stdout, "done\n");
+      const grandchildPid = Number(readFileSync(pidFile, "utf8").trim());
+      const dead = await waitUntil(() => !isAlive(grandchildPid));
+      assert.equal(dead, true, `grandchild pid ${grandchildPid} survived a successful leader exit`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reaps a background descendant even when the leader exits with an error", { timeout: 5000 }, async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-exec-tree-"));
+    const pidFile = join(dir, "grandchild.pid");
+    try {
+      await assert.rejects(
+        execFileWithInput(
+          "bash",
+          ["-c", "sleep 300 >/dev/null 2>&1 & echo $! > \"$1\"; disown; exit 1", "_", pidFile],
+          { timeoutMs: 5000 },
+        ),
+      );
+      const grandchildPid = Number(readFileSync(pidFile, "utf8").trim());
+      const dead = await waitUntil(() => !isAlive(grandchildPid));
+      assert.equal(dead, true, `grandchild pid ${grandchildPid} survived a failed leader exit`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not settle until a SIGTERM-ignoring descendant has actually been reaped via SIGKILL", { timeout: 5000 }, async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gc-exec-tree-"));
+    const pidFile = join(dir, "grandchild.pid");
+    // SIG_IGN survives exec (POSIX), so this grandchild is immune to SIGTERM
+    // and only SIGKILL can end it — exercising the TERM-then-grace-SIGKILL
+    // escalation for real, unlike `sleep`, which dies on plain SIGTERM.
+    const script = "sh -c 'trap \"\" TERM; exec sleep 300' >/dev/null 2>&1 & echo $! > \"$1\"; wait";
+    try {
+      await assert.rejects(
+        execFileWithInput("bash", ["-c", script, "_", pidFile], {
+          timeoutMs: 150,
+          killGraceMs: 200,
+        }),
+        (err) => err.code === "ETIMEDOUT",
+      );
+      // By the time the call has settled, the grandchild must already be
+      // dead — not "will die eventually." Settlement racing ahead of cleanup
+      // is the bug: the caller sees a terminal result while the descendant
+      // lives on.
+      const grandchildPid = Number(readFileSync(pidFile, "utf8").trim());
+      assert.equal(isAlive(grandchildPid), false, `grandchild pid ${grandchildPid} was still alive when the call settled`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stops growing buffered output once maxBuffer is exceeded, instead of appending forever", { timeout: 5000 }, async () => {
+    // Emit well past maxBuffer across many small chunks so a saturation bug
+    // (re-appending the same stale "remaining allowance" on every later
+    // chunk) would blow the cap many times over instead of stopping near it.
+    const maxBuffer = 1024;
+    await assert.rejects(
+      execFileWithInput(
+        "bash",
+        ["-c", "for i in $(seq 1 4000); do printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'; done"],
+        { timeoutMs: 5000, maxBuffer },
+      ),
+      (err) => {
+        assert.equal(err.code, "ERR_CHILD_PROCESS_STDIO_MAXBUFFER");
+        assert.ok(
+          err.stdout.length <= maxBuffer * 2,
+          `stdout grew to ${err.stdout.length} bytes, far past the ${maxBuffer}-byte cap — maxBuffer is not bounding output`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("fails closed on a non-POSIX platform instead of silently killing only the direct child", async () => {
+    const original = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      await assert.rejects(
+        execFileWithInput("bash", ["-c", "true"], { timeoutMs: 1000 }),
+        /POSIX process-group/,
+      );
+    } finally {
+      Object.defineProperty(process, "platform", original);
+    }
+  });
+});

--- a/mcp/ground-control/lib.parsecodextimeoutms-bounded-env-parsing.test.js
+++ b/mcp/ground-control/lib.parsecodextimeoutms-bounded-env-parsing.test.js
@@ -1,0 +1,48 @@
+// GC_CODEX_TIMEOUT_MS is host configuration, not repository policy. A zero,
+// negative, malformed, or excessive value must never disable or effectively
+// remove the wall-clock cap every codex/claude subprocess runs under
+// (issue #1518).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CODEX_TIMEOUT_MS_DEFAULT,
+  CODEX_TIMEOUT_MS_MAX,
+  CODEX_TIMEOUT_MS_MIN,
+  parseCodexTimeoutMs,
+} from "./lib/runtime-primitives.js";
+
+describe("parseCodexTimeoutMs", () => {
+  it("falls back to the default when unset", () => {
+    assert.equal(parseCodexTimeoutMs(undefined), CODEX_TIMEOUT_MS_DEFAULT);
+    assert.equal(parseCodexTimeoutMs(""), CODEX_TIMEOUT_MS_DEFAULT);
+    assert.equal(parseCodexTimeoutMs("   "), CODEX_TIMEOUT_MS_DEFAULT);
+  });
+
+  it("uses a valid in-range value as-is", () => {
+    assert.equal(parseCodexTimeoutMs("60000"), 60000);
+  });
+
+  it("falls back to the default on malformed input", () => {
+    assert.equal(parseCodexTimeoutMs("abc"), CODEX_TIMEOUT_MS_DEFAULT);
+    assert.equal(parseCodexTimeoutMs("12.5"), CODEX_TIMEOUT_MS_DEFAULT);
+  });
+
+  it("falls back to the default on zero (does not disable the cap)", () => {
+    assert.equal(parseCodexTimeoutMs("0"), CODEX_TIMEOUT_MS_DEFAULT);
+  });
+
+  it("falls back to the default on a negative value (does not disable the cap)", () => {
+    assert.equal(parseCodexTimeoutMs("-5000"), CODEX_TIMEOUT_MS_DEFAULT);
+  });
+
+  it("falls back to the default on an excessive value", () => {
+    assert.equal(parseCodexTimeoutMs(String(CODEX_TIMEOUT_MS_MAX + 1)), CODEX_TIMEOUT_MS_DEFAULT);
+    assert.equal(parseCodexTimeoutMs("99999999999"), CODEX_TIMEOUT_MS_DEFAULT);
+  });
+
+  it("accepts the exact MIN and MAX bounds", () => {
+    assert.equal(parseCodexTimeoutMs(String(CODEX_TIMEOUT_MS_MIN)), CODEX_TIMEOUT_MS_MIN);
+    assert.equal(parseCodexTimeoutMs(String(CODEX_TIMEOUT_MS_MAX)), CODEX_TIMEOUT_MS_MAX);
+  });
+});

--- a/mcp/ground-control/lib.process-group.test.js
+++ b/mcp/ground-control/lib.process-group.test.js
@@ -1,0 +1,46 @@
+// POSIX process-group primitives that let a caller terminate a whole
+// subprocess tree, not just the process it spawned directly (issue #1518).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { isPosixProcessGroupCapable, isProcessGroupAlive, signalProcessGroup } from "./lib/process-group.js";
+
+function spawnDetachedGroup(script) {
+  return spawn("bash", ["-c", script], { detached: true, stdio: "ignore" });
+}
+
+describe("isPosixProcessGroupCapable", () => {
+  it("is true on the current (Linux) platform", () => {
+    assert.equal(isPosixProcessGroupCapable(), process.platform !== "win32");
+  });
+});
+
+describe("isProcessGroupAlive / signalProcessGroup", () => {
+  it("reports a freshly spawned group as alive, then dead after SIGKILL", async () => {
+    const child = spawnDetachedGroup("sleep 300");
+    try {
+      assert.equal(isProcessGroupAlive(child.pid), true);
+      const result = signalProcessGroup(child.pid, "SIGKILL");
+      assert.equal(result.ok, true);
+      await new Promise((resolve) => child.once("exit", resolve));
+      assert.equal(isProcessGroupAlive(child.pid), false);
+    } finally {
+      try {
+        process.kill(-child.pid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+  });
+
+  it("signalling an already-empty group returns ok (ESRCH is success, not failure)", async () => {
+    const child = spawnDetachedGroup("true");
+    await new Promise((resolve) => child.once("exit", resolve));
+    // Give the kernel a moment to fully reap the group after exit.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const result = signalProcessGroup(child.pid, "SIGTERM");
+    assert.equal(result.ok, true);
+    assert.equal(result.error, undefined);
+  });
+});

--- a/mcp/ground-control/lib/codex-engine-env.js
+++ b/mcp/ground-control/lib/codex-engine-env.js
@@ -1,0 +1,15 @@
+// Minimal environment for the `codex` child (issue #1518). The spawn sites
+// previously forwarded `{...process.env}` in full, exposing every unrelated
+// GitHub, Sonar, cloud, and Claude credential on the host to a sandboxed
+// process whose reads are not confined by `--sandbox`. Allowlist only what
+// `codex exec` needs to run and authenticate.
+const CODEX_ENV_ALLOWLIST = ["HOME", "PATH", "OPENAI_API_KEY", "CODEX_HOME"];
+
+export function codexEngineEnv(baseEnv = process.env) {
+  const env = {};
+  for (const key of CODEX_ENV_ALLOWLIST) {
+    if (baseEnv[key] !== undefined) env[key] = baseEnv[key];
+  }
+  env.NO_COLOR = "1";
+  return env;
+}

--- a/mcp/ground-control/lib/codex-verify.js
+++ b/mcp/ground-control/lib/codex-verify.js
@@ -8,6 +8,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readRequirementByUid } from "./requirement-files.js";
+import { codexEngineEnv } from "./codex-engine-env.js";
 import { evaluateCodexVerifyCycleCap, postCodexVerifyCycleMarker, readPriorCodexVerifyCycleCount } from "./codex-verify-cap.js";
 import { buildCodexArchitecturePreflightPrompt, getIssueContext } from "./codex-workflow-3.js";
 import { buildCodexArchitectureExecArgs, findNewWorkingTreeChanges, readGeneratedCodexSummary } from "./codex-workflow.js";
@@ -119,7 +120,7 @@ export async function runCodexArchitecturePreflight({
         input: prompt,
         cwd: repoRoot,
         maxBuffer: 10 * 1024 * 1024,
-        env: { ...process.env, NO_COLOR: "1" },
+        env: codexEngineEnv(),
         timeoutMs: DEFAULT_CODEX_TIMEOUT_MS,
         signal,
       },
@@ -272,7 +273,7 @@ export async function runCodexVerifyFinding({
         input: prompt,
         cwd: repoRoot,
         maxBuffer: 10 * 1024 * 1024,
-        env: { ...process.env, NO_COLOR: "1" },
+        env: codexEngineEnv(),
         timeoutMs: DEFAULT_CODEX_TIMEOUT_MS,
       },
     ));

--- a/mcp/ground-control/lib/codex-workflow-3.js
+++ b/mcp/ground-control/lib/codex-workflow-3.js
@@ -224,6 +224,7 @@ export function buildCodexArchitecturePreflightPrompt({ requirement = null, trac
     "- You may add or update ADRs, design notes, workflow notes, or other guidance docs when they materially reduce design risk.",
     "- Keep guidance minimal but sufficient. Do not write an implementation plan.",
     "- Do not invent new abstractions if existing cross-cutting concerns, schemas, error handling, validation, logging, or workflow patterns already cover the need.",
+    "- Repository-wide inspection means the current repository only. Use the working directory or repo-relative paths for any search (grep, find, ripgrep, etc.). Never recursively search `/`, a parent directory, a home directory, `/proc`, or another checkout — `-C`/the sandbox do not confine reads to the repo, so an unscoped search root is never appropriate for a lookup that is inherently repo-scoped.",
     "",
     "Quality bar:",
     "- Hold the upcoming implementation to a top-tier production engineering bar for maintainability, reliability, security, consistency, reuse of existing cross-cutting concerns, clear boundaries, and avoidance of abstraction or concept confusion.",

--- a/mcp/ground-control/lib/grc-legacy-compat-4.js
+++ b/mcp/ground-control/lib/grc-legacy-compat-4.js
@@ -8,6 +8,7 @@ import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { parsePhaseMarkers } from "./codex-review.js";
+import { codexEngineEnv } from "./codex-engine-env.js";
 import { MCP_LAUNCH_CWD, evaluateExecutionObligations, isDefaultImplementHooksPath, parseExecutionObligationMarkers, readGeneratedCodexSummary } from "./codex-workflow.js";
 import { ENRICH_THREAD_PAGE_CAP } from "./grc-legacy-compat-2.js";
 import { getAuthenticatedGitHubLogin, getOwnerRepo, hasVerifiedStructuredWontfixAuthorization, readIssueCommentBodies, readIssueCommentsWithAuthors, resolveExecutionObligationTrust } from "./grc-legacy-compat-3.js";
@@ -461,7 +462,7 @@ export async function runSingleCodexReview({ repoRoot, prompt, signal = undefine
         input: prompt,
         cwd: repoRoot,
         maxBuffer: 10 * 1024 * 1024,
-        env: { ...process.env, NO_COLOR: "1" },
+        env: codexEngineEnv(),
         timeoutMs: DEFAULT_CODEX_TIMEOUT_MS,
         signal,
       },

--- a/mcp/ground-control/lib/model-subprocess.js
+++ b/mcp/ground-control/lib/model-subprocess.js
@@ -1,0 +1,245 @@
+// Extracted from runtime-primitives.js (issue #1518) to stay under the
+// repo's 500-LOC file gate. runtime-primitives.js re-exports execFileWithInput
+// and the timeout constants, so every existing caller's import path is
+// unchanged.
+
+import { spawn } from "node:child_process";
+import { isProcessGroupAlive, isPosixProcessGroupCapable, signalProcessGroup } from "./process-group.js";
+
+export const CODEX_TIMEOUT_MS_MIN = 1000; // 1 second floor
+export const CODEX_TIMEOUT_MS_MAX = 3600000; // 1 hour ceiling
+export const CODEX_TIMEOUT_MS_DEFAULT = 1200000; // 20 minutes
+// GC_CODEX_TIMEOUT_MS is host configuration, not repository policy (issue
+// #1518). A zero, negative, malformed, or excessive value must fall back to
+// the finite default rather than disabling or effectively removing the wall
+// cap that bounds every codex/claude subprocess this server spawns.
+export function parseCodexTimeoutMs(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return CODEX_TIMEOUT_MS_DEFAULT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed < CODEX_TIMEOUT_MS_MIN || parsed > CODEX_TIMEOUT_MS_MAX) {
+    return CODEX_TIMEOUT_MS_DEFAULT;
+  }
+  return parsed;
+}
+export const DEFAULT_CODEX_TIMEOUT_MS = parseCodexTimeoutMs(process.env.GC_CODEX_TIMEOUT_MS);
+const KILL_GRACE_MS_DEFAULT = 5000;
+const MAX_BUFFER_DEFAULT = 1024 * 1024; // 1 MiB, matches Node's own execFile default
+// child_process.execFile() silently drops `detached` before it reaches the
+// real spawn() call (it forwards only an explicit options allowlist), so it
+// can never produce a real process-group leader — confirmed by reading
+// Node's own execFile source. execFileWithInput therefore builds directly on
+// spawn(), reimplementing the small slice of execFile's behavior (buffered
+// stdout/stderr, maxBuffer enforcement, exit-code/signal error shape) that
+// every caller here relies on (issue #1518).
+export async function execFileWithInput(
+  file,
+  args,
+  {
+    input,
+    timeoutMs,
+    killSignal = "SIGTERM",
+    killGraceMs = KILL_GRACE_MS_DEFAULT,
+    signal,
+    maxBuffer = MAX_BUFFER_DEFAULT,
+    ...options
+  } = {},
+) {
+  // Ground Control and its CI run on Linux; POSIX process groups are the
+  // supported tree-termination contract. Fail closed rather than silently
+  // degrade to a direct-child-only kill on a platform that can't provide it
+  // (issue #1518).
+  if (!isPosixProcessGroupCapable()) {
+    throw new Error(
+      `execFileWithInput requires POSIX process-group support to bound ${file}'s subprocess tree; `
+      + "this platform has no tested tree-termination equivalent (issue #1518)",
+    );
+  }
+  return await new Promise((resolve, reject) => {
+    let timedOut = false;
+    let aborted = false;
+    let maxBufferExceeded = null;
+    let killTimer = null;
+    let graceTimer = null;
+    let settled = false;
+    let pendingCleanup = null;
+
+    const finish = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      if (killTimer) clearTimeout(killTimer);
+      fn(value);
+    };
+
+    // Detached so child.pid is also its POSIX process-group id: signalling
+    // -pid reaches every subprocess the child spawns (e.g. a shell tool
+    // call), not just the direct child. A signal to the direct pid alone let
+    // a codex-spawned `ugrep` outlive its leader and run orphaned for 10+
+    // days once reparented to init (issue #1518).
+    const child = spawn(file, args, { ...options, detached: true });
+
+    const killGroup = (sig) => {
+      if (!child.pid) return;
+      const result = signalProcessGroup(child.pid, sig);
+      if (!result.ok) {
+        // eslint-disable-next-line no-console
+        console.error(`[execFileWithInput] failed to signal ${file}'s process group with ${sig}: ${result.error.message}`);
+      }
+    };
+
+    // TERM the group, then SIGKILL anything still alive after the grace
+    // period, confirming the group is actually empty before resolving.
+    // Returns a promise that resolves only once that full escalation
+    // completes — settlement awaits it (see the `close` handler) so a
+    // SIGTERM-ignoring descendant can't outlive a call that already resolved
+    // or rejected. Polls rather than waiting out a single fixed delay: most
+    // signalled processes die well inside the grace window, and death is
+    // never instantaneous with the signal call returning (true even for
+    // SIGKILL — the kernel needs a moment to actually reap the group), so a
+    // one-shot check-then-settle races both directions. A no-op re-signal on
+    // an already-empty group is safe, so concurrent triggers (timeout,
+    // abort, maxBuffer, leader-exit) collapse onto this one in-flight
+    // escalation rather than racing separate ones.
+    const POLL_INTERVAL_MS = 20;
+    const POST_SIGKILL_CONFIRM_MS = 2000; // bounded; SIGKILL cannot be blocked, only delayed by the kernel
+    const ensureGroupEmpty = () => {
+      if (pendingCleanup) return pendingCleanup;
+      if (!child.pid || !isProcessGroupAlive(child.pid)) return Promise.resolve();
+      const pgid = child.pid;
+      pendingCleanup = new Promise((settleCleanup) => {
+        killGroup(killSignal);
+        const termDeadline = Date.now() + killGraceMs;
+        let killSent = false;
+        let killDeadline = null;
+        const poll = () => {
+          if (!isProcessGroupAlive(pgid)) {
+            settleCleanup();
+            return;
+          }
+          const now = Date.now();
+          if (!killSent && now >= termDeadline) {
+            killGroup("SIGKILL");
+            killSent = true;
+            killDeadline = now + POST_SIGKILL_CONFIRM_MS;
+          } else if (killSent && now >= killDeadline) {
+            // eslint-disable-next-line no-console
+            console.error(`[execFileWithInput] ${file}'s process group survived SIGKILL (pgid ${pgid})`);
+            settleCleanup();
+            return;
+          }
+          graceTimer = setTimeout(poll, POLL_INTERVAL_MS);
+        };
+        graceTimer = setTimeout(poll, POLL_INTERVAL_MS);
+      });
+      return pendingCleanup;
+    };
+
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    let stdoutLen = 0;
+    let stderrLen = 0;
+    // Saturates currentLen to maxBuffer on overflow so every later chunk for
+    // this stream is dropped outright, instead of re-appending the same
+    // stale "remaining allowance" on every subsequent data event.
+    const trackChunk = (chunks, chunk, which, currentLen) => {
+      if (currentLen >= maxBuffer) return currentLen;
+      const length = Buffer.byteLength(chunk);
+      if (currentLen + length > maxBuffer) {
+        const allowed = maxBuffer - currentLen;
+        if (allowed > 0) chunks.push(chunk.slice(0, allowed));
+        if (!maxBufferExceeded) {
+          maxBufferExceeded = which;
+          ensureGroupEmpty();
+        }
+        return maxBuffer;
+      }
+      chunks.push(chunk);
+      return currentLen + length;
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdoutLen = trackChunk(stdoutChunks, chunk, "stdout", stdoutLen);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderrLen = trackChunk(stderrChunks, chunk, "stderr", stderrLen);
+    });
+
+    child.on("error", (error) => {
+      finish(reject, error);
+    });
+
+    child.on("close", (code, closeSignal) => {
+      // Await any in-flight group cleanup before settling — a straggler
+      // descendant must be confirmed gone (or given its full TERM-then-KILL
+      // treatment) before the caller sees a terminal result, not just before
+      // the leader's own stdio has drained.
+      Promise.resolve(pendingCleanup).then(() => {
+        const stdout = stdoutChunks.join("");
+        const stderr = stderrChunks.join("");
+        if (timedOut || aborted) {
+          const e = new Error(
+            timedOut
+              ? `${file} did not exit within ${timeoutMs}ms (sent ${killSignal}, then SIGKILL after ${killGraceMs}ms grace)`
+              : `${file} aborted via AbortSignal`,
+          );
+          e.code = timedOut ? "ETIMEDOUT" : "ABORT_ERR";
+          if (aborted && !timedOut) e.name = "AbortError";
+          e.killed = true;
+          e.stdout = stdout;
+          e.stderr = stderr;
+          finish(reject, e);
+          return;
+        }
+        if (maxBufferExceeded) {
+          const e = new Error(`${file} exceeded maxBuffer on ${maxBufferExceeded}`);
+          e.code = "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+          e.stdout = stdout;
+          e.stderr = stderr;
+          finish(reject, e);
+          return;
+        }
+        if (code !== 0 || closeSignal !== null) {
+          const e = new Error(`Command failed: ${file} ${args.join(" ")}\n${stderr}`);
+          e.code = code;
+          e.signal = closeSignal;
+          e.stdout = stdout;
+          e.stderr = stderr;
+          finish(reject, e);
+          return;
+        }
+        finish(resolve, { stdout, stderr });
+      });
+    });
+
+    // The leader may exit while a background descendant it spawned (and did
+    // not wait on) is still running. `close` — which the handler above waits
+    // for — doesn't fire until every process sharing the child's stdio pipes
+    // exits, so a live straggler would otherwise hang this call forever.
+    // `exit` fires as soon as the leader itself terminates, independent of
+    // its descendants, which is what actually lets this reap them.
+    child.on("exit", () => {
+      ensureGroupEmpty();
+    });
+
+    if (timeoutMs && timeoutMs > 0) {
+      killTimer = setTimeout(() => {
+        timedOut = true;
+        ensureGroupEmpty();
+      }, timeoutMs);
+    }
+
+    if (signal) {
+      const onAbort = () => {
+        aborted = true;
+        ensureGroupEmpty();
+      };
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    if (input != null) {
+      child.stdin.end(input);
+    }
+  });
+}

--- a/mcp/ground-control/lib/process-group.js
+++ b/mcp/ground-control/lib/process-group.js
@@ -1,0 +1,29 @@
+// Process-group containment for long-running model subprocesses (issue #1518).
+//
+// POSIX-only: Ground Control and its CI run on Linux. There is no tested
+// Windows tree-termination equivalent, so a caller that needs bounded
+// containment must fail closed on other platforms rather than silently
+// degrade to signalling only the direct child.
+
+export function isPosixProcessGroupCapable() {
+  return process.platform !== "win32";
+}
+
+export function isProcessGroupAlive(pgid) {
+  try {
+    process.kill(-pgid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function signalProcessGroup(pgid, sig) {
+  try {
+    process.kill(-pgid, sig);
+    return { ok: true };
+  } catch (error) {
+    if (error.code === "ESRCH") return { ok: true };
+    return { ok: false, error };
+  }
+}

--- a/mcp/ground-control/lib/runtime-primitives.js
+++ b/mcp/ground-control/lib/runtime-primitives.js
@@ -11,6 +11,19 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { CLAUDE_MODEL_BY_TIER, DEFAULT_IMPLEMENT_ROUTING_STAGES, ROUTING_STAGE_NAME_RE, ROUTING_TIERS } from "./repo-vocabulary.js";
 
+// execFileWithInput and the GC_CODEX_TIMEOUT_MS parsing/bounds live in
+// model-subprocess.js (issue #1518, split out to stay under the 500-LOC file
+// gate). Re-exported here so this remains the single import path every
+// existing caller already uses.
+export {
+  CODEX_TIMEOUT_MS_DEFAULT,
+  CODEX_TIMEOUT_MS_MAX,
+  CODEX_TIMEOUT_MS_MIN,
+  DEFAULT_CODEX_TIMEOUT_MS,
+  execFileWithInput,
+  parseCodexTimeoutMs,
+} from "./model-subprocess.js";
+
 export const execFile = promisify(execFileCb);
 export const GROUND_CONTROL_PROJECT_RE = /^[a-z0-9][a-z0-9-]*$/;
 // Shared with the .ground-control.yaml parser and the repo-identity resolver. It lives beside its
@@ -159,82 +172,6 @@ export function buildSuggestedGroundControlYaml(project = "your-project-id") {
     "",
   ].join("\n");
 }
-export const DEFAULT_CODEX_TIMEOUT_MS = (() => {
-  const raw = Number.parseInt(process.env.GC_CODEX_TIMEOUT_MS || "", 10);
-  if (!Number.isInteger(raw)) return 1200000; // 20 minutes
-  return raw;
-})();
-const KILL_GRACE_MS_DEFAULT = 5000;
-export async function execFileWithInput(
-  file,
-  args,
-  {
-    input,
-    timeoutMs,
-    killSignal = "SIGTERM",
-    killGraceMs = KILL_GRACE_MS_DEFAULT,
-    ...options
-  } = {},
-) {
-  return await new Promise((resolve, reject) => {
-    let timedOut = false;
-    let killTimer = null;
-    let graceTimer = null;
-    let settled = false;
-
-    const finish = (fn, value) => {
-      if (settled) return;
-      settled = true;
-      if (killTimer) clearTimeout(killTimer);
-      if (graceTimer) clearTimeout(graceTimer);
-      fn(value);
-    };
-
-    const child = execFileCb(file, args, options, (error, stdout, stderr) => {
-      if (timedOut) {
-        const e = new Error(
-          `${file} did not exit within ${timeoutMs}ms (sent ${killSignal}, then SIGKILL after ${killGraceMs}ms grace)`,
-        );
-        e.code = "ETIMEDOUT";
-        e.killed = true;
-        e.stdout = stdout;
-        e.stderr = stderr;
-        finish(reject, e);
-        return;
-      }
-      if (error) {
-        error.stdout = stdout;
-        error.stderr = stderr;
-        finish(reject, error);
-        return;
-      }
-      finish(resolve, { stdout, stderr });
-    });
-
-    if (timeoutMs && timeoutMs > 0) {
-      killTimer = setTimeout(() => {
-        timedOut = true;
-        try {
-          child.kill(killSignal);
-        } catch {
-          // Already exited between the timer firing and the kill call.
-        }
-        graceTimer = setTimeout(() => {
-          try {
-            child.kill("SIGKILL");
-          } catch {
-            // Already exited.
-          }
-        }, killGraceMs);
-      }, timeoutMs);
-    }
-
-    if (input != null) {
-      child.stdin.end(input);
-    }
-  });
-}
-
 // Default fallback-auth file (issue #1500). A launcher — Codex especially, or
 // any non-interactive shell — may hand the MCP an environment with NO Claude
 // auth (no Vertex/Bedrock vars, no CLAUDE_CONFIG_DIR, no key), so the review

--- a/mcp/ground-control/package-lock.json
+++ b/mcp/ground-control/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^4.3.1",
         "proper-lockfile": "^4.1.2",
         "zod": "^3.23.0"
       },
@@ -1432,9 +1432,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/mcp/ground-control/package.json
+++ b/mcp/ground-control/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "proper-lockfile": "^4.1.2",
     "zod": "^3.23.0"
   },


### PR DESCRIPTION
## Summary

A codex architecture-preflight run left an orphaned `ugrep` running for 10+ days at ~11 cores because execFileWithInput's timeout/cancel path only killed the direct `codex` child, never the descendants it spawned. execFileWithInput now spawns detached, owns the whole POSIX process group, and terminates it on timeout, AbortSignal, maxBuffer overflow, and leader exit/close, waiting until the group is actually confirmed empty before settling. This required moving off Node's execFile (which silently drops `detached` before its internal spawn() call) onto spawn() directly. Also minimizes the codex child's environment to an explicit allowlist instead of forwarding the full host environment, and adds a repo-scope guardrail to the preflight prompt, since `--sandbox`/`-C` do not confine reads.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1518

## ADR Impact

- ADR-021
- ADR-031

## Changes

- mcp/ground-control/lib/model-subprocess.js (new): execFileWithInput rebuilt on spawn(); detached process-group ownership; TERM-then-grace-SIGKILL escalation on timeout/abort/maxBuffer-overflow/leader-exit, gated so settlement waits for the group to actually empty; GC_CODEX_TIMEOUT_MS parsing clamped to a bounded range so 0/negative/malformed/excessive values can no longer disable the wall-clock cap
- mcp/ground-control/lib/process-group.js (new): POSIX process-group primitives (isPosixProcessGroupCapable, isProcessGroupAlive, signalProcessGroup) with signal failures surfaced, never silently swallowed
- mcp/ground-control/lib/codex-engine-env.js (new): codexEngineEnv() allowlists HOME/PATH/OPENAI_API_KEY/CODEX_HOME instead of forwarding the full host environment (GitHub/Sonar/cloud/Claude credentials) into the sandboxed child
- mcp/ground-control/lib/runtime-primitives.js: re-exports execFileWithInput and the timeout constants from model-subprocess.js (500-LOC file gate)
- mcp/ground-control/lib/codex-verify.js, mcp/ground-control/lib/grc-legacy-compat-4.js: both codex spawn sites use codexEngineEnv()
- mcp/ground-control/lib/codex-workflow-3.js: architecture-preflight prompt states repository-wide inspection means the current repository only, never `/`/parent/home/`/proc`/another checkout
- architecture/adrs/031-codex-review-stopping-model.md, architecture/notes/codex-subprocess-containment-preflight.md: architecture preflight's binding guardrails and ADR-031 correction (cancellation previously claimed to guarantee no orphan; it did not, for descendants)

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: issue #1518 ← mcp/ground-control/lib/model-subprocess.js, issue #1518 ← mcp/ground-control/lib/process-group.js, issue #1518 ← mcp/ground-control/lib/codex-engine-env.js, issue #1518 ← mcp/ground-control/lib/codex-workflow-3.js
- TESTS: issue #1518 ← mcp/ground-control/lib.execfilewithinput-process-tree-kill.test.js, issue #1518 ← mcp/ground-control/lib.process-group.test.js, issue #1518 ← mcp/ground-control/lib.parsecodextimeoutms-bounded-env-parsing.test.js, issue #1518 ← mcp/ground-control/lib.codexengineenv-minimal-environment.test.js, issue #1518 ← mcp/ground-control/lib.buildcodexarchitecturepreflightprompt-repo-scope.test.js

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.