### PR TITLE
docs: add repository map and refresh stale onboarding docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,130 +1,99 @@
 # Contributing to Ground Control
 
-## Getting Started
+Ground Control is the MCP server for the `/implement` workflow over repo-local files
+(issue #1500). There is no backend, database, or frontend; if a doc still tells you to
+start PostgreSQL or run Gradle, it is stale (see the
+[architecture overview](docs/architecture/ARCHITECTURE.md)).
+
+## Getting started
 
 ### Prerequisites
 
-- Java 21 (Eclipse Temurin recommended)
-- Docker Engine 24+ and Docker Compose v2
-- Gradle 8.x (via included wrapper - no manual install needed)
+- Node.js 20+
+- `gh` CLI, authenticated (`gh auth status`)
+- `git`
+- Python 3 (for the repo policy tooling)
 
-### Local Development Setup
+### Local setup
 
 ```bash
-# 1. Clone and branch
+# 1. Clone and branch from dev
 git clone https://github.com/autarchy-ai/Ground-Control.git
 cd Ground-Control
-git checkout -b feature/your-feature dev
+git checkout -b <issue-number>-short-slug dev
 
-# 2. Activate commit-time hooks for THIS clone (required once per clone, ADR-079)
-make hooks                         # writes + verifies the pre-commit/pre-push hooks
+# 2. Activate commit-time hooks for THIS clone (once per clone, ADR-079)
+make hooks
 
-# 3. Start PostgreSQL and Redis
-cp .env.example .env
-make up
+# 3. Install the MCP server dependencies
+make ground-control-mcp-install   # npm ci in mcp/ground-control
 
-# 4. Build and test
-make rapid                         # Format + compile (~1s with warm daemon)
-make test                          # Unit tests
-
-# 5. Start development server
-make dev                           # Spring Boot on :8000
+# 4. Run the test and policy gates
+make mcp-test                     # node --test suite (primary gate)
+make policy                       # repo-native guardrails + MCP lint + Vale
 ```
 
-### Makefile Targets
+### Makefile targets
 
 | Target | Description |
 |--------|-------------|
-| `make hooks` | Activate + verify commit-time pre-commit hooks for this clone (run once per clone) |
-| `make rapid` | Format + compile, no tests or static analysis (~1 second warm) |
-| `make test` | Run unit tests (no static analysis) |
-| `make check` | Full build + tests + static analysis + coverage (CI-equivalent) |
-| `make verify` | check + integration tests + OpenJML ESC |
-| `make format` | Format code with Spotless |
-| `make lint` | Check formatting |
-| `make integration` | Integration tests (Testcontainers) |
-| `make dev` | Start Spring Boot development server |
-| `make up` | Start Docker Compose services (PostgreSQL, Redis) |
-| `make down` | Stop Docker Compose services |
-| `make clean` | Remove build artifacts |
+| `make ground-control-mcp-install` | `npm ci` in `mcp/ground-control` |
+| `make mcp-test` | Run the MCP `node --test` suite (primary test gate) |
+| `make mcp-lint` | ESLint on the MCP server |
+| `make policy` | Repo-native ADR/workflow/spec guardrails + MCP lint + Vale |
+| `make policy-tests` | Python unit tests for the policy tooling |
+| `make vale-lint` | Prose lint on changed docs |
+| `make hooks` | Activate + verify commit-time hooks for this clone |
+| `make graphify` | (Optional) rebuild the disposable Graphify index |
+| `make help` | List all targets |
 
-Use `make rapid` for the inner dev loop. Use `make check` before pushing.
+Run `make mcp-test` for the inner loop. Run `make policy` as well when you touch
+workflow, ADR, MCP, policy, or requirement-spec surfaces.
 
-## Branch Strategy
+## Branch strategy
 
-- `main` - production-ready, protected
-- `dev` - integration branch, all PRs target this
-- `feature/*` - feature branches, branched from `dev`
+- `main` is production-ready and protected.
+- `dev` is the integration branch; all PRs target it.
+- Work on a branch cut from `dev`, named `<issue-number>-short-slug`.
 
-## Coding Standards
+## Coding standards
 
-Read [`docs/CODING_STANDARDS.md`](docs/CODING_STANDARDS.md) for the complete reference. Key points below.
+Read [`docs/CODING_STANDARDS.md`](docs/CODING_STANDARDS.md) for the full reference. In
+short: Node.js ES modules with `zod` tool schemas and thin handlers delegating to
+`lib/`; one `node --test` test per significant behavior; no abstraction below three call
+sites; comments for non-obvious rationale only; and the 500-line file-size limit is
+enforced by policy.
 
-### Java Backend
+## Commit messages
 
-| Tool | Purpose | Command |
-|------|---------|---------|
-| Spotless + Palantir | Formatting | `cd backend && ./gradlew spotlessApply` |
-| Error Prone | Compile-time bug detection | Runs as part of `./gradlew check` |
-| SpotBugs | Static analysis | Runs as part of `./gradlew check` |
-| Checkstyle | Naming/coding patterns | Runs as part of `./gradlew check` |
-| JaCoCo | Test coverage | `cd backend && ./gradlew jacocoTestReport` |
+- Imperative subject: `Add repository-map gate`, not `Added repository-map gate`.
+- Do not edit `CHANGELOG.md`. Release Please owns the changelog and product version
+  (GC-P027): it derives both from Conventional Commit history on `main` and opens a
+  release PR that regenerates `CHANGELOG.md`. Feature PRs do not file a fragment.
 
-- **Records for DTOs**: Use Java records for command objects and API request/response types
-- **No `var` abuse**: Use `var` only when the type is obvious from the right-hand side
-- **Domain layer purity**: No Spring web imports in `domain/` (enforced by ArchUnit)
+## Pull requests
 
-### Naming Conventions (Java)
-
-| Element | Convention | Example |
-|---------|-----------|---------|
-| Packages | `lowercase` | `requirements.service` |
-| Classes | `PascalCase` | `RequirementService` |
-| Methods | `camelCase` | `createRelation()` |
-| Constants | `UPPER_SNAKE_CASE` | `MAX_RETRY_COUNT` |
-| Enums | `UPPER_SNAKE_CASE` | `DEPENDS_ON` |
-
-## Architecture Rules
-
-The dependency rule is enforced by ArchUnit in CI:
-
-```
-api/ -> domain/ <- infrastructure/
-```
-
-- `domain/` has **zero** Spring web imports (no controllers, no HTTP)
-- `api/` depends on `domain/` - never imports `infrastructure/`
-- `infrastructure/` implements interfaces defined in `domain/`
-
-Enforced by ArchUnit tests in `ArchitectureTest.java`.
-
-## Commit Messages
-
-- Imperative mood: `Add risk scoring engine` not `Added risk scoring engine`
-- Do not edit `CHANGELOG.md` directly. Release Please owns it (GC-P027): it derives the version bump and the changelog entries from Conventional Commit history on `main` and opens a release PR that regenerates `CHANGELOG.md` mechanically. Feature PRs do not file a fragment - the old `changelog.d/` / Towncrier convention is retired.
-
-## Pull Requests
-
-- Target `dev`, not `main`
-- **PR title must be a Conventional Commit** (`type(optional-scope): subject`, lowercase-leading subject) - enforced by CI (`.github/workflows/pr-title.yml`, `amannn/action-semantic-pull-request`). Release Please parses merged commit history to compute the next version and `CHANGELOG.md` entries, so the title is load-bearing, not cosmetic.
-- PRs require passing CI (build + tests + static analysis + ArchUnit)
-- No coverage regression
-- Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+- Target `dev`, not `main`.
+- **The PR title must be a Conventional Commit** (`type(optional-scope): lowercase
+  subject`), enforced by CI (`.github/workflows/pr-title.yml`). Release Please parses
+  merged commit history to compute the next version and changelog, so the title is
+  load-bearing, not cosmetic.
+- CI must pass: the `node --test` suite, `make policy` (guardrails, MCP lint, Vale), and
+  the SonarCloud gate.
+- Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md).
 
 ## Testing
 
-```
-backend/src/test/java/com/keplerops/groundcontrol/
-├── unit/domain/   # Domain logic only. No DB, no Spring context. JUnit 5 + Mockito.
-├── integration/   # With real PostgreSQL (Testcontainers). Spring Boot test.
-│                  # Tags: @Tag("integration") for standard, @Tag("age") for AGE
-└── architecture/  # ArchUnit rules (layer enforcement, naming).
-```
+- **`node --test`** is the primary gate (`make mcp-test`); suites are `*.test.js` under
+  `mcp/ground-control/`. Property tests use `fast-check`.
+- **Python `unittest`** covers the policy tooling (`make policy-tests`,
+  `tools/tests/test_*.py`).
+- Write one test per significant behavior, and drive new behavior test-first. Test names
+  describe behavior, not implementation.
 
-- **JUnit 5** for unit and integration tests
-- **jqwik** for property-based testing (state machines, enums) - tagged `@Tag("slow")`
-- **Testcontainers** for integration tests (PostgreSQL 16, Apache AGE)
-- **ArchUnit** for architecture rule enforcement
-- **Repo policy checks** via `make policy` for ADR/workflow parity, controller docs/MCP parity, migration companion updates, and PR body requirements
-- Test names describe behavior: `archiveFromDraftFails`, not `testArchiveMethod`
-- Tests are independent - no shared mutable state (except ordered E2E tests using `@TestInstance(PER_CLASS)`)
+## The `/implement` workflow
+
+This repository is developed through its own gated `/implement` loop (plan, TDD, review,
+CI, requirement transition, traceability reconciliation), specified in
+[`docs/DEVELOPMENT_WORKFLOW.md`](docs/DEVELOPMENT_WORKFLOW.md). Requirements and ADRs are
+repo-local files reviewed in the PR like any other change.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,29 @@ backend:
 Requirement status and traceability are recorded by the agent directly in the
 requirement file, reviewed in the PR like any other change.
 
