### PR TITLE
fix(implement): pin identity guard to shared common git dir

### DIFF
--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -879,8 +879,22 @@ iterations-to-green denominators, so an outage never reads as rework.
 The `/implement` mutation tools are repository-bound at the server boundary. Their
 `repo_path` must resolve to the Git workspace captured when that repository's
 MCP server launched and retain the exact launch-time origin identity; supplying
-another on-host checkout or retargeting origin is rejected. Raw remote URLs
-never enter branch-tool results. Obligation replay checks every record author
+another on-host checkout or retargeting origin is rejected. The Git-store half of
+that identity is pinned to the shared common Git directory (`--git-common-dir`),
+not the per-worktree pointer (`--absolute-git-dir`), so the guard is stable across
+every linked worktree of the same repository. Raw remote URLs
+never enter branch-tool results.
+
+**Concurrent worktrees and MCP relaunch (issue #1502).** Run one Ground Control
+MCP server per checkout, launched from that checkout. Each server captures the
+launch workspace once; a second `/implement` in a sibling linked worktree gets its
+own server and its own captured identity. Because the guard pins the shared common
+Git directory and origin rather than the per-worktree Git-dir pointer, sibling
+worktree maintenance (`git worktree repair`/`prune`) no longer trips the identity
+guard mid-run. A run that still returns `implement_repo_identity_changed` (for
+example after the client relaunched the server against a different checkout) needs
+the Ground Control MCP server restarted from the target worktree so it re-captures
+the workspace identity; the error message says the same. Obligation replay checks every record author
 for effective repository write permission rather than trusting organization
 membership or coarse comment associations. `wontfix` authorization is a
 structured two-step record: an authorized repository writer posts exactly

--- a/mcp/ground-control/gc-implement-base-sync.pre-pr-implement-synchronization-2.test.js
+++ b/mcp/ground-control/gc-implement-base-sync.pre-pr-implement-synchronization-2.test.js
@@ -27,13 +27,15 @@ const RECORD = "4".repeat(32);
 const TREE = "5".repeat(40);
 
 async function workspaceAuthorization() {
-  const [gitDir, origin] = await Promise.all([
+  const [gitDir, gitCommonDir, origin] = await Promise.all([
     execFile("git", ["-C", REPO_ROOT, "rev-parse", "--absolute-git-dir"]),
+    execFile("git", ["-C", REPO_ROOT, "rev-parse", "--path-format=absolute", "--git-common-dir"]),
     execFile("git", ["-C", REPO_ROOT, "remote", "get-url", "origin"]),
   ]);
   return {
     workspaceRoot: REPO_ROOT,
     gitDir: realpathSync(gitDir.stdout.trim()),
+    gitCommonDir: realpathSync(gitCommonDir.stdout.trim()),
     origin: origin.stdout.trim(),
     owner: "autarchy-ai",
     name: "ground-control",

--- a/mcp/ground-control/gc-implement-base-sync.pre-pr-implement-synchronization.test.js
+++ b/mcp/ground-control/gc-implement-base-sync.pre-pr-implement-synchronization.test.js
@@ -33,13 +33,15 @@ const RECORD = "4".repeat(32);
 const TREE = "5".repeat(40);
 
 async function workspaceAuthorization() {
-  const [gitDir, origin] = await Promise.all([
+  const [gitDir, gitCommonDir, origin] = await Promise.all([
     execFile("git", ["-C", REPO_ROOT, "rev-parse", "--absolute-git-dir"]),
+    execFile("git", ["-C", REPO_ROOT, "rev-parse", "--path-format=absolute", "--git-common-dir"]),
     execFile("git", ["-C", REPO_ROOT, "remote", "get-url", "origin"]),
   ]);
   return {
     workspaceRoot: REPO_ROOT,
     gitDir: realpathSync(gitDir.stdout.trim()),
+    gitCommonDir: realpathSync(gitCommonDir.stdout.trim()),
     origin: origin.stdout.trim(),
     owner: "autarchy-ai",
     name: "ground-control",

--- a/mcp/ground-control/gc-implement-base-sync.synchronized-pr-gate.test.js
+++ b/mcp/ground-control/gc-implement-base-sync.synchronized-pr-gate.test.js
@@ -47,13 +47,15 @@ function renderedPrBody() {
 }
 
 async function workspaceAuthorization() {
-  const [gitDir, origin] = await Promise.all([
+  const [gitDir, gitCommonDir, origin] = await Promise.all([
     execFile("git", ["-C", REPO_ROOT, "rev-parse", "--absolute-git-dir"]),
+    execFile("git", ["-C", REPO_ROOT, "rev-parse", "--path-format=absolute", "--git-common-dir"]),
     execFile("git", ["-C", REPO_ROOT, "remote", "get-url", "origin"]),
   ]);
   return {
     workspaceRoot: REPO_ROOT,
     gitDir: realpathSync(gitDir.stdout.trim()),
+    gitCommonDir: realpathSync(gitCommonDir.stdout.trim()),
     origin: origin.stdout.trim(),
     owner: "autarchy-ai",
     name: "ground-control",

--- a/mcp/ground-control/gc-implement-contract.execution-obligation-ledger.test.js
+++ b/mcp/ground-control/gc-implement-contract.execution-obligation-ledger.test.js
@@ -31,11 +31,15 @@ function initRepo() {
 }
 
 function authorizationForRepo(repo) {
+  // A freshly `git init`'d repo is a main worktree, so --absolute-git-dir and
+  // --git-common-dir resolve to the same `.git` (issue #1502).
+  const gitDir = realpathSync(
+    execFileSync("git", ["-C", repo, "rev-parse", "--absolute-git-dir"], { encoding: "utf8" }).trim(),
+  );
   return {
     workspaceRoot: realpathSync(repo),
-    gitDir: realpathSync(
-      execFileSync("git", ["-C", repo, "rev-parse", "--absolute-git-dir"], { encoding: "utf8" }).trim(),
-    ),
+    gitDir,
+    gitCommonDir: gitDir,
     origin: execFileSync(
       "git", ["-C", repo, "remote", "get-url", "origin"], { encoding: "utf8" },
     ).trim(),

--- a/mcp/ground-control/gc-implement-contract.same-checkout-implement-branch-operation.test.js
+++ b/mcp/ground-control/gc-implement-contract.same-checkout-implement-branch-operation.test.js
@@ -23,11 +23,15 @@ function initRepo() {
 }
 
 function authorizationForRepo(repo) {
+  // A freshly `git init`'d repo is a main worktree, so --absolute-git-dir and
+  // --git-common-dir resolve to the same `.git` (issue #1502).
+  const gitDir = realpathSync(
+    execFileSync("git", ["-C", repo, "rev-parse", "--absolute-git-dir"], { encoding: "utf8" }).trim(),
+  );
   return {
     workspaceRoot: realpathSync(repo),
-    gitDir: realpathSync(
-      execFileSync("git", ["-C", repo, "rev-parse", "--absolute-git-dir"], { encoding: "utf8" }).trim(),
-    ),
+    gitDir,
+    gitCommonDir: gitDir,
     origin: execFileSync(
       "git", ["-C", repo, "remote", "get-url", "origin"], { encoding: "utf8" },
     ).trim(),
@@ -91,6 +95,39 @@ describe("same-checkout /implement branch operation", () => {
         realpathSync(repo),
       );
       assert.doesNotMatch(readFileSync(log, "utf8"), /worktree/);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(bin, { recursive: true, force: true });
+    }
+  });
+
+  it("authorizes when only the per-worktree Git dir diverges (issue #1502)", async () => {
+    const repo = initRepo();
+    const bin = mkdtempSync(join(tmpdir(), "gc-implement-bin-"));
+    const log = join(bin, "gh.log");
+    writeFileSync(log, "");
+    installGhDevelopShim(bin, log);
+    try {
+      // A concurrent /implement in a sibling linked worktree (or an MCP relaunch) can
+      // shift the captured per-worktree --absolute-git-dir while the shared repository
+      // store, origin, and owner/name are unchanged. The guard pins the common dir, so
+      // this no longer fails with implement_repo_identity_changed.
+      const authorization = {
+        ...authorizationForRepo(repo),
+        gitDir: join(repo, ".git", "worktrees", "stale-pointer"),
+      };
+      const result = await withPath(bin, () =>
+        runPrepareImplementBranch({
+          repoPath: repo,
+          invocationRoot: repo,
+          issueNumber: 1502,
+          branchName: "1502-worktree-identity-guard",
+          baseBranch: "dev",
+          checkoutMode: "same_checkout",
+        }, { workspaceAuthorizationResolver: async () => authorization }),
+      );
+      assert.equal(result.ok, true, JSON.stringify(result));
+      assert.equal(result.branch, "1502-worktree-identity-guard");
     } finally {
       rmSync(repo, { recursive: true, force: true });
       rmSync(bin, { recursive: true, force: true });

--- a/mcp/ground-control/lib/grc-legacy-compat-4.js
+++ b/mcp/ground-control/lib/grc-legacy-compat-4.js
@@ -36,6 +36,7 @@ async function captureImplementWorkspaceAuthorization(cwd) {
   return Object.freeze({
     workspaceRoot,
     gitDir: identity.gitDir,
+    gitCommonDir: identity.gitCommonDir,
     origin: identity.origin,
     owner: owner.toLowerCase(),
     name: name.toLowerCase(),
@@ -58,7 +59,7 @@ export async function authorizeImplementRepoRoot(repoRoot, workspaceAuthorizatio
     authorization == null
     || typeof authorization !== "object"
     || typeof authorization.workspaceRoot !== "string"
-    || typeof authorization.gitDir !== "string"
+    || typeof authorization.gitCommonDir !== "string"
     || typeof authorization.origin !== "string"
     || typeof authorization.owner !== "string"
     || typeof authorization.name !== "string"
@@ -89,8 +90,16 @@ export async function authorizeImplementRepoRoot(repoRoot, workspaceAuthorizatio
       message: "The requested repository identity could not be verified",
     };
   }
+  // Pin the shared repository store (--git-common-dir), not the per-worktree Git
+  // directory (--absolute-git-dir). The workspaceRoot check above already binds the run
+  // to one checkout; pinning the per-worktree pointer on top of it was fragile, because a
+  // concurrent /implement in a sibling linked worktree (git worktree repair/prune) or an
+  // MCP relaunch could shift that pointer's realpath while the repository is unchanged,
+  // firing implement_repo_identity_changed mid-run with no recovery (issue #1502). The
+  // origin/owner/name checks stay strict, so an origin retarget to a different repo is
+  // still rejected.
   if (
-    current.gitDir !== realpathSync(authorization.gitDir)
+    current.gitCommonDir !== realpathSync(authorization.gitCommonDir)
     || current.origin !== authorization.origin
     || currentOwnerRepo.owner.toLowerCase() !== authorization.owner.toLowerCase()
     || currentOwnerRepo.name.toLowerCase() !== authorization.name.toLowerCase()
@@ -98,27 +107,41 @@ export async function authorizeImplementRepoRoot(repoRoot, workspaceAuthorizatio
     return {
       ok: false,
       error: "implement_repo_identity_changed",
-      message: "The checkout origin or Git directory differs from the identity captured at MCP launch",
+      message:
+        "The checkout origin or Git repository differs from the identity captured at MCP launch. "
+        + "If you are in a linked worktree or the Ground Control MCP server was relaunched, "
+        + "restart the server from this worktree so it re-captures the workspace identity.",
     };
   }
   return {
     ok: true,
     workspaceRoot,
     gitDir: current.gitDir,
+    gitCommonDir: current.gitCommonDir,
     origin: authorization.origin,
     owner: authorization.owner,
     name: authorization.name,
   };
 }
 export async function readGitIdentity(repoRoot) {
-  const [top, gitDir, origin] = await Promise.all([
+  const [top, gitDir, gitCommonDir, origin] = await Promise.all([
     execFile("git", ["-C", repoRoot, "rev-parse", "--show-toplevel"]),
     execFile("git", ["-C", repoRoot, "rev-parse", "--absolute-git-dir"]),
+    execFile("git", ["-C", repoRoot, "rev-parse", "--git-common-dir"]),
     execFile("git", ["-C", repoRoot, "remote", "get-url", "origin"]),
   ]);
+  // --git-common-dir returns the shared repository store: for a linked worktree it is
+  // the main checkout's `.git` (stable across every worktree of the repo), while
+  // --absolute-git-dir is the per-worktree `<common>/worktrees/<name>` pointer. Git may
+  // return it relative to repoRoot (typically bare `.git` in the main worktree), so
+  // resolve against repoRoot before realpath. See issue #1502.
+  const rawCommonDir = gitCommonDir.stdout.trim();
   return {
     topLevel: realpathSync(top.stdout.trim()),
     gitDir: realpathSync(gitDir.stdout.trim()),
+    gitCommonDir: realpathSync(
+      isAbsolute(rawCommonDir) ? rawCommonDir : join(repoRoot, rawCommonDir),
+    ),
     origin: origin.stdout.trim(),
   };
 }


### PR DESCRIPTION
## Summary

The /implement repo-identity guard captured the per-worktree Git directory (`--absolute-git-dir`) at MCP launch and compared it on every guarded call. In a linked worktree, a concurrent /implement in a sibling worktree (`git worktree repair`/`prune`) or an MCP relaunch could shift that per-worktree pointer's realpath while the repository was unchanged, firing `implement_repo_identity_changed` mid-run with no in-tool recovery and blocking the pre-push gates. The guard now pins the shared common Git directory (`--git-common-dir`), which is stable across every linked worktree of the same repository. The origin/owner/name checks stay strict, so an origin retarget to a different repo is still rejected, and the error message now names the restart-from-worktree recovery path.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1502

## ADR Impact

- ADR-027

## Changes

- readGitIdentity now also derives the shared common Git directory (--git-common-dir), resolved to an absolute realpath
- authorizeImplementRepoRoot pins and compares gitCommonDir instead of the fragile per-worktree gitDir; origin/owner/name remain strict
- implement_repo_identity_changed message now points at the restart-from-worktree recovery path
- Regression test: a divergent per-worktree gitDir no longer trips the guard when common-dir/origin/owner/name match
- DEVELOPMENT_WORKFLOW.md documents the one-server-per-worktree / relaunch-recovery story

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

make mcp-test (1356 tests, pass) and make policy (170 policy tests + bin/policy + vale, pass).

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed