### PR TITLE
fix(implement): run repository gates through a size-safe command runner

### DIFF
--- a/mcp/ground-control/implement/verify.js
+++ b/mcp/ground-control/implement/verify.js
@@ -4,7 +4,8 @@
 // (docs/CODING_STANDARDS.md). gc-implement-mechanical.js remains the tool entry point.
 
 import { implementGateEnvironment, resolveWorkflowPolicyCommand } from "../lib.js";
-import { childGateArtifactPaths, commandFailure, emitPolicyAndValeAttempts, emitSpotbugsAttempt, failure, readStatus } from "./gate-helpers.js";
+import { runGateCommand } from "../lib/gate-command-runner.js";
+import { childGateArtifactPaths, commandFailure, emitPolicyAndValeAttempts, emitSpotbugsAttempt, execFileAsync, failure, readStatus } from "./gate-helpers.js";
 
 export async function runVerify(args, deps) {
   const action = "verify";
@@ -56,12 +57,18 @@ export async function runVerify(args, deps) {
   // is parsed (issue #1355).
   const artifacts = childGateArtifactPaths(repoRoot);
   const childEnv = { ...gateEnv, GC_POLICY_JSON: artifacts.policy, GC_VALE_JSON: artifacts.vale };
+  // The completion and policy gates emit the full test-suite / policy transcript,
+  // which overflows execFile's maxBuffer on a large tree and aborts before the
+  // exit status is seen (issue #1501). Only the exit status is consumed here, so
+  // the production default runner is swapped for the size-safe gate runner; an
+  // injected runner (tests) is honored unchanged. Git reads keep deps.execFile.
+  const gateRunner = deps.execFile === execFileAsync ? runGateCommand : deps.execFile;
   const before = await readStatus(repoRoot, deps.runGit, deps.execFile);
   const completionStartedAt = new Date();
   const completionStartedMs = Date.now();
   let completionError = null;
   try {
-    await deps.execFile("bash", ["-c", command], { cwd: repoRoot, env: childEnv });
+    await gateRunner("bash", ["-c", command], { cwd: repoRoot, env: childEnv });
   } catch (error) {
     completionError = error;
   }
@@ -79,7 +86,7 @@ export async function runVerify(args, deps) {
   const policyStartedAt = new Date();
   let policyError = null;
   try {
-    await deps.execFile("bash", ["-c", policyCommand], { cwd: repoRoot, env: childEnv });
+    await gateRunner("bash", ["-c", policyCommand], { cwd: repoRoot, env: childEnv });
   } catch (error) {
     policyError = error;
   }

--- a/mcp/ground-control/implement/verify.js
+++ b/mcp/ground-control/implement/verify.js
@@ -4,8 +4,7 @@
 // (docs/CODING_STANDARDS.md). gc-implement-mechanical.js remains the tool entry point.
 
 import { implementGateEnvironment, resolveWorkflowPolicyCommand } from "../lib.js";
-import { runGateCommand } from "../lib/gate-command-runner.js";
-import { childGateArtifactPaths, commandFailure, emitPolicyAndValeAttempts, emitSpotbugsAttempt, execFileAsync, failure, readStatus } from "./gate-helpers.js";
+import { childGateArtifactPaths, commandFailure, emitPolicyAndValeAttempts, emitSpotbugsAttempt, failure, readStatus } from "./gate-helpers.js";
 
 export async function runVerify(args, deps) {
   const action = "verify";
@@ -57,18 +56,12 @@ export async function runVerify(args, deps) {
   // is parsed (issue #1355).
   const artifacts = childGateArtifactPaths(repoRoot);
   const childEnv = { ...gateEnv, GC_POLICY_JSON: artifacts.policy, GC_VALE_JSON: artifacts.vale };
-  // The completion and policy gates emit the full test-suite / policy transcript,
-  // which overflows execFile's maxBuffer on a large tree and aborts before the
-  // exit status is seen (issue #1501). Only the exit status is consumed here, so
-  // the production default runner is swapped for the size-safe gate runner; an
-  // injected runner (tests) is honored unchanged. Git reads keep deps.execFile.
-  const gateRunner = deps.execFile === execFileAsync ? runGateCommand : deps.execFile;
   const before = await readStatus(repoRoot, deps.runGit, deps.execFile);
   const completionStartedAt = new Date();
   const completionStartedMs = Date.now();
   let completionError = null;
   try {
-    await gateRunner("bash", ["-c", command], { cwd: repoRoot, env: childEnv });
+    await deps.execFile("bash", ["-c", command], { cwd: repoRoot, env: childEnv });
   } catch (error) {
     completionError = error;
   }
@@ -86,7 +79,7 @@ export async function runVerify(args, deps) {
   const policyStartedAt = new Date();
   let policyError = null;
   try {
-    await gateRunner("bash", ["-c", policyCommand], { cwd: repoRoot, env: childEnv });
+    await deps.execFile("bash", ["-c", policyCommand], { cwd: repoRoot, env: childEnv });
   } catch (error) {
     policyError = error;
   }

--- a/mcp/ground-control/lib.gate-command-runner.test.js
+++ b/mcp/ground-control/lib.gate-command-runner.test.js
@@ -1,0 +1,35 @@
+// The gate command runner must observe the gate's exit status no matter how
+// verbose the command is. execFile aborts a completion command whose stdout
+// exceeds its 1 MiB maxBuffer before the child exits, so the completion
+// boundary could never be satisfied on a large merged tree (issue #1501).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { runGateCommand } from "./lib/gate-command-runner.js";
+
+// Comfortably past execFile's 1 MiB maxBuffer default; the pre-fix runner
+// aborted with ERR_CHILD_PROCESS_STDIO_MAXBUFFER at this size.
+const OVER_MAXBUFFER = "head -c 2000000 </dev/zero | tr '\\0' a";
+const TAIL_CAP_BYTES = 64 * 1024;
+
+describe("runGateCommand", () => {
+  it("observes a success exit status behind multi-megabyte stdout", async () => {
+    const result = await runGateCommand("bash", ["-c", `${OVER_MAXBUFFER}; printf ZZZEND; exit 0`]);
+    // The exit status is what the gate boundary reads; the transcript is kept
+    // only as a bounded tail, so the freshest output survives while memory stays
+    // capped.
+    assert.ok(result.stdout.endsWith("ZZZEND"));
+    assert.ok(Buffer.byteLength(result.stdout, "utf8") <= TAIL_CAP_BYTES);
+  });
+
+  it("surfaces a non-zero exit status with a bounded stderr tail behind large output", async () => {
+    await assert.rejects(
+      runGateCommand("bash", ["-c", `${OVER_MAXBUFFER} >&2; exit 7`]),
+      (error) => {
+        assert.equal(error.code, 7);
+        assert.ok(Buffer.byteLength(error.stderr, "utf8") <= TAIL_CAP_BYTES);
+        return true;
+      },
+    );
+  });
+});

--- a/mcp/ground-control/lib/codex-workflow-2.js
+++ b/mcp/ground-control/lib/codex-workflow-2.js
@@ -150,13 +150,30 @@ export function implementGateEnvironment(
   }
   return { ...baseEnv, [REQUIREMENT_UID_GATE_ENV_VAR]: requestedRequirementUid };
 }
-// Greedy capture rather than the lazy `(.+?)\s*$` these replaced: the trailing
-// whitespace is stripped by the consumers (heading titles are trimmed; bullet
-// tokens are split on whitespace), so a greedy tail is equivalent while it
-// avoids the super-linear backtracking a lazy quantifier before an optional
-// trailing group can exhibit (Sonar S8786).
-const REQUIREMENTS_HEADING_RE = /^(#{1,6})\s+(.+)$/;
-const REQUIREMENTS_BULLET_RE = /^\s*[-*+]\s+(.+)$/;
+// These rewrite the lazy `\s+(.+?)\s*$` that reads as super-linear backtracking
+// (Sonar S8786), each exactly equivalent because heading titles are trimmed and
+// bullet tokens split on whitespace. Heading uses an unquantified `\s` before
+// `(.+)`, removing the quantifier-vs-quantifier ambiguity while still matching a
+// whitespace-only title (`##␠␠`) as the original did, so section breaks are
+// unchanged. Bullet keeps `\s+` (it must eat every space after the marker) and
+// anchors the capture at the first non-space `\S`; since `\s+` already consumed
+// the whitespace, that changes nothing behaviorally.
+const REQUIREMENTS_HEADING_RE = /^(#{1,6})\s(.+)$/;
+const REQUIREMENTS_BULLET_RE = /^\s*[-*+]\s+(\S.*)$/;
+
+const UID_TOKEN_LEADING_WRAPPERS = "`[(";
+const UID_TOKEN_TRAILING_WRAPPERS = "`)].:";
+
+// Strip wrapping punctuation a UID token may carry in prose (backticks,
+// brackets, parens, trailing sentence marks). A linear character scan; the
+// equivalent `[...]+$` regex reads as super-linear to the analyzer (S8786).
+function stripUidTokenWrappers(token) {
+  let start = 0;
+  let end = token.length;
+  while (start < end && UID_TOKEN_LEADING_WRAPPERS.includes(token[start])) start += 1;
+  while (end > start && UID_TOKEN_TRAILING_WRAPPERS.includes(token[end - 1])) end -= 1;
+  return token.slice(start, end);
+}
 
 // Collect the lines under a level 2-4 `## Requirements` section, ending at the
 // next heading of the same or higher level.
@@ -192,7 +209,7 @@ function requirementUidsFromBullet(line) {
   if (!bullet) return [];
   const uids = [];
   for (const token of bullet[1].split(/[\s,;]+/)) {
-    const candidate = token.replace(/^[`[(]+/, "").replace(/[`)\].:]+$/, "");
+    const candidate = stripUidTokenWrappers(token);
     if (!isRequirementUidToken(candidate)) break;
     uids.push(candidate);
   }

--- a/mcp/ground-control/lib/codex-workflow-2.js
+++ b/mcp/ground-control/lib/codex-workflow-2.js
@@ -11,6 +11,7 @@ import { extractGhErrorMessage } from "./grc-legacy-compat-2.js";
 import { assertSafeImplementCheckoutConfiguration, authorizeImplementRepoRoot, ensureGitRepo, readGitIdentity, resolveMcpLaunchWorkspaceAuthorization } from "./grc-legacy-compat-4.js";
 import { isSafeGitRefName, resolveWorkflowPolicyCommand, resolveWorkflowPrecommitCommand } from "./repo-context.js";
 import { EXACT_REQUIREMENT_UID_RE, execFile, isRequirementUidToken } from "./runtime-primitives.js";
+import { runGateCommand } from "./gate-command-runner.js";
 
 export async function runPrepareImplementBranch({
   repoPath,
@@ -264,7 +265,12 @@ export async function runImplementPreCommit(
   context = null,
   requestedRequirementUid = null,
 ) {
-  return commandRunner(
+  // A verbose pre-commit hook set can overflow execFile's maxBuffer the same way
+  // the completion gate does (issue #1501); only the exit status is consumed, so
+  // the production default runner is swapped for the size-safe gate runner while
+  // an injected runner (tests) is honored unchanged.
+  const gateRunner = commandRunner === execFile ? runGateCommand : commandRunner;
+  return gateRunner(
     "bash",
     ["-c", resolveWorkflowPrecommitCommand(context)],
     {
@@ -431,14 +437,19 @@ export async function runImplementFinalTreeGates(
   }
   const beforeTree = await readImplementIndexTreeOid(repoRoot, commandRunner);
   const gateEnv = implementGateEnvironment(requestedRequirementUid);
-  await commandRunner(
+  // The completion command's stdout on a large merged tree overflows execFile's
+  // maxBuffer and aborts before its exit status is seen (issue #1501). Only the
+  // exit status matters here, so the production default runner is swapped for
+  // the size-safe gate runner; an injected runner (tests) is honored unchanged.
+  const gateRunner = commandRunner === execFile ? runGateCommand : commandRunner;
+  await gateRunner(
     "bash",
     ["-c", completionCommand],
     { cwd: repoRoot, env: gateEnv },
   );
   // Completion and policy are separate mandatory gates; neither substitutes
   // for the other. Both run through the same repo-authored-command boundary.
-  await commandRunner(
+  await gateRunner(
     "bash",
     ["-c", resolveWorkflowPolicyCommand(context)],
     { cwd: repoRoot, env: gateEnv },

--- a/mcp/ground-control/lib/codex-workflow-2.js
+++ b/mcp/ground-control/lib/codex-workflow-2.js
@@ -150,46 +150,64 @@ export function implementGateEnvironment(
   }
   return { ...baseEnv, [REQUIREMENT_UID_GATE_ENV_VAR]: requestedRequirementUid };
 }
-export function extractInScopeRequirementUids(issueBody) {
-  if (typeof issueBody !== "string" || issueBody === "") return [];
+// Greedy capture rather than the lazy `(.+?)\s*$` these replaced: the trailing
+// whitespace is stripped by the consumers (heading titles are trimmed; bullet
+// tokens are split on whitespace), so a greedy tail is equivalent while it
+// avoids the super-linear backtracking a lazy quantifier before an optional
+// trailing group can exhibit (Sonar S8786).
+const REQUIREMENTS_HEADING_RE = /^(#{1,6})\s+(.+)$/;
+const REQUIREMENTS_BULLET_RE = /^\s*[-*+]\s+(.+)$/;
 
+// Collect the lines under a level 2-4 `## Requirements` section, ending at the
+// next heading of the same or higher level.
+function requirementsSectionLines(issueBody) {
   const sectionLines = [];
   let sectionLevel = null;
   for (const line of issueBody.split(/\r?\n/)) {
-    const heading = line.match(/^(#{1,6})\s+(.+?)\s*$/);
-    if (heading) {
-      const level = heading[1].length;
-      const title = heading[2].trim().toLowerCase();
-      if (sectionLevel == null) {
-        if (level >= 2 && level <= 4 && title === "requirements") {
-          sectionLevel = level;
-        }
-        continue;
-      }
-      if (level <= sectionLevel) break;
-      sectionLines.push(line);
+    const heading = REQUIREMENTS_HEADING_RE.exec(line);
+    if (!heading) {
+      if (sectionLevel != null) sectionLines.push(line);
       continue;
     }
-    if (sectionLevel != null) sectionLines.push(line);
+    const level = heading[1].length;
+    const title = heading[2].trim().toLowerCase();
+    if (sectionLevel == null) {
+      if (level >= 2 && level <= 4 && title === "requirements") sectionLevel = level;
+      continue;
+    }
+    if (level <= sectionLevel) break;
+    sectionLines.push(line);
   }
+  return sectionLines;
+}
 
+// Read the leading run of UID tokens from one bullet line, stopping at the first
+// token that is not a recognizable UID. Recognition, not identity validation:
+// these tokens come from free-form issue prose, so the bounded-identifier
+// contract would accept ordinary words. The anchored recognizer still finds
+// allocator-minted short UIDs like APP-2, so a requirement-backed run is not
+// silently reduced to a requirement-free one (issue #1425).
+function requirementUidsFromBullet(line) {
+  const bullet = REQUIREMENTS_BULLET_RE.exec(line);
+  if (!bullet) return [];
+  const uids = [];
+  for (const token of bullet[1].split(/[\s,;]+/)) {
+    const candidate = token.replace(/^[`[(]+/, "").replace(/[`)\].:]+$/, "");
+    if (!isRequirementUidToken(candidate)) break;
+    uids.push(candidate);
+  }
+  return uids;
+}
+
+export function extractInScopeRequirementUids(issueBody) {
+  if (typeof issueBody !== "string" || issueBody === "") return [];
   const seen = new Set();
   const result = [];
-  for (const line of sectionLines) {
-    const bullet = line.match(/^\s*[-*+]\s+(.+?)\s*$/);
-    if (!bullet) continue;
-    for (const token of bullet[1].split(/[\s,;]+/)) {
-      const candidate = token.replace(/^[`[(]+|[`)\].:]+$/g, "");
-      // Recognition, not identity validation: these tokens come from free-form
-      // issue prose, so the bounded-identifier contract would accept ordinary
-      // words. The anchored recognizer still finds allocator-minted short UIDs
-      // like APP-2, so a requirement-backed run is not silently reduced to a
-      // requirement-free one (issue #1425).
-      if (!isRequirementUidToken(candidate)) break;
-      if (!seen.has(candidate)) {
-        seen.add(candidate);
-        result.push(candidate);
-      }
+  for (const line of requirementsSectionLines(issueBody)) {
+    for (const candidate of requirementUidsFromBullet(line)) {
+      if (seen.has(candidate)) continue;
+      seen.add(candidate);
+      result.push(candidate);
     }
   }
   return result;
@@ -265,12 +283,7 @@ export async function runImplementPreCommit(
   context = null,
   requestedRequirementUid = null,
 ) {
-  // A verbose pre-commit hook set can overflow execFile's maxBuffer the same way
-  // the completion gate does (issue #1501); only the exit status is consumed, so
-  // the production default runner is swapped for the size-safe gate runner while
-  // an injected runner (tests) is honored unchanged.
-  const gateRunner = commandRunner === execFile ? runGateCommand : commandRunner;
-  return gateRunner(
+  return commandRunner(
     "bash",
     ["-c", resolveWorkflowPrecommitCommand(context)],
     {

--- a/mcp/ground-control/lib/gate-command-runner.js
+++ b/mcp/ground-control/lib/gate-command-runner.js
@@ -1,0 +1,75 @@
+// A size-safe runner for the repository gate commands (completion, policy, and
+// pre-commit) that the implement/quickfix workflow runs on a checkout (issue
+// #1501).
+//
+// Those gates are invoked through the same execFile-shaped seam the git calls
+// use, which means Node's `child_process.execFile` and its 1 MiB `maxBuffer`
+// default. A gate command's console output is not a bounded value like a git
+// SHA: a full test suite's stdout on a large merged tree routinely exceeds a
+// megabyte. execFile treats that overflow as fatal — it kills the child and
+// rejects with ERR_CHILD_PROCESS_STDIO_MAXBUFFER *before* the child exits — so
+// the gate's own pass/fail exit status is never observed and the completion
+// boundary can never be satisfied. The failure is output-size driven, so a
+// retry re-hits it deterministically.
+//
+// The gate boundary only needs the exit status; the full transcript is
+// discarded on success. This runner therefore streams stdout/stderr and keeps
+// only a bounded tail for a failure diagnostic, so it never holds the whole
+// transcript in memory and never overflows regardless of how verbose the gate
+// command is. Its resolve/reject shape mirrors execFile (`{stdout, stderr}` on
+// success; an Error carrying `code`, `signal`, `stdout`, and `stderr` on a
+// non-zero exit or a terminating signal) so it is a drop-in substitute at the
+// existing call sites and the shared failure formatters keep working.
+
+import { spawn } from "node:child_process";
+
+// 64 KiB per stream is far more than a failure diagnostic needs while staying a
+// hard ceiling on retained memory. A test suite's actionable failure output
+// lives at the tail, which is exactly what is kept.
+const GATE_TAIL_BYTES = 64 * 1024;
+
+// Retains only the last `limitBytes` of everything pushed. Concatenating then
+// slicing on each chunk keeps the live buffer at or below the cap; a truncated
+// leading multibyte character can only ever land in a diagnostic tail, never in
+// the exit status the boundary actually reads.
+function boundedTail(limitBytes) {
+  let buffer = Buffer.alloc(0);
+  return {
+    push(chunk) {
+      const combined = Buffer.concat([buffer, chunk]);
+      buffer = combined.length > limitBytes ? combined.subarray(combined.length - limitBytes) : combined;
+    },
+    toString() {
+      return buffer.toString("utf8");
+    },
+  };
+}
+
+export async function runGateCommand(file, args, options = {}) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(file, args, options);
+    const stdoutTail = boundedTail(GATE_TAIL_BYTES);
+    const stderrTail = boundedTail(GATE_TAIL_BYTES);
+    // Draining both pipes as data arrives is also what prevents the child from
+    // blocking on a full OS pipe buffer once its output passes ~64 KiB — the
+    // failure mode a "discard the output" runner that stopped reading would
+    // reintroduce.
+    child.stdout.on("data", (chunk) => stdoutTail.push(chunk));
+    child.stderr.on("data", (chunk) => stderrTail.push(chunk));
+    child.on("error", (error) => reject(error));
+    child.on("close", (code, signal) => {
+      const stdout = stdoutTail.toString();
+      const stderr = stderrTail.toString();
+      if (code === 0 && signal == null) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      const error = new Error(`Command failed: ${file} ${args.join(" ")}\n${stderr}`);
+      error.code = code ?? undefined;
+      error.signal = signal ?? undefined;
+      error.stdout = stdout;
+      error.stderr = stderr;
+      reject(error);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`gc_implement_mechanical action=publish` and `gc_synchronize_implement_branch action=complete` both aborted with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` ("The final merged tree did not pass its completion boundary") whenever the completion command's stdout on the merged tree exceeded Node's 1 MiB `execFile` `maxBuffer` default. A full test suite's output on a large merged tree routinely does; `execFile` kills the child and rejects before its exit status is seen, so the boundary could never be satisfied — deterministic on retry.

Both symptoms share one helper, `runImplementFinalTreeGates`, which runs the completion and policy gate commands. It now routes those two commands through a new spawn-based runner (`lib/gate-command-runner.js`) that streams stdout/stderr into a bounded 64 KiB diagnostic tail. The boundary only needs the exit status (the transcript is discarded on success), so the runner never holds the full output in memory and never overflows. Its resolve/reject shape mirrors `execFile`, so it is a drop-in and the shared failure formatters keep working; git reads keep `execFile`, and an injected runner (tests) is honored unchanged.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1501

## ADR Impact

- No ADR required

## Changes

- Add lib/gate-command-runner.js: a spawn-based runner that keeps a bounded 64 KiB stdout/stderr tail and returns an execFile-shaped result/error
- Route the completion and policy gate commands in runImplementFinalTreeGates through the size-safe runner (fixes both the publish and base-sync completion symptoms)
- Simplify extractInScopeRequirementUids in the same file into small helpers with non-backtracking regexes (equivalent behavior; clears cognitive-complexity and super-linear-regex smells on the touched lines)
- Add lib.gate-command-runner.test.js covering >1 MiB output on both success and non-zero exit

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

make mcp-test (1358 tests) green; make policy green; pre-commit run --all-files clean. New test asserts a ~2 MB gate command still yields its exit status (success and non-zero) with a bounded tail.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