+## Repository map
+
+Where each top-level directory belongs, so a contributor can tell where a new file
+goes. The [Documentation](#documentation) table further down is the reading index;
+this is the ownership map.
+
+| Path | What lives here |
+|------|-----------------|
+| `mcp/` | The MCP servers. `mcp/ground-control/` is the only running service (Node.js ES modules); see the [MCP server reference](mcp/ground-control/README.md). `mcp/citation/` is a separate research companion. |
+| `skills/` | Agent-neutral workflow skills. The gated `/implement` loop lives in [`skills/implement/`](skills/implement/); the [development workflow](docs/DEVELOPMENT_WORKFLOW.md) explains it. |
+| `docs/` | Requirements (`docs/requirements/<UID>/requirement.md`), the [architecture overview](docs/architecture/ARCHITECTURE.md), [coding standards](docs/CODING_STANDARDS.md), and the [knowledge base](docs/knowledge/). |
+| `architecture/` | Architecture Decision Records ([`architecture/adrs/`](architecture/adrs/)) and the machine-enforced [ADR policy](architecture/policies/adr-policy.json). |
+| `tools/` | Repo-native policy checks ([`tools/policy/`](tools/policy/)) and their tests, plus CI, Sonar, and release tooling. Run by `make policy`. |
+| `bin/` | Executable entry points for the gates ([`bin/policy`](bin/policy), `bin/adr-guard`, `bin/check-pr-body`). |
+| `scripts/` | Developer and CI shell helpers ([`scripts/`](scripts/)): hook install, bootstrap, PR-body checks. |
+| `.github/` | GitHub Actions [workflows](.github/workflows/), issue/PR templates, `CODEOWNERS`, and the branch-protection baseline. |
+
+Agent/editor tooling directories (`.claude`, `.cursor`, `.gc`, `.serena`, `.vale`)
+are configuration, not source surfaces, and are intentionally left out. The map is
+kept in sync with the tracked directory tree by a policy gate
+(`tools/policy/repo_map.py`, GC-P029 /
+[ADR-095](architecture/adrs/095-repository-map-freshness-gate.md)).
+
 ## Getting started
 
 **Prerequisites:** Node.js 20+, `gh` CLI (authenticated), `git`.

--- a/architecture/adrs/095-repository-map-freshness-gate.md
+++ b/architecture/adrs/095-repository-map-freshness-gate.md
@@ -1,0 +1,73 @@
+# ADR-095: Keep the README repository map fresh with a repo policy gate
+
+- **Status:** Accepted
+- **Date:** 2026-08-19
+- **Issue:** #543
+- **Supersedes:** none
+
+## Context
+
+The root `README.md` describes the product and quick-start but had no map of the
+repository itself, so a contributor asking "where does a new X go" had to discover
+`docs/`, `architecture/adrs/`, `architecture/policies/adr-policy.json`, and the rest
+by hand (audit finding A1-12, #543).
+
+A navigation section added once and never enforced drifts the same way the 500-LOC
+limit did before ADR-092 gave it a gate: a new top-level directory is added and never
+listed, a listed directory is removed and its row lingers, or a link rots because the
+repo has no automated Markdown link checker. The re-platform (#1500, ADR-089) is the
+concrete precedent: it deleted `backend/`, `frontend/`, and the database while the
+onboarding docs kept describing them, which is exactly what makes a stale map worse
+than no map.
+
+## Decision
+
+Add the map to `README.md` and enforce it with a repo-native gate,
+`tools/policy/repo_map.py::run_repository_map_freshness_check`, run from
+`tools/policy/cli.py::main` and therefore from `make policy` and CI.
+
+1. **Completeness (two-sided).** Every tracked top-level directory (the first path
+   segment of `git ls-files`) that is not in an explicit exclusion set must appear in
+   the map as an inline-code `` `name/` `` token, and every `` `name/` `` the map lists
+   must be a real tracked top-level directory. Neither a missing row nor a phantom row
+   passes.
+
+2. **The exclusion set shrinks, and every entry is justified.** `.claude`, `.cursor`,
+   `.gc`, `.serena`, and `.vale` are agent/editor/lint tooling configuration, not
+   source surfaces a contributor navigates, so they are excluded, each with a written
+   reason in `MAP_EXCLUDED_DIRS`. `.github` is deliberately *not* excluded: CI,
+   templates, and CODEOWNERS are contributor-relevant. An excluded directory that no
+   longer exists is itself a violation, so the set cannot outlive what it names.
+
+3. **Links resolve.** Every repo-relative Markdown link in the map section must exist
+   on disk. There is no Markdown link checker in the repo, so the map's own links
+   (the "authoritative reference doc" A1-12 asks for) are verified here.
+
+The gate is anchored on requirement **GC-P029** for traceability, matching the
+GC-P028 ⇄ ADR-092 file-size-gate precedent.
+
+## Consequences
+
+- Adding a top-level directory now fails `make policy` until the map (and, if it is
+  tooling-only, the reasoned exclusion set) is updated in the same change: the
+  intended one-row extension seam.
+- The map's links cannot silently rot; a moved or deleted target fails the gate.
+- The map is scoped to orientation and stays distinct from the README Documentation
+  table (the reading index). The gate checks structure (directory coverage and link
+  resolution), not prose quality, which review and Vale already cover.
+- This ADR reverses, on purpose, the #543 architecture preflight's "no policy check /
+  no ADR" proportionality recommendation. Correctness and drift-resistance were judged
+  to outweigh the low change rate of the surface; the same call the file-size gate made.
+
+## Alternatives considered
+
+- **Documentation-only, no gate (the preflight's recommendation).** Lowest effort, but
+  an unenforced map drifts, and the re-platform showed how badly stale onboarding docs
+  mislead. Rejected in favor of the root-cause fix.
+- **A generated directory map.** A generator would remove hand-maintenance but also the
+  one-line human descriptions that make the map useful, and it is far more machinery
+  than a low-change-rate navigation surface warrants. The gate enforces the hand-written
+  map instead of replacing it.
+- **Rely on Vale or a generic link checker.** Vale lints prose, not structure, and the
+  repo ships no Markdown link checker. A focused policy check covers both the directory
+  drift and the link resolution in one place already wired into `make policy`.

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -2,358 +2,101 @@
 
 These are mandatory rules. Follow them exactly when writing or modifying code.
 
-## Development Workflow
+## Development philosophy (pre-alpha)
 
-Ground Control uses a phased approach to formal methods rigor. During **pre-alpha** (current), the priority is velocity - get the differentiating features built. The bar rises at beta.
+Ship features, not ceremony. Ground Control is the MCP server for the `/implement`
+workflow over repo-local files (issue #1500); there is no backend, database, or
+frontend. The bar is working code plus one test per significant behavior. See
+`CLAUDE.md` for the short version and [ADR-089](../architecture/adrs/089-retire-grc-product-and-next-issue-recommendation.md)
+for what the re-platform removed.
 
-### Pre-alpha workflow
+## Languages and tooling
 
-1. **Write code.** Implementation first. Get it working.
-2. **Add JML contracts where they prevent silent corruption** - state transitions, security boundaries, cross-field invariants. Not on every method.
-3. **Write one test per significant behavior.** No two-tests-per-contract requirement. No mandatory violation tests for simple CRUD.
-4. **Run `make rapid`.** Format + compile in ~3–5 s. Tests run in CI.
-5. **Run `make policy`** when you changed workflow, ADR, controller, migration, MCP, or PR-policy surfaces.
+| Surface | Language | How it runs |
+|---------|----------|-------------|
+| MCP server | Node.js 20+ ES modules (`mcp/ground-control/`) | `node --test`, `make mcp-test` |
+| Tool input schemas | `zod` | validated at the tool boundary |
+| Repo policy checks | Python 3 (`tools/policy/`) | `python3 bin/policy`, `make policy` |
+| Policy tests | Python `unittest` (`tools/tests/`) | `make policy-tests` |
+| Prose | Markdown | Vale (`make vale-lint`) |
 
-### Assurance levels
+Always install dependencies through the package manager (`make ground-control-mcp-install`
+runs `npm ci` in `mcp/ground-control`). Do not hand-edit `package-lock.json`.
 
-| Level | Name | When to use (pre-alpha) | What you must produce |
-|-------|------|-------------------------|----------------------|
-| L0 | Standard | **Default.** Everything unless escalated below | Working code + one test per significant behavior |
-| L1 | Contracted | State transitions, security boundaries, methods where invalid input causes silent data corruption | JML contracts + tests for the contracted behavior |
-| L2 | Property-Verified | State machines, DAG operations | L1 + jqwik property tests |
-| L3 | Formally Specified | Future | L2 + KeY/Lean proofs |
+## MCP server (Node.js) rules
 
-**When in doubt, use L0.** Ship features. The bar rises at beta.
-
-### Decision rules
-
-| If you are writing... | Level |
-|-----------------------|-------|
-| A state machine, transition table, or workflow | **L2** |
-| DAG operations (cycle detection, topological sort, reachability) | **L2** |
-| Security boundary logic (auth checks, permission guards) | **L1** |
-| A domain model method where invalid input causes silent data corruption | **L1** |
-| Everything else | **L0** |
-
-### JML contracts (when writing L1+ code)
-
-JML annotations use block comment syntax (`/*@ @*/`). Do not use `// @` - it is not valid JML and OpenJML will not parse it.
-
-```java
-/*@ requires newStatus != null;
-  @ requires status.canTransitionTo(newStatus);
-  @ ensures status == newStatus; @*/
-public void transitionStatus(Status newStatus) { ... }
-```
-
-For method modifiers (`pure`, `non_null`), use inline annotations:
-
-```java
-public /*@ pure @*/ Set<Status> validTargets() { ... }
-```
-
-- `/*@ requires @*/` for preconditions
-- `/*@ ensures @*/` for postconditions
-- `/*@ public invariant @*/` for class invariants
-- `/*@ pure @*/` on methods called from JML expressions
-- `/*@ spec_public @*/` on private fields referenced in public specs
-- Keep conditions simple and side-effect-free
-- Files with JML annotations need `@SuppressWarnings("java:S125")` to suppress SonarQube false positives (except files in ESC scope that use only inline annotations)
-
-### Post-alpha target
-
-At beta, the default rises to L1. Every L1+ public method gets contracts, every contract gets a happy-path and violation test, and the full SDD loop (Classify → Spec → Test → Code → Verify) becomes mandatory. See ADR-012 for the full rationale.
-
-## Architecture Rules
-
-These rules are enforced by ArchUnit tests in `src/test/java/.../architecture/ArchitectureTest.java`. Violations fail the build.
-
-### Dependency rule
-
-```
-api/ → domain/ ← infrastructure/
-```
-
-| Rule | Meaning | Consequence of violation |
-|------|---------|------------------------|
-| `domain/` must not import `api/` | Domain logic is framework-independent | Build fails |
-| `domain/` must not import `infrastructure/` | Domain logic has no external adapter dependencies | Build fails |
-| `api/` must not import `infrastructure/` | Controllers talk to domain, not adapters | Build fails |
-| All exceptions must extend `GroundControlException` | Uniform error handling | Build fails |
-
-### When to add new ArchUnit rules
-
-Add a new `@ArchTest` rule to `ArchitectureTest.java` whenever you:
-- Add a new top-level package (enforce its dependency constraints)
-- Introduce a naming convention that must hold project-wide
-- Add a new annotation that must only appear in specific layers
-- Discover a dependency violation pattern that could recur
-
-ArchUnit rules are JUnit 5 tests. They run with `./gradlew test`. No separate tooling.
-
-## Repo Policy Guardrails
-
-The repository also enforces ADR-aligned workflow policy outside Java:
-
-- `architecture/policies/adr-policy.json` defines machine-readable guardrails
-- `python3 bin/policy` enforces changed-file policies for ADR sync, controller/MCP/docs parity, migration companion updates, and PR body structure
-- `make policy` is required before completion for both Claude and Codex work in this repo
-
-## Package Structure
-
-```
-backend/src/main/java/com/keplerops/groundcontrol/
-├── domain/           # Business logic. No Spring web imports.
-│   └── requirements/
-│       ├── model/        # JPA entities with JML contracts
-│       ├── state/        # Enums (Status, RequirementType, Priority, RelationType)
-│       ├── service/      # Domain services (write-owners of entities)
-│       └── repository/   # Spring Data JPA interfaces
-│   └── exception/       # Domain exception hierarchy (shared across all domain areas)
-├── api/              # REST controllers only. Thin handlers that delegate to services.
-├── infrastructure/   # External adapters (AGE graph, external APIs)
-└── shared/           # Cross-cutting concerns (logging filters, utilities)
-```
-
-**Placement rules:**
-- New domain concept? Create a new sub-package under `domain/` following the same structure.
-- New REST endpoint? Add a controller in `api/`. It must only call domain services.
-- New external integration? Add an adapter in `infrastructure/`. Domain defines the interface.
-- New cross-cutting concern? Add to `shared/`.
-
-## Exceptions
-
-All application exceptions must extend `GroundControlException`. This is enforced by ArchUnit.
-
-| Exception | `error_code` | HTTP Status | When to throw |
-|-----------|-------------|-------------|---------------|
-| `NotFoundException` | `not_found` | 404 | Entity lookup returns empty |
-| `DomainValidationException` | `validation_error` | 422 | Business rule violation, invalid state transition |
-| `AuthenticationException` | `authentication_error` | 401 | Missing or invalid credentials |
-| `AuthorizationException` | `authorization_error` | 403 | Authenticated but not permitted |
-| `ConflictException` | `conflict` | 409 | Duplicate key, optimistic lock failure |
-| `GroundControlException` | `ground_control_error` | 500 | Fallback for unclassified domain errors |
-
-**Rules:**
-- Domain layer throws these exceptions. Never throw `ResponseStatusException` or Spring HTTP exceptions from domain code.
-- `GlobalExceptionHandler` maps them to the `{"error": {"code", "message", "detail"}}` JSON envelope. Do not create additional exception handlers.
-- `DomainValidationException` accepts a `Map<String, Object> detail` for structured error context. Use it.
-- Never catch `Exception` broadly. Catch the specific exception you expect.
-- Wrap external library exceptions in `infrastructure/` - domain code must never leak third-party exception types.
-
-## JML Contract Reference
-
-JML annotations use block comment syntax (`/*@ @*/`). Do not use `// @` - it is not valid JML and OpenJML will not parse it.
-
-```java
-// Class invariant - must hold after every public method returns
-/*@ public invariant archivedAt == null || status == Status.ARCHIVED; @*/
-
-// Precondition - must be true when the method is called
-// Postcondition - must be true when the method returns
-/*@ requires newStatus != null;
-  @ requires status.canTransitionTo(newStatus);
-  @ ensures status == newStatus; @*/
-
-// Inline non-null annotation
-public void transitionStatus(/*@ non_null @*/ Status newStatus) { ... }
-```
-
-**When to write JML:**
-- Every L1+ public method gets `requires` and `ensures`. No exceptions.
-- Every L1+ class with cross-field constraints gets a `public invariant`
-- Do NOT write JML on `@Configuration` classes, records with no methods, filters, or test code
-
-## OpenJML ESC Scoping
-
-OpenJML Extended Static Checking (ESC) runs the Z3 SMT solver to formally prove JML contracts hold. However, OpenJML's bundled specs for `java.lang.CharSequence` and `java.lang.String` have invariant bugs that produce false positives when verifying classes that pass `String` parameters through constructors. JPA entities also fail ESC due to the no-arg constructor required by Hibernate (all fields are `null` after construction, triggering `NullField` violations).
-
-### What gets L2 ESC verification
-
-ESC runs on **pure logic classes** with no String constructor parameters and no framework annotations:
-- `domain/requirements/state/` - enums, state machines, transition tables. This now also includes `ConfidenceLevel` and `StatusDriftSignal` (status-drift analysis support per ADR-011 §9): pure value enums - `ConfidenceLevel` has a `compareTo`-based ordering helper, `StatusDriftSignal` a `switch`-mapped `defaultConfidence()` accessor - with no transitions or invariants. They are L0 in classification but, being inside this package, are proven trivially by ESC.
-- `domain/verification/state/`: `VerificationStatus`, `AssuranceLevel` enums (simple value enums, L0)
-- Future pure domain logic classes that follow the same pattern
-
-Other `state/` packages contain simple value enums (L0) that are **not** ESC-verified:
-- `domain/identity/state/`: identity lifecycle values and the versioned
-  `PermissionKey` catalog. These enums contain no transition tables. Audited
-  aggregates own lifecycle changes, and the authorization service, delegation
-  adapter, and last-effective-administrator guard are L1 security boundaries
-  covered by unit and PostgreSQL integration tests.
-- `domain/assets/state/`: `AssetType`, `AssetLinkTargetType`, `AssetLinkType`, `AssetRelationType`, `ObservationCategory`, plus the GC-M012 trio `AssetCriticality` / `AssetEnvironment` / `AssetScope`, plus the GC-M011 `AssetSubtypeSchemaStatus` (`ACTIVE → DEPRECATED`; pure value enum; the one-ACTIVE-per-`(project, assetType, subtype)` invariant lives in `AssetService.registerSubtypeSchema` rather than the enum, so the enum itself stays L0), plus the GC-M018 `KnowledgeState` (`CONFIRMED` / `PROVISIONAL` / `UNKNOWN`; pure value enum with an explicit-strength `atLeast` comparator - strength is declared as a numeric field rather than read from `Enum.ordinal()` because errorprone's `EnumOrdinal` flags ordinal-based comparison; no transitions, no invariants)
-- `domain/controls/state/`: `ControlFunction`, `ControlStatus`, `ControlLinkTargetType`, `ControlLinkType`, `ControlTestMethodology`, `ControlTestConclusion` (ADR-039: pure value enums for GC-I012 - no transitions, no invariants)
-- `domain/riskscenarios/state/` - risk scenario link and status enums (pure value enums, no transitions or invariants; L0)
-- `domain/riskcontrol/state/`: `MappingControlRole` (`PREVENTIVE`, `DETECTIVE`, `CORRECTIVE`, `DETERRENT`, `COMPENSATING`, `RECOVERY`, `DIRECTIVE`; pure value enum for GC-T003 - no transitions, no invariants; L0)
-- `domain/plugins/state/`: `PluginType` (`EVIDENCE_COLLECTOR` included for GC-S001 adapter registration), `PluginLifecycleState` enums
-- `domain/evidence/collection/iam/`: GC-S002 IAM evidence adapter specification - `IamEvidenceProvider` (`OKTA`, `AZURE_AD`, `AWS_IAM`; stable provider keys) and `IamEvidenceFamily` (the five evidence families as canonical `iam-*` scope types / output-schema ids, all `OBSERVATION_SUMMARY`) are pure value enums with no transitions or invariants; `IamEvidenceSpecification` is the normative entry point (versioned output schemas, descriptor capability sets, conformance check) over the GC-S001 `EvidenceCollectionAdapter` port - not a new adapter interface. L0.
-- `domain/evidence/collection/cloud/`: GC-S003 cloud infrastructure evidence adapter specification - `CloudEvidenceProvider` (`AWS`, `AZURE`, `GCP`; stable provider keys) and `CloudEvidenceFamily` (the five evidence families as canonical `cloud-*` scope types / output-schema ids - security group configs, encryption-at-rest, logging configs, backup policies, compliance scan results - all `OBSERVATION_SUMMARY`, with the compliance scanner source carried as a summary field rather than a separate adapter type) are pure value enums with no transitions or invariants; `CloudEvidenceSpecification` is the normative entry point (versioned output schemas, descriptor capability sets, conformance check) over the GC-S001 `EvidenceCollectionAdapter` port - not a new adapter interface. L0.
-- `domain/evidence/collection/cmdb/`: GC-S004 CMDB/asset-management evidence adapter specification - `CmdbEvidenceProvider` (`SERVICENOW`, `SNIPE_IT`, `JAMF`; stable provider keys) and `CmdbEvidenceFamily` (the five evidence families as canonical `cmdb-*` scope types / output-schema ids - asset inventory, configuration item status, patch levels, software license compliance, end-of-life tracking - all `OBSERVATION_SUMMARY`, carrying bounded counts and external references rather than raw provider exports) are pure value enums with no transitions or invariants; `CmdbEvidenceSpecification` is the normative entry point (versioned output schemas, descriptor capability sets, conformance check) over the GC-S001 `EvidenceCollectionAdapter` port - not a new adapter interface. L0.
-- `domain/packregistry/state/`: `PackType`, `CatalogStatus`, `TrustOutcome`, `InstallOutcome`, `TrustPolicyField`, `TrustPolicyRuleOperator` enums (L0 - no transition logic or invariants)
-- `domain/threatmodels/state/`: `ThreatModelStatus` (simple DRAFT→ACTIVE→ARCHIVED lifecycle, same pattern as `RiskScenarioStatus`), `StrideCategory`, `ThreatModelLinkTargetType` (now includes `FINDING` per GC-H009 - still a pure value enum, no invariants; dispatch lives in `GraphTargetResolverService`), `ThreatModelLinkType` (pure value enums, no invariants; ADR-024 treats threat modeling as an analysis surface at L0)
-- `domain/findings/state/`: `FindingStatus` (the 4-state remediation lifecycle `OPEN → REMEDIATION_IN_PROGRESS → REMEDIATION_COMPLETE → VERIFIED_CLOSED` with a `REMEDIATION_COMPLETE → REMEDIATION_IN_PROGRESS` reopen edge; L2 - property-tested in `FindingStatusPropertyTest`, see ADR-038 and ADR-012), `FindingType`, `FindingSeverity`, `FindingLinkTargetType`, `FindingLinkType` (pure value enums, no invariants; L0)
-- `domain/testcases/state/`: `TestCaseStatus` (4-state lifecycle `DRAFT → APPROVED → DEPRECATED → ARCHIVED` with `DEPRECATED → APPROVED` revive and a terminal `ARCHIVED`; L0 - exhaustively matrix-tested in `TestCaseStatusTest` and rejected with `DomainValidationException` at `TestCase.transitionStatus`, per ADR-040 / TC-001), `TestCaseType` (`MANUAL`, `AUTOMATED`, `HYBRID`), `TestCasePriority` (`CRITICAL`, `HIGH`, `MEDIUM`, `LOW`) - both pure value enums, no invariants, L0; `TestCaseFormat` (`STEP_BASED`, `GHERKIN`) - pure value enum, immutable on `TestCase` after create; format-vs-children invariant lives in the services (`TestCaseStepService.create` rejects on a non-`STEP_BASED` parent, `TestCaseGherkinService.requireGherkinTestCase` rejects on a non-`GHERKIN` parent), not on the enum; L0 - per ADR-042 / TC-004. `TestPlanStatus` (5-state execution lifecycle `DRAFT → ACTIVE → IN_PROGRESS → COMPLETED → ARCHIVED`, with `IN_PROGRESS → ACTIVE` re-pause and `COMPLETED → ACTIVE` re-open edges; `ARCHIVED` is terminal) - same enum-transition pattern as `TestCaseStatus`, exhaustively matrix-tested in `TestPlanStatusTest` and rejected with `DomainValidationException` at `TestPlan.transitionStatus`; L0 - per ADR-044 / TC-006. `TestSuitePopulationMode` (`STATIC`, `REQUIREMENTS_BASED`, `QUERY_BASED`) - pure value discriminator with no transitions; immutable on `TestSuite` after create (no setter; CHECK constraint at the SQL layer). Mode-specific field invariants and mode-mismatch operation rejections live in `TestSuite` / `TestSuiteService`, not on the enum; L0 - per ADR-047 / TC-007. `TestRunStatus` (5-state run lifecycle `PLANNED → IN_PROGRESS → COMPLETED → ARCHIVED`, with `PLANNED → ABORTED` / `IN_PROGRESS → ABORTED` aborts and `ARCHIVED` terminal; unlike `TestPlanStatus` there are **no** backwards arcs out of `COMPLETED` or `ABORTED` - a run is a single execution pass and re-running is a new run; L0 - exhaustively matrix-tested in `TestRunStatusTest` and rejected with `DomainValidationException` at `TestRun.transitionStatus`, per ADR-049 / TC-008). `TestRunCaseResultStatus` (`NOT_RUN`, `PASSED`, `FAILED`, `BLOCKED`, `SKIPPED`) - pure value enum with no transition graph; per-case results may flip freely as re-tests, descopes, and unblocks happen over the life of a run. L0 - per ADR-049 / TC-008
-- `domain/evidence/state/`: `EvidenceType` (semantic role tag: `OBSERVATION_SUMMARY`, `CONTROL_TEST_SUMMARY`, `ASSURANCE_CONCLUSION`, `VERIFICATION_SUMMARY`, `ATTESTATION`, `MIXED`), `EvidenceSourceKind` (`OBSERVATION`, `CONTROL_TEST`, `CONTROL_EFFECTIVENESS_ASSESSMENT`, `VERIFICATION_RESULT`, `RISK_ASSESSMENT_RESULT`, `FINDING`, `ATTESTATION`, `EXTERNAL` with an `isInternal()` predicate). Pure value enums for GC-M016 / ADR-045 - no transitions and no invariants; append-only enforcement on the parent `EvidenceArtifact` lives in `EvidenceArtifactService.supersede`, not on the enum (L0).
-- `domain/audits/state/`: `AuditStatus` (5-state audit lifecycle `PLANNED → IN_PROGRESS → DRAFT_REPORT → FINAL_REPORT → CLOSED`, with a `FINAL_REPORT → DRAFT_REPORT` rework loop; `CLOSED` is terminal; L2 - property-tested in `AuditStatusPropertyTest`, see ADR-047 and ADR-012), `AuditType` (`INTERNAL`, `EXTERNAL`, `REGULATORY`, `SPECIAL`), `AuditPhaseKind` (`PLANNING`, `FIELDWORK`, `REPORTING`, `FOLLOWUP`), `AuditLinkTargetType`, `AuditLinkType` (pure value enums, no invariants; L0).
-These pack-registry enums remain L0 typed value surfaces. Use them to remove stringly typed branching and policy fields in the generic registry, but do not expand ESC scope unless they gain real transition logic or invariants.
-`TrustPolicyField` includes both informational fields (for example `signatureVerified`) and trust-safe fields (for example `signerTrusted`); validation that rejects unsupported trust-policy rules belongs in domain services, not in the value enum.
-
-### What ESC cannot verify (and why)
-
-- `domain/requirements/model/` - JPA entities (Hibernate no-arg constructor produces `NullField` false positives)
-- `domain/exception/` - exception hierarchy (OpenJML `CharSequence.jml` spec bug on String constructors)
-- `domain/requirements/service/` - services that take String parameters
-
-These classes keep their JML contracts as documentation. Contracts are enforced by tests, not by ESC.
-
-### Design guidelines for ESC-verifiable code
-
-When writing new domain logic, prefer designs that isolate pure logic from String-heavy construction:
-
-- **Prefer enums over String constants.** Enums verify cleanly; String constants do not.
-- **Extract pure logic into separate classes/methods** that operate on enums, numbers, or domain types rather than Strings. These can be ESC-verified independently.
-- **Do not distort code to avoid Strings.** If a method naturally takes a `String`, keep it. The cost of a readable API is worth more than an ESC proof on an awkward abstraction.
-- **State machines, validation rules, and computations** should live in classes without String constructors so they remain ESC eligible.
+- **Tool registration pattern.** A tool is a `zod` input schema plus a thin handler
+  that delegates to a function in `lib/`. Keep handlers thin; put logic in `lib/` where
+  it is unit-testable without the protocol layer. `mcp/ground-control/tools/query.js` is
+  the canonical example.
+- **The server owns privileged side effects.** All `gh`, `git`, and `curl` calls happen
+  from the MCP server through its pinned repository identity and single error boundary.
+  Never invoke `gh` / `git` / `curl` from a codex or claude sandbox
+  ([ADR-027](../architecture/adrs/027-agent-neutral-implement-workflow-packaging.md),
+  [ADR-031](../architecture/adrs/031-codex-review-stopping-model.md)).
+- **No abstraction below three call sites.** Three similar lines beat a premature
+  helper. Extract when the third caller appears, not before.
+- **Comments explain WHY, not WHAT.** Reserve comments for non-obvious constraints,
+  invariants, or workaround context. Do not restate what the code plainly does.
+- **Lint is a gate.** `make mcp-lint` runs ESLint 9 with `eslint-plugin-security`.
+  It is part of `make policy` and CI. No `console.log` left in committed code paths.
 
 ## Testing
 
-### Test organization
+- **`node --test` is the primary gate.** Behaviors are covered by `*.test.js` suites in
+  `mcp/ground-control/`, run by `make mcp-test`. Property tests use `fast-check`.
+- **One test per significant behavior.** Skip trivial pass-throughs. Edge cases,
+  failure modes, and security-enforcing behavior get a test that goes red if the
+  behavior is removed, not one that only asserts a value exists.
+- **TDD in `/implement`.** New behavior is driven red-green-refactor: write the failing
+  test first and see it fail for the right reason before writing the code.
+- **Policy tooling has Python tests.** New or changed `tools/policy/` checks ship with a
+  `tools/tests/test_*.py` unit test, run by `make policy-tests`.
+- Test names describe behavior, not implementation.
 
-```
-src/test/java/com/keplerops/groundcontrol/
-├── unit/domain/       # No DB, no Spring context. Fast. Run always.
-├── integration/       # Testcontainers PostgreSQL. Slow. Run in CI.
-└── architecture/      # ArchUnit rules. Fast. Run always.
-```
+## Repo policy guardrails
 
-### Test requirements by assurance level (pre-alpha)
+`make policy` runs the repo-native guardrails shared by Claude and Codex:
 
-| Level | Required tests |
-|-------|---------------|
-| L0 | One test per significant behavior. Skip trivial getters/setters. |
-| L1 | L0 + at least one test per JML contract |
-| L2 | L1 + jqwik `@Property` tests (tagged `@Tag("slow")`, skippable locally) |
-| L3 | Future |
+- `python3 bin/policy` enforces changed-file and structural policies: ADR
+  synchronization (`architecture/policies/adr-policy.json`), requirement-spec
+  frontmatter, the `/implement` execution and workflow contracts, reviewer-separation
+  decision records, repo identity, version mirrors, the file-size limit, the
+  repository-map freshness gate, and the PR-body contract.
+- `make mcp-lint` (ESLint) and `make vale-lint` (prose) run in the same target.
 
-Integration tests: write smoke tests to verify the feature works end-to-end. Exhaustive endpoint coverage is a post-alpha concern.
+Run `make policy` before completion whenever you touch workflow, ADR, MCP, policy, or
+requirement-spec surfaces.
 
-### Naming and style
+## File-size limit (enforced in policy)
 
-- Test class: `FooTest` for unit, `FooIntegrationTest` for integration
-- Test method: describes behavior, not implementation - `archiveFromDraftFails`, not `testArchiveMethod`
-- Use `@Nested` classes to group related tests: `Defaults`, `StatusTransitions`, `Archive`
-- Use AssertJ for assertions: `assertThat(x).isEqualTo(y)`, not JUnit `assertEquals`
-- Use `assertThatThrownBy(() -> ...).isInstanceOf(...)` for exception tests
+`docs/CODING_STANDARDS.md` caps source files at 500 lines (Sonar `python:S104`), and
+`make policy` enforces it (`tools/policy/file_size.py`, issue #1467,
+[ADR-092](../architecture/adrs/092-file-size-limit-gate.md)). The gate is two-sided: an
+oversized file that is not grandfathered fails the build, and a grandfather entry that
+is no longer oversized or no longer present also fails, so the list can only shrink. It
+applies to `.java`, `.js`, `.mjs`, `.cjs`, `.ts`, `.tsx`, `.py`, and `.kts`; generated
+trees (`contracts/gen/`) are excluded because only their generator can change them.
 
-### jqwik property tests
+When you split a file:
 
-Tag with `@Tag("slow")`. Provide an `@Provide` method for custom arbitraries.
+- Split along real seams: the dependency graph, not section comments.
+- Keep the public surface. Leave the original path as a barrel that re-exports the
+  modules, so callers and tests are untouched and the split is verifiable as
+  behavior-neutral by the existing suite.
+- Export a name only if it was public before, or a sibling now needs it.
+- If a single declaration is over the limit on its own, decompose the declaration; a
+  file-level split alone cannot fix it.
+- Use a comment-aware scanner: splitting on delimiters inside comments and string
+  literals breaks the rejoin.
 
-```java
-@Tag("slow")
-class TransitionPropertyTest {
+## Static analysis thresholds (SonarCloud)
 
-    @Provide
-    Arbitrary<Status> statuses() {
-        return Arbitraries.of(Status.values());
-    }
-
-    @Property
-    void validTransitionAlwaysChangesStatus(
-            @ForAll("statuses") Status source,
-            @ForAll("statuses") Status target) {
-        Assume.that(source.canTransitionTo(target));
-        // ... assert the transition works
-    }
-}
-```
-
-### Coverage
-
-- Pre-alpha: 30% minimum (current JaCoCo threshold). Will increase as the platform matures.
-- Post-alpha targets: domain 80%, API/infrastructure 70%.
-
-## Logging
-
-Use SLF4J. Never `System.out.println()`.
-
-```java
-private static final Logger log = LoggerFactory.getLogger(RequirementService.class);
-
-// Semantic event name, structured key-value pairs
-log.info("requirement_created: uid={}", requirement.getUid());
-```
-
-**Rules:**
-- Use semantic event names: `requirement_created`, `status_changed`, not `"Created a new requirement"`
-- Never log secrets, tokens, passwords, or PII
-- `RequestLoggingFilter` auto-binds `request_id` to MDC - do not set it manually
-- Production uses JSON output (Logstash Encoder). Dev uses console. Selected by Spring profile.
-
-## Java Style
-
-- Formatting: Spotless + Palantir Java Format. Run `./gradlew spotlessApply` before committing.
-- Line length: 120 (Palantir default). Do not override.
-- Javadoc: on public API boundaries only. Do not add javadoc to private methods or obvious code.
-- No `System.out.println()`, no `System.err.println()`.
-- Use records for DTOs and value objects: `RequirementRequest`, `RequirementResponse`, `ErrorResponse`.
-- Use `var` for local variables when the type is obvious from the right-hand side.
-- Use `sealed` classes/interfaces when a type hierarchy is closed.
-
-### Naming
-
-| Element | Convention | Example |
-|---------|-----------|---------|
-| Packages | `lowercase` | `requirements` |
-| Classes | `PascalCase` | `RequirementService` |
-| Methods | `camelCase` | `createRequirement()` |
-| Constants | `UPPER_SNAKE_CASE` | `MAX_RETRY_COUNT` |
-| Private fields | `camelCase` | `requirementType` |
-| DTOs | Records | `RequirementRequest` |
-| Test classes | `FooTest` / `FooIntegrationTest` | `RequirementTest` |
-
-## Error Responses
-
-All error responses use this envelope. Do not invent new formats.
-
-```json
-{
-  "error": {
-    "code": "not_found",
-    "message": "Requirement REQ-42 not found",
-    "detail": null
-  }
-}
-```
-
-- `code`: machine-readable, matches exception's `errorCode`
-- `message`: human-readable description
-- `detail`: optional `Map<String, Object>` with structured context (for example, `{"current_status": "DRAFT", "target_status": "ARCHIVED"}`)
-
-## TypeScript / Frontend Style
-
-The frontend (`frontend/`) is a React 19 / TypeScript 5 SPA. It follows these rules:
-
-- Formatting and linting: Biome. Run `cd frontend && npm run format` and `npm run lint`.
-- No `any` types. Use `unknown` and narrow.
-- All API calls go through TanStack Query hooks - no manual `fetch` + `useState` patterns.
-- Component files: `PascalCase.tsx`. Utility/hook files: `camelCase.ts`.
-- Avoid framework lock-in for UI components - prefer shadcn/ui (copy-paste Radix primitives).
-- Never `console.log()` in committed code.
-
-## Static Analysis Thresholds (SonarCloud)
-
-Ground Control runs SonarCloud against every project. Sonar way, the built-in
-profile, leaves complexity and size rules tuned too loose to catch real
-god-class and god-method problems. Every Ground Control repo runs a
-tightened profile instead, or the closest analyzer-specific equivalent when a
-rule is not available for the language at hand.
-
-The thresholds below are the house targets. Apply them to every new project
-brought onto SonarCloud. Sonar rule IDs vary across analyzers; the IDs
-listed are the canonical reference for Java and Python.
-
-### Cross-language thresholds (size, complexity, duplication)
+Ground Control runs SonarCloud with a tightened profile, since the built-in "Sonar way"
+leaves size and complexity rules too loose to catch real god-class and god-method
+problems. Rule IDs vary across analyzers; the IDs below are the canonical reference,
+and porting to a new analyzer should prefer the nearest concept (file LOC, function
+length, nesting, cognitive complexity) over an exact rule-ID match.
 
 | Bound | Threshold | Reference rule |
 |-------|-----------|----------------|
@@ -366,91 +109,28 @@ listed are the canonical reference for Java and Python.
 | String literal duplication | 3 occurrences | `S1192` |
 | Regex complexity | 20 | `S5843` |
 
-### Java-specific thresholds (god class, god method, OO depth)
+Captured quality-profile XML lives in [`tools/sonar/`](../tools/sonar/); each export is
+date-stamped and prior snapshots stay in place so profile drift is auditable.
 
-| Bound | Threshold | Rule |
-|-------|-----------|------|
-| Inheritance depth | 5 | `java:S110` |
-| `switch` case count | 30 | `java:S1479` |
-| Assertions per test | 25 | `java:S5961` |
-| God-class coupling | 20 | `java:S6539` |
-| Brain method | nesting=3, cyclomatic=15, LOC=65, NODV=7 | `java:S6541` |
-| Statements per line | 5 | `java:S8444` |
+## Git and CI
 
-When porting these to a new analyzer, prefer the nearest concept (file LOC,
-function length, nesting, cognitive complexity) over a perfect rule-ID match.
+- All code goes through a PR targeting `dev`. No direct push to `main` or `dev`.
+- Activate commit-time hooks once per clone with `make hooks`
+  ([ADR-079](../architecture/adrs/079-commit-time-pre-commit-hook-activation.md)); they run
+  private-key detection and gitleaks. Do not bypass with `--no-verify`.
+- Commit subjects are imperative: `Add repository-map gate`, not `Added ...`.
+- **PR titles must be Conventional Commits** (`type(optional-scope): lowercase subject`),
+  enforced by `.github/workflows/pr-title.yml`. Release Please parses merged commit
+  history to compute the version and `CHANGELOG.md`, so the title is load-bearing.
+- **Do not edit `CHANGELOG.md`** or file a changelog fragment. Release Please owns the
+  changelog and the product version (GC-P027,
+  [ADR-063](../architecture/adrs/063-release-deployment-model.md)); feature PRs only need
+  a valid Conventional Commit title.
 
-### The file-size limit is enforced in policy
+## Documentation
 
-`make policy` fails on any tracked source file over 500 lines
-(`tools/policy/file_size.py`, issue #1467). Before it existed, 60 files had
-drifted past the limit and the largest were the ones edited most often, and
-size was not a cosmetic problem: decomposing a 20,634-line module turned up
-policy checks that located their subject by reading one file and would have
-**passed silently** once that file became a barrel.
-
-The gate applies to `.java`, `.js`, `.mjs`, `.cjs`, `.ts`, `.tsx`, `.py` and
-`.kts`. Generated trees (`contracts/gen/`) are excluded, since only their
-generator can change them.
-
-Files still over the limit are listed with a reason in
-`tools/policy/file_size_grandfather.json`. That list is **shrink-only**: the gate
-also fails when a listed file is no longer oversized or no longer exists, so an
-entry cannot outlive the work it covers. Add an entry only when the file is
-already being decomposed elsewhere and doing it twice would conflict. Never add one to
-park a file you did not want to split.
-
-When you do split one:
-
-- Split along real seams: the dependency graph, not section comments. Grouping
-  a module by its own headings closed a 20-group import cycle; packing
-  declaration-level SCCs in topological order made the module graph acyclic by
-  construction.
-- Keep the public surface. Leaving the original path as a barrel that re-exports
-  the modules means callers and tests are untouched, which is what makes a split
-  verifiable as behaviour-neutral by the existing suite.
-- Export a name only if it was public before, or a sibling now needs it.
-- If a single declaration is over the limit on its own, decompose the
-  declaration; a file-level split alone cannot fix it.
-- Use a comment-aware scanner. Splitting on `;` or on line matches breaks on
-  delimiters inside comments and string literals, and the rejoin does not
-  compile.
-The intent is to bound module and method size; the specific rule is the
-mechanism.
-
-### Profile artifacts
-
-Captured quality profile XML lives in [`tools/sonar/`](../tools/sonar/).
-Each export is date-stamped and prior snapshots stay in place, so profile
-drift remains auditable. See that directory's README for the capture and
-restore procedure.
-
-## Git & CI
-
-- All code goes through PR targeting `dev`. No direct push to `main` or `dev`.
-- PRs require: `./gradlew check` passes (build + spotlessCheck + test + jacocoTestReport).
-- Commit messages: imperative mood. `Add risk scoring engine` not `Added risk scoring engine`.
-- Pre-commit hooks run file checks + gitleaks + Spotless auto-format + `./gradlew check` (full CI-equivalent: build + tests + static analysis + coverage) + `./gradlew openjmlEsc` (formal verification of JML contracts in ESC scope) + Terraform fmt/validate + Checkov IaC security scanning (on `deploy/terraform/`). Do not bypass with `--no-verify`.
-
-## Enum placement under `domain/**/state/`
-
-The `state/` package holds two distinct kinds of enums and the formal-methods
-classification depends on which kind:
-
-- **State machines.** Enums that define a `canTransitionTo(...)` lifecycle,
-  for example `FindingStatus` and `ControlStatus`. These are L1+
-  contract surfaces; transition rules must be unit-tested and ADR-012's L1
-  rule applies.
-- **Tag enums.** Enums that are pure classifiers with no transition surface,
-  for example `AssetLinkTargetType` and `ObservationCategory`. These are
-  L0 data; the placement under `state/` follows convention only.
-
-Identity lifecycle values and `PermissionKey` follow the tag-enum rule. The
-identity aggregates and services own state changes and security invariants;
-putting the vocabulary under `domain/identity/state/` does not make the enums
-state machines.
-
-When adding a new file under `state/`, classify it explicitly in the file
-header or the introducing PR's plan. The policy rule that requires this
-section to be touched alongside new state files is a forcing function; the
-real classification is the one above.
+Keep docs and ADRs current with the code in the same change. Requirements live at
+`docs/requirements/<UID>/requirement.md` and ADRs at `architecture/adrs/*.md`; both are
+edited as ordinary file changes and reviewed in the PR
+([ADR-093](../architecture/adrs/093-requirements-specs-as-code.md)). Prose is linted by
+Vale; keep em-dash density low (at most one per paragraph) so `make vale-lint` passes.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -2,398 +2,164 @@
 
 ## Mission
 
-Ground Control is a requirements management system with traceability and graph analysis. It manages requirements, tracks relations, links to external artifacts, and runs graph-based analysis (cycles, orphans, coverage gaps, impact, cross-wave validation). Status-drift analysis follows the contract below when added to the sweep surface.
+Ground Control is the **MCP server for the `/implement` workflow**: a gated, agentic
+development loop that gives coding agents full codebase context, from requirement to
+implementation, while keeping the coding agent separated from its reviewers. It
+operates over repo-local files and the GitHub issue thread. There is no backend,
+database, or web console.
 
-See [ADR-014](../../architecture/adrs/014-pluggable-verification-architecture.md) for the verification architecture and [ADR-011](../../architecture/adrs/011-requirements-data-model.md) for the requirements data model.
+> **Re-platform (issue #1500, [ADR-089](../../architecture/adrs/089-retire-grc-product-and-next-issue-recommendation.md)).**
+> Ground Control was previously a graph-native GRC/requirements product built on Java,
+> Spring Boot, PostgreSQL, and a React console. That product surface was retired and the
+> repository stripped to the MCP server alone. If you find a document that still
+> describes controllers, JPA entities, Flyway migrations, or a frontend, it is stale;
+> this file is the current picture.
 
-## Stack
+## What runs
 
-### Backend
+The MCP server (`mcp/ground-control/`) is the only running service. It is a
+Node.js ES-module process that speaks the Model Context Protocol to a driver
+(Claude Code, Codex, or Cursor per [ADR-027](../../architecture/adrs/027-agent-neutral-implement-workflow-packaging.md)),
+and it owns the privileged `gh` and `git` side effects: branches, the GitHub issue
+thread, pull requests, and CI/Sonar reads. Coding-agent and reviewer sandboxes never
+call `gh`, `git`, or `curl` directly; they ask the server, which performs those
+operations through a pinned repository identity and a single error boundary
+(ADR-027, [ADR-031](../../architecture/adrs/031-codex-review-stopping-model.md)).
+Editing repo-local files (requirements, ADRs, docs) is not privileged: the agent
+changes them directly in the working tree, and they are reviewed in the PR like any
+other diff.
 
-| Component | Technology |
-|-----------|-----------|
-| Language | Java 21 (Eclipse Temurin) |
-| Framework | Spring Boot 3.4 |
-| Build | Gradle (Kotlin DSL) with included wrapper |
-| Database | PostgreSQL 16 + Apache AGE (graph queries) |
-| ORM | Hibernate 6 + Spring Data JPA |
-| Auditing | Hibernate Envers |
-| Migrations | Flyway |
-| Contracts | JML (verified by OpenJML ESC + Z3) |
-| Testing | JUnit 5 + jqwik + ArchUnit + Testcontainers |
-| Static analysis | Error Prone, SpotBugs, Checkstyle |
-| Formatting | Spotless + Palantir Java Format |
-| Coverage | JaCoCo |
-| Logging | SLF4J + Logback (JSON in prod, console in dev) |
-| API docs | Springdoc-OpenAPI |
-| Container | Docker (multi-stage, non-root, JDK 21) |
-| Registry | GHCR (`ghcr.io/autarchy-ai/ground-control`) |
-
-See [ADR-013](../../architecture/adrs/013-java-spring-boot-rewrite.md) for the Java migration rationale.
-
-### Frontend
+### Stack
 
 | Component | Technology |
 |-----------|-----------|
-| Framework | React 19 |
-| Language | TypeScript 5 |
-| Bundler | Vite 6 |
-| Routing | React Router 7 |
-| Server state | TanStack Query 5 |
-| Styling | Tailwind CSS 4 |
-| Components | shadcn/ui (Radix primitives) |
-| Graph viz | Cytoscape.js + dagre |
-| Linting/Format | Biome |
-| Testing | Vitest |
-| Deployment | Embedded in Spring Boot static resources |
+| Runtime | Node.js 20+, ES modules |
+| Protocol | `@modelcontextprotocol/sdk` |
+| Tool input schemas | `zod` |
+| YAML / locking | `js-yaml`, `proper-lockfile` |
+| Tests | `node --test` (`*.test.js`), property tests with `fast-check` |
+| Lint | ESLint 9 + `eslint-plugin-security` |
+| Repo policy | Python (`tools/policy/`), run by `make policy` and `bin/policy` |
+| Prose lint | Vale (`make vale-lint`) |
+| External CLIs | `gh` (authenticated), `git` |
 
-See [ADR-017](../../architecture/adrs/017-interactive-web-application.md) for the frontend decision rationale.
+## Repository-local records
 
-## Package Structure
+Ground Control keeps its durable state as files in the repository and on the GitHub
+issue thread, not in a database:
 
-```
-backend/src/main/java/com/keplerops/groundcontrol/
-├── api/                          # REST controllers, DTOs, exception handler
-│   ├── requirements/             # RequirementController, request/response records
-│   ├── baselines/                # BaselineController, request/response records
-│   ├── admin/                    # ImportController, SweepController, AnalysisController, GraphController, EmbeddingController
-│   ├── verification/             # VerificationResultController, request/response records
-│   ├── plugins/                  # PluginController, request/response records
-│   └── GlobalExceptionHandler.java
-├── domain/                       # Business logic (Spring-web-free)
-│   ├── exception/                # Domain exception hierarchy
-│   ├── projects/                 # Project entity, repository, service
-│   ├── baselines/                # Baseline entity, repository, service
-│   ├── verification/             # VerificationResult entity, VerificationStatus/AssuranceLevel enums, repository, service
-│   ├── evidence/                 # EvidenceArtifact aggregate plus evidence collection adapter contracts
-│   ├── plugins/                  # Plugin interface, PluginRegistry, RegisteredPlugin entity, PluginType/PluginLifecycleState enums
-│   └── requirements/
-│       ├── model/                # JPA entities (Requirement, RequirementRelation, TraceabilityLink, RequirementEmbedding, etc.)
-│       ├── repository/           # Spring Data JPA repository interfaces
-│       ├── service/              # RequirementService, AnalysisService, SimilarityService, EmbeddingService, etc.
-│       └── state/                # Enums (Status, RelationType, ArtifactType, LinkType, etc.)
-├── infrastructure/               # External adapter implementations
-│   ├── age/                      # AgeGraphService (Apache AGE Cypher queries)
-│   ├── embedding/                # NoOpEmbeddingProvider, OpenAiEmbeddingProvider, config
-│   ├── github/                   # GitHubCliClient (gh CLI adapter)
-│   ├── sweep/                    # ScheduledSweepRunner, notifiers
-│   └── web/                      # CORS config, SPA routing
-├── shared/
-│   ├── logging/                  # RequestLoggingFilter (MDC request_id)
-│   ├── security/                 # ApiSecurityConfig, BrowserSecurityConfig,
-│   │                             # BearerTokenAuthFilter,
-│   │                             # IpAllowlistFilter, ApiAuthenticationEntryPoint,
-│   │                             # ApiAccessDeniedHandler, SecurityProperties (ADR-026)
-│   └── web/                      # ActorFilter (audit identity from SecurityContext)
-└── GroundControlApplication.java
-```
+- **Requirements** live at `docs/requirements/<UID>/requirement.md` with a small
+  versioned YAML frontmatter contract, read through
+  `mcp/ground-control/lib/requirement-files.js`
+  ([ADR-093](../../architecture/adrs/093-requirements-specs-as-code.md)). There is no
+  requirement graph or backend record.
+- **Architecture Decision Records** live at `architecture/adrs/*.md`, governed by the
+  machine-readable `architecture/policies/adr-policy.json` guardrails.
+- **The GitHub issue thread is the durable workflow record**
+  ([ADR-029](../../architecture/adrs/029-issue-thread-gate-model.md)): the plan,
+  decision records, phase markers, execution obligations, and the final report all
+  post there, so the record survives PR merge or close.
 
-## Dependency Rule
+## Boundary contract
 
 ```
-api/ -> domain/ <- infrastructure/
+driver (Claude Code / Codex / Cursor)
+  ├─ edits repo-local files directly (requirements, ADRs, docs) → reviewed in the PR
+  └─ asks the MCP server for every privileged operation
+        MCP server (mcp/ground-control)  ← the only privileged actor
+          → gh / git: branches, the GitHub issue thread, pull requests, CI/Sonar reads
 ```
 
-- `domain/` has no imports from `api/` or `infrastructure/` and no Spring web imports
-- `api/` depends on `domain/` - never imports `infrastructure/`
-- `infrastructure/` implements interfaces defined in `domain/`
+The trust boundary is the tool layer: workflow prose that the MCP tools cannot enforce
+is not a control. The privileged actor is the MCP server, and it is privileged only for
+`gh` / `git` operations. Reviewer engines (codex) return structured findings; the server
+performs the GitHub writes (ADR-031). Requirements, ADRs, and docs are edited by the
+agent as ordinary working-tree changes and reviewed in the PR like any other diff.
 
-Enforced at compile time by ArchUnit tests in `ArchitectureTest.java`.
-
-## Configuration
-
-Spring profiles drive environment-specific behavior:
-
-- `application.yml` - base config (datasource, JPA, Flyway, server port, security defaults)
-- `application-dev.yml` - local dev (`groundcontrol.security.enabled=false`)
-- `application-test.yml` - test overrides (Testcontainers, security disabled)
-
-Environment variables use the `GC_` prefix (for example, `GC_DATABASE_URL`, `GC_SERVER_PORT`). See `.env.example`.
-
-## Request filter chains
-
-Once Spring Security is enabled (production default; `dev`/`test` profiles
-opt out), requests pass through two explicit, non-overlapping Spring Security
-chains:
+## Package structure
 
 ```
-Bearer request chain (@Order(1), Authorization: Bearer ...)
-IpAllowlistFilter           # CIDR check (skipped if allowlist empty)
-  → BearerTokenAuthFilter   # token → SecurityContext
-    → AuthorizationFilter   # path-matrix / ROLE_USER / ROLE_ADMIN
-      → ActorFilter         # populates ActorHolder + MDC actor_id=<principal>
-        → controllers
-
-Browser/session chain (@Order(2), every non-bearer request)
-IpAllowlistFilter           # same network gate
-  → form login / session / CSRF
-    → AuthorizationFilter   # same API path matrix for /api/v1/**
-      → ActorFilter         # same audit actor projection
-        → controllers
+mcp/ground-control/
+├── index.js              # server entry: registers the tool surface
+├── lib/                  # implementation modules (thin tools delegate here)
+│   ├── requirement-files.js   # repo-local requirement reader (ADR-093)
+│   ├── ...                     # git/GitHub mechanics, review, CI/Sonar, records
+├── tools/                # MCP tool registrations (zod schema + thin handler)
+├── implement/            # /implement mechanical orchestration helpers
+├── knowledge_ingest.js   # repo-local knowledge ingest engine (ADR-025)
+└── *.test.js             # node --test suites (the primary test gate)
 ```
 
-The shared API authorization matrix lives in `ApiPathMatrix` and is applied by
-both `ApiSecurityConfig` (bearer traffic) and `BrowserSecurityConfig`
-(session-authenticated browser traffic). The browser chain leaves `/login`,
-`/logout`, and required static assets anonymous, but the SPA shell (`/`,
-`/index.html`) and SPA client routes require a browser session; unauthenticated
-navigation redirects to `/login`, while API-shaped unauthenticated XHRs receive
-the standard JSON 401 envelope. Controllers do not perform per-method auth
-checks - the one deliberate exception,
-`PackRegistryAccessGuard`, is a defense-in-depth bridge that re-derives the
-admin principal from the same `SecurityContext` and re-asserts `ROLE_ADMIN`
-(see ADR-033 §4). `ActorFilter` runs after the security chain so audit
-identity tracks the authenticated principal; it writes the principal to MDC
-key `actor_id`, the key `logback-spring.xml`'s production JSON appender
-exports (alongside `request_id` / `tenant_id`). See [ADR-033](../../architecture/adrs/033-authenticated-audit-actor-provenance.md).
+The registration pattern is a `zod` input schema plus a thin handler that delegates to
+a `lib/` function; `mcp/ground-control/tools/query.js` is the canonical example. New
+abstractions are not introduced below three call sites, and comments are reserved for
+non-obvious rationale rather than restating the code.
 
-ADR-085's identity/RBAC foundation is the first permission-backed exception to
-the legacy two-role matrix. Requests under `/api/v1/admin/identity/**` use an
-`IdentityAuthorizationManager` before the broader `/api/v1/admin/**` matcher:
-a UUID-backed `IdentityPrincipal` must hold the closed-catalog
-`IDENTITY_ADMIN` permission, while existing `ROLE_ADMIN` callers receive a
-narrow compatibility bridge only on that namespace. The domain authorization
-decision is `(identity user UUID, permission key, optional project UUID)`;
-project-scoped decisions require both a direct/group role path and an
-independent direct/group project-access grant. V059 browser users and
-configuration bearer credentials remain authoritative until #1411, so this
-foundation does not silently reinterpret legacy principal names as identity
-rows.
+## The tool surface
 
-## What Exists vs. What Doesn't
+The surviving tools (roughly 27, down from 215 before the re-platform) are exactly what
+the `/implement` workflow needs, each operating over `gh` / `git` / files:
 
-### Exists
+- **Orchestration.** `gc_implement_mechanical` drives the mechanical bands (bootstrap,
+  verify, publish, monitor, readiness, finalize); `gc_codex_job` carries the long async
+  actions; `gc_get_repo_ground_control_context` reads `.ground-control.yaml`.
+- **Git / GitHub mechanics.** Branch prep, issue pickup, issue-thread reads, base sync,
+  synchronized PR creation, PR-body rendering, issue close, and issue creation from a
+  requirement file.
+- **CI / quality signals.** `gc_watch_ci_run` and `gc_watch_sonar_analysis` read live.
+- **Reviewer separation.** The codex review, architecture-preflight, verify, and
+  test-quality tools plus the review-cap disposition; the coding agent never reviews
+  its own work.
+- **Durable records.** Plan, decision records, execution obligations, and the final
+  report all post to the GitHub issue thread.
 
-**Domain entities:** Requirement, RequirementRelation, TraceabilityLink,
-GitHubIssueSync, RequirementImport, plus the ADR-085 identity family
-(`IdentityUser`, `IdentityGroup`, `GroupMembership`, `IdentityRole`,
-`RolePermissionAssignment`, `RoleGrant`, `ProjectAccessGrant`) - all JPA with
-Envers auditing.
+## The `/implement` workflow
 
-**Services:** RequirementService (9 methods), TraceabilityService (forward and reverse artifact lookup, with canonical positive-decimal identity enforcement for GitHub issues and pull requests), ImportService (StrictDoc parser + idempotent import), GitHubIssueSyncService (CLI-based GitHub sync), AnalysisService (cycle/orphan/coverage/impact/cross-wave; status drift belongs here as read-only analysis), AgeGraphService (Apache AGE graph materialization + Cypher queries).
+The gated loop (plan, TDD, verify, review, publish, CI, Sonar, requirement transition,
+traceability reconciliation) is specified in
+[`docs/DEVELOPMENT_WORKFLOW.md`](../DEVELOPMENT_WORKFLOW.md) and the agent-neutral skill
+under `skills/implement/`. The user's only synchronous touchpoint is PR merge (ADR-029).
 
-**Requirement UID allocation (ADR-060, issues #532, #1052):** `RequirementUidAllocator` assigns the next free `{PREFIX}-{N}` UID atomically per project via `pg_advisory_xact_lock`, reading the current high-water mark from `findMaxUidSuffix` (archived rows included, so no suffix is ever recycled). `TraceabilityService.findByArtifact` accepts an optional `projectId` to scope the reverse lookup to a single project; this prevents cross-project issue-number collisions from returning or flagging another project's `GITHUB_ISSUE` links.
+## Verification surface
 
-**API:** RequirementController (9 REST endpoints), AnalysisController (5 endpoints), ImportController, SyncController, GraphController. GlobalExceptionHandler maps domain exceptions to HTTP error envelopes.
+There is no Gradle, JaCoCo, Testcontainers, or ArchUnit. Verification is:
 
-**Audit read surface:** Envers revision data is exposed read-only through `/requirements/{id}/history` (per-revision requirement snapshots with field-level `changes` diffs), `/requirements/{id}/timeline` (unified requirement / relation / traceability-link timeline), and `/requirements/{id}/diff` (two-revision comparison). Diffs use a single `oldValue`/`newValue` vocabulary (`FieldChange` → `FieldChangeResponse`); ADD revisions render as `(null, value)` and DEL revisions as `(value, null)`, so status transitions and traceability-link create/delete appear as discrete diffed events. Large string values are truncated at the API response mapper (`AuditDiffTruncation`, 200-character preview, `truncated` flag) by default, with `?expand=true` returning full values. No new JPA aggregate, Envers table, or migration.
+- `make mcp-test` runs the `node --test` suites; this is the primary test gate.
+- `make policy` runs the repo-native Python guardrails (`tools/policy/`, `bin/policy`),
+  the MCP ESLint gate, and Vale. It covers ADR synchronization, requirement-spec
+  frontmatter, the `/implement` execution and workflow contracts, reviewer-separation
+  decision records, repo identity, version mirrors, the file-size limit, and the
+  repository-map freshness gate. See
+  [ADR-091](../../architecture/adrs/091-ci-verification-topology.md) for the CI
+  verification topology.
 
-**Threat-control mapping (GC-H006):** `RiskControlMapping` accepts `ThreatModel` as a third analysis-side endpoint, generalizing the exactly one invariant from `(risk_scenario_id XOR risk_register_record_id)` to `(threat_model_id XOR risk_scenario_id XOR risk_register_record_id)`. Enforced at the DB level via CHECK constraint `ck_rcm_analysis_side` (V137) and in the service layer via `RiskControlMappingService.validateExactlyOneAnalysisEndpoint`. Unique constraints `uq_rcm_control_threat_asset` and `uq_rcm_scoped_threat_asset` prevent duplicate mappings. Two read-only endpoints under `GET /api/v1/analysis/risk-control/`: `unmapped-threats` and `threat-unmapped-controls`. (A third, `threats-insufficient-effectiveness`, was published only as an MCP action backed by a REST route that never existed on `RiskControlAnalysisController`; it and its `as_of`/`minEffectiveness`/`freshnessWindowDays` parameters were retired in #1309 as dead, divergent as-of surface—see "As-Of Time Semantics" below.) Graph projection contributor emits `MAPS_THREAT_MODEL` edges. V137 adds `threat_model_id` to `risk_control_mapping` and its audit shadow table.
+## Optional comprehension index
 
-**Research run lifecycle & stage gating (GC-RSCH-R001 / GC-RSCH-R003 / GC-RSCH-F004, ADR-064 / ADR-065 / ADR-066):** `ResearchRun` is a project-scoped execution aggregate (`domain/research`) that tracks a single research effort through a closed eight-stage lifecycle (`ResearchRunStage`: methodology selection → protocol planning → source search → screening → charting → synthesis → argument construction → prose drafting), kept deliberately separate from run *status* (`ResearchRunStatus`: IN_PROGRESS / BLOCKED / STOPPED / FAILED / COMPLETED). Stage advancement is governed by a service-owned prerequisite matrix (each stage names the predecessor artifact it requires) and by run-scoped human gates (`ResearchRunGate` at five `ResearchGatePoint`s); whether a gate requires a human, auto-accepts, or is disabled is resolved from the run's autonomy level (`ResearchGateBehavior`), so the same lifecycle runs supervised or autonomous without code changes. Gate decision history records the question, recommendation, rationale, decision, actor, and timestamp as persisted research state; workspace `decisions.md` is only a local mirror/export, and recommendation provenance stays separate from human decision provenance. Stage outputs are recorded as `ResearchRunArtifact` manifest rows that are the checkpoint authority: idempotent on an optional key and *superseded* rather than mutated on rework, so a stopped or failed run resumes from its last completed stage without duplicating work, and gate reopening follows artifact supersession. The aggregate stores only bounded, low-cardinality execution state (stage, status, autonomy, budgets, observed token/cost usage, source counts, last-error class) and never prompts, manuscripts, or workspace file paths; manuscript content stays in the workspace, not the record. CRUD + lifecycle live at `/api/v1/research-runs` (start, list, get, advance, record artifact, gate decision, stop, fail, resume, complete, record usage), with a bounded `GET /{id}/snapshot` observability read (current stage, pending gates, artifact readiness, source counts, cost, last error) composed only from persisted state; cross-project access is concealed as `404`. The path is allowlisted for `gc_query` MCP reads. The aggregate is `@Audited` (Hibernate Envers); migrations `V144` through `V149` add the three tables and their audit shadows. Orchestration, curated MCP writes, and a frontend surface are explicit ADR non-goals for this slice.
+[Graphify](../../architecture/adrs/094-graphify-comprehension-index.md) is an optional,
+disposable code-plus-docs index an agent may build (`make graphify`, see
+[docs/GRAPHIFY.md](../GRAPHIFY.md)). It is not required and is not part of the
+repository's architecture of record.
 
-**Protocol plan (GC-RSCH-F008 / GC-RSCH-F009, ADR-083):** `ProtocolPlanAggregate` (`domain/research/service`) records the structured phase-2 protocol plan behind the run's active `PROTOCOL_PLAN` artifact attempt: a `ProtocolPlanCoverage` row resolves each ADR-080 methodology-requirements-contract `REQUIREMENT`/`OPEN_PROTOCOL_QUESTION` entry to exactly one `ProtocolCoverageDisposition` (FILLED / RESOLVED_BY_USER_DECISION / DEFERRED_NON_BLOCKING / NOT_APPLICABLE_WITH_RATIONALE / BLOCKING_DECISION_REQUIRED), classifying `FILLED` answers by `ProtocolAnswerProvenance`; a `ProtocolPlanSection` row records one method-specific output section per `ProtocolSectionKind` (`ProtocolMethodShape` derives which section kinds the selected method profile requires), with `ProtocolSourceRole` legal only on `SOURCE_ROLES` sections of the `taxonomy_development` method. A plan with any `BLOCKING_DECISION_REQUIRED` coverage disposition blocks the `SOURCE_SEARCH` stage from starting. The method key, method profile version, methodology-requirements-contract id/attempt, and artifact attempt are all resolved server-side from the run's active selection and active artifacts, never client-supplied. CRUD lives at `/api/v1/research-runs/{id}/protocol-plan` (record, get); migrations `V184`-`V187` add the plan, plan-audit, coverage, and section tables. The endpoint is allowlisted for `gc_query` MCP reads.
+## Knowledge ingest engine
 
-**Frontend:** React 19 / TypeScript SPA served as embedded static resources from the Spring Boot JAR. Views: Dashboard (project health metrics), Requirements Explorer (browse/filter/author), Requirement Detail (fields, relations, traceability, audit), Dependency Graph (Cytoscape.js DAG visualization). The composed GRC Portfolio, Control and Assurance Workspace, Evidence and State Explorer, Threat Modeling Workspace, and Risk Scenario Workspace views (GC-Q009/Q010/Q011/Q012/Q013) are retired product surface (ADR-089, issue #1346); their underlying lower-level aggregates (`ThreatModel`, `RiskScenario`, `Control`, `ControlTest`, `EvidenceArtifact`, risk-control mapping) remain available through their own CRUD/analysis endpoints, just not through a composed workspace view. The console shell, navigation groups, design-system foundations, authenticated-session UX, and workflow-operations interaction patterns are specified in [Console Information Architecture and Design-System Foundations](../../architecture/design/console-ia-design-system.md), which is the construction reference for GC-Q015 and GC-Q016. GC-Q015 implements that reference: a grouped, responsive `AppShell` (rail on desktop, drawer on small screens) with a user menu, a transient notification surface, and semantic design tokens; the day-to-day usage reference is [Console Design System](../frontend/design-system.md). In-app session awareness reads the authenticated principal from `GET /api/v1/session` (`SessionController` → a credential-free `SessionResponse` of display name, a compatibility role projection, and a `canAdminister` presentation hint sourced from the `SecurityContext`); authorization stays enforced by `ApiPathMatrix` and the service layer, and the login bundle remains a separate anonymous asset graph (ADR-037). See [ADR-017](../../architecture/adrs/017-interactive-web-application.md).
+A repository that uses Ground Control can declare an agent-maintained knowledge base
+under `docs/knowledge/` via the `knowledge` section of its `.ground-control.yaml`. The
+`gc_remember` tool captures an observation into that repo's inbox; a detached ingest
+subprocess decides update-versus-create, writes the wiki page, and commits under a
+per-repo lock. The engine lives at `mcp/ground-control/knowledge_ingest.js` with a thin
+CLI at `mcp/ground-control/knowledge_ingest_cli.js`
+([ADR-025](../../architecture/adrs/025-knowledge-ingest-engine.md)).
 
-**Contract surface (GC-O014 / ADR-082):** `contracts/` is the committed
-contract surface for externally consumed API and workflow shapes. The backend
-remains the semantic source: `generateContractOpenApi` captures Springdoc
-OpenAPI, `make contracts` refreshes `contracts/openapi/openapi.json` and
-`contracts/gen/typescript/api.ts`, and `frontend/src/types/api.ts` is only a
-compatibility re-export to the generated artifact. JSON Schemas under
-`contracts/schemas/` carry invariant inventories, and
-`contracts/authz/path-matrix.yaml` is checked against `ApiPathMatrix.java`.
-`make contracts-check` is the local regenerate-and-diff drift gate; CI also
-runs the breaking-change check against `contracts/CHANGES.md`.
+## Binding ADRs
 
-**Tooling:** Status state machine with JML contracts (verified by OpenJML ESC + Z3), Flyway migrations, Spotless/Error Prone/SpotBugs/Checkstyle/JaCoCo, ArchUnit architecture tests, CLD oracle battery scaffolds for conformance/property/negative/golden/differential tests, CI pipeline (build + test + integration + verify), production Dockerfile, GHCR publishing, E2E integration tests.
-
-## As-Of Time Semantics (ADR-084 §5)
-
-The canonical as-of coordinate for the whole system is the **Envers revision number** (`revinfo.rev`)—a single, already-total order over every audited entity, with actor attribution. There is exactly one resolution rule, owned by `AsOfRevisionResolver` (`domain/audit/service`, backed by `RevisionRepository`). The resolver returns the greatest `rev` whose `revinfo.revtstmp` is at or before the given instant (an inclusive boundary), or `Optional.empty()` when no revision satisfies that condition (including when nothing has ever been audited yet).
-
-The resolver is global, not project-scoped. A revision is a coordinate, not an authorization, so project-scoped filtering stays the responsibility of each consumer. For example, `BaselineService` resolves a revision and then filters requirements by project when reconstructing a snapshot.
-
-Per-service reimplementation of "as of" semantics using a bespoke query against a business timestamp or a second temporal parameter shape is a defect. Issue #1309 retired the one surviving example (a dead MCP action, `threats-insufficient-effectiveness`, calling a REST route that never existed) and deleted seven repository methods that filtered "current" rows by *business* time (`observedAt`, `derivedAt`, `testDate`) rather than system revision time. An OpenAPI structural guard (`OpenApiAsOfParameterGuardTest`) fails the build if any controller or request DTO ever declares an as-of-shaped parameter again.
-
-**Consumers of the spine:**
-
-- **Baselines** (`BaselineService.create`) pin a baseline to `asOfRevisionResolver.currentRevision()`. `Optional.empty()` (nothing audited yet) maps to the persisted origin sentinel `0` at this one boundary—`Baseline.revisionNumber` is a persisted `int` and `getRequirementsAtRevision(0)` is defined to return an empty list; the resolver itself never invents a `0` revision.
-- **AGE graph snapshots** (`age_graph_snapshot.source_revision`, added V201) record the revision visible to the snapshot's own `REPEATABLE_READ` publishing transaction: `AgeGraphService.materializeGraph()` resolves it strictly after the publication advisory lock and strictly before `GraphProjectionRegistryService.buildProjection()`, so the resolver query and every contributor read inside the projection observe the same PostgreSQL snapshot. `source_revision` is nullable with **no FK to `revinfo`** and **no backfill**: `AuditRetentionJob` deletes old `revinfo` rows, so a FK would either block that cleanup or silently turn old snapshots into retention pins, and a materialization spans time—the revision visible at publication cannot be reconstructed after the fact from `published_at`. Legacy snapshot rows (published before V201) stay explicitly `NULL`. `source_revision`, `version` (the snapshot lifecycle counter), the revision's own timestamp, and `published_at` (the wall-clock publication instant, `clock_timestamp()` not `now()` so a long build doesn't understate it) are four genuinely distinct clocks—do not conflate them.
-- **Every mutable graph contributor's backing entity must be `@Audited`.** A snapshot's `source_revision` claim is only honest if every entity the projection reads is on the Envers spine—an unaudited entity could change graph contents without advancing any revision. `Document` was the one historical exception (closed in #1309: `@Audited` + `document_audit`, V202). ADR-061's workflow reporting model joined the graph in #1311 only after `WorkflowRun` and `WorkflowPhaseEvent` gained audit shadows in V203. A structural guard (`GraphProjectionContributorAuditGuardTest`) fails the build if a future `GraphProjectionContributor` reads an unaudited entity.
-- **A stored `source_revision` is a coordinate, not a retention guarantee.** `AuditRetentionJob` purges `revinfo` rows (and their audit-shadow rows) past the configured retention window; an old snapshot's recorded revision can become unreconstructable once its `revinfo` row is gone. The graph itself does not need that history to keep serving reads—only a hypothetical future historical-reconstruction feature would.
-
-**Event-history, not competing spines:** ADR-045's evidence supersession chains and the research provenance ledger (`ResearchProvenanceNode`/`Edge`, ADR-069/070) are unchanged by this—they are event-history semantics layered *on* the Envers spine, not alternative time coordinates. Neither introduces a second "as of" query surface; both remain relational aggregates whose own revisions are, like everything else, addressable through the one resolver if a future feature needs to.
-
-**Non-goal:** there is no historical graph query API yet (`resolveAsOf(Instant) → Optional<Integer>` is the seam a future one would consume) and no conversion of business-effective dates into system revision time.
-
-## Mixed-Entity Graph Participants
-
-The mixed-entity graph (materialized via `AgeGraphService` + Apache AGE) includes the following first-class domain participants, each backed by a `GraphProjectionContributor` that emits typed nodes into the project-scoped graph: Requirement, OperationalAsset (and Observation), RiskScenario, Control, ControlTest, VerificationResult, ThreatModel, Finding, EvidenceArtifact, Audit, RiskControlMapping, ScopedControlImplementation, Document (added GC-G007), the research provenance trio `RESEARCH_RUN` / `RESEARCH_ARTIFACT` / `RESEARCH_PROVENANCE_NODE` (added ADR-070, #1003), and ADR-061 workflow reporting runs (added #1311). The research participants project the existing relational research ledger (`ResearchRun`, `ResearchRunArtifact`, `ResearchProvenanceNode`/`Edge`) read-only: `ACTIVE` rows of the current reproducibility chain only (`FAILED` runs and superseded rows are excluded from the default projection), provenance edges preserve the ADR-069 upstream→downstream direction via `ProvenanceEdgeRelation`, and only bounded identifiers/enums/hashes/counts are projected, never raw research content. Workflow reporting projects an audited `WORKFLOW_RUN` node plus a deduplicated workflow-family `WORK_ITEM_REFERENCE` for complete `(project, repo, issueNumber)` identities. `RUN_FOR_WORK_ITEM` records the stable association and every persisted phase event remains a distinct directed `WORKFLOW_PHASE_EVENT` edge; incomplete identities remain isolated run nodes. It does not revive a workflow executor or first-class work-item aggregate. Requirement traceability is part of the same projection: `IMPLEMENTS`, `TESTS`, `DOCUMENTS`, `CONSTRAINS`, and `VERIFIES` run from a requirement to its artifact endpoint. Live controls and risk scenarios resolve to their canonical graph nodes; GitHub issues, code references, and other artifacts without a live projected aggregate use deduplicated `ARTIFACT_REFERENCE` nodes keyed by an exact, project-qualified identifier tuple. Every first-class participant exposes a stable `graphNodeId` field on its REST response (via `GraphIds.nodeId`) for client-side graph navigation. Property keys emitted by contributors must be registered in `AgeGraphService.APPROVED_PROPERTY_KEYS` (ADR-032), and each new contributor must ship a regression test asserting that registration.
-
-## Mixed-Entity Graph Operations
-
-The four public operations on the mixed-entity graph (GC-G008) are:
-
-- `GET /api/v1/graph/visualization` - returns the full project-scoped graph as a flat node+edge list.
-- `POST /api/v1/graph/subgraph/query` - extracts a subgraph anchored at caller-supplied root node IDs.
-- `POST /api/v1/graph/traversal/query` - BFS neighborhood traversal with configurable depth and optional entity-type filter.
-- `POST /api/v1/graph/paths/query` - shortest-path queries between two node IDs.
-
-**Routing:** `GraphController` → `MixedGraphService` → `MixedGraphClient` → `AgeGraphService` (with JPA-projection fallback when Apache AGE is unavailable, per ADR-032). The JPA fallback builds the same `GraphProjection` shape from JPA aggregates so callers receive a consistent response regardless of AGE availability.
-
-**Node IDs** follow the form `GraphEntityType:identity` (for example, `CONTROL:a1b2c3d4-…`), produced by `GraphIds`. Aggregate-backed nodes use their UUID. `ARTIFACT_REFERENCE` nodes use a bounded SHA-256 digest of length-framed project id, artifact type, and exact persisted identifier components, preventing long identifiers and cross-project collisions. All four endpoints validate IDs against the resolved project's projection (not globally), so cross-project references are always rejected.
-
-**Project-scope enforcement:** every operation resolves a single project (via the `project` query parameter) before the graph projection is built. Caller-supplied node IDs are validated only after that projection is materialized, ensuring no cross-project data leaks through traversal.
-
-**Traversal bounds:** `GraphTraversalLimits` is the canonical bound policy covering:
-- Maximum root node count per request.
-- Maximum BFS depth cap.
-- Projection node and edge caps (guards against pathologically large graphs).
-- Path result count cap (limits `paths/query` result sets).
-
-**Legacy compatibility:** `/api/v1/requirements/graph/**` routes remain available as requirement-only compatibility endpoints. They must not be extended for mixed-entity traversal; all new cross-entity graph operations go through `/api/v1/graph/**`.
-
-## Status Drift Analysis
-
-Status drift analysis is a read-only requirements-domain analysis. It flags requirements that are still `DRAFT` while independent artifacts suggest implementation or design completion has already landed. It does not create traceability links, transition requirements, or relax the `IMPLEMENTS`-only on `ACTIVE` rule.
-
-The analysis must build on the existing graph contracts:
-
-- Requirements are project-scoped per ADR-016; all status drift queries must resolve a single project, and every evidence signal must be derived from data owned by that project. Never compare UIDs across projects without project context, and never read project- or repo-unscoped caches (for example, the GitHub issue/PR sync tables) from this path - a project-scoped analysis must not surface another project's (or another repo's) artifacts.
-- Evidence is link-based: an `IMPLEMENTS` traceability link on a `DRAFT` requirement (the strongest signal - `IMPLEMENTS` to an issue is allowed pre-`ACTIVE` in the GC-O007/#794 shape), a `DOCUMENTS` link to an `ACCEPTED` ADR (`ArchitectureDecisionRecord` + `TraceabilityLink` with `artifactType=ADR`, `linkType=DOCUMENTS`), a non-`IMPLEMENTS` link to a GitHub issue or pull request, or a non-`IMPLEMENTS` link to a code/test/spec/proof artifact. A `DOCUMENTS` link is evidence, not an implementation link.
-- Traceability identifiers follow ADR-011 conventions. GitHub issues and pull requests use raw decimal identifiers; ADRs use ADR UIDs; code/test/config evidence uses repo-relative identifiers. Do not add alternate encodings such as `#42`, `owner/repo#42`, `file:...`, or `adr:021`.
-- The analysis path must not shell out to `gh` or scan arbitrary filesystem paths; network and process execution belong in the GitHub sync adapter, not the analysis service.
-
-The report contract is derived evidence: each finding carries the DRAFT requirement, strongest signal type, confidence (`HIGH`, `MEDIUM`, `LOW`), and specific evidence artifacts. Sweep/report callers own the confidence threshold, defaulting to `MEDIUM` so `HIGH` and `MEDIUM` findings are shown while `LOW` remains opt-in.
-
-### Does not exist yet
-
-- Identity-backed login, credential ownership, and OIDC flows. The existing
-  ADR-026 bearer and ADR-037 browser stores still authenticate callers; #1411
-  performs the authoritative credential cutover.
-- Redis integration (Redis is in docker-compose.yml but nothing in the app uses it)
-- Multi-tenancy
-- Search
-- Concrete verifier adapter implementations in `infrastructure/verifiers/` (ADR-014 §6). The `VerifierAdapter` port interface and request/outcome contracts are defined in the domain layer; future work is implementing adapters for each prover (OpenJML, TLA+/TLC, OPA/Rego, Frama-C, manual review).
-- Concrete evidence collection adapter implementations. The `EvidenceCollectionAdapter` port interface, request/result contracts, and classpath/dynamic descriptor registry are defined in the domain layer; external-system collectors belong in infrastructure or trusted plugin code.
-- Research high-risk operation **executors** and sandbox runtime. ADR-086's
-  authorization control plane now exists (see "Exists now"), but the executors
-  that perform generated-code execution, browser activity, lab/hardware actions,
-  and external writes (and the sandbox runtime they run in) are not implemented
-  yet. An executor must present an unexpired, matching authorization record and
-  run under the declared sandbox profile before performing any effect.
-- Traceability Matrix view (`/traceability`) and Audit Timeline view (`/audit`) in the frontend
-- Apache AGE is optional - the app gracefully degrades to JPA-only analysis when AGE is unavailable
-
-### Exists now
-
-- `specs/tla/` for design-level verification artifacts and state-machine specs, aligned with ADR-014
-- Verification result storage (VerificationResult entity with eager-loaded target/requirement, enums, CRUD API, MCP tools) - ADR-014 §2 common schema
-- Pluggable verifier adapter interface (`VerifierAdapter`, `VerificationRequest`, `VerificationOutcome`) - ADR-014 §6 port contract for multi-tool integration
-- Pluggable evidence collection adapter interface (`EvidenceCollectionAdapter`, `EvidenceCollectionRequest`, `EvidenceCollectionResult`) plus `EvidenceCollectionAdapterRegistry` in the evidence service package. This is the GC-S001 port contract for agent-invoked external evidence collection.
-- IAM evidence adapter specification (`domain/evidence/collection/iam/`: `IamEvidenceProvider`, `IamEvidenceFamily`, `IamEvidenceSpecification`). This is the GC-S002 normative contract: it specifies - as data over the GC-S001 port, not a new adapter hierarchy - the supported providers (Okta, Azure AD, AWS IAM), the five evidence families (user access reviews, provisioning/deprovisioning events, MFA enrollment, privileged access, dormant accounts) as canonical scope types and versioned `1.0.0` output schemas, and the descriptor capabilities a conforming IAM collector advertises. Concrete provider collectors remain out of scope (see "Does not exist yet"); design rationale in `architecture/notes/iam-evidence-adapter-spec-preflight.md`.
-- Cloud infrastructure evidence adapter specification (`domain/evidence/collection/cloud/`: `CloudEvidenceProvider`, `CloudEvidenceFamily`, `CloudEvidenceSpecification`). This is the GC-S003 normative contract: it specifies - as data over the GC-S001 port, not a new adapter hierarchy - the supported providers (AWS, Azure, GCP), the five evidence families (security group configurations, encryption-at-rest status, logging configurations, backup policies, compliance scan results from AWS Config / Azure Policy / GCP Security Command Center) as canonical scope types and versioned `1.0.0` output schemas, and the descriptor capabilities a conforming cloud collector advertises. Concrete provider collectors remain out of scope (see "Does not exist yet"); design rationale in `architecture/notes/cloud-infrastructure-evidence-adapter-spec-preflight.md`.
-- CMDB/asset-management evidence adapter specification (`domain/evidence/collection/cmdb/`: `CmdbEvidenceProvider`, `CmdbEvidenceFamily`, `CmdbEvidenceSpecification`). This is the GC-S004 normative contract: it specifies - as data over the GC-S001 port, not a new adapter hierarchy - the supported providers (ServiceNow, Snipe-IT, Jamf), the five evidence families (asset inventory, configuration item status, patch levels, software license compliance, end-of-life tracking) as canonical scope types and versioned `1.0.0` output schemas, and the descriptor capabilities a conforming CMDB collector advertises. External CMDB/device records stay separate from `OperationalAsset` (mapping is a deliberate sync behavior through `AssetExternalId`); concrete provider collectors remain out of scope (see "Does not exist yet"); design rationale in `architecture/notes/cmdb-asset-evidence-adapter-spec-preflight.md`.
-- Self-referential traceability enforcement - `check_live_policy.mjs` verifies substantive code files have reverse traceability links to requirements (GC-O002), using the `GET /requirements/traceability/by-artifact` reverse lookup endpoint. Lookup errors are tracked separately for debuggability when the endpoint is unavailable.
-- Server-side quality gates (`QualityGateService.evaluate`) synced from `tools/ground_control/policy.json`, evaluated in CI (`make policy-live`) and enforced at the `/implement` completion gate via `gc_assert_quality_gates`. Enforced metric types are `COVERAGE` (IMPLEMENTS / TESTS / DOCUMENTS link coverage for ACTIVE requirements), `ORPHAN_COUNT`, and `COMPLETENESS`; a failing gate blocks the run with a `{name, metric_type, threshold, actual}` envelope.
-- ADR metadata drift checks (`check_adr_drift.mjs` and `sync_policy.mjs`) use
-  `tools/ground_control/common.mjs` to normalize the live ADR title from the
-  API's `folder_title` field, keeping repo ADR titles and live Ground Control
-  records comparable under the MCP client's response normalization.
-- Research high-risk operation authorization control plane (GC-RSCH-R005 /
-  GC-RSCH-N005 / GC-RSCH-N006 / GC-RSCH-N014, ADR-086). A run snapshots its
-  high-risk operation policy at start (`allowedTools` inventory, structured
-  default-deny `egressPolicy`, and display-only `privacyConstraints`) so later
-  intake edits never re-authorize an active run. `ResearchOperationAuthorizationService`
-  owns a durable, run-scoped `ResearchRunOperationAuthorization` record: a request
-  lands `PROPOSED`, an admin/operator decision (an `AUTONOMOUS` run cannot
-  self-approve) moves it to `APPROVED`/`DENIED` only when the run's snapshotted
-  egress policy permits the `(dataClass, destinationClass, requestedForm)` tuple
-  (`EgressPolicyEvaluator`, default-deny), and a one-time-use `APPROVED` record is
-  spent to `CONSUMED`. Research artifacts carry an optional `dataClass`. Policy and
-  authorization fields are closed enums built only from structured, service-validated
-  inputs, so retrieved/untrusted content can never set tools, egress, sandbox, or
-  approval state (prompt-injection as a data-flow rule). REST at
-  `/api/v1/research-runs/{runId}/operation-authorizations/**` (the decision route is
-  admin-gated in `ApiPathMatrix`) and the `gc_research_operation_authorization` MCP
-  tool. Executors and the sandbox runtime remain out of scope (see "Does not exist
-  yet").
-
-- Live workflow-run telemetry transport (issue #1436, ADR-061 #1436 amendment). `GET
-  /api/v1/workflow-runs/stream?project=…` is a project-scoped Server-Sent Events surface over the
-  existing ADR-061 reporting model—a delivery path for committed facts, not a second store,
-  workflow engine, or liveness signal. `WorkflowTelemetryService` publishes an identifier-only
-  `WorkflowTelemetryChangeEvent` from each committed run mutation and phase-event append;
-  `WorkflowRunStreamHub` (`api/workflowtelemetry/stream/`, a `@Component` because `@Service` is
-  reserved for the domain and `SseEmitter` must not enter `domain/`) consumes it on an
-  `AFTER_COMMIT` `@TransactionalEventListener`, reloads the project-scoped projection in a new
-  read-only transaction, and fans out the existing `WorkflowRunResponse` / `PhaseEventResponse`
-  shapes as `workflow-run` and `phase-event` events. `SseEmitter` supplies no backpressure, so the
-  hub enforces a global and per-principal connection cap taken atomically, a finite emitter
-  lifetime, a heartbeat below it, a bounded per-connection FIFO drained by at most one task, and a
-  bounded delivery executor; publishing threads only enqueue, and overflow or send failure
-  disconnects the consumer rather than dropping an update while still calling the stream live.
-  Bounds live in a startup-validated `groundcontrol.workflow-telemetry.stream.*`
-  `@ConfigurationProperties`. The console's `useWorkflowRunStream` reconciles into the existing
-  React Query cache by entity id (aggregates are invalidated, never recomputed in the browser),
-  suppresses the 30-second fallback poll only while connected, and renders `Live` / `Connecting` /
-  `Polling` as *transport* health—never as evidence that a workflow process is alive. Fan-out is
-  process-local, matching ADR-030's single-backend topology; the identifier-only notification is
-  the seam a multi-instance deployment replaces with a broker or outbox.
-
-- Live Activity read projection (issue #1437, ADR-061 #1437 amendment). `GET
-  /api/v1/workflow-runs/activity?project=…` composes a bounded project snapshot from the existing
-  `WorkflowRun`, ADR-061 lifecycle/station events, ADR-036 routing observations, and subordinate
-  gate-finding counts. Repository batch queries select one latest observation per run/station, and
-  `WorkflowActivityService` joins them to station-catalogue titles/order without N+1 reads. The
-  response exposes its server `asOf`, open total/truncation, effective attention threshold, open
-  rows, and a bounded recent-terminal band. The React page derives elapsed/attention display from
-  one server-anchored clock, invalidates the snapshot for either existing SSE frame, and polls only
-  when push is degraded. The attention flag means "no lifecycle transition observed within the
-  configured duration"; it is not durable state, a lease, process liveness, stale-run reaping, or a
-  control surface.
-
-- Gate outcome and finding measurement (issue #1355, ADR-090 amendment). The station-result
-  axis is now persisted on the ADR-061 write path, and the findings a station observed are
-  subordinate rows on `workflow_gate_finding`, written in the same transaction as the terminal
-  event of their attempt. `WorkflowPhaseEvent` keeps `PhaseEventType` as its lifecycle axis and
-  gains `stationId` + `stationResult`; the two answer different questions, so `COMPLETED` still
-  means the phase finished rather than that its inspection passed. Rows written before the axis
-  existed read `UNOBSERVED` and stay out of every formula denominator instead of being backfilled
-  into passes they never recorded. `GET /api/v1/workflow-runs/measurement` reports per-station
-  first-pass yield, iterations to green, rework, and finding counts by reviewer/detector,
-  category, severity, and disposition, each with its numerator, denominator, and unresolved
-  count. The `spotbugs`, `policy`, and `vale` child gates report their own verdicts from the
-  structured artifacts their own runs write, so no canonical gate is executed twice to be
-  measured and the parent command's duration is never divided among them.
-
-- Durable ADR-036 step observations (issue #1354, ADR-090 amendment). `gc_log_step_telemetry`
-  no longer writes a gitignored per-clone JSONL file: it records each routed `/implement` step as
-  a durable observation on the same `WorkflowPhaseEvent` row, distinguished by an `emitter`
-  (`ADR036_STEP_JSONL` vs the default `ADR061_WORKFLOW_TELEMETRY`). The row adds the ADR-036 facts
-  that had no owner (capability `tier`, reported/expected `model` and their consistency flag,
-  optional token counts, `measurement_version`, and the numbered SKILL step as a non-identity
-  `step_alias`) while its `phase` carries the stable ADR-036 stage id and the backend resolves the
-  catalogue `station_id` from it. The observation reports operation outcome only, so `station_result`
-  stays `UNOBSERVED` and it can never produce first-pass yield; a namespaced `(run_id, source_id)`
-  (`adr036_step:<stage>:<attempt>`) keeps it from colliding with a live station attempt. Per-step
-  reads select the emitter from the existing run-scoped event surface, while the phase hot-spot
-  aggregate and the context-graph projection exclude the step emitter so step economics never inflate
-  gate counts or graph edges. The write is fail-open with no local-file fallback.
-
-- Production-line measurement contract (issue #1438, ADR-090, ADR-082, GC-O014). The
-  ADR-090 measurement model is published as versioned contract artifacts rather than ADR
-  prose: `contracts/schemas/measurement/measurement-record.v1.schema.json` is the record
-  shape every emitter maps onto, and
-  `contracts/schemas/measurement/station-catalogue.v1.schema.json` plus the data at
-  `contracts/measurement/gc-station-catalogue-v1.json` publish station identity. A
-  `station_id` is authoritative; ADR-061 `phase` strings, ADR-036 routing stages,
-  issue-thread `gc:phase` values, MCP action names, and SKILL step numbers are aliases
-  declared by kind, and display labels are declared explicitly non-identity so a UI rename
-  is never a breaking contract change. Stations (which inspect something and can yield a
-  station result) and lifecycle markers (which record a transition and inspect nothing)
-  are disjoint sets, so `ready_for_review` or `traceability_reconciled` can never be
-  counted as a gate attempt. The three ADR-090 outcome axes are separate properties over
-  separate closed enums that share no value, so a tool succeeding cannot be read as a gate
-  passing. `run_measurement_catalogue_check` is what makes the catalogue authoritative: it
-  reads the emitter sources directly and fails when an emitted station id, a `gc:phase`
-  marker, or a routing stage resolves to nothing declared. This surface is data and gates
-  only, with no aggregate, endpoint, MCP tool, dashboard, or retention job.
-
-## Knowledge Ingest Engine (repo-local, out of the product model)
-
-Each repository that uses Ground Control can declare an agent-maintained knowledge base under `docs/knowledge/` via the `knowledge` section of its `.ground-control.yaml`. The `gc_remember` MCP tool captures observations into that repo's inbox; a detached ingest subprocess reads the inbox item, decides update-vs-create via codex, writes the wiki page, and commits the change under a per-repo interprocess lock. The engine lives at `mcp/ground-control/knowledge_ingest.js` with a thin CLI entry at `mcp/ground-control/knowledge_ingest_cli.js`.
-
-The knowledge subsystem is deliberately repo-local tooling, not a Spring backend product feature. No REST controller, DTO, JPA entity, migration, or graph node is added by issues #522–#527. See [ADR-025](../../architecture/adrs/025-knowledge-ingest-engine.md) for the decision to co-locate the engine with the MCP server, use codex as the ingest agent, and serialize via `proper-lockfile`. Rollout phasing lives in `docs/notes/agent-knowledge-system-design.md`.
+| ADR | One-liner |
+|-----|-----------|
+| [ADR-025](../../architecture/adrs/025-knowledge-ingest-engine.md) | Repo-local knowledge ingest engine co-located with the MCP server |
+| [ADR-027](../../architecture/adrs/027-agent-neutral-implement-workflow-packaging.md) | `.ground-control.yaml` + `gc_get_repo_ground_control_context` are the agent-neutral context contract |
+| [ADR-029](../../architecture/adrs/029-issue-thread-gate-model.md) | The GitHub issue thread is the durable workflow record |
+| [ADR-031](../../architecture/adrs/031-codex-review-stopping-model.md) | Codex returns structured findings; the MCP server performs the GitHub writes |
+| [ADR-089](../../architecture/adrs/089-retire-grc-product-and-next-issue-recommendation.md) | Retire the graph-native GRC product surface |
+| [ADR-091](../../architecture/adrs/091-ci-verification-topology.md) | CI verification topology |
+| [ADR-092](../../architecture/adrs/092-file-size-limit-gate.md) | Enforce the 500-LOC file-size limit in repo policy |
+| [ADR-093](../../architecture/adrs/093-requirements-specs-as-code.md) | Requirements are repo-local files, not a backend/graph record |
+| [ADR-094](../../architecture/adrs/094-graphify-comprehension-index.md) | Graphify is an optional, not-required comprehension index |

--- a/docs/requirements/GC-P029/requirement.md
+++ b/docs/requirements/GC-P029/requirement.md
@@ -1,0 +1,51 @@
+---
+id: GC-P029
+title: "Repository Map Freshness Enforced in Repo Policy"
+status: DRAFT
+type: CONSTRAINT
+priority: SHOULD
+wave: 2
+created_at: 2026-08-19T00:00:00Z
+updated_at: 2026-08-19T00:00:00Z
+---
+
+# GC-P029 — Repository Map Freshness Enforced in Repo Policy
+
+## Statement
+
+The root `README.md` shall carry a "Repository map" section that names each
+top-level directory of the repository with a one-line explanation, and the map's
+correspondence to the actual repository shall be enforced by a repo-native policy
+check rather than documented alone. The check shall be two-sided over the tracked
+top-level directories (the first path segment of `git ls-files`): a tracked
+top-level directory that is not in an explicit, reason-annotated exclusion set and
+is not listed in the map fails the build, AND a directory the map lists that is not
+a tracked top-level directory also fails. Every exclusion-set entry shall carry a
+written reason and shall itself fail when the directory it names no longer exists,
+so the exclusion set is shrink-only. Every repo-relative Markdown link in the map
+section shall resolve on disk, since the repository ships no Markdown link checker.
+Agent/editor/lint tooling directories (`.claude`, `.cursor`, `.gc`, `.serena`,
+`.vale`) are the excluded configuration surfaces; `.github` is contributor-relevant
+and shall be listed.
+
+## Rationale
+
+Issue #543 (audit finding A1-12). The root `README.md` had no repository map, so a
+contributor had to discover the layout by hand. A navigation section added once and
+never enforced drifts: the re-platform (#1500, ADR-089) deleted `backend/`,
+`frontend/`, and the database while the onboarding docs kept describing them, which
+is what makes a stale map worse than none. This is the same class of failure the
+500-LOC file-size gate (GC-P028, ADR-092) exists to prevent, and it takes the same
+shape of fix: a repo-native `make policy` / CI gate with two-sided, shrink-only
+enforcement. Anchors the issue #543 repository-map structural gate
+(`tools/policy/repo_map.py`, ADR-095) for traceability per the /implement
+structural-gate planning rule.
+
+## Traceability
+
+- DOCUMENTS → ADR `architecture/adrs/095-repository-map-freshness-gate.md` (ADR-095: Keep the README repository map fresh with a repo policy gate)
+- IMPLEMENTS → CODE_FILE `tools/policy/repo_map.py` (Repository-map freshness gate: two-sided directory coverage, shrink-only exclusions, link resolution)
+- IMPLEMENTS → CODE_FILE `tools/policy/cli.py` (Registers run_repository_map_freshness_check in the policy run)
+- TESTS → TEST `tools/tests/test_policy_repo_map.py` (Gate tests: missing dir fails, phantom fails, stale exclusion fails, broken link fails, real repo is clean)
+- DOCUMENTS → DOCUMENTATION `README.md` (Repository map section)
+- IMPLEMENTS → GITHUB_ISSUE `543` (#543 [Arch] A1-12 — No root-level repository map / contributor onboarding section)

--- a/tools/policy/cli.py
+++ b/tools/policy/cli.py
@@ -54,6 +54,9 @@ from .authz_matrix import (
 from .requirement_specs import (
     run_requirement_specs_frontmatter_check,
 )
+from .repo_map import (
+    run_repository_map_freshness_check,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -88,6 +91,7 @@ def main(argv: list[str] | None = None) -> int:
     violations.extend(run_sonar_strictness_contract())
     violations.extend(run_file_size_limit_check())
     violations.extend(run_requirement_specs_frontmatter_check())
+    violations.extend(run_repository_map_freshness_check())
 
     base_ref, head_ref = _resolve_pr_refs(args)
     if args.skip_pr_body or _is_release_pr(base_ref, head_ref):

--- a/tools/policy/repo_map.py
+++ b/tools/policy/repo_map.py
@@ -111,12 +111,63 @@ def _git_top_level_dirs(repo_root: Path) -> set[str]:
     return dirs
 
 
+def _coverage_violations(
+    actual: set[str], documented: set[str], exclusions: dict[str, str]
+) -> list[Violation]:
+    """Two-sided directory drift: required-but-undocumented and documented-but-absent."""
+    violations = [
+        Violation(
+            DRIFT_CODE,
+            f"top-level directory `{name}/` is not listed in the README Repository map",
+        )
+        for name in sorted(actual)
+        if name not in exclusions and name not in documented
+    ]
+    violations.extend(
+        Violation(
+            DRIFT_CODE,
+            f"Repository map lists `{name}/`, which is not a tracked top-level directory",
+        )
+        for name in sorted(documented)
+        if name not in actual
+    )
+    return violations
+
+
+def _stale_exclusion_violations(exclusions: dict[str, str], actual: set[str]) -> list[Violation]:
+    """Excluded directories that no longer exist (the exclusion set is shrink-only)."""
+    return [
+        Violation(
+            DRIFT_CODE,
+            f"excluded directory `{name}/` no longer exists; remove it from "
+            "MAP_EXCLUDED_DIRS in tools/policy/repo_map.py",
+        )
+        for name in sorted(exclusions)
+        if name not in actual
+    ]
+
+
+def _broken_link_violations(section: str, root: Path) -> list[Violation]:
+    """Repo-relative Markdown links in the section that do not resolve on disk."""
+    return [
+        Violation(LINK_CODE, f"Repository map links to `{target}`, which does not exist")
+        for target in _relative_link_targets(section)
+        if not (root / target).exists()
+    ]
+
+
 def run_repository_map_freshness_check(
     readme_path: Path | None = None,
     repo_root: Path | None = None,
     top_level_dirs: set[str] | None = None,
     excluded: dict[str, str] | None = None,
 ) -> list[Violation]:
+    """Enforce that the README "Repository map" section matches the repository.
+
+    Reports a violation when a tracked top-level directory is undocumented, a
+    documented directory is not tracked, an excluded directory has disappeared, or a
+    repo-relative link in the section does not resolve. See ADR-095 / GC-P029.
+    """
     readme = readme_path if readme_path is not None else README_PATH
     root = repo_root if repo_root is not None else REPO_ROOT
     exclusions = excluded if excluded is not None else MAP_EXCLUDED_DIRS
@@ -138,43 +189,8 @@ def run_repository_map_freshness_check(
     actual = set(top_level_dirs) if top_level_dirs is not None else _git_top_level_dirs(root)
     documented = _documented_dirs(section)
 
-    violations: list[Violation] = []
-
-    for name in sorted(actual):
-        if name not in exclusions and name not in documented:
-            violations.append(
-                Violation(
-                    DRIFT_CODE,
-                    f"top-level directory `{name}/` is not listed in the README Repository map",
-                )
-            )
-
-    for name in sorted(documented):
-        if name not in actual:
-            violations.append(
-                Violation(
-                    DRIFT_CODE,
-                    f"Repository map lists `{name}/`, which is not a tracked top-level directory",
-                )
-            )
-
-    for name in sorted(exclusions):
-        if name not in actual:
-            violations.append(
-                Violation(
-                    DRIFT_CODE,
-                    f"excluded directory `{name}/` no longer exists; remove it from "
-                    "MAP_EXCLUDED_DIRS in tools/policy/repo_map.py",
-                )
-            )
-
-    for target in _relative_link_targets(section):
-        if not (root / target).exists():
-            violations.append(
-                Violation(
-                    LINK_CODE,
-                    f"Repository map links to `{target}`, which does not exist",
-                )
-            )
-
-    return violations
+    return [
+        *_coverage_violations(actual, documented, exclusions),
+        *_stale_exclusion_violations(exclusions, actual),
+        *_broken_link_violations(section, root),
+    ]

--- a/tools/policy/repo_map.py
+++ b/tools/policy/repo_map.py
@@ -1,0 +1,180 @@
+"""Policy check: README repository-map freshness (issue #543, ADR-095, GC-P029).
+
+The root ``README.md`` carries a "Repository map" section so a contributor can see
+where each top-level directory of the repo belongs. A navigation doc nothing
+enforces drifts: a new top-level directory is added and never listed, or a listed
+directory is removed and the row lingers. This check keeps the map honest, the same
+shrink-only discipline the file-size gate (GC-P028) applies to its grandfather list.
+
+It is deliberately dependency-free and enforces four things over the map section:
+
+- every tracked top-level directory (not in the exclusion set) is listed;
+- every directory the map lists is a real tracked top-level directory;
+- every excluded directory still exists (the exclusion set can only shrink);
+- every repo-relative Markdown link in the section resolves on disk (the repo has
+  no automated Markdown link checker, so the map's links are verified here).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from .core import REPO_ROOT, Violation
+
+README_PATH = REPO_ROOT / "README.md"
+
+# Heading text (case-insensitive) that introduces the map section.
+MAP_HEADING = "repository map"
+
+# Top-level directories intentionally omitted from the contributor map, each with a
+# reason. These are agent/editor/lint tooling configuration, not a source surface a
+# contributor navigates. `.github` is deliberately NOT here: CI, templates, and
+# CODEOWNERS are contributor-relevant, so the map must document it.
+MAP_EXCLUDED_DIRS: dict[str, str] = {
+    ".claude": "Claude Code runtime adapter/config, not a source surface",
+    ".cursor": "Cursor runtime adapter/config, not a source surface",
+    ".gc": "Ground Control local run config (plan rules, telemetry), tooling not source",
+    ".serena": "Serena code-index tool config",
+    ".vale": "Vale prose-lint styles",
+}
+
+SECTION_CODE = "repo-map-section"
+DRIFT_CODE = "repo-map-drift"
+LINK_CODE = "repo-map-broken-link"
+
+_INLINE_CODE = re.compile(r"`([^`]+)`")
+_MARKDOWN_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+_TOP_LEVEL_DIR_TOKEN = re.compile(r"^[A-Za-z0-9._-]+/$")
+_URL_SCHEME = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
+
+
+def _extract_section(text: str, heading: str) -> str | None:
+    """Return the body under the ``## <heading>`` section, or None when absent.
+
+    The section runs from the heading to the next level-1 or level-2 heading, so a
+    nested ``###`` subheading stays inside it.
+    """
+    lines = text.splitlines()
+    start: int | None = None
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("## ") and stripped[3:].strip().lower() == heading:
+            start = index + 1
+            break
+    if start is None:
+        return None
+    body: list[str] = []
+    for line in lines[start:]:
+        if re.match(r"^#{1,2} ", line):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def _documented_dirs(section: str) -> set[str]:
+    """Top-level directory names the section lists as inline-code ``name/`` tokens."""
+    names: set[str] = set()
+    for token in _INLINE_CODE.findall(section):
+        if _TOP_LEVEL_DIR_TOKEN.match(token):
+            names.add(token[:-1])
+    return names
+
+
+def _relative_link_targets(section: str) -> list[str]:
+    """Repo-relative Markdown link targets in the section (skips URLs and anchors)."""
+    targets: list[str] = []
+    for raw in _MARKDOWN_LINK.findall(section):
+        target = raw.strip()
+        # Drop any #fragment / ?query so the on-disk path is what remains.
+        target = target.split("#", 1)[0].split("?", 1)[0]
+        if not target or _URL_SCHEME.match(target):
+            continue
+        targets.append(target)
+    return targets
+
+
+def _git_top_level_dirs(repo_root: Path) -> set[str]:
+    """Tracked top-level directories: the first path segment of each tracked file."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    dirs: set[str] = set()
+    for path in result.stdout.splitlines():
+        head, sep, _ = path.partition("/")
+        if sep:
+            dirs.add(head)
+    return dirs
+
+
+def run_repository_map_freshness_check(
+    readme_path: Path | None = None,
+    repo_root: Path | None = None,
+    top_level_dirs: set[str] | None = None,
+    excluded: dict[str, str] | None = None,
+) -> list[Violation]:
+    readme = readme_path if readme_path is not None else README_PATH
+    root = repo_root if repo_root is not None else REPO_ROOT
+    exclusions = excluded if excluded is not None else MAP_EXCLUDED_DIRS
+
+    try:
+        text = readme.read_text(encoding="utf-8")
+    except OSError:
+        return [Violation(SECTION_CODE, f"{readme.name} is missing or unreadable")]
+
+    section = _extract_section(text, MAP_HEADING)
+    if section is None:
+        return [
+            Violation(
+                SECTION_CODE,
+                f"{readme.name} has no '## Repository map' section (issue #543 / GC-P029)",
+            )
+        ]
+
+    actual = set(top_level_dirs) if top_level_dirs is not None else _git_top_level_dirs(root)
+    documented = _documented_dirs(section)
+
+    violations: list[Violation] = []
+
+    for name in sorted(actual):
+        if name not in exclusions and name not in documented:
+            violations.append(
+                Violation(
+                    DRIFT_CODE,
+                    f"top-level directory `{name}/` is not listed in the README Repository map",
+                )
+            )
+
+    for name in sorted(documented):
+        if name not in actual:
+            violations.append(
+                Violation(
+                    DRIFT_CODE,
+                    f"Repository map lists `{name}/`, which is not a tracked top-level directory",
+                )
+            )
+
+    for name in sorted(exclusions):
+        if name not in actual:
+            violations.append(
+                Violation(
+                    DRIFT_CODE,
+                    f"excluded directory `{name}/` no longer exists; remove it from "
+                    "MAP_EXCLUDED_DIRS in tools/policy/repo_map.py",
+                )
+            )
+
+    for target in _relative_link_targets(section):
+        if not (root / target).exists():
+            violations.append(
+                Violation(
+                    LINK_CODE,
+                    f"Repository map links to `{target}`, which does not exist",
+                )
+            )
+
+    return violations

--- a/tools/tests/test_policy_repo_map.py
+++ b/tools/tests/test_policy_repo_map.py
@@ -1,0 +1,170 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.policy.repo_map import (
+    DRIFT_CODE,
+    LINK_CODE,
+    SECTION_CODE,
+    run_repository_map_freshness_check,
+)
+
+CLEAN_README = """# Test
+
+## Repository map
+
+| Path | What lives here |
+|------|-----------------|
+| `architecture/` | Decisions, see [ADRs](architecture/adrs/). |
+| `mcp/` | The server. |
+
+## Something else
+
+Not part of the map: `unlisted/` should be ignored here.
+"""
+
+
+def _write_readme(root: Path, body: str) -> Path:
+    readme = root / "README.md"
+    readme.write_text(body, encoding="utf-8")
+    return readme
+
+
+class RepositoryMapFreshnessCheckTest(unittest.TestCase):
+    def test_clean_injected_map_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "architecture" / "adrs").mkdir(parents=True)  # link target exists
+            readme = _write_readme(root, CLEAN_README)
+            violations = run_repository_map_freshness_check(
+                readme_path=readme,
+                repo_root=root,
+                top_level_dirs={"architecture", "mcp"},
+                excluded={},
+            )
+            self.assertEqual(violations, [])
+
+    def test_missing_directory_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "architecture" / "adrs").mkdir(parents=True)
+            readme = _write_readme(root, CLEAN_README)
+            violations = run_repository_map_freshness_check(
+                readme_path=readme,
+                repo_root=root,
+                top_level_dirs={"architecture", "mcp", "tools"},
+                excluded={},
+            )
+            rendered = "\n".join(v.render() for v in violations)
+            self.assertTrue(violations)
+            self.assertEqual(violations[0].code, DRIFT_CODE)
+            self.assertIn("tools/", rendered)
+
+    def test_phantom_directory_fails(self):
+        phantom = CLEAN_README.replace("| `mcp/` | The server. |", "| `ghost/` | Nope. |")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "architecture" / "adrs").mkdir(parents=True)
+            readme = _write_readme(root, phantom)
+            violations = run_repository_map_freshness_check(
+                readme_path=readme,
+                repo_root=root,
+                top_level_dirs={"architecture"},
+                excluded={},
+            )
+            rendered = "\n".join(v.render() for v in violations)
+            self.assertTrue(violations)
+            self.assertIn("ghost/", rendered)
+
+    def test_excluded_directory_not_required(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "architecture" / "adrs").mkdir(parents=True)
+            readme = _write_readme(root, CLEAN_README)
+            violations = run_repository_map_freshness_check(
+                readme_path=readme,
+                repo_root=root,
+                top_level_dirs={"architecture", "mcp", ".vale"},
+                excluded={".vale": "prose-lint config, not a source surface"},
+            )
+            self.assertEqual(violations, [])
+
+    def test_stale_exclusion_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "architecture" / "adrs").mkdir(parents=True)
+            readme = _write_readme(root, CLEAN_README)
+            violations = run_repository_map_freshness_check(
+                readme_path=readme,
+                repo_root=root,
+                top_level_dirs={"architecture", "mcp"},
+                excluded={".gone": "removed long ago"},
+            )
+            rendered = "\n".join(v.render() for v in violations)
+            self.assertTrue(violations)
+            self.assertIn(".gone", rendered)
+
+    def test_broken_link_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # deliberately do NOT create architecture/adrs -> link is broken
+            readme = _write_readme(root, CLEAN_README)
+            violations = run_repository_map_freshness_check(
+                readme_path=readme,
+                repo_root=root,
+                top_level_dirs={"architecture", "mcp"},
+                excluded={},
+            )
+            rendered = "\n".join(v.render() for v in violations)
+            self.assertTrue(any(v.code == LINK_CODE for v in violations))
+            self.assertIn("architecture/adrs/", rendered)
+
+    def test_external_and_anchor_links_are_ignored(self):
+        body = (
+            "# Test\n\n## Repository map\n\n"
+            "| `mcp/` | See [site](https://example.com) and [top](#test). |\n\n## End\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            readme = _write_readme(root, body)
+            violations = run_repository_map_freshness_check(
+                readme_path=readme,
+                repo_root=root,
+                top_level_dirs={"mcp"},
+                excluded={},
+            )
+            self.assertEqual(violations, [])
+
+    def test_missing_section_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            readme = _write_readme(root, "# Test\n\nNo map here.\n")
+            violations = run_repository_map_freshness_check(
+                readme_path=readme,
+                repo_root=root,
+                top_level_dirs={"mcp"},
+                excluded={},
+            )
+            self.assertTrue(violations)
+            self.assertEqual(violations[0].code, SECTION_CODE)
+
+    def test_missing_readme_is_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            violations = run_repository_map_freshness_check(
+                readme_path=root / "nope.md",
+                repo_root=root,
+                top_level_dirs={"mcp"},
+                excluded={},
+            )
+            self.assertTrue(violations)
+            self.assertEqual(violations[0].code, SECTION_CODE)
+
+    def test_real_repository_map_is_clean(self):
+        # Drift canary: the committed README map must match the real tracked
+        # top-level directories and every link in it must resolve.
+        self.assertEqual(run_repository_map_freshness_check(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a root-level Repository map to README.md, enforces its freshness with a repo-native policy gate, and corrects the stale onboarding docs the map points to (ARCHITECTURE, CODING_STANDARDS, CONTRIBUTING) to the current MCP-server-only reality.

## Requirement UIDs

- `GC-P029`

## Related Issues

Closes #543

## ADR Impact

- ADR-095

## Changes

- README.md: new `## Repository map` section with one row per tracked top-level directory, linking current accurate references and kept distinct from the Documentation table.
- tools/policy/repo_map.py (+ cli.py registration): run_repository_map_freshness_check enforces two-sided directory coverage, shrink-only reason-annotated exclusions, and repo-relative link resolution; runs in make policy and CI.
- docs/architecture/ARCHITECTURE.md, docs/CODING_STANDARDS.md, CONTRIBUTING.md: rewritten from the deleted Java/Spring/PostgreSQL/React stack to the current Node.js MCP-server reality (fixes the stale docs A1-12 would otherwise point contributors to).
- docs/requirements/GC-P029 (DRAFT) and ADR-095: anchor the gate, mirroring the GC-P028/ADR-092 file-size-gate precedent.

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass if applicable
- [x] Configured completion command passes
- [x] No coverage regression

## Ground Control Checks

- [x] Configured repository policy command passes
- [x] Pre-push code review and test-quality review completed; all findings fixed or dispositioned

## Traceability

- IMPLEMENTS: GC-P029 ← tools/policy/repo_map.py, GC-P029 ← tools/policy/cli.py
- TESTS: GC-P029 ← tools/tests/test_policy_repo_map.py

## Checklist

- [x] Code follows the project's coding standards
- [x] Changelog: owned by Release Please (generated from the Conventional Commit PR title; no per-PR fragment)
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.