### PR TITLE
ci: run the MCP ESLint gate in the required policy path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,12 @@ jobs:
         run: python3 -m unittest discover -s tools/tests -p 'test_*.py'
       - name: MCP server tests
         run: npm --prefix mcp/ground-control test
+      # ESLint on the MCP server. `make mcp-lint` is the one canonical invocation;
+      # `make policy` depends on the same target, so CI and the local guardrail run
+      # one command. Deps were installed above by `npm ci`. A lint error fails this
+      # already-required job; the existing eslint-plugin-security warnings are advisory.
+      - name: MCP ESLint
+        run: make mcp-lint
       - name: Repo policy checks
         if: github.event_name == 'pull_request'
         run: >

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ground-control-mcp-install mcp-test graphify vale-install vale-lint \
+.PHONY: ground-control-mcp-install mcp-test mcp-lint graphify vale-install vale-lint \
        policy policy-tests hooks devmain ci-timings help
 
 # Ground Control is the MCP server for the /implement workflow over repo-local
@@ -13,6 +13,9 @@ ground-control-mcp-install: ## Install dependencies for the repo-local Ground Co
 
 mcp-test: ## Run the MCP server node test suite (primary test gate)
 	npm --prefix mcp/ground-control test
+
+mcp-lint: ## Run ESLint on the Ground Control MCP server (repo-native lint gate)
+	npm --prefix mcp/ground-control run lint
 
 # --- Comprehension index (opt-in) ---
 
@@ -48,7 +51,7 @@ vale-lint: vale-install ## Run Vale on .md docs changed vs BASE_REF, incl. uncom
 policy-tests: ## Run unit tests for repo policy tooling
 	python3 -m unittest discover -s tools/tests -p 'test_*.py'
 
-policy: policy-tests vale-lint ## Run repo-native policy checks shared by Claude and Codex
+policy: policy-tests mcp-lint vale-lint ## Run repo-native policy checks shared by Claude and Codex
 	@BASE_REF="$${BASE_REF:-origin/dev}"; \
 	python3 bin/policy --base "$$BASE_REF" --skip-pr-body $${GC_POLICY_JSON:+--json "$$GC_POLICY_JSON"}
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Code (and Codex / Cursor per ADR-027). See the
 
 ```bash
 make mcp-test     # MCP node --test suite (primary test gate)
-make policy       # repo-native ADR/workflow/spec guardrails + Vale
+make mcp-lint     # ESLint on the MCP server (also run by `make policy`)
+make policy       # repo-native ADR/workflow/spec guardrails + MCP lint + Vale
 make vale-lint    # prose lint on changed docs
 make graphify     # (optional) rebuild the disposable Graphify index
 ```

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -415,7 +415,13 @@ The guard is a pre-execution *lexical* policy control, not an OS sandbox. It pro
   (`measurement-catalogue-routing-stage-drift`). Adding a station or an alias is a
   catalogue edit; a breaking station-id or vocabulary change is a new schema version
   under ADR-082, never an in-place edit of a published one.
-- `make policy` is the common path for Claude, Codex, and CI
+- `make policy` is the common path for Claude, Codex, and CI; it runs the policy
+  tool tests, the MCP ESLint gate (`make mcp-lint`), `bin/policy`, and Vale. The CI
+  `policy` job runs the same `make mcp-lint` target as a required step, so an ESLint
+  error on the MCP server fails a required check (issue #255). `make mcp-lint`
+  delegates to the package-owned `npm --prefix mcp/ground-control run lint`, keeping
+  one canonical invocation; the current baseline reports advisory
+  `eslint-plugin-security` warnings and no errors
 - `make sync-ground-control-policy` and `make policy-live` keep Ground Control quality gates and ADR metadata aligned when a live GC instance is available
 
 Commit-time pre-commit activation is a separate per-clone contract from the

--- a/tools/tests/test_ci_mcp_lint_gate.py
+++ b/tools/tests/test_ci_mcp_lint_gate.py
@@ -1,0 +1,179 @@
+"""The MCP ESLint gate must be reachable AND enforcing on the repo-native path (issue #255).
+
+Post-#1500 CI ran the MCP node test suite but never `npm --prefix mcp/ground-control
+run lint`, so an ESLint regression could not fail a required check. These tests lock
+the wiring so it cannot silently disappear again: one canonical `mcp-lint` Make target
+owns the invocation, `make policy` (the documented guardrail) depends on it, and CI's
+required `policy` job runs the same target.
+
+Presence of the command string is not enough — a gate is only real if it can still
+fail. So each site is also checked against the common neutralizers that would leave the
+exact text present while stopping it from ever blocking: a trailing no-op shell operator
+(`|| true`, `; exit 0`), a Make recipe that ignores its own errors (a leading `-`), or a
+CI `continue-on-error: true` / step-level `if:` that skips the step. The ESLint warning
+count is deliberately NOT asserted — it is advisory (`eslint-plugin-security` recommends
+warnings) and unrelated to this contract.
+"""
+
+import json
+import unittest
+
+import yaml
+
+from tools.policy.core import REPO_ROOT
+
+LINT_NPM_COMMAND = "npm --prefix mcp/ground-control run lint"
+MAKE_LINT_TARGET = "mcp-lint"
+
+# Trailing no-op operators that leave a command textually present while stopping it
+# from ever failing the check it is supposed to be.
+_SHELL_NEUTRALIZERS = ("|| true", "|| :", "|| exit 0", "; true", "; exit 0", "; :")
+
+
+def _shell_neutralizer(command: str) -> str | None:
+    """Return the no-op operator that would neutralize `command`, or None if clean."""
+    for token in _SHELL_NEUTRALIZERS:
+        if token in command:
+            return token
+    return None
+
+
+def _make_recipe_ignores_errors(recipe_line: str) -> bool:
+    """True when a Make recipe line suppresses its own failure via a leading `-`.
+
+    Make's `@` silences the echo and `-` ignores the exit status; they can be combined
+    in either order, so strip a leading `@` before checking for the error-ignoring `-`.
+    """
+    return recipe_line.lstrip("@").startswith("-")
+
+
+def _recipe_for(makefile_text: str, target: str) -> list[str] | None:
+    """Return a Make target's recipe lines (tab stripped), or None if absent."""
+    lines = makefile_text.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith(f"{target}:"):
+            recipe: list[str] = []
+            for follow in lines[index + 1 :]:
+                if follow.startswith("\t"):
+                    recipe.append(follow[1:])
+                else:
+                    break
+            return recipe
+    return None
+
+
+def _prerequisites_for(makefile_text: str, target: str) -> list[str] | None:
+    """Return a Make target's prerequisite names, or None if the target is absent."""
+    for line in makefile_text.splitlines():
+        if line.startswith(f"{target}:"):
+            after_colon = line[len(target) + 1 :].split("##", 1)[0]
+            return after_colon.split()
+    return None
+
+
+class NeutralizerDetectionTest(unittest.TestCase):
+    """The guards themselves must fire — otherwise the wiring tests give false assurance."""
+
+    def test_shell_neutralizer_flags_trailing_noops(self) -> None:
+        self.assertEqual(_shell_neutralizer("make mcp-lint || true"), "|| true")
+        self.assertEqual(_shell_neutralizer("make mcp-lint ; exit 0"), "; exit 0")
+        self.assertIsNone(_shell_neutralizer("make mcp-lint"))
+
+    def test_make_recipe_ignore_errors_is_detected(self) -> None:
+        self.assertTrue(_make_recipe_ignores_errors(f"-{LINT_NPM_COMMAND}"))
+        self.assertTrue(_make_recipe_ignores_errors(f"@-{LINT_NPM_COMMAND}"))
+        self.assertTrue(_make_recipe_ignores_errors(f"-@{LINT_NPM_COMMAND}"))
+        self.assertFalse(_make_recipe_ignores_errors(LINT_NPM_COMMAND))
+        self.assertFalse(_make_recipe_ignores_errors(f"@{LINT_NPM_COMMAND}"))
+
+
+class McpLintGateTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+        self.workflow = yaml.safe_load(
+            (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        )
+
+    def test_package_json_lint_script_enforces_eslint(self) -> None:
+        package = json.loads(
+            (REPO_ROOT / "mcp/ground-control/package.json").read_text(encoding="utf-8")
+        )
+        lint_script = package.get("scripts", {}).get("lint", "")
+        self.assertIn("eslint", lint_script)
+        self.assertIsNone(
+            _shell_neutralizer(lint_script),
+            "the package lint script must be able to fail",
+        )
+
+    def test_make_target_enforces_npm_lint(self) -> None:
+        recipe = _recipe_for(self.makefile, MAKE_LINT_TARGET)
+        self.assertIsNotNone(recipe, "Makefile is missing the `mcp-lint` target")
+        self.assertIn(
+            LINT_NPM_COMMAND,
+            "\n".join(recipe),
+            "`mcp-lint` must delegate to the package-owned npm lint script",
+        )
+        for line in recipe:
+            self.assertFalse(
+                _make_recipe_ignores_errors(line),
+                f"`mcp-lint` recipe line ignores its own failure: {line!r}",
+            )
+            self.assertIsNone(
+                _shell_neutralizer(line),
+                f"`mcp-lint` recipe line neutralizes the lint: {line!r}",
+            )
+
+    def test_policy_target_depends_on_mcp_lint(self) -> None:
+        prerequisites = _prerequisites_for(self.makefile, "policy")
+        self.assertIsNotNone(prerequisites, "Makefile is missing the `policy` target")
+        self.assertIn(
+            MAKE_LINT_TARGET,
+            prerequisites,
+            "`make policy` (the documented guardrail) must reach the MCP lint",
+        )
+
+    def test_ci_policy_job_enforces_make_mcp_lint(self) -> None:
+        policy_job = self.workflow["jobs"]["policy"]
+        self.assertIsNot(
+            policy_job.get("continue-on-error", False),
+            True,
+            "the policy job must not swallow step failures",
+        )
+        lint_steps = [
+            step
+            for step in policy_job["steps"]
+            if "make mcp-lint" in step.get("run", "")
+        ]
+        self.assertEqual(
+            len(lint_steps),
+            1,
+            "the required CI `policy` job must run `make mcp-lint` exactly once",
+        )
+        step = lint_steps[0]
+        self.assertIsNone(
+            _shell_neutralizer(step["run"]),
+            "the CI MCP ESLint step must be able to fail",
+        )
+        self.assertIsNot(
+            step.get("continue-on-error", False),
+            True,
+            "the CI MCP ESLint step must not set continue-on-error",
+        )
+        self.assertNotIn(
+            "if",
+            step,
+            "the CI MCP ESLint step must run unconditionally, not behind a skip `if:`",
+        )
+
+    def test_ci_runs_on_pull_requests(self) -> None:
+        # `on` round-trips through YAML as the boolean True key, so accept either form.
+        triggers = self.workflow.get("on", self.workflow.get(True, {}))
+        self.assertIn(
+            "pull_request",
+            triggers,
+            "the gate must run on pull requests (issue #255 acceptance)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Post-#1500 CI ran the MCP node test suite but never `npm --prefix mcp/ground-control run lint`, so an ESLint regression could not fail a required check. This wires the existing `eslint .` script (0 errors today; advisory eslint-plugin-security warnings) into the repo-native required path with one canonical invocation: a phony `mcp-lint` Make target, a dependency from `make policy` (the documented guardrail), and a named step in CI's already-required `policy` job. A structural test locks the wiring and verifies each site can still fail — it is not neutralized by a trailing no-op (`|| true`), an error-ignoring Make recipe, or a CI `continue-on-error`/skip `if:`. No new workflow, no path filter; ESLint rules and the pre-existing warnings are unchanged and out of scope.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #255

## ADR Impact

- ADR-091
- ADR-021

## Changes

- Add a phony `mcp-lint` Make target delegating to `npm --prefix mcp/ground-control run lint` — the single canonical invocation for humans and automation.
- Make `make policy` depend on `mcp-lint` so the documented repo-native guardrail reaches the MCP lint.
- Add a named "MCP ESLint" step to CI's required `policy` job running `make mcp-lint` (after the existing `npm ci`); no new workflow/job/context, no path filter, read-only permissions unchanged.
- Add `tools/tests/test_ci_mcp_lint_gate.py` locking the wiring and verifying each site actually enforces (neutralization-detection predicates are themselves unit-tested).
- Document `make mcp-lint` in `README.md` and `docs/DEVELOPMENT_WORKFLOW.md`.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

`make mcp-lint` exits 0 (0 errors, 268 advisory eslint-plugin-security warnings). `make policy` and `make mcp-test` (1445/1445) green on the final tree.

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: tools/tests/test_ci_mcp_lint_gate.py ← CI `policy` job + `make policy` run `make mcp-lint` (issue #255)

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.